### PR TITLE
Add custom range split generation logic based on primary key of table.

### DIFF
--- a/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/manager/JdbcMetadataHandler.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/manager/JdbcMetadataHandler.java
@@ -62,6 +62,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -288,12 +289,15 @@ public abstract class JdbcMetadataHandler
                         ResultSet minMaxResultSet = statement.executeQuery(String.format(SQL_SPLITS_STRING, primaryKeyColumns.get(0), primaryKeyColumns.get(0),
                                 tableName.getSchemaName(), tableName.getTableName()))) {
                     minMaxResultSet.next(); // expecting one result row
-                    Splitter splitter = splitterFactory.getSplitter(primaryKeyColumns.get(0), minMaxResultSet, DEFAULT_NUM_SPLITS);
+                    Optional<Splitter> optionalSplitter = splitterFactory.getSplitter(primaryKeyColumns.get(0), minMaxResultSet, DEFAULT_NUM_SPLITS);
 
-                    while (splitter.hasNext()) {
-                        String splitClause = splitter.nextRangeClause();
-                        LOGGER.info("Split generated {}", splitClause);
-                        splitClauses.add(splitClause);
+                    if (optionalSplitter.isPresent()) {
+                        Splitter splitter = optionalSplitter.get();
+                        while (splitter.hasNext()) {
+                            String splitClause = splitter.nextRangeClause();
+                            LOGGER.info("Split generated {}", splitClause);
+                            splitClauses.add(splitClause);
+                        }
                     }
                 }
             }

--- a/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/mysql/MySqlQueryStringBuilder.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/mysql/MySqlQueryStringBuilder.java
@@ -23,6 +23,9 @@ import com.amazonaws.athena.connector.lambda.domain.Split;
 import com.amazonaws.connectors.athena.jdbc.manager.JdbcSplitQueryBuilder;
 import com.google.common.base.Strings;
 
+import java.util.Collections;
+import java.util.List;
+
 /**
  * Extends {@link JdbcSplitQueryBuilder} and implements MySql specific SQL clauses for split.
  *
@@ -56,5 +59,11 @@ public class MySqlQueryStringBuilder
         }
 
         return String.format(" FROM %s PARTITION(%s) ", tableName, partitionName);
+    }
+
+    @Override
+    protected List<String> getPartitionWhereClauses(final Split split)
+    {
+        return Collections.emptyList();
     }
 }

--- a/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/splits/IntegerSplitter.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/splits/IntegerSplitter.java
@@ -1,0 +1,98 @@
+/*-
+ * #%L
+ * athena-jdbc
+ * %%
+ * Copyright (C) 2019 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.connectors.athena.jdbc.splits;
+
+import org.apache.commons.lang3.Validate;
+
+/**
+ * Integer splits iterator. Guarantees number of splits expected of a split range. Uses `(high-low)/numSplits + 1` as step to calculate splits. For a non-zero remainder `r`, extra
+ * value will be added to first `r` splits.
+ *
+ * Example: [1, 10] as input split range
+ * 1. expected splits = 2, remainder = 0
+ *  Splits = [1,5], [6,10]
+ *
+ * 2. expected splits = 3, remainder = 1
+ *  Splits = [1,4], [5,7], [8,10] // note that the remainder gets added in first split only.
+ *
+ * 3. expected splits = 4, remainder = 2
+ *  Splits = [1,3], [4,6], [7,8], [9,10] // note that the remainder gets distributed in first two splits.
+ */
+public class IntegerSplitter
+        implements Splitter<Integer>
+{
+    private final SplitInfo<Integer> splitInfo;
+    private int current;
+    private int step;
+    private int remainder;
+    private int currentSplit;
+
+    /**
+     * @param splitInfo split information. E.g. split range, expected splits, column name.
+     */
+    public IntegerSplitter(SplitInfo<Integer> splitInfo)
+    {
+        this.splitInfo = Validate.notNull(splitInfo);
+        this.current = splitInfo.getSplitRange().getLow();
+        Validate.isTrue(splitInfo.getSplitRange().getHigh() >= splitInfo.getSplitRange().getLow(), "high is lower than low");
+        if (splitInfo.getSplitRange().getHigh().equals(splitInfo.getSplitRange().getLow())) {
+            this.step = 0;
+            this.remainder = 0;
+        }
+        else {
+            int diff = splitInfo.getSplitRange().getHigh() - splitInfo.getSplitRange().getLow() + 1;
+            int numSplits = splitInfo.getNumSplits();
+
+            this.remainder = diff % numSplits;
+            this.step = diff / numSplits;
+        }
+        this.currentSplit = 1;
+    }
+
+    @Override
+    public boolean hasNext()
+    {
+        return this.current < splitInfo.getSplitRange().getHigh();
+    }
+
+    @Override
+    public SplitRange<Integer> next()
+    {
+        // subtraction due to closed interval and inclusive endpoints.
+        int high = this.current + step - 1;
+        high += this.remainder >= this.currentSplit ? 1 : 0;
+        int low = this.current;
+        if (high > this.splitInfo.getSplitRange().getHigh()) {
+            high = this.splitInfo.getSplitRange().getHigh();
+        }
+
+        this.current = high + 1;
+        this.currentSplit++;
+
+        return new SplitRange<>(low, high);
+    }
+
+    @Override
+    public String nextRangeClause()
+    {
+        SplitRange<Integer> splitRange = next();
+        return String.format("(%s >= %s AND %s <= %s)", this.splitInfo.getColumnName(), splitRange.getLow(), splitInfo.getColumnName(), splitRange.getHigh());
+    }
+}

