### PR TITLE
Adding source table name and column name mapping for Glue handlers

### DIFF
--- a/athena-dynamodb/README.md
+++ b/athena-dynamodb/README.md
@@ -28,11 +28,15 @@ question.  These properties are automatically set if you use Glue's DynamoDB Cra
 the columns and types that the Crawler discovered.
 
 1. **dynamodb** - String indicating that the table can be used for supplemental meta-data by the Athena DynamoDB Connector. This string can be in any one of the following places:
-    1. in the table properites/parameters under a field called "classification" (exact match).
+    1. in the table properties/parameters under a field called "classification" (exact match).
     2. in the table's storage descriptor's location field (substring match).
     3. in the table's storage descriptor's parameters under a field called "classification" (exact match).
 2. **dynamo-db-flag** - String indicating that the *database* contains tables used for supplemental meta-data by the Athena DynamoDB Connector.  This is required for any Glue databases other than "default"
 and is useful for filtering out irrelevant databases in accounts that have lots of them.  This string should be in the Location URI of the Glue Database (substring match).
+3. **sourceTable** - Optional table property/parameter that defines the source table name in DynamoDB.  Use this if Glue table naming rules prevent you from creating a Glue table with the same name as
+your DynamoDB table (e.g. capital letters are not permitted in Glue table names but are permitted in DynamoDB table names).
+4. **columnMapping** - Optional table property/parameter that define column name mappings.  Use this if Glue column naming rules prevent you from creating a Glue table with the same column names as
+your DynamoDB table (e.g. capital letters are not permitted in Glue column names but are permitted in DynamoDB column names).  This is expected be be in the format `col1=Col1,col2=Col2`.
 
 
 ### Required Permissions

--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/constants/DynamoDBConstants.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/constants/DynamoDBConstants.java
@@ -29,7 +29,7 @@ public final class DynamoDBConstants
     public static final String SCAN_PARTITION_TYPE = "scan";
     public static final String SEGMENT_COUNT_METADATA = "segmentCount";
     public static final String SEGMENT_ID_PROPERTY = "segmentId";
-    public static final String TABLE_METADATA = "table";
+    public static final String TABLE_METADATA = "sourceTable";
     public static final String INDEX_METADATA = "index";
     public static final String HASH_KEY_NAME_METADATA = "hashKeyName";
     public static final String RANGE_KEY_NAME_METADATA = "rangeKeyName";

--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/util/DDBTypeUtils.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/util/DDBTypeUtils.java
@@ -158,4 +158,22 @@ public final class DDBTypeUtils
                 throw new RuntimeException("Unknown type[" + attributeType + "] for field[" + attributeName + "]");
         }
     }
+
+    public static Object coerceDecimalToExpectedType(BigDecimal value, Types.MinorType fieldType)
+    {
+        switch (fieldType) {
+            case INT:
+            case TINYINT:
+            case SMALLINT:
+                return value.intValue();
+            case BIGINT:
+                return value.longValue();
+            case FLOAT4:
+                return value.floatValue();
+            case FLOAT8:
+                return value.doubleValue();
+            default:
+                return value;
+        }
+    }
 }

--- a/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBMetadataHandlerTest.java
+++ b/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBMetadataHandlerTest.java
@@ -480,7 +480,7 @@ public class DynamoDBMetadataHandlerTest
         GetTableRequest getTableRequest = new GetTableRequest(TEST_IDENTITY, TEST_QUERY_ID, TEST_CATALOG_NAME, tableName);
         GetTableResponse getTableResponse = handler.doGetTable(allocator, getTableRequest);
         logger.info("validateSourceTableNamePropagation: GetTableResponse[{}]", getTableResponse);
