### PR TITLE
Fix BigQuery constraint push down.

### DIFF
--- a/athena-bigquery/src/main/java/com/amazonaws/athena/connectors/bigquery/BigQuerySqlUtils.java
+++ b/athena-bigquery/src/main/java/com/amazonaws/athena/connectors/bigquery/BigQuerySqlUtils.java
@@ -23,14 +23,24 @@ package com.amazonaws.athena.connectors.bigquery;
 import com.amazonaws.athena.connector.lambda.domain.Split;
 import com.amazonaws.athena.connector.lambda.domain.TableName;
 import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
-import com.amazonaws.athena.connector.lambda.domain.predicate.EquatableValueSet;
 import com.amazonaws.athena.connector.lambda.domain.predicate.Range;
 import com.amazonaws.athena.connector.lambda.domain.predicate.SortedRangeSet;
 import com.amazonaws.athena.connector.lambda.domain.predicate.ValueSet;
+import com.google.cloud.bigquery.QueryParameterValue;
+import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
 
@@ -39,6 +49,10 @@ import java.util.StringJoiner;
  */
 class BigQuerySqlUtils
 {
+    private static final Logger LOGGER = LoggerFactory.getLogger(BigQueryMetadataHandler.class);
+
+    private static final String BIGQUERY_QUOTE_CHAR = "`";
+
     private BigQuerySqlUtils()
     {
     }
@@ -51,116 +65,160 @@ class BigQuerySqlUtils
      * @param schema The schema of the table that we are querying.
      * @param constraints The constraints that we want to apply to the query.
      * @param split The split information to add as a constraint.
+     * @param parameterValues Query parameter values for parameterized query.
      * @return SQL Statement that represents the table, columns, split, and constraints.
      */
-    static String buildSqlFromSplit(TableName tableName, Schema schema, Constraints constraints, Split split)
+    static String buildSqlFromSplit(TableName tableName, Schema schema, Constraints constraints, Split split, List<QueryParameterValue> parameterValues)
     {
         StringBuilder sqlBuilder = new StringBuilder("SELECT ");
 
         StringJoiner sj = new StringJoiner(",");
         if (schema.getFields().isEmpty()) {
-            sj.add("*");
+            sj.add("null");
         }
         else {
             for (Field field : schema.getFields()) {
-                sj.add(field.getName());
+                sj.add(quote(field.getName()));
             }
         }
         sqlBuilder.append(sj.toString())
             .append(" from ")
-            .append(tableName.getSchemaName())
+            .append(quote(tableName.getSchemaName()))
             .append(".")
-            .append(tableName.getTableName());
+            .append(quote(tableName.getTableName()));
 
-        //Buids Where Clause
-        sj = new StringJoiner(") AND (");
-        for (Map.Entry<String, ValueSet> summary : constraints.getSummary().entrySet()) {
-            final ValueSet value = summary.getValue();
-            final String columnName = summary.getKey();
-            if (value instanceof EquatableValueSet) {
-                if (value.isSingleValue()) {
-                    if (value.isNullAllowed()) {
-                        sj.add(columnName + " is null");
-                    }
-                    else {
-                        //Check Arrow type to see if we
-                        sj.add(columnName + " = " + getValueForWhereClause(columnName, value.getSingleValue(), value.getType()));
-                    }
-                }
-                //TODO:: process multiple values in "IN" clause.
-            }
-            else if (value instanceof SortedRangeSet) {
-                SortedRangeSet sortedRangeSet = (SortedRangeSet) value;
-                if (sortedRangeSet.isNone()) {
-                    if (sortedRangeSet.isNullAllowed()) {
-                        sj.add(columnName + " is null");
-                    }
-                    //If there is no values and null is not allowed, then that means ignore this valueset.
-                    continue;
-                }
-                Range range = sortedRangeSet.getSpan();
-                if (!sortedRangeSet.isNullAllowed() && range.getLow().isLowerUnbounded() && range.getHigh().isUpperUnbounded()) {
-                    sj.add(columnName + " is not null");
-                    continue;
-                }
-                if (!range.getLow().isLowerUnbounded() && !range.getLow().isNullValue()) {
-                    final String sqlValue = getValueForWhereClause(columnName, range.getLow().getValue(), value.getType());
-                    switch (range.getLow().getBound()) {
-                        case ABOVE:
-                            sj.add(columnName + " > " + sqlValue);
-                            break;
-                        case EXACTLY:
-                            sj.add(columnName + " >= " + sqlValue);
-                            break;
-                        case BELOW:
-                            throw new IllegalArgumentException("Low Marker should never use BELOW bound: " + range);
-                        default:
-                            throw new AssertionError("Unhandled bound: " + range.getLow().getBound());
-                    }
-                }
-                if (!range.getHigh().isUpperUnbounded() && !range.getHigh().isNullValue()) {
-                    final String sqlValue = getValueForWhereClause(columnName, range.getHigh().getValue(), value.getType());
-                    switch (range.getHigh().getBound()) {
-                        case ABOVE:
-                            throw new IllegalArgumentException("High Marker should never use ABOVE bound: " + range);
-                        case EXACTLY:
-                            sj.add(columnName + " <= " + sqlValue);
-                            break;
-                        case BELOW:
-                            sj.add(columnName + " < " + sqlValue);
-                            break;
-                        default:
-                            throw new AssertionError("Unhandled bound: " + range.getHigh().getBound());
-                    }
-                }
-            }
-        }
-        if (sj.length() > 0) {
-            sqlBuilder.append(" WHERE (")
-                .append(sj.toString())
-                .append(")");
+        List<String> clauses = toConjuncts(schema.getFields(), constraints, split.getProperties(), parameterValues);
+
+        if (!clauses.isEmpty()) {
+            sqlBuilder.append(" WHERE ")
+                    .append(Joiner.on(" AND ").join(clauses));
         }
 
         return sqlBuilder.toString();
     }
 
+    private static String quote(final String identifier)
+    {
+        return BIGQUERY_QUOTE_CHAR + identifier + BIGQUERY_QUOTE_CHAR;
+    }
+
+    private static List<String> toConjuncts(List<Field> columns, Constraints constraints, Map<String, String> partitionSplit, List<QueryParameterValue> parameterValues)
+    {
+        ImmutableList.Builder<String> builder = ImmutableList.builder();
+        for (Field column : columns) {
+            if (partitionSplit.containsKey(column.getName())) {
+                continue; // Ignore constraints on partition name as RDBMS does not contain these as columns. Presto will filter these values.
+            }
+            ArrowType type = column.getType();
+            if (constraints.getSummary() != null && !constraints.getSummary().isEmpty()) {
+                ValueSet valueSet = constraints.getSummary().get(column.getName());
+                if (valueSet != null) {
+                    builder.add(toPredicate(column.getName(), valueSet, type, parameterValues));
+                }
+            }
+        }
+        return builder.build();
+    }
+
+    private static String toPredicate(String columnName, ValueSet valueSet, ArrowType type, List<QueryParameterValue> parameterValues)
+    {
+        List<String> disjuncts = new ArrayList<>();
+        List<Object> singleValues = new ArrayList<>();
+
+        // TODO Add isNone and isAll checks once we have data on nullability.
+
+        if (valueSet instanceof SortedRangeSet) {
+            if (valueSet.isNone() && valueSet.isNullAllowed()) {
+                return String.format("(%s IS NULL)", columnName);
+            }
+
+            if (valueSet.isNullAllowed()) {
+                disjuncts.add(String.format("(%s IS NULL)", columnName));
+            }
+
+            Range rangeSpan = ((SortedRangeSet) valueSet).getSpan();
+            if (!valueSet.isNullAllowed() && rangeSpan.getLow().isLowerUnbounded() && rangeSpan.getHigh().isUpperUnbounded()) {
+                return String.format("(%s IS NOT NULL)", columnName);
+            }
+
+            for (Range range : valueSet.getRanges().getOrderedRanges()) {
+                if (range.isSingleValue()) {
+                    singleValues.add(range.getLow().getValue());
+                }
+                else {
+                    List<String> rangeConjuncts = new ArrayList<>();
+                    if (!range.getLow().isLowerUnbounded()) {
+                        switch (range.getLow().getBound()) {
+                            case ABOVE:
+                                rangeConjuncts.add(toPredicate(columnName, ">", range.getLow().getValue(), type, parameterValues));
+                                break;
+                            case EXACTLY:
+                                rangeConjuncts.add(toPredicate(columnName, ">=", range.getLow().getValue(), type, parameterValues));
+                                break;
+                            case BELOW:
+                                throw new IllegalArgumentException("Low marker should never use BELOW bound");
+                            default:
+                                throw new AssertionError("Unhandled bound: " + range.getLow().getBound());
+                        }
+                    }
+                    if (!range.getHigh().isUpperUnbounded()) {
+                        switch (range.getHigh().getBound()) {
+                            case ABOVE:
+                                throw new IllegalArgumentException("High marker should never use ABOVE bound");
+                            case EXACTLY:
+                                rangeConjuncts.add(toPredicate(columnName, "<=", range.getHigh().getValue(), type, parameterValues));
+                                break;
+                            case BELOW:
+                                rangeConjuncts.add(toPredicate(columnName, "<", range.getHigh().getValue(), type, parameterValues));
+                                break;
+                            default:
+                                throw new AssertionError("Unhandled bound: " + range.getHigh().getBound());
+                        }
+                    }
+                    // If rangeConjuncts is null, then the range was ALL, which should already have been checked for
+                    Preconditions.checkState(!rangeConjuncts.isEmpty());
+                    disjuncts.add("(" + Joiner.on(" AND ").join(rangeConjuncts) + ")");
+                }
+            }
+
+            // Add back all of the possible single values either as an equality or an IN predicate
+            if (singleValues.size() == 1) {
+                disjuncts.add(toPredicate(columnName, "=", Iterables.getOnlyElement(singleValues), type, parameterValues));
+            }
+            else if (singleValues.size() > 1) {
+                for (Object value : singleValues) {
+                    parameterValues.add(getValueForWhereClause(columnName, value, type));
+                }
+                String values = Joiner.on(",").join(Collections.nCopies(singleValues.size(), "?"));
+                disjuncts.add(quote(columnName) + " IN (" + values + ")");
+            }
+        }
+
+        return "(" + Joiner.on(" OR ").join(disjuncts) + ")";
+    }
+
+    private static String toPredicate(String columnName, String operator, Object value, ArrowType type,
+            List<QueryParameterValue> parameterValues)
+    {
+        parameterValues.add(getValueForWhereClause(columnName, value, type));
+        return quote(columnName) + " " + operator + " ?";
+    }
+
     //Gets the representation of a value that can be used in a where clause, ie String values need to be quoted, numeric doesn't.
-    private static String getValueForWhereClause(String columnName, Object value, ArrowType arrowType)
+    private static QueryParameterValue getValueForWhereClause(String columnName, Object value, ArrowType arrowType)
     {
         switch (arrowType.getTypeID()) {
             case Int:
+                return QueryParameterValue.int64(((Number) value).longValue());
             case Decimal:
+                ArrowType.Decimal decimalType = (ArrowType.Decimal) arrowType;
+                QueryParameterValue.numeric(BigDecimal.valueOf((long) value, decimalType.getScale()));
             case FloatingPoint:
-                return value.toString();
+                return QueryParameterValue.float64((double) value);
             case Bool:
-                if ((Boolean) value) {
-                    return "true";
-                }
-                else {
-                    return "false";
-                }
+                return QueryParameterValue.bool((Boolean) value);
             case Utf8:
-                return "'" + value.toString() + "'";
+                return QueryParameterValue.string(value.toString());
             case Date:
             case Time:
             case Timestamp:

--- a/athena-bigquery/src/test/java/com/amazonaws/athena/connectors/bigquery/BigQuerySqlUtilsTest.java
+++ b/athena-bigquery/src/test/java/com/amazonaws/athena/connectors/bigquery/BigQuerySqlUtilsTest.java
@@ -24,19 +24,23 @@ import com.amazonaws.athena.connector.lambda.data.BlockAllocatorImpl;
 import com.amazonaws.athena.connector.lambda.data.SchemaBuilder;
 import com.amazonaws.athena.connector.lambda.domain.Split;
 import com.amazonaws.athena.connector.lambda.domain.TableName;
-import com.amazonaws.athena.connector.lambda.domain.predicate.AllOrNoneValueSet;
 import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
 import com.amazonaws.athena.connector.lambda.domain.predicate.EquatableValueSet;
 import com.amazonaws.athena.connector.lambda.domain.predicate.Marker;
 import com.amazonaws.athena.connector.lambda.domain.predicate.Range;
 import com.amazonaws.athena.connector.lambda.domain.predicate.SortedRangeSet;
 import com.amazonaws.athena.connector.lambda.domain.predicate.ValueSet;
+import com.google.cloud.bigquery.QueryParameterValue;
+import com.google.common.collect.ImmutableList;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.junit.Test;
+import org.mockito.Mockito;
 
-import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -44,28 +48,11 @@ import static org.junit.Assert.assertEquals;
 public class BigQuerySqlUtilsTest
 {
     static final TableName tableName = new TableName("schema", "table");
-    static final Split split = null;
+    static final Split split = Mockito.mock(Split.class);
 
     static final ArrowType BOOLEAN_TYPE = ArrowType.Bool.INSTANCE;
     static final ArrowType INT_TYPE = new ArrowType.Int(32, true);
-
-    @Test
-    public void testSqlWithConstraintsEquality()
-        throws Exception
-    {
-        Map<String, ValueSet> constraintMap = new LinkedHashMap<>();
-        constraintMap.put("bool1", EquatableValueSet.newBuilder(new BlockAllocatorImpl(), BOOLEAN_TYPE,
-            true, false).add(false).build());
-        constraintMap.put("int1", EquatableValueSet.newBuilder(new BlockAllocatorImpl(), INT_TYPE,
-            true, false).add(14).build());
-        constraintMap.put("nullableField", EquatableValueSet.newBuilder(new BlockAllocatorImpl(), INT_TYPE,
-            true, true).build());
-
-        try (Constraints constraints = new Constraints(constraintMap)) {
-            String sql = BigQuerySqlUtils.buildSqlFromSplit(tableName, makeSchema(constraintMap), constraints, split);
-            assertEquals("SELECT bool1,int1,nullableField from schema.table WHERE (bool1 = false) AND (int1 = 14) AND (nullableField is null)", sql);
-        }
-    }
+    static final ArrowType STRING_TYPE = new ArrowType.Utf8();
 
     @Test
     public void testSqlWithConstraintsRanges()
@@ -77,18 +64,45 @@ public class BigQuerySqlUtilsTest
 
         ValueSet isNullRangeSet = SortedRangeSet.newBuilder(INT_TYPE, true).build();
 
-        ValueSet isNonNullRangeSet = SortedRangeSet.newBuilder(INT_TYPE, false).add(
-            new Range(Marker.lowerUnbounded(new BlockAllocatorImpl(), INT_TYPE),
-                      Marker.upperUnbounded(new BlockAllocatorImpl(), INT_TYPE)))
-            .build();
+        ValueSet isNonNullRangeSet = SortedRangeSet.newBuilder(INT_TYPE, false)
+                .add(new Range(Marker.lowerUnbounded(new BlockAllocatorImpl(), INT_TYPE), Marker.upperUnbounded(new BlockAllocatorImpl(), INT_TYPE)))
+                .build();
+
+        ValueSet stringRangeSet = SortedRangeSet.newBuilder(STRING_TYPE, false).add(new Range(Marker.exactly(new BlockAllocatorImpl(), STRING_TYPE, "a_low"),
+                Marker.below(new BlockAllocatorImpl(), STRING_TYPE, "z_high"))).build();
+
+        ValueSet booleanRangeSet = SortedRangeSet.newBuilder(BOOLEAN_TYPE, false).add(new Range(Marker.exactly(new BlockAllocatorImpl(), BOOLEAN_TYPE, true),
+                Marker.exactly(new BlockAllocatorImpl(), BOOLEAN_TYPE, true))).build();
+
+        ValueSet integerInRangeSet = SortedRangeSet.newBuilder(INT_TYPE, false)
+                .add(new Range(Marker.exactly(new BlockAllocatorImpl(), INT_TYPE, 10), Marker.exactly(new BlockAllocatorImpl(), INT_TYPE, 10)))
+                .add(new Range(Marker.exactly(new BlockAllocatorImpl(), INT_TYPE, 1000_000), Marker.exactly(new BlockAllocatorImpl(), INT_TYPE, 1000_000)))
+                .build();
 
         constraintMap.put("integerRange", rangeSet);
         constraintMap.put("isNullRange", isNullRangeSet);
         constraintMap.put("isNotNullRange", isNonNullRangeSet);
+        constraintMap.put("stringRange", stringRangeSet);
+        constraintMap.put("booleanRange", booleanRangeSet);
+        constraintMap.put("integerInRange", integerInRangeSet);
+
+        Mockito.when(split.getProperties()).thenReturn(Collections.emptyMap());
+
+        final List<QueryParameterValue> expectedParameterValues = ImmutableList.of(QueryParameterValue.int64(10), QueryParameterValue.int64(20),
+                QueryParameterValue.string("a_low"), QueryParameterValue.string("z_high"),
+                QueryParameterValue.bool(true),
+                QueryParameterValue.int64(10), QueryParameterValue.int64(1000000));
 
         try (Constraints constraints = new Constraints(constraintMap)) {
-            String sql = BigQuerySqlUtils.buildSqlFromSplit(tableName, makeSchema(constraintMap), constraints, split);
-            assertEquals("SELECT integerRange,isNullRange,isNotNullRange from schema.table WHERE (integerRange > 10) AND (integerRange <= 20) AND (isNullRange is null) AND (isNotNullRange is not null)", sql);
+            List<QueryParameterValue> parameterValues = new ArrayList<>();
+            String sql = BigQuerySqlUtils.buildSqlFromSplit(tableName, makeSchema(constraintMap), constraints, split, parameterValues);
+            assertEquals(expectedParameterValues, parameterValues);
+            assertEquals("SELECT `integerRange`,`isNullRange`,`isNotNullRange`,`stringRange`,`booleanRange`,`integerInRange` from `schema`.`table` " +
+                    "WHERE ((integerRange IS NULL) OR (`integerRange` > ? AND `integerRange` <= ?)) " +
+                    "AND (isNullRange IS NULL) AND (isNotNullRange IS NOT NULL) " +
+                    "AND ((`stringRange` >= ? AND `stringRange` < ?)) " +
+                    "AND (`booleanRange` = ?) " +
+                    "AND (`integerInRange` IN (?,?))", sql);
         }
     }
 
@@ -106,6 +120,7 @@ public class BigQuerySqlUtilsTest
                     break;
                 case Utf8:
                     builder.addStringField(field.getKey());
+                    break;
                 default:
                     throw new UnsupportedOperationException("Type Not Implemented: " + typeId.name());
             }


### PR DESCRIPTION
*Description of changes:*
Following fixes:
1. Fix for condition `x = a or x is null`. It currently only returns x = a rows.
2. For for condition `x = 1 or x = 1000_000`. It does not push down right and overscans by generating SQL like `x >= 1 and x <= 1000_000`. This is due to use of range span.
3. Use parameterized SQL for protection against SQL injection.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
