### PR TITLE
Fixing Issue #72 - Tables with even 1 unsupported columns are unqueriable

### DIFF
--- a/athena-docdb/src/main/java/com/amazonaws/athena/connectors/docdb/SchemaUtils.java
+++ b/athena-docdb/src/main/java/com/amazonaws/athena/connectors/docdb/SchemaUtils.java
@@ -239,6 +239,7 @@ public class SchemaUtils
         }
 
         String className = value.getClass() == null ? "null" : value.getClass().getName();
-        throw new RuntimeException("Unknown type[" + className + "] for field[" + key + "]");
+        logger.warn("Unknown type[" + className + "] for field[" + key + "], defaulting to varchar.");
+        return new Field(key, FieldType.nullable(Types.MinorType.VARCHAR.getType()), null);
     }
 }

--- a/athena-docdb/src/test/java/com/amazonaws/athena/connectors/docdb/DocDBMetadataHandlerTest.java
+++ b/athena-docdb/src/test/java/com/amazonaws/athena/connectors/docdb/DocDBMetadataHandlerTest.java
@@ -184,6 +184,7 @@ public class DocDBMetadataHandlerTest
         doc1.put("intCol", 1);
         doc1.put("doubleCol", 2.2D);
         doc1.put("longCol", 100L);
+        doc1.put("unsupported", new UnsupportedType());
 
         Document doc2 = new Document();
         documents.add(doc2);
@@ -214,7 +215,7 @@ public class DocDBMetadataHandlerTest
         GetTableResponse res = handler.doGetTable(allocator, req);
         logger.info("doGetTable - {}", res);
 
-        assertEquals(8, res.getSchema().getFields().size());
+        assertEquals(9, res.getSchema().getFields().size());
 
         Field stringCol = res.getSchema().findField("stringCol");
         assertEquals(Types.MinorType.VARCHAR, Types.getMinorTypeForArrowType(stringCol.getType()));
@@ -239,6 +240,9 @@ public class DocDBMetadataHandlerTest
 
         Field longCol2 = res.getSchema().findField("longCol2");
         assertEquals(Types.MinorType.BIGINT, Types.getMinorTypeForArrowType(longCol2.getType()));
+
+        Field unsupported = res.getSchema().findField("unsupported");
+        assertEquals(Types.MinorType.VARCHAR, Types.getMinorTypeForArrowType(unsupported.getType()));
 
         logger.info("doGetTable - exit");
     }

--- a/athena-docdb/src/test/java/com/amazonaws/athena/connectors/docdb/DocDBRecordHandlerTest.java
+++ b/athena-docdb/src/test/java/com/amazonaws/athena/connectors/docdb/DocDBRecordHandlerTest.java
@@ -138,6 +138,7 @@ public class DocDBRecordHandlerTest
                 .addField("varbinary", Types.MinorType.VARBINARY.getType())
                 .addField("decimal", new ArrowType.Decimal(10, 2))
                 .addField("decimalLong", new ArrowType.Decimal(36, 2))
+                .addField("unsupported", Types.MinorType.VARCHAR.getType())
                 .addStructField("struct")
                 .addChildField("struct", "struct_string", Types.MinorType.VARCHAR.getType())
                 .addChildField("struct", "struct_int", Types.MinorType.INT.getType())
@@ -194,15 +195,6 @@ public class DocDBRecordHandlerTest
         allocator.close();
     }
 
-    private Document makeDocument(Schema schema, int seed)
-    {
-        Document doc = new Document();
-        doc.put("stringCol", "stringVal");
-        doc.put("intCol", 1);
-        doc.put("col3", 22.0D);
-        return doc;
-    }
-
     @Test
     public void doReadRecordsNoSpill()
             throws Exception
@@ -226,6 +218,7 @@ public class DocDBRecordHandlerTest
         Document doc3 = DocumentGenerator.makeRandomRow(schemaForRead.getFields(), docNum++);
         documents.add(doc3);
         doc3.put("col3", 21.0D);
+        doc3.put("unsupported",new UnsupportedType());
 
         MongoDatabase mockDatabase = mock(MongoDatabase.class);
         MongoCollection mockCollection = mock(MongoCollection.class);