--- a/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/splits/IntegerSplitter.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/splits/IntegerSplitter.java
@@ -69,6 +69,9 @@ public class IntegerSplitter
     @Override
     public boolean hasNext()
     {
+        if (this.step <= 1) {
+            return this.current <= splitInfo.getSplitRange().getHigh();
+        }
         return this.current < splitInfo.getSplitRange().getHigh();
     }
 

--- a/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/splits/SplitInfo.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/splits/SplitInfo.java
@@ -1,0 +1,104 @@
+/*-
+ * #%L
+ * athena-jdbc
+ * %%
+ * Copyright (C) 2019 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.connectors.athena.jdbc.splits;
+
+import org.apache.commons.lang3.Validate;
+
+import java.util.Objects;
+
+/**
+ * Split information. Example: split range, column name, type and expected splits.
+ *
+ * @param <T> type of the split. E.g. Integer.
+ */
+public class SplitInfo<T>
+{
+    private final SplitRange<T> splitRange;
+    private final String columnName;
+    private final int columnType;
+    private final int numSplits;
+
+    /**
+     * @param splitRange split range of type T.
+     * @param columnName database column name.
+     * @param columnType database column type.
+     * @param numSplits expected number of splits.
+     */
+    public SplitInfo(final SplitRange<T> splitRange, final String columnName, final int columnType, final int numSplits)
+    {
+        this.splitRange = Validate.notNull(splitRange, "splitRange must not be null");
+        this.columnName = Validate.notBlank(columnName, "columnName must not be blank");
+        this.columnType = columnType;
+        this.numSplits = numSplits < 1 ? 1 : numSplits;
+    }
+
+    public SplitRange<T> getSplitRange()
+    {
+        return splitRange;
+    }
+
+    public String getColumnName()
+    {
+        return columnName;
+    }
+
+    public int getColumnType()
+    {
+        return columnType;
+    }
+
+    public int getNumSplits()
+    {
+        return numSplits;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SplitInfo<?> splitInfo = (SplitInfo<?>) o;
+        return getColumnType() == splitInfo.getColumnType() &&
+                getNumSplits() == splitInfo.getNumSplits() &&
+                Objects.equals(getSplitRange(), splitInfo.getSplitRange()) &&
+                Objects.equals(getColumnName(), splitInfo.getColumnName());
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(getSplitRange(), getColumnName(), getColumnType(), getNumSplits());
+    }
+
+    @Override
+    public String toString()
+    {
+        return "SplitInfo{" +
+                "splitRange=" + splitRange +
+                ", columnName='" + columnName + '\'' +
+                ", columnType=" + columnType +
+                ", numSplits=" + numSplits +
+                '}';
+    }
+}

