### PR TITLE
removing hardcoded region in connector validator

### DIFF
--- a/athena-federation-sdk-tools/src/main/java/com/amazonaws/athena/connector/validation/LambdaMetadataProvider.java
+++ b/athena-federation-sdk-tools/src/main/java/com/amazonaws/athena/connector/validation/LambdaMetadataProvider.java
@@ -36,7 +36,6 @@ import com.amazonaws.athena.connector.lambda.metadata.MetadataRequest;
 import com.amazonaws.athena.connector.lambda.metadata.MetadataResponse;
 import com.amazonaws.athena.connector.lambda.security.FederatedIdentity;
 import com.amazonaws.athena.connector.lambda.serde.ObjectMapperFactory;
-import com.amazonaws.regions.Regions;
 import com.amazonaws.services.lambda.AWSLambdaClientBuilder;
 import com.amazonaws.services.lambda.invoke.LambdaFunction;
 import com.amazonaws.services.lambda.invoke.LambdaFunctionNameResolver;
@@ -250,8 +249,7 @@ public class LambdaMetadataProvider
   private static MetadataService getService(String lambdaFunction)
   {
     return LambdaInvokerFactory.builder()
-                   .lambdaClient(AWSLambdaClientBuilder.standard().withRegion(Regions.US_EAST_2)
-                                         .build())
+                   .lambdaClient(AWSLambdaClientBuilder.defaultClient())
                    .objectMapper(ObjectMapperFactory.create(BLOCK_ALLOCATOR))
                    .lambdaFunctionNameResolver(new Mapper(lambdaFunction))
                    .build(MetadataService.class);

--- a/athena-federation-sdk-tools/src/main/java/com/amazonaws/athena/connector/validation/LambdaRecordProvider.java
+++ b/athena-federation-sdk-tools/src/main/java/com/amazonaws/athena/connector/validation/LambdaRecordProvider.java
@@ -28,7 +28,6 @@ import com.amazonaws.athena.connector.lambda.records.RecordRequest;
 import com.amazonaws.athena.connector.lambda.records.RecordResponse;
 import com.amazonaws.athena.connector.lambda.security.FederatedIdentity;
 import com.amazonaws.athena.connector.lambda.serde.ObjectMapperFactory;
-import com.amazonaws.regions.Regions;
 import com.amazonaws.services.lambda.AWSLambdaClientBuilder;
 import com.amazonaws.services.lambda.invoke.LambdaFunction;
 import com.amazonaws.services.lambda.invoke.LambdaFunctionNameResolver;
@@ -128,8 +127,7 @@ public class LambdaRecordProvider
   private static RecordService getService(String lambdaFunction)
   {
     return LambdaInvokerFactory.builder()
-                   .lambdaClient(AWSLambdaClientBuilder.standard().withRegion(Regions.US_EAST_2)
-                                         .build())
+                   .lambdaClient(AWSLambdaClientBuilder.defaultClient())
                    .objectMapper(ObjectMapperFactory.create(BLOCK_ALLOCATOR))
                    .lambdaFunctionNameResolver(new Mapper(lambdaFunction))
                    .build(RecordService.class);


### PR DESCRIPTION
*Issue #, if available:* 9

*Description of changes:* Removed hardcoded region from connector validator classes.

*Testing:*
Ran validate_connector.sh after manipulating AWS_REGION environment variable.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
