### PR TITLE
Handle empty Maps in DynamoDB Connector

### DIFF
--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBMetadataHandler.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBMetadataHandler.java
@@ -229,7 +229,10 @@ public class DynamoDBMetadataHandler
                 return super.doGetTable(allocator, request);
             }
             catch (RuntimeException e) {
-                logger.warn("doGetTable: Unable to retrieve table {} from AWSGlue in database/schema {}", request.getTableName().getSchemaName(), e);
+                logger.warn("doGetTable: Unable to retrieve table {} from AWSGlue in database/schema {}. " +
+                                "Falling back to schema inference. If inferred schema is incorrect, create " +
+                                "a matching table in Glue to define schema (see README)",
+                        request.getTableName().getTableName(), request.getTableName().getSchemaName(), e);
             }
         }
 

--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/util/DDBTableUtils.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/util/DDBTableUtils.java
@@ -35,6 +35,7 @@ import com.amazonaws.services.dynamodbv2.model.ScanRequest;
 import com.amazonaws.services.dynamodbv2.model.ScanResult;
 import com.amazonaws.services.dynamodbv2.model.TableDescription;
 import com.google.common.collect.ImmutableList;
+import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -142,8 +143,11 @@ public final class DDBTableUtils
             for (Map<String, AttributeValue> item : items) {
                 for (Map.Entry<String, AttributeValue> column : item.entrySet()) {
                     if (!discoveredColumns.contains(column.getKey()) && !Boolean.TRUE.equals(column.getValue().getNULL())) {
-                        schemaBuilder.addField(DDBTypeUtils.getArrowField(column.getKey(), ItemUtils.toSimpleValue(column.getValue())));
-                        discoveredColumns.add(column.getKey());
+                        Field arrowField = DDBTypeUtils.inferArrowField(column.getKey(), ItemUtils.toSimpleValue(column.getValue()));
+                        if (arrowField != null) {
+                            schemaBuilder.addField(arrowField);
+                            discoveredColumns.add(column.getKey());
+                        }
                     }
                 }
             }

--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/util/DDBTableUtils.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/util/DDBTableUtils.java
@@ -35,7 +35,6 @@ import com.amazonaws.services.dynamodbv2.model.ScanRequest;
 import com.amazonaws.services.dynamodbv2.model.ScanResult;
 import com.amazonaws.services.dynamodbv2.model.TableDescription;
 import com.google.common.collect.ImmutableList;
-import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -143,11 +142,8 @@ public final class DDBTableUtils
             for (Map<String, AttributeValue> item : items) {
                 for (Map.Entry<String, AttributeValue> column : item.entrySet()) {
                     if (!discoveredColumns.contains(column.getKey()) && !Boolean.TRUE.equals(column.getValue().getNULL())) {
-                        Field arrowField = DDBTypeUtils.inferArrowField(column.getKey(), ItemUtils.toSimpleValue(column.getValue()));
-                        if (arrowField != null) {
-                            schemaBuilder.addField(arrowField);
-                            discoveredColumns.add(column.getKey());
-                        }
+                        schemaBuilder.addField(DDBTypeUtils.getArrowField(column.getKey(), ItemUtils.toSimpleValue(column.getValue())));
+                        discoveredColumns.add(column.getKey());
                     }
                 }
             }

--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/util/DDBTableUtils.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/util/DDBTableUtils.java
@@ -142,7 +142,7 @@ public final class DDBTableUtils
             for (Map<String, AttributeValue> item : items) {
                 for (Map.Entry<String, AttributeValue> column : item.entrySet()) {
                     if (!discoveredColumns.contains(column.getKey()) && !Boolean.TRUE.equals(column.getValue().getNULL())) {
-                        schemaBuilder.addField(DDBTypeUtils.getArrowField(column.getKey(), ItemUtils.toSimpleValue(column.getValue())));
+                        schemaBuilder.addField(DDBTypeUtils.inferArrowField(column.getKey(), ItemUtils.toSimpleValue(column.getValue())));
                         discoveredColumns.add(column.getKey());
                     }
                 }

--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/util/DDBTypeUtils.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/util/DDBTypeUtils.java
@@ -104,7 +104,7 @@ public final class DDBTypeUtils
                     }
                 }
                 if (allElementsAreSameType) {
-                    child = inferArrowField(key +".element", firstValue);
+                    child = inferArrowField(key + ".element", firstValue);
                 }
                 else {
                     logger.warn("Automatic schema inference encountered List or Set {} containing multiple element types. Falling back to VARCHAR representation of elements", key);

--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/util/DDBTypeUtils.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/util/DDBTypeUtils.java
@@ -94,12 +94,20 @@ public final class DDBTypeUtils
         }
         else if (value instanceof Map) {
             List<Field> children = new ArrayList<>();
+            // keys are always Strings in DDB's case
             Map<String, Object> doc = (Map<String, Object>) value;
             for (String childKey : doc.keySet()) {
                 Object childVal = doc.get(childKey);
                 Field child = getArrowField(childKey, childVal);
                 children.add(child);
             }
+
+            // Athena requires Maps to have child types and not be empty
+            // TODO handle this more generally
+            if (children.isEmpty()) {
+                children.add(getArrowField("placeHolderForEmptyMap", ""));
+            }
+
             return new Field(key, FieldType.nullable(Types.MinorType.STRUCT.getType()), children);
         }
 

