### PR TITLE
Standardizing SAR parameter configuration across connectors and adding Lambda function name validation.

### DIFF
--- a/athena-aws-cmdb/athena-aws-cmdb.yaml
+++ b/athena-aws-cmdb/athena-aws-cmdb.yaml
@@ -14,13 +14,14 @@ Metadata:
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AthenaCatalogName:
-    Description: 'The name you will give to this catalog in Athena. It will also be used as the function name.'
+    Description: 'The name you will give to this catalog in Athena. It will also be used as the function name. This name must satisfy the pattern ^[a-z0-9-_]{1,64}$'
     Type: String
+    AllowedPattern: ^[a-z0-9-_]{1,64}$
   SpillBucket:
-    Description: 'The bucket where this function can spill data.'
+    Description: 'The name of the bucket where this function can spill data.'
     Type: String
   SpillPrefix:
-    Description: 'The bucket prefix where this function can spill large responses.'
+    Description: 'The prefix within SpillBucket where this function can spill data.'
     Type: String
     Default: athena-spill
   LambdaTimeout:

--- a/athena-cloudwatch-metrics/athena-cloudwatch-metrics.yaml
+++ b/athena-cloudwatch-metrics/athena-cloudwatch-metrics.yaml
@@ -14,13 +14,14 @@ Metadata:
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AthenaCatalogName:
-    Description: 'The name you will give to this catalog in Athena. It will also be used as the function name.'
+    Description: 'The name you will give to this catalog in Athena. It will also be used as the function name. This name must satisfy the pattern ^[a-z0-9-_]{1,64}$'
     Type: String
+    AllowedPattern: ^[a-z0-9-_]{1,64}$
   SpillBucket:
-    Description: 'The bucket where this function can spill data.'
+    Description: 'The name of the bucket where this function can spill data.'
     Type: String
   SpillPrefix:
-    Description: 'The bucket prefix where this function can spill large responses.'
+    Description: 'The prefix within SpillBucket where this function can spill data.'
     Type: String
     Default: athena-spill
   LambdaTimeout:

--- a/athena-cloudwatch/athena-cloudwatch.yaml
+++ b/athena-cloudwatch/athena-cloudwatch.yaml
@@ -14,13 +14,14 @@ Metadata:
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AthenaCatalogName:
-    Description: 'The name you will give to this catalog in Athena. It will also be used as the function name.'
+    Description: 'The name you will give to this catalog in Athena. It will also be used as the function name. This name must satisfy the pattern ^[a-z0-9-_]{1,64}$'
     Type: String
+    AllowedPattern: ^[a-z0-9-_]{1,64}$
   SpillBucket:
-    Description: 'The bucket where this function can spill data.'
+    Description: 'The name of the bucket where this function can spill data.'
     Type: String
   SpillPrefix:
-    Description: 'The bucket prefix where this function can spill large responses.'
+    Description: 'The prefix within SpillBucket where this function can spill data.'
     Type: String
     Default: athena-spill
   LambdaTimeout:

--- a/athena-docdb/athena-docdb.yaml
+++ b/athena-docdb/athena-docdb.yaml
@@ -14,14 +14,14 @@ Metadata:
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AthenaCatalogName:
-    Description: 'The name you will give to this catalog in Athena. It will also be used as the function name.'
+    Description: 'The name you will give to this catalog in Athena. It will also be used as the function name. This name must satisfy the pattern ^[a-z0-9-_]{1,64}$'
     Type: String
+    AllowedPattern: ^[a-z0-9-_]{1,64}$
   SpillBucket:
-    Description: 'The bucket where this function can spill data.'
+    Description: 'The name of the bucket where this function can spill data.'
     Type: String
-    Default: athena-federation-spill
   SpillPrefix:
-    Description: 'The bucket prefix where this function can spill large responses.'
+    Description: 'The prefix within SpillBucket where this function can spill data.'
     Type: String
     Default: athena-spill
   LambdaTimeout:

--- a/athena-dynamodb/athena-dynamodb.yaml
+++ b/athena-dynamodb/athena-dynamodb.yaml
@@ -14,13 +14,14 @@ Metadata:
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AthenaCatalogName:
-    Description: 'The name you will give to this catalog in Athena. It will also be used as the function name.'
+    Description: 'The name you will give to this catalog in Athena. It will also be used as the function name. This name must satisfy the pattern ^[a-z0-9-_]{1,64}$'
     Type: String