--- a/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/splits/SplitRange.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/splits/SplitRange.java
@@ -1,0 +1,78 @@
+/*-
+ * #%L
+ * athena-jdbc
+ * %%
+ * Copyright (C) 2019 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.connectors.athena.jdbc.splits;
+
+import java.util.Objects;
+
+/**
+ * Represents a closed interval. Endpoints are inclusive.
+ *
+ * @param <T> type
+ */
+public class SplitRange<T>
+{
+    T low;
+    T high;
+
+    public SplitRange(T low, T high)
+    {
+        this.low = low;
+        this.high = high;
+    }
+
+    public T getLow()
+    {
+        return low;
+    }
+
+    public T getHigh()
+    {
+        return high;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SplitRange<?> that = (SplitRange<?>) o;
+        return Objects.equals(getLow(), that.getLow()) &&
+                Objects.equals(getHigh(), that.getHigh());
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(getLow(), getHigh());
+    }
+
+    @Override
+    public String toString()
+    {
+        return "SplitRange{" +
+                "low=" + low +
+                ", high=" + high +
+                '}';
+    }
+}

--- a/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/splits/SplitRange.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/splits/SplitRange.java
@@ -28,8 +28,8 @@ import java.util.Objects;
  */
 public class SplitRange<T>
 {
-    T low;
-    T high;
+    private final T low;
+    private final T high;
 
     public SplitRange(T low, T high)
     {

--- a/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/splits/Splitter.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/splits/Splitter.java
@@ -1,0 +1,37 @@
+/*-
+ * #%L
+ * athena-jdbc
+ * %%
+ * Copyright (C) 2019 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.connectors.athena.jdbc.splits;
+
+import java.util.Iterator;
+
+/**
+ * Split iterator for type T.
+ *
+ * @param <T> type of splitter
+ */
+public interface Splitter<T>
+        extends Iterator<SplitRange<T>>
+{
+    /**
+     * Provides the next split clause to be used in SQL queries.
+     * @return SQL clause for the range, both endpoints inclusive.
+     */
+    String nextRangeClause();
+}

--- a/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/splits/SplitterFactory.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/splits/SplitterFactory.java
@@ -22,6 +22,7 @@ package com.amazonaws.connectors.athena.jdbc.splits;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
+import java.util.Optional;
 
 /**
  * Creates splitter depending on split column data type.
@@ -32,18 +33,18 @@ public class SplitterFactory
      * @param columnName split column name.
      * @param resultSet split min and max values.
      * @param maxSplits number of splits.
-     * @return {@link Splitter}
+     * @return {@link Splitter} optional.
      * @throws SQLException exception accessing min and max values from {@link ResultSet}.
      */
-    public Splitter getSplitter(final String columnName, final ResultSet resultSet, final int maxSplits)
+    public Optional<Splitter> getSplitter(final String columnName, final ResultSet resultSet, final int maxSplits)
             throws SQLException
     {
         int type = resultSet.getMetaData().getColumnType(1);
         switch (type) {
             case Types.INTEGER:
-                return new IntegerSplitter(new SplitInfo<>(new SplitRange<>(resultSet.getInt(1), resultSet.getInt(2)), columnName, type, maxSplits));
+                return Optional.of(new IntegerSplitter(new SplitInfo<>(new SplitRange<>(resultSet.getInt(1), resultSet.getInt(2)), columnName, type, maxSplits)));
             default:
-                throw new RuntimeException("No splitter found for type " + type);
+               return Optional.empty();
         }
     }
 }

--- a/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/splits/SplitterFactory.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/splits/SplitterFactory.java
@@ -1,0 +1,49 @@
+/*-
+ * #%L
+ * athena-jdbc
+ * %%
+ * Copyright (C) 2019 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.connectors.athena.jdbc.splits;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+
+/**
+ * Creates splitter depending on split column data type.
+ */
+public class SplitterFactory
+{
+    /**
+     * @param columnName split column name.
+     * @param resultSet split min and max values.
+     * @param maxSplits number of splits.
+     * @return {@link Splitter}
+     * @throws SQLException exception accessing min and max values from {@link ResultSet}.
+     */
+    public Splitter getSplitter(final String columnName, final ResultSet resultSet, final int maxSplits)
+            throws SQLException
+    {
+        int type = resultSet.getMetaData().getColumnType(1);
+        switch (type) {
+            case Types.INTEGER:
+                return new IntegerSplitter(new SplitInfo<>(new SplitRange<>(resultSet.getInt(1), resultSet.getInt(2)), columnName, type, maxSplits));
+            default:
+                throw new RuntimeException("No splitter found for type " + type);
+        }
+    }
+}

--- a/athena-jdbc/src/test/java/com/amazonaws/connectors/athena/jdbc/splits/IntegerSplitterTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/connectors/athena/jdbc/splits/IntegerSplitterTest.java
@@ -72,6 +72,10 @@ public class IntegerSplitterTest
         Object[][] data = new Object[][]{
                 {new SplitRange<>(1,10), 2, Arrays.asList(new SplitRange<>(1,5), new SplitRange<>(6, 10)),
                         Arrays.asList("(testColumn >= 1 AND testColumn <= 5)", "(testColumn >= 6 AND testColumn <= 10)")},
+                {new SplitRange<>(1,2), 10, Arrays.asList(new SplitRange<>(1,1), new SplitRange<>(2, 2)),
+                        Arrays.asList("(testColumn >= 1 AND testColumn <= 1)", "(testColumn >= 2 AND testColumn <= 2)")},
+                {new SplitRange<>(1,2), 2, Arrays.asList(new SplitRange<>(1,1), new SplitRange<>(2, 2)),
+                        Arrays.asList("(testColumn >= 1 AND testColumn <= 1)", "(testColumn >= 2 AND testColumn <= 2)")},
                 {new SplitRange<>(1,10), 1, Collections.singletonList(new SplitRange<>(1, 10)),
                         Collections.singletonList("(testColumn >= 1 AND testColumn <= 10)")},
                 {new SplitRange<>(1,10), 0, Collections.singletonList(new SplitRange<>(1, 10)),

--- a/athena-jdbc/src/test/java/com/amazonaws/connectors/athena/jdbc/splits/IntegerSplitterTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/connectors/athena/jdbc/splits/IntegerSplitterTest.java
@@ -1,0 +1,86 @@
+/*-
+ * #%L
+ * athena-jdbc
+ * %%
+ * Copyright (C) 2019 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.connectors.athena.jdbc.splits;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+@RunWith(Parameterized.class)
+public class IntegerSplitterTest
+{
+    private SplitRange<Integer> inputRange;
+    private int numSplits;
+    private List<SplitRange<Integer>> expectedRanges;
+    private List<String> expectedClauses;
+
+    public IntegerSplitterTest(final SplitRange<Integer> inputRange, final int numSplits, final List<SplitRange<Integer>> expectedRanges, final List<String> expectedClauses) {
+        this.inputRange = inputRange;
+        this.numSplits = numSplits;
+        this.expectedRanges = expectedRanges;
+        this.expectedClauses = expectedClauses;
+    }
+
+    @Test
+    public void splitTest()
+    {
+        SplitInfo<Integer> splitInfo = new SplitInfo<>(this.inputRange, "testColumn", Types.INTEGER, this.numSplits);
+        IntegerSplitter integerSplitter = new IntegerSplitter(splitInfo);
+
+        List<SplitRange<Integer>> splitRanges = ImmutableList.copyOf(integerSplitter);
+        Assert.assertEquals(this.expectedRanges, splitRanges);
+
+        SplitInfo<Integer> splitClauseInfo = new SplitInfo<>(this.inputRange, "testColumn", Types.INTEGER, this.numSplits);
+        IntegerSplitter integerClauseSplitter = new IntegerSplitter(splitClauseInfo);
+
+        List<String> splitClauses = new ArrayList<>();
+        while(integerClauseSplitter.hasNext()) {
+            splitClauses.add(integerClauseSplitter.nextRangeClause());
+        }
+        Assert.assertEquals(this.expectedClauses, splitClauses);
+    }
+
+    @Parameterized.Parameters(name = "{index}: Test with inputRange={0}, numSplits ={1}, expectedRanges is:{2}")
+    public static Collection<Object[]> data()
+    {
+        Object[][] data = new Object[][]{
+                {new SplitRange<>(1,10), 2, Arrays.asList(new SplitRange<>(1,5), new SplitRange<>(6, 10)),
+                        Arrays.asList("(testColumn >= 1 AND testColumn <= 5)", "(testColumn >= 6 AND testColumn <= 10)")},
+                {new SplitRange<>(1,10), 1, Collections.singletonList(new SplitRange<>(1, 10)),
+                        Collections.singletonList("(testColumn >= 1 AND testColumn <= 10)")},
+                {new SplitRange<>(1,10), 0, Collections.singletonList(new SplitRange<>(1, 10)),
+                        Collections.singletonList("(testColumn >= 1 AND testColumn <= 10)")},
+                {new SplitRange<>(1,10), -10, Collections.singletonList(new SplitRange<>(1, 10)),
+                        Collections.singletonList("(testColumn >= 1 AND testColumn <= 10)")},
+                {new SplitRange<>(1,10), 3, Arrays.asList(new SplitRange<>(1,4), new SplitRange<>(5, 7), new SplitRange<>(8, 10)),
+                        Arrays.asList("(testColumn >= 1 AND testColumn <= 4)", "(testColumn >= 5 AND testColumn <= 7)", "(testColumn >= 8 AND testColumn <= 10)")},
+        };
+        return Arrays.asList(data);
+    }
+}

--- a/athena-jdbc/src/test/java/com/amazonaws/connectors/athena/jdbc/splits/SplitterFactoryTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/connectors/athena/jdbc/splits/SplitterFactoryTest.java
@@ -1,0 +1,91 @@
+/*-
+ * #%L
+ * athena-jdbc
+ * %%
+ * Copyright (C) 2019 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.connectors.athena.jdbc.splits;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+
+public class SplitterFactoryTest
+{
+    private static final String TEST_COLUMN_NAME = "testColumn";
+    private static final int MAX_SPLITS = 10;
+    private ResultSet resultSet;
+    private SplitterFactory splitterFactory;
+
+    @Before
+    public void setup() {
+        resultSet = Mockito.mock(ResultSet.class, Mockito.RETURNS_DEEP_STUBS);
+        splitterFactory = new SplitterFactory();
+    }
+
+    @Test
+    public void getIntegerSplitter()
+            throws SQLException
+    {
+        Mockito.when(resultSet.getMetaData().getColumnType(1)).thenReturn(Types.INTEGER);
+        Assert.assertEquals(IntegerSplitter.class, splitterFactory.getSplitter(TEST_COLUMN_NAME, resultSet, MAX_SPLITS).getClass());
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void getStringSplitter()
+            throws SQLException
+    {
+        Mockito.when(resultSet.getMetaData().getColumnType(1)).thenReturn(Types.VARCHAR);
+        splitterFactory.getSplitter(TEST_COLUMN_NAME, resultSet, MAX_SPLITS);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void getFloatSplitter()
+            throws SQLException
+    {
+        Mockito.when(resultSet.getMetaData().getColumnType(1)).thenReturn(Types.FLOAT);
+        splitterFactory.getSplitter(TEST_COLUMN_NAME, resultSet, MAX_SPLITS);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void getDoubleSplitter()
+            throws SQLException
+    {
+        Mockito.when(resultSet.getMetaData().getColumnType(1)).thenReturn(Types.DOUBLE);
+        splitterFactory.getSplitter(TEST_COLUMN_NAME, resultSet, MAX_SPLITS);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void getDateSplitter()
+            throws SQLException
+    {
+        Mockito.when(resultSet.getMetaData().getColumnType(1)).thenReturn(Types.DATE);
+        splitterFactory.getSplitter(TEST_COLUMN_NAME, resultSet, MAX_SPLITS);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void getDecimalSplitter()
+            throws SQLException
+    {
+        Mockito.when(resultSet.getMetaData().getColumnType(1)).thenReturn(Types.DECIMAL);
+        splitterFactory.getSplitter(TEST_COLUMN_NAME, resultSet, MAX_SPLITS);
+    }
+}

--- a/athena-jdbc/src/test/java/com/amazonaws/connectors/athena/jdbc/splits/SplitterFactoryTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/connectors/athena/jdbc/splits/SplitterFactoryTest.java
@@ -27,6 +27,7 @@ import org.mockito.Mockito;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
+import java.util.Optional;
 
 public class SplitterFactoryTest
 {
@@ -46,46 +47,48 @@ public class SplitterFactoryTest
             throws SQLException
     {
         Mockito.when(resultSet.getMetaData().getColumnType(1)).thenReturn(Types.INTEGER);
-        Assert.assertEquals(IntegerSplitter.class, splitterFactory.getSplitter(TEST_COLUMN_NAME, resultSet, MAX_SPLITS).getClass());
+        Optional<Splitter> splitter = splitterFactory.getSplitter(TEST_COLUMN_NAME, resultSet, MAX_SPLITS);
+        Assert.assertTrue(splitter.isPresent());
+        Assert.assertEquals(IntegerSplitter.class, splitter.get().getClass());
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void getStringSplitter()
             throws SQLException
     {
         Mockito.when(resultSet.getMetaData().getColumnType(1)).thenReturn(Types.VARCHAR);
-        splitterFactory.getSplitter(TEST_COLUMN_NAME, resultSet, MAX_SPLITS);
+        Assert.assertFalse(splitterFactory.getSplitter(TEST_COLUMN_NAME, resultSet, MAX_SPLITS).isPresent());
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void getFloatSplitter()
             throws SQLException
     {
         Mockito.when(resultSet.getMetaData().getColumnType(1)).thenReturn(Types.FLOAT);
-        splitterFactory.getSplitter(TEST_COLUMN_NAME, resultSet, MAX_SPLITS);
+        Assert.assertFalse(splitterFactory.getSplitter(TEST_COLUMN_NAME, resultSet, MAX_SPLITS).isPresent());
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void getDoubleSplitter()
             throws SQLException
     {
         Mockito.when(resultSet.getMetaData().getColumnType(1)).thenReturn(Types.DOUBLE);
-        splitterFactory.getSplitter(TEST_COLUMN_NAME, resultSet, MAX_SPLITS);
+        Assert.assertFalse(splitterFactory.getSplitter(TEST_COLUMN_NAME, resultSet, MAX_SPLITS).isPresent());
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void getDateSplitter()
             throws SQLException
     {
         Mockito.when(resultSet.getMetaData().getColumnType(1)).thenReturn(Types.DATE);
-        splitterFactory.getSplitter(TEST_COLUMN_NAME, resultSet, MAX_SPLITS);
+        Assert.assertFalse(splitterFactory.getSplitter(TEST_COLUMN_NAME, resultSet, MAX_SPLITS).isPresent());
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void getDecimalSplitter()
             throws SQLException
     {
         Mockito.when(resultSet.getMetaData().getColumnType(1)).thenReturn(Types.DECIMAL);
-        splitterFactory.getSplitter(TEST_COLUMN_NAME, resultSet, MAX_SPLITS);
+        Assert.assertFalse(splitterFactory.getSplitter(TEST_COLUMN_NAME, resultSet, MAX_SPLITS).isPresent());
     }
 }


### PR DESCRIPTION
*Description of changes:*
Adds a custom split generation logic based on table primary key. Creates basic equal ranges to generate expected number of splits. This logic works best when data is not skewed. 

This is a first version so has some limitations:

1. Number of splits is static, will be taken as input later.
2. Supports Integer splitter only. Can be expanded later to other data types.
3. Does not work for composite primary keys.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