--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/util/DDBTypeUtils.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/util/DDBTypeUtils.java
@@ -26,11 +26,14 @@ import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.Text;
 import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -40,6 +43,8 @@ import java.util.Set;
  */
 public final class DDBTypeUtils
 {
+    private static final Logger logger = LoggerFactory.getLogger(DDBTypeUtils.class);
+
     // DDB attribute "types"
     private static final String STRING = "S";
     private static final String NUMBER = "N";
@@ -54,13 +59,14 @@ public final class DDBTypeUtils
     private DDBTypeUtils() {}
 
     /**
-     * Converts a given field's Java type to a corresponding Arrow type.
+     * Infers an Arrow field from an object.  This has limitations when it comes to complex types such as Lists and Maps
+     * and will fallback to VARCHAR fields in those cases.
      *
      * @param key the name of the field
-     * @param value the valie of the field
-     * @return the converted Arrow field
+     * @param value the value of the field
+     * @return the inferred Arrow field
      */
-    public static Field getArrowField(String key, Object value)
+    public static Field inferArrowField(String key, Object value)
     {
         if (value instanceof String) {
             return new Field(key, FieldType.nullable(Types.MinorType.VARCHAR.getType()), null);
@@ -75,19 +81,35 @@ public final class DDBTypeUtils
             return new Field(key, FieldType.nullable(new ArrowType.Decimal(38, 9)), null);
         }
         else if (value instanceof List || value instanceof Set) {
-            Field child;
+            Field child = null;
             if (((Collection) value).isEmpty()) {
                 try {
                     Object subVal = ((Collection) value).getClass()
                             .getTypeParameters()[0].getGenericDeclaration().newInstance();
-                    child = getArrowField("", subVal);
+                    child = inferArrowField(key + ".child", subVal);
                 }
                 catch (IllegalAccessException | InstantiationException ex) {
                     throw new RuntimeException(ex);
                 }
             }
             else {
-                child = getArrowField("", ((Collection) value).iterator().next());
+                Iterator iterator = ((Collection) value).iterator();
+                Object firstValue = iterator.next();
+                Class<?> aClass = firstValue.getClass();
+                boolean allElementsAreSameType = true;
+                while (iterator.hasNext()) {
+                    if (!aClass.equals(iterator.next().getClass())) {
+                        allElementsAreSameType = false;
+                        break;
+                    }
+                }
+                if (allElementsAreSameType) {
+                    child = inferArrowField(key +".element", firstValue);
+                }
+                else {
+                    logger.warn("Automatic schema inference encountered List or Set {} containing multiple element types. Falling back to VARCHAR representation of elements", key);
+                    child = inferArrowField("", "");
+                }
             }
             return new Field(key, FieldType.nullable(Types.MinorType.LIST.getType()),
                     Collections.singletonList(child));
@@ -98,14 +120,14 @@ public final class DDBTypeUtils
             Map<String, Object> doc = (Map<String, Object>) value;
             for (String childKey : doc.keySet()) {
                 Object childVal = doc.get(childKey);
-                Field child = getArrowField(childKey, childVal);
+                Field child = inferArrowField(childKey, childVal);
                 children.add(child);
             }
 
-            // Athena requires Maps to have child types and not be empty
-            // TODO handle this more generally
+            // Athena requires Structs to have child types and not be empty
             if (children.isEmpty()) {
-                children.add(getArrowField("placeHolderForEmptyMap", ""));
+                logger.warn("Automatic schema inference encountered empty Map {}. Unable to determine element types. Falling back to VARCHAR representation", key);
+                return new Field(key, FieldType.nullable(Types.MinorType.VARCHAR.getType()), null);
             }
 
             return new Field(key, FieldType.nullable(Types.MinorType.STRUCT.getType()), children);

--- a/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/TestBase.java
+++ b/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/TestBase.java
@@ -125,7 +125,7 @@ public class TestBase
             item.put("col_4", toAttributeValue(dateTime.toLocalDate().toEpochDay()));
             item.put("col_5", toAttributeValue(Timestamp.valueOf(dateTime).toInstant().toEpochMilli()));
             item.put("col_6", toAttributeValue(i % 128 == 0 ? null : i % 128));
-            item.put("col_7", toAttributeValue(-i));
+            item.put("col_7", toAttributeValue(ImmutableMap.of("negative", -i, "mostlyEmptyMap", i % 100 == 0 ? ImmutableMap.of("rareKey", "rareValue") : ImmutableMap.of())));
             item.put("col_8", toAttributeValue(ImmutableSet.of(i - 100, i - 200)));
             item.put("col_9", toAttributeValue(100.0f + i));
             tableWriteItems.addItemToPut(toItem(item));

--- a/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/TestBase.java
+++ b/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/TestBase.java
@@ -125,8 +125,9 @@ public class TestBase
             item.put("col_4", toAttributeValue(dateTime.toLocalDate().toEpochDay()));
             item.put("col_5", toAttributeValue(Timestamp.valueOf(dateTime).toInstant().toEpochMilli()));
             item.put("col_6", toAttributeValue(i % 128 == 0 ? null : i % 128));
-            item.put("col_7", toAttributeValue(ImmutableMap.of("negative", -i, "mostlyEmptyMap", i % 100 == 0 ? ImmutableMap.of("rareKey", "rareValue") : ImmutableMap.of())));
-            item.put("col_8", toAttributeValue(ImmutableSet.of(i - 100, i - 200)));
+            item.put("col_7", toAttributeValue(ImmutableList.of(-i, String.valueOf(i))));
+            item.put("col_8", toAttributeValue(ImmutableList.of(ImmutableMap.of("mostlyEmptyMap",
+                    i % 128 == 0 ? ImmutableMap.of("subtractions", ImmutableSet.of(i - 100, i - 200)) : ImmutableMap.of()))));
             item.put("col_9", toAttributeValue(100.0f + i));
             tableWriteItems.addItemToPut(toItem(item));
 

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/BlockUtils.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/BlockUtils.java
@@ -307,6 +307,7 @@ public class BlockUtils
                         ((VarCharVector) vector).setSafe(pos, (Text) value);
                     }
                     else {
+                        // always fall back to the object's toString()
                         ((VarCharVector) vector).setSafe(pos, value.toString().getBytes(Charsets.UTF_8));
                     }
                     break;
@@ -754,14 +755,7 @@ public class BlockUtils
                     }
                     break;
                 case VARCHAR:
-                    if (value instanceof String) {
-                        byte[] bytes = ((String) value).getBytes(Charsets.UTF_8);
-                        try (ArrowBuf buf = allocator.buffer(bytes.length)) {
-                            buf.writeBytes(bytes);
-                            writer.varChar().writeVarChar(0, buf.readableBytes(), buf);
-                        }
-                    }
-                    else if (value instanceof ArrowBuf) {
+                    if (value instanceof ArrowBuf) {
                         ArrowBuf buf = (ArrowBuf) value;
                         writer.varChar().writeVarChar(0, buf.readableBytes(), buf);
                     }
@@ -773,7 +767,7 @@ public class BlockUtils
                         }
                     }
                     else {
-                        // fall back to the object's toString()
+                        // always fall back to the object's toString()
                         byte[] bytes = value.toString().getBytes(Charsets.UTF_8);
                         try (ArrowBuf buf = allocator.buffer(bytes.length)) {
                             buf.writeBytes(bytes);

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/BlockUtils.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/BlockUtils.java
@@ -303,11 +303,11 @@ public class BlockUtils
                     }
                     break;
                 case VARCHAR:
-                    if (value instanceof String) {
-                        ((VarCharVector) vector).setSafe(pos, ((String) value).getBytes(Charsets.UTF_8));
+                    if (value instanceof Text) {
+                        ((VarCharVector) vector).setSafe(pos, (Text) value);
                     }
                     else {
-                        ((VarCharVector) vector).setSafe(pos, (Text) value);
+                        ((VarCharVector) vector).setSafe(pos, value.toString().getBytes(Charsets.UTF_8));
                     }
                     break;
                 case BIT:

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/BlockUtils.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/BlockUtils.java
@@ -772,6 +772,14 @@ public class BlockUtils
                             writer.varChar().writeVarChar(0, buf.readableBytes(), buf);
                         }
                     }
+                    else {
+                        // fall back to the object's toString()
+                        byte[] bytes = value.toString().getBytes(Charsets.UTF_8);
+                        try (ArrowBuf buf = allocator.buffer(bytes.length)) {
+                            buf.writeBytes(bytes);
+                            writer.varChar().writeVarChar(0, buf.readableBytes(), buf);
+                        }
+                    }
                     break;
                 case BIT:
                     if (value instanceof Integer && (int) value > 0) {


### PR DESCRIPTION
**Issue #, if available:** https://github.com/awslabs/aws-athena-query-federation/issues/75

**Description of changes:** This change handles empty Maps that DDB allows but Athena does not.  We fallback to VARCHAR whenever we cannot infer the element types of the complex DDB Map and List types.  Also added warning logs to let the customer know this is happening and that they can use Glue to to better specify the types.

**Testing**: Unit tests and empirical testing with various DDB tables and Athena and Lambda.  The VARCHAR fallback works well and is probably better than hiding the data.  Also sanity checked the few SDK changes with the CW-Metrics connector.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
