### PR TITLE
Yufjiang/kms example new

### DIFF
--- a/athena-udfs/README.md
+++ b/athena-udfs/README.md
@@ -18,6 +18,21 @@ This would return result 'eJwLLinKzEsPyXdKdc7PLShKLS5OTQEAUrEH9w=='.
 
 This would return result 'StringToBeCompressed'.
 
+3. "encrypt": encrypt the data with a data key stored in AWS Secrets Manager
+
+Before testing this query, you would need to create a secret in AWS Secrets Manager. Make sure to use "DefaultEncryptionKey". If you choose to use your KMS key, you would need to update ./athena-udfs.yaml to allow access to your KMS key. Remove all the json brackets and store a base64 encoded string as data key. Sample data is like `AQIDBAUGBwgJAAECAwQFBg==`. 
+
+Example query:
+
+`USING FUNCTION encrypt(col VARCHAR, secretName VARCHAR) RETURNS VARCHAR TYPE LAMBDA_INVOKE WITH (lambda_name = '<lambda name>') SELECT encrypt('plaintext', 'my_secret_name');`
+
+3. "decrypt": decrypt the data with a data key stored in AWS Secrets Manager
+
+Example query:
+
+`USING FUNCTION decyprt(col VARCHAR, secretName VARCHAR) RETURNS VARCHAR TYPE LAMBDA_INVOKE WITH (lambda_name = '<lambda name>') SELECT decyprt('tEgyixKs1d0RsnL51ypMgg==', 'my_secret_name');`
+
+
 ### Deploying The Connector
 
 To use this connector in your queries, navigate to AWS Serverless Application Repository and deploy a pre-built version of this connector. Alternatively, you can build and deploy this connector from source follow the below steps or use the more detailed tutorial in the athena-example module:

--- a/athena-udfs/athena-udfs.yaml
+++ b/athena-udfs/athena-udfs.yaml
@@ -24,6 +24,9 @@ Parameters:
     Description: 'Lambda memory in MB (min 128 - 3008 max).'
     Default: 3008
     Type: Number
+  SecretNameOrPrefix:
+    Description: 'The name or prefix of a set of names within Secrets Manager that this function should have access to. (e.g. database-*).'
+    Type: String
 Resources:
   ConnectorConfig:
     Type: 'AWS::Serverless::Function'
@@ -35,3 +38,10 @@ Resources:
       Runtime: java8
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
+      Policies:
+        - Statement:
+            - Action:
+                - secretsmanager:GetSecretValue
+              Effect: Allow
+              Resource: !Sub 'arn:aws:secretsmanager:*:*:secret:${SecretNameOrPrefix}'
+          Version: '2012-10-17'


### PR DESCRIPTION
*Description of changes:*

Added UDF example to use AWS Secret Manager to encrypt data.

build succeeded

```
[INFO] Amazon Athena Query Federation SDK 2019.47.1 ....... SUCCESS [01:48 min]
[INFO] aws-athena-query-federation 1.0 .................... SUCCESS [  1.106 s]
[INFO] athena-cloudwatch 1.0 .............................. SUCCESS [ 14.894 s]
[INFO] athena-docdb 1.0 ................................... SUCCESS [ 24.383 s]
[INFO] athena-redis 1.0 ................................... SUCCESS [  9.049 s]
[INFO] athena-bigquery 1.0 ................................ SUCCESS [ 10.644 s]
[INFO] athena-aws-cmdb 1.0 ................................ SUCCESS [ 13.170 s]
[INFO] athena-android 1.0 ................................. SUCCESS [  6.640 s]
[INFO] athena-dynamodb 1.0 ................................ SUCCESS [ 24.380 s]
[INFO] athena-hbase 1.0 ................................... SUCCESS [ 40.335 s]
[INFO] athena-cloudwatch-metrics 1.0 ...................... SUCCESS [  9.002 s]
[INFO] athena-example 1.0 ................................. SUCCESS [  7.491 s]
[INFO] athena-tpcds 1.0 ................................... SUCCESS [ 17.341 s]
[INFO] athena-jdbc 1.0 .................................... SUCCESS [ 12.894 s]
[INFO] Amazon Athena Query Federation SDK Tools 1.0 ....... SUCCESS [  5.474 s]
[INFO] athena-udfs 1.0 .................................... SUCCESS [  5.092 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  05:10 min
[INFO] Finished at: 2019-11-19T17:28:30-08:00
[INFO] ------------------------------------------------------------------------
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
