### PR TITLE
Changing SAR publisher to be something generic to avoid confusion wit…

### DIFF
--- a/athena-aws-cmdb/athena-aws-cmdb.yaml
+++ b/athena-aws-cmdb/athena-aws-cmdb.yaml
@@ -3,7 +3,7 @@ Metadata:
   'AWS::ServerlessRepo::Application':
     Name: AthenaAwsCmdbConnector
     Description: 'This connector enables Amazon Athena to communicate with various AWS Services, making your resource inventories accessible via SQL.'
-    Author: 'Amazon Athena'
+    Author: 'default_author'
     SpdxLicenseId: Apache-2.0
     LicenseUrl: LICENSE.txt
     ReadmeUrl: README.md

--- a/athena-bigquery/athena-bigquery.yaml
+++ b/athena-bigquery/athena-bigquery.yaml
@@ -4,7 +4,7 @@ Metadata:
   AWS::ServerlessRepo::Application:
     Name: AthenaBigQueryConnector
     Description: An Athena connector to interact with BigQuery
-    Author: Amazon Athena
+    Author: 'default_author'
     SpdxLicenseId: Apache-2.0
     LicenseUrl: LICENSE.txt
     ReadmeUrl: README.md

--- a/athena-cloudwatch-metrics/athena-cloudwatch-metrics.yaml
+++ b/athena-cloudwatch-metrics/athena-cloudwatch-metrics.yaml
@@ -3,7 +3,7 @@ Metadata:
   'AWS::ServerlessRepo::Application':
     Name: AthenaCloudwatchMetricsConnector
     Description: 'This connector enables Amazon Athena to communicate with Cloudwatch Metrics, making your metrics data accessible via SQL.'
-    Author: 'Amazon Athena'
+    Author: 'default_author'
     SpdxLicenseId: Apache-2.0
     LicenseUrl: LICENSE.txt
     ReadmeUrl: README.md

--- a/athena-cloudwatch/athena-cloudwatch.yaml
+++ b/athena-cloudwatch/athena-cloudwatch.yaml
@@ -3,7 +3,7 @@ Metadata:
   'AWS::ServerlessRepo::Application':
     Name: AthenaCloudwatchConnector
     Description: 'This connector enables Amazon Athena to communicate with Cloudwatch, making your logs accessible via SQL.'
-    Author: 'Amazon Athena'
+    Author: 'default_author'
     SpdxLicenseId: Apache-2.0
     LicenseUrl: LICENSE.txt
     ReadmeUrl: README.md

--- a/athena-docdb/athena-docdb.yaml
+++ b/athena-docdb/athena-docdb.yaml
@@ -3,7 +3,7 @@ Metadata:
   'AWS::ServerlessRepo::Application':
     Name: AthenaDocumentDBConnector
     Description: This connector enables Amazon Athena to communicate with your DocumentDB instance(s), making your DocumentDB data accessible via SQL.
-    Author: 'Amazon Athena'
+    Author: 'default_author'
     SpdxLicenseId: Apache-2.0
     LicenseUrl: LICENSE.txt
     ReadmeUrl: README.md

--- a/athena-dynamodb/athena-dynamodb.yaml
+++ b/athena-dynamodb/athena-dynamodb.yaml
@@ -3,7 +3,7 @@ Metadata:
   'AWS::ServerlessRepo::Application':
     Name: AthenaDynamoDBConnector
     Description: 'This connector enables Amazon Athena to communicate with DynamoDB, making your tables accessible via SQL.'
-    Author: 'Amazon Athena'
+    Author: 'default_author'
     SpdxLicenseId: Apache-2.0
     LicenseUrl: LICENSE.txt
     ReadmeUrl: README.md

--- a/athena-example/athena-example.yaml
+++ b/athena-example/athena-example.yaml
@@ -4,7 +4,7 @@ Metadata:
   AWS::ServerlessRepo::Application:
     Name: ExampleAthenaConnector
     Description: ExampleAthenaConnector Description
-    Author: user1
+    Author: 'default_author'
     SpdxLicenseId: Apache-2.0
     LicenseUrl: LICENSE.txt
     ReadmeUrl: README.md

--- a/athena-federation-sdk/athena-federation-sdk.yaml
+++ b/athena-federation-sdk/athena-federation-sdk.yaml
@@ -3,7 +3,7 @@ Metadata:
   'AWS::ServerlessRepo::Application':
     Name: AthenaDataGeneratorConnector
     Description: 'This connector enables Amazon Athena to communicate with a randomly generated data source.'
-    Author: 'Amazon Athena'
+    Author: 'default_author'
     SpdxLicenseId: Apache-2.0
     LicenseUrl: LICENSE.txt
     ReadmeUrl: README.md

--- a/athena-hbase/athena-hbase.yaml
+++ b/athena-hbase/athena-hbase.yaml
@@ -3,7 +3,7 @@ Metadata:
   'AWS::ServerlessRepo::Application':
     Name: AthenaHBaseConnector
     Description: 'This connector enables Amazon Athena to communicate with your HBase instance(s), making your HBase data accessible via SQL.'
-    Author: 'Amazon Athena'
+    Author: 'default_author'
     SpdxLicenseId: Apache-2.0
     LicenseUrl: LICENSE.txt
     ReadmeUrl: README.md

--- a/athena-jdbc/athena-jdbc.yaml
+++ b/athena-jdbc/athena-jdbc.yaml
@@ -3,7 +3,7 @@ Metadata:
   'AWS::ServerlessRepo::Application':
     Name: AthenaJdbcConnector
     Description: 'This connector enables Amazon Athena to communicate with your Database instance(s) using JDBC driver.'
-    Author: 'Amazon Athena'
+    Author: 'default_author'
     SpdxLicenseId: Apache-2.0
     LicenseUrl: LICENSE.txt
     ReadmeUrl: README.md

--- a/athena-redis/athena-redis.yaml
+++ b/athena-redis/athena-redis.yaml
@@ -3,7 +3,7 @@ Metadata:
   'AWS::ServerlessRepo::Application':
     Name: AthenaRedisConnector
     Description: 'This connector enables Amazon Athena to communicate with your Redis instance(s), making your Redis data accessible via SQL.'
-    Author: 'Amazon Athena'
+    Author: 'default_author'
     SpdxLicenseId: Apache-2.0
     LicenseUrl: LICENSE.txt
     ReadmeUrl: README.md

--- a/athena-tpcds/athena-tpcds.yaml
+++ b/athena-tpcds/athena-tpcds.yaml
@@ -3,7 +3,7 @@ Metadata:
   'AWS::ServerlessRepo::Application':
     Name: AthenaTPCDSConnector
     Description: 'This connector enables Amazon Athena to communicate with a randomly generated TPC-DS data source.'
-    Author: 'Amazon Athena'
+    Author: 'default_author'
     SpdxLicenseId: Apache-2.0
     LicenseUrl: LICENSE.txt
     ReadmeUrl: README.md

--- a/athena-udfs/athena-udfs.yaml
+++ b/athena-udfs/athena-udfs.yaml
@@ -3,7 +3,7 @@ Metadata:
   'AWS::ServerlessRepo::Application':
     Name: AthenaUserDefinedFunctions
     Description: 'This connector enables Amazon Athena to leverage common UDFs made available via Lambda.'
-    Author: 'Amazon Athena'
+    Author: 'default_author'
     SpdxLicenseId: Apache-2.0
     LicenseUrl: LICENSE.txt
     ReadmeUrl: README.md


### PR DESCRIPTION
*Description of changes:*
Changing SAR publisher to be something generic to avoid confusion with Athena's reserved publisher name.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