+    AllowedPattern: ^[a-z0-9-_]{1,64}$
   SpillBucket:
-    Description: 'The bucket where this function can spill data.'
+    Description: 'The name of the bucket where this function can spill data.'
     Type: String
   SpillPrefix:
-    Description: 'The bucket prefix where this function can spill large responses.'
+    Description: 'The prefix within SpillBucket where this function can spill data.'
     Type: String
     Default: athena-spill
   LambdaTimeout:

--- a/athena-example/athena-example.yaml
+++ b/athena-example/athena-example.yaml
@@ -17,18 +17,19 @@ Metadata:
 # to your template when you create a stack
 Parameters:
   AthenaCatalogName:
-    Description: "The name you will give to this catalog in Athena will also be used as you Lambda function name."
+    Description: 'The name you will give to this catalog in Athena. It will also be used as the function name. This name must satisfy the pattern ^[a-z0-9-_]{1,64}$'
     Type: String
+    AllowedPattern: ^[a-z0-9-_]{1,64}$
   SpillBucket:
-    Description: "The bucket where this function can spill large responses."
+    Description: 'The name of the bucket where this function can spill data.'
     Type: String
   DataBucket:
       Description: "The bucket where this tutorial's data lives."
       Type: String
   SpillPrefix:
-    Description: "The bucket prefix where this function can spill large responses."
+    Description: 'The prefix within SpillBucket where this function can spill data.'
     Type: String
-    Default: "athena-spill"
+    Default: athena-spill
   LambdaTimeout:
     Description: "Maximum Lambda invocation runtime in seconds. (min 1 - 900 max)"
     Default: 900

--- a/athena-federation-sdk/athena-federation-sdk.yaml
+++ b/athena-federation-sdk/athena-federation-sdk.yaml
@@ -14,13 +14,14 @@ Metadata:
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AthenaCatalogName:
-    Description: 'The name you will give to this catalog in Athena. It will also be used as the function name.'
+    Description: 'The name you will give to this catalog in Athena. It will also be used as the function name. This name must satisfy the pattern ^[a-z0-9-_]{1,64}$'
     Type: String
+    AllowedPattern: ^[a-z0-9-_]{1,64}$
   SpillBucket:
-    Description: 'The bucket where this function can spill data.'
+    Description: 'The name of the bucket where this function can spill data.'
     Type: String
   SpillPrefix:
-    Description: 'The bucket prefix where this function can spill large responses.'
+    Description: 'The prefix within SpillBucket where this function can spill data.'
     Type: String
     Default: athena-spill
   LambdaTimeout:

--- a/athena-hbase/athena-hbase.yaml
+++ b/athena-hbase/athena-hbase.yaml
@@ -14,14 +14,14 @@ Metadata:
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AthenaCatalogName:
-    Description: 'The name you will give to this catalog in Athena. It will also be used as the function name.'
+    Description: 'The name you will give to this catalog in Athena. It will also be used as the function name. This name must satisfy the pattern ^[a-z0-9-_]{1,64}$'
     Type: String
+    AllowedPattern: ^[a-z0-9-_]{1,64}$
   SpillBucket:
-    Description: 'The bucket where this function can spill data.'
+    Description: 'The name of the bucket where this function can spill data.'
     Type: String
-    Default: athena-federation-spill
   SpillPrefix:
-    Description: 'The bucket prefix where this function can spill large responses.'
+    Description: 'The prefix within SpillBucket where this function can spill data.'
     Type: String
     Default: athena-spill
   LambdaTimeout:

--- a/athena-jdbc/athena-jdbc.yaml
+++ b/athena-jdbc/athena-jdbc.yaml
@@ -14,8 +14,9 @@ Metadata:
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   LambdaFunctionName:
-    Description: 'The name you will give to the Function accessing Database instance. This is also the name you can  use to query your database from athena using the registration-less catalog of “lambda:<func_name>”.'
+    Description: 'The name you will give to this catalog in Athena. It will also be used as the function name. This name must satisfy the pattern ^[a-z0-9-_]{1,64}$'
     Type: String