-        assertThat(getTableResponse.getSchema().getCustomMetadata().get("table"), equalTo(TEST_TABLE));
+        assertThat(getTableResponse.getSchema().getCustomMetadata().get(SOURCE_TABLE_PROPERTY), equalTo(TEST_TABLE));
 
         GetTableLayoutRequest getTableLayoutRequest = new GetTableLayoutRequest(TEST_IDENTITY,
                 TEST_QUERY_ID,

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/handlers/GlueMetadataHandlerTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/handlers/GlueMetadataHandlerTest.java
@@ -51,6 +51,7 @@ import com.amazonaws.services.glue.model.GetTablesResult;
 import com.amazonaws.services.glue.model.StorageDescriptor;
 import com.amazonaws.services.glue.model.Table;
 import com.amazonaws.services.secretsmanager.AWSSecretsManager;
+import com.google.common.collect.ImmutableSet;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
@@ -66,11 +67,13 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.amazonaws.athena.connector.lambda.handlers.GlueMetadataHandler.COLUMN_NAME_MAPPING_PROPERTY;
 import static com.amazonaws.athena.connector.lambda.handlers.GlueMetadataHandler.SOURCE_TABLE_PROPERTY;
 import static com.amazonaws.athena.connector.lambda.handlers.GlueMetadataHandler.getSourceTableName;
 import static com.amazonaws.athena.connector.lambda.handlers.GlueMetadataHandler.populateSourceTableNameIfAvailable;
@@ -245,9 +248,11 @@ public class GlueMetadataHandlerTest
     {
         logger.info("doGetTable - enter");
 
+        String sourceTable = "My-Table";
+
         Map<String, String> expectedParams = new HashMap<>();
-        expectedParams.put("param1", "val1");
-        expectedParams.put("param2", "val2");
+        expectedParams.put(SOURCE_TABLE_PROPERTY, sourceTable);
+        expectedParams.put(COLUMN_NAME_MAPPING_PROPERTY, "col2=Col2,col3=Col3, col4=Col4");
 
         List<Column> columns = new ArrayList<>();
         columns.add(new Column().withName("col1").withType("int").withComment("comment"));
@@ -282,23 +287,15 @@ public class GlueMetadataHandlerTest
 
         logger.info("doGetTable - {}", res);
 
-        assertTrue(res.getSchema().getFields().size() > 0);
+        assertTrue(res.getSchema().getFields().size() == 3);
         assertTrue(res.getSchema().getCustomMetadata().size() > 0);
-        assertNull(getSourceTableName(res.getSchema()));
+        assertEquals(sourceTable, getSourceTableName(res.getSchema()));
+
+        //Verify column name mapping works
+        assertNotNull(res.getSchema().findField("col1"));
+        assertNotNull(res.getSchema().findField("Col2"));
 
         logger.info("doGetTable - exit");
-    }
-
-    @Test
-    public void populateSourceTableFromProperty() {
-        String sourceTable = "My-Table";
-        Map<String, String> params = new HashMap<>();
-        params.put(SOURCE_TABLE_PROPERTY, sourceTable);
-        Table table = new Table().withParameters(params);
-        SchemaBuilder schemaBuilder = new SchemaBuilder();
-        populateSourceTableNameIfAvailable(table, schemaBuilder);
-        Schema schema = schemaBuilder.build();
-        assertEquals(sourceTable, getSourceTableName(schema));
     }
 
     @Test


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/aws-athena-query-federation/issues/78

*Description of changes:* Adding source table name and column name mapping for Glue handlers.  Data sources such as DynamoDB allow more characters and upper case in table names while Glue does not, meaning that it may not be possible for customers to make a Glue table with the same exact name
as their data source's table.  This allows customers to add a table property in Glue with the source table name.  This can also extract the source table name from an ARN populated in the Glue table's 
StorageDescriptor.Location property (Glue crawlers populate this).  It also enables a table property for column mapping.

I adapted the Dynamo connector to use this.  The other connectors expose table names directly from the source (DocDB and HBase) or don't have sources tables (Redis).

*Testing*: Unit tests and empirical testing with an uploaded Dynamo connector and a crawled table with different name than the source.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
