### PR TITLE
Fixing "show database" query part

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ tldr; Get Started:
 1. Look for entries published by the "Amazon Athena Federation" author.
 1. Deploy the application
 1. Go to the [Athena Console in us-east-1 (N. Virginia)](https://console.aws.amazon.com/athena/home) and create a workgroup called "AmazonAthenaPreviewFunctionality", any queries run from that workgroup will be able to use Preview features described in this repository.
-1. Run a query "show databses in \`lambda:<func_name>\`" where <func_name> is the name of the Lambda function you deployed in the previous steps.
+1. Run a query "show databases in \`lambda:<func_name>\`" where <func_name> is the name of the Lambda function you deployed in the previous steps.
 
 For more information please consult:
 


### PR DESCRIPTION
In previous version, the README.md in root directory shows;

```
6. Run a query "show databses in `lambda:<func_name>`" where <func_name> is the name of the Lambda function you deployed in the previous steps.
```

Just fixing this typo (`show databses`) to "show databases in `lambda:<func_name>`".