+    AllowedPattern: ^[a-z0-9-_]{1,64}$
   DefaultConnectionString:
     Description: 'The default connection string is used when catalog is "lambda:${LambdaFunctionName}". Catalog specific Connection Strings can be added later. Format: ${DatabaseType}://${NativeJdbcConnectionString}.'
     Type: String
@@ -23,13 +24,12 @@ Parameters:
       Description: 'Used to create resource-based authorization policy for "secretsmanager:GetSecretValue" action. E.g. All Athena JDBC Federation secret names can be prefixed with "AthenaJdbcFederation" and authorization policy will allow "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:AthenaJdbcFederation*". Parameter value in this case should be "AthenaJdbcFederation". If you do not have a prefix, you can manually update the IAM policy to add allow any secret names.'
       Type: String
   SpillBucket:
-    Description: 'The bucket where this function can spill data.'
+    Description: 'The name of the bucket where this function can spill data.'
     Type: String
-    Default: athena-federation-spill
   SpillPrefix:
-    Description: 'The bucket prefix where this function can spill large responses.'
+    Description: 'The prefix within SpillBucket where this function can spill data.'
     Type: String
-    Default: athena-spill/jdbc
+    Default: athena-spill
   LambdaTimeout:
     Description: 'Maximum Lambda invocation runtime in seconds. (min 1 - 900 max)'
     Default: 900

--- a/athena-redis/athena-redis.yaml
+++ b/athena-redis/athena-redis.yaml
@@ -14,14 +14,14 @@ Metadata:
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AthenaCatalogName:
-    Description: 'The name you will give to this catalog in Athena. It will also be used as the function name.'
+    Description: 'The name you will give to this catalog in Athena. It will also be used as the function name. This name must satisfy the pattern ^[a-z0-9-_]{1,64}$'
     Type: String
+    AllowedPattern: ^[a-z0-9-_]{1,64}$
   SpillBucket:
-    Description: 'The bucket where this function can spill data.'
+    Description: 'The name of the bucket where this function can spill data.'
     Type: String
-    Default: athena-federation-spill
   SpillPrefix:
-    Description: 'The bucket prefix where this function can spill large responses.'
+    Description: 'The prefix within SpillBucket where this function can spill data.'
     Type: String
     Default: athena-spill
   LambdaTimeout:

--- a/athena-tpcds/athena-tpcds.yaml
+++ b/athena-tpcds/athena-tpcds.yaml
@@ -14,13 +14,14 @@ Metadata:
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AthenaCatalogName:
-    Description: 'The name you will give to this catalog in Athena. It will also be used as the function name.'
+    Description: 'The name you will give to this catalog in Athena. It will also be used as the function name. This name must satisfy the pattern ^[a-z0-9-_]{1,64}$'
     Type: String
+    AllowedPattern: ^[a-z0-9-_]{1,64}$
   SpillBucket:
-    Description: 'The bucket where this function can spill data.'
+    Description: 'The name of the bucket where this function can spill data.'
     Type: String
   SpillPrefix:
-    Description: 'The bucket prefix where this function can spill large responses.'
+    Description: 'The prefix within SpillBucket where this function can spill data.'
     Type: String
     Default: athena-spill
   LambdaTimeout:

--- a/athena-udfs/athena-udfs.yaml
+++ b/athena-udfs/athena-udfs.yaml
@@ -14,8 +14,9 @@ Metadata:
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   LambdaFunctionName:
-      Description: 'The name you want to give the Lambda function that will contain your UDFs.'
-      Type: String
+    Description: 'The name you will give to Lambda function which executes your UDFs. This name must satisfy the pattern ^[a-z0-9-_]{1,64}$'
+    Type: String
+    AllowedPattern: ^[a-z0-9-_]{1,64}$
   LambdaTimeout:
     Description: 'Maximum Lambda invocation runtime in seconds. (min 1 - 900 max)'
     Default: 900


### PR DESCRIPTION
Closes #73 

This change standardizes the descriptions, allowed patterns, and default values for SAR parameters across all of the connectors in this repository. When this is merged, SAR will not allow users to create invalid Lambda function names (also able to be referenced in Athena as the catalog using the format "lambda:<function-name>"), exposing an informative error message when the function name does not match the required pattern.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