--- a/athena-docdb/src/test/java/com/amazonaws/athena/connectors/docdb/TypeUtilsTest.java
+++ b/athena-docdb/src/test/java/com/amazonaws/athena/connectors/docdb/TypeUtilsTest.java
@@ -1,0 +1,42 @@
+/*-
+ * #%L
+ * athena-docdb
+ * %%
+ * Copyright (C) 2019 - 2020 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.docdb;
+
+import com.amazonaws.athena.connector.lambda.data.FieldBuilder;
+import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.junit.Test;
+
+import java.util.LinkedList;
+
+import static org.junit.Assert.*;
+
+public class TypeUtilsTest
+{
+
+    @Test
+    public void unsupportedCoerce()
+    {
+        Object result = TypeUtils.coerce(FieldBuilder.newBuilder("unsupported", Types.MinorType.VARCHAR.getType()).build(), new UnsupportedType());
+        assertEquals("UnsupportedType{}", result);
+        assertTrue(result instanceof String);
+    }
+
+}

--- a/athena-docdb/src/test/java/com/amazonaws/athena/connectors/docdb/UnsupportedType.java
+++ b/athena-docdb/src/test/java/com/amazonaws/athena/connectors/docdb/UnsupportedType.java
@@ -1,0 +1,35 @@
+/*-
+ * #%L
+ * athena-docdb
+ * %%
+ * Copyright (C) 2019 - 2020 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.docdb;
+
+/**
+ * This is a place holder that is used as a type we won't really be able to coerce meaningfully with
+ * a blanket strategy even as we add increasing type support. Basically, we wanted a type that we'd
+ * never expect to actually get asked to add support for so that we know when these tests break.
+ */
+public class UnsupportedType
+{
+
+    @Override
+    public String toString()
+    {
+        return "UnsupportedType{}";
+    }
+}

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/SupportedTypes.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/SupportedTypes.java
@@ -1,0 +1,130 @@
+/*-
+ * #%L
+ * Amazon Athena Query Federation SDK
+ * %%
+ * Copyright (C) 2019 - 2020 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connector.lambda.data;
+
+import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * This enum defines the ApacheArrow types which are supported by this SDK. Using types not
+ * in this enum may lead to unpredictable performance or errors as different engines (e.g. Athena)
+ * may support these types to a different extent.
+ */
+public enum SupportedTypes
+{
+    BIT(Types.MinorType.BIT),
+    DATEMILLI(Types.MinorType.DATEMILLI),
+    DATEDAY(Types.MinorType.DATEDAY),
+    FLOAT8(Types.MinorType.FLOAT8),
+    FLOAT4(Types.MinorType.FLOAT4),
+    INT(Types.MinorType.INT),
+    TINYINT(Types.MinorType.TINYINT),
+    SMALLINT(Types.MinorType.SMALLINT),
+    BIGINT(Types.MinorType.BIGINT),
+    VARBINARY(Types.MinorType.VARBINARY),
+    DECIMAL(Types.MinorType.DECIMAL),
+    VARCHAR(Types.MinorType.VARCHAR),
+    STRUCT(Types.MinorType.STRUCT),
+    LIST(Types.MinorType.LIST);
+
+    private Types.MinorType arrowMinorType;
+
+    static final Set<Types.MinorType> SUPPORTED_TYPES = new HashSet<>();
+
+    static {
+        for (SupportedTypes next : values()) {
+            SUPPORTED_TYPES.add(next.arrowMinorType);
+        }
+    }
+
+    SupportedTypes(Types.MinorType arrowMinorType)
+    {
+        this.arrowMinorType = arrowMinorType;
+    }
+
+    public Types.MinorType getArrowMinorType()
+    {
+        return arrowMinorType;
+    }
+
+    /**
+     * Tests if the provided type is supported.
+     *
+     * @param minorType The minor type to test
+     * @return True if the minor type is supported, false otherwise.
+     */
+    public static boolean isSupported(Types.MinorType minorType)
+    {
+        return SUPPORTED_TYPES.contains(minorType);
+    }
+
+    /**
+     * Tests if the provided type is supported.
+     *
+     * @param arrowType The arrow type to test
+     * @return True if the arrow type is supported, false otherwise.
+     */
+    public static boolean isSupported(ArrowType arrowType)
+    {
+        return isSupported(Types.getMinorTypeForArrowType(arrowType));
+    }
+
+    /**
+     * Asserts if the provided field (and its children) all use supported types.
+     *
+     * @param field The field to test.
+     * @return The field being asserted, if all types used by the field and its children are supported.
+     * @throws RuntimeException If any of the types used by this field or its children are not supported.
+     */
+    public static boolean isSupported(Field field)
+    {
+        if (!isSupported(Types.getMinorTypeForArrowType(field.getType()))) {
+            return false;
+        }
+
+        if (field.getChildren() != null) {
+            for (Field nextChild : field.getChildren()) {
+                if (!isSupported(nextChild)) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Asserts if the provided field (and its children) all use supported types.
+     *
+     * @param field The field to test.
+     * @throws RuntimeException If any of the types used by this field or its children are not supported.
+     */
+    public static void assertSupported(Field field)
+    {
+        if (!isSupported(field)) {
+            throw new RuntimeException("Detected unsupported type[" + field.getType() + " / " + Types.getMinorTypeForArrowType(field.getType()) +
+                    " for column[" + field.getName() + "]");
+        }
+    }
+}

--- a/athena-jdbc/src/test/java/com/amazonaws/connectors/athena/jdbc/manager/JdbcMetadataHandlerTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/connectors/athena/jdbc/manager/JdbcMetadataHandlerTest.java
@@ -169,7 +169,8 @@ public class JdbcMetadataHandlerTest
             throws SQLException
     {
         String[] schema = {"DATA_TYPE", "COLUMN_SIZE", "COLUMN_NAME", "DECIMAL_DIGITS", "NUM_PREC_RADIX"};
-        Object[][] values = {{Types.INTEGER, 12, "testCol1", 0, 0}, {Types.VARCHAR, 25, "testCol2", 0, 0}};
+        Object[][] values = {{Types.INTEGER, 12, "testCol1", 0, 0}, {Types.VARCHAR, 25, "testCol2", 0, 0},
+                {Types.TIMESTAMP, 93, "testCol3", 0, 0},  {Types.TIMESTAMP_WITH_TIMEZONE, 93, "testCol4", 0, 0}};
         AtomicInteger rowNumber = new AtomicInteger(-1);
         ResultSet resultSet = mockResultSet(schema, values, rowNumber);
 


### PR DESCRIPTION
Fixing Issue #72 - Tables with even 1 unsupported columns are unqueriable

*Issue #, if available:* #72

*Description of changes:*
- Add explicit validation to all connectors to ensure we don't accidentally return unsupported Types. This should surface this issue earlier in connector development for future mismatches.
- If an unsupported type is encountered for the JDBC connector it will be ignored and we will log an error.
- It also seems the docdb connector is vulnerable to the same issue so I'll include fixing that in this PR as well.
- Updated unit tests to ensure unsupported columns are not returned

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
