### PR TITLE
Fix JDBC README: Timestamp is currently not supported.

### DIFF
--- a/athena-jdbc/README.md
+++ b/athena-jdbc/README.md
@@ -138,7 +138,6 @@ spill_prefix    Spill bucket key prefix. Required.
 |float|Float4|
 |Double|Float8|
 |Date|DateDay|
-|Timestamp|DateMilli|
 |String|Varchar|
 |Bytes|Varbinary|
 |BigDecimal|Decimal|


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-athena-query-federation/issues/72

*Description of changes:*
Fix JDBC README: Timestamp is currently not supported.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
