### PR TITLE
Fix for #7 - Add dependency to JavaBeans Activation Framework.

### DIFF
--- a/athena-federation-sdk/pom.xml
+++ b/athena-federation-sdk/pom.xml
@@ -121,6 +121,12 @@
             <scope>test</scope>
         </dependency>
 
+	<dependency>
+	    <groupId>com.sun.activation</groupId>
+	    <artifactId>javax.activation</artifactId>
+	    <version>1.2.0</version>
+	</dependency>
+
     </dependencies>
 
     <build>


### PR DESCRIPTION
This patch adds the JavaBeans Activation framework to allow
compiling the SDK with Java greater version 8.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
