### PR TITLE
Setting startFromHead flag for correct pagination in CloudwatchRecord…

### DIFF
--- a/athena-cloudwatch/src/main/java/com/amazonaws/athena/connectors/cloudwatch/CloudwatchRecordHandler.java
+++ b/athena-cloudwatch/src/main/java/com/amazonaws/athena/connectors/cloudwatch/CloudwatchRecordHandler.java
@@ -111,6 +111,8 @@ public class CloudwatchRecordHandler
                                     //We use the property instead of the table name because of the special all_streams table
                                     .withLogStreamName(split.getProperty(LOG_STREAM_FIELD))
                                     .withNextToken(actualContinuationToken)
+                                    // must be set to use nextToken correctly
+                                    .withStartFromHead(true)
                     )));
 
             if (continuationToken == null || !continuationToken.equals(logEventsResult.getNextForwardToken())) {


### PR DESCRIPTION
…Handler

*Issue #, if available:*

*Description of changes:* A customer reported that their query was returning incomplete data.  After investigation, I discovered that we were not using the GetLogEvents API correctly.  The documentation states that in order to use nextToken, startFromHead must be set to true.  I asked them to test this fix and all data was being returned.

https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_GetLogEvents.html#API_GetLogEvents_RequestParameters


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
