### PR TITLE
[BUG #112] Improving error messages when schema inference is unable to identify …

### DIFF
--- a/athena-docdb/src/main/java/com/amazonaws/athena/connectors/docdb/SchemaUtils.java
+++ b/athena-docdb/src/main/java/com/amazonaws/athena/connectors/docdb/SchemaUtils.java
@@ -249,7 +249,7 @@ public class SchemaUtils
             return new Field(key, FieldType.nullable(Types.MinorType.STRUCT.getType()), children);
         }
 
-        String className = value.getClass() == null ? "null" : value.getClass().getName();
+        String className = (value == null || value.getClass() == null) ? "null" : value.getClass().getName();
         logger.warn("Unknown type[" + className + "] for field[" + key + "], defaulting to varchar.");
         return new Field(key, FieldType.nullable(Types.MinorType.VARCHAR.getType()), null);
     }

--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/util/DDBTypeUtils.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/util/DDBTypeUtils.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -133,7 +133,7 @@ public final class DDBTypeUtils
             return new Field(key, FieldType.nullable(Types.MinorType.STRUCT.getType()), children);
         }
 
-        String className = value.getClass() == null ? "null" : value.getClass().getName();
+        String className = (value == null || value.getClass() == null) ? "null" : value.getClass().getName();
         throw new RuntimeException("Unknown type[" + className + "] for field[" + key + "]");
     }
 
@@ -156,6 +156,7 @@ public final class DDBTypeUtils
 
     /**
      * Converts from DynamoDB Attribute Type to Arrow type.
+     *
      * @param attributeName the DDB Attribute name
      * @param attributeType the DDB Attribute type
      * @return the converted-to Arrow Field

--- a/athena-hbase/src/main/java/com/amazonaws/athena/connectors/hbase/HbaseSchemaUtils.java
+++ b/athena-hbase/src/main/java/com/amazonaws/athena/connectors/hbase/HbaseSchemaUtils.java
@@ -284,6 +284,7 @@ public class HbaseSchemaUtils
             return ByteBuffer.allocate(1).put((byte) ((boolean) value ? 1 : 0)).array();
         }
 
-        throw new RuntimeException("Unsupported object type for " + value + " " + value.getClass().getName());
+        String className = (value == null || value.getClass() == null) ? "null" : value.getClass().getName();
+        throw new RuntimeException("Unsupported object type for " + value + " with class name " + className);
     }
 }


### PR DESCRIPTION
Improving error messages when schema inference is unable to identify a field type.

*Issue #, if available:* #112 

*Description of changes:*
Fixing NPE in how we crafted the error message for types that failed infrrence.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
