### PR TITLE
Improving DDB schema inference if the table is not registered in glue

### DIFF
--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/util/DDBTableUtils.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/util/DDBTableUtils.java
@@ -144,7 +144,6 @@ public final class DDBTableUtils
                 for (Map.Entry<String, AttributeValue> column : item.entrySet()) {
                     if (!discoveredColumns.contains(column.getKey())) {
                         Field field = DDBTypeUtils.inferArrowField(column.getKey(), ItemUtils.toSimpleValue(column.getValue()));
-                        logger.info("retrieved key {} type {} childrenValue {}", field.getName(), field.getFieldType(), field.getChildren());
                         if (field != null) {
                             schemaBuilder.addField(field);
                             discoveredColumns.add(column.getKey());

--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/util/DDBTableUtils.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/util/DDBTableUtils.java
@@ -35,6 +35,7 @@ import com.amazonaws.services.dynamodbv2.model.ScanRequest;
 import com.amazonaws.services.dynamodbv2.model.ScanResult;
 import com.amazonaws.services.dynamodbv2.model.TableDescription;
 import com.google.common.collect.ImmutableList;
+import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -141,9 +142,13 @@ public final class DDBTableUtils
         if (!items.isEmpty()) {
             for (Map<String, AttributeValue> item : items) {
                 for (Map.Entry<String, AttributeValue> column : item.entrySet()) {
-                    if (!discoveredColumns.contains(column.getKey()) && !Boolean.TRUE.equals(column.getValue().getNULL())) {
-                        schemaBuilder.addField(DDBTypeUtils.inferArrowField(column.getKey(), ItemUtils.toSimpleValue(column.getValue())));
-                        discoveredColumns.add(column.getKey());
+                    if (!discoveredColumns.contains(column.getKey())) {
+                        Field field = DDBTypeUtils.inferArrowField(column.getKey(), ItemUtils.toSimpleValue(column.getValue()));
+                        logger.info("retrieved key {} type {} childrenValue {}", field.getName(), field.getFieldType(), field.getChildren());
+                        if (field != null) {
+                            schemaBuilder.addField(field);
+                            discoveredColumns.add(column.getKey());
+                        }
                     }
                 }
             }

--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/util/DDBTypeUtils.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/util/DDBTypeUtils.java
@@ -69,7 +69,6 @@ public final class DDBTypeUtils
     public static Field inferArrowField(String key, Object value)
     {
         if (value == null) {
-            logger.info("NULL encountered for {}", key);
             return null;
         }
 

--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/util/DDBTypeUtils.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/util/DDBTypeUtils.java
@@ -68,6 +68,11 @@ public final class DDBTypeUtils
      */
     public static Field inferArrowField(String key, Object value)
     {
+        if (value == null) {
+            logger.info("NULL encountered for {}", key);
+            return null;
+        }
+
         if (value instanceof String) {
             return new Field(key, FieldType.nullable(Types.MinorType.VARCHAR.getType()), null);
         }
@@ -111,8 +116,10 @@ public final class DDBTypeUtils
                     child = inferArrowField("", "");
                 }
             }
-            return new Field(key, FieldType.nullable(Types.MinorType.LIST.getType()),
-                    Collections.singletonList(child));
+            return child == null
+                    ? null
+                    : new Field(key, FieldType.nullable(Types.MinorType.LIST.getType()),
+                                Collections.singletonList(child));
         }
         else if (value instanceof Map) {
             List<Field> children = new ArrayList<>();
@@ -121,7 +128,9 @@ public final class DDBTypeUtils
             for (String childKey : doc.keySet()) {
                 Object childVal = doc.get(childKey);
                 Field child = inferArrowField(childKey, childVal);
-                children.add(child);
+                if (child != null) {
+                    children.add(child);
+                }
             }
 
             // Athena requires Structs to have child types and not be empty

--- a/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBMetadataHandlerTest.java
+++ b/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBMetadataHandlerTest.java
@@ -221,6 +221,7 @@ public class DynamoDBMetadataHandlerTest
         List<TableName> expectedTables = tableNames.stream().map(table -> new TableName(DEFAULT_SCHEMA, table)).collect(Collectors.toList());
         expectedTables.add(TEST_TABLE_NAME);
         expectedTables.add(new TableName(DEFAULT_SCHEMA, "test_table2"));
+        expectedTables.add(new TableName(DEFAULT_SCHEMA, "test_table4"));
 
         assertThat(new HashSet<>(res.getTables()), equalTo(new HashSet<>(expectedTables)));
 

--- a/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBRecordHandlerTest.java
+++ b/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBRecordHandlerTest.java
@@ -23,9 +23,12 @@ import com.amazonaws.athena.connector.lambda.data.BlockAllocator;
 import com.amazonaws.athena.connector.lambda.data.BlockAllocatorImpl;
 import com.amazonaws.athena.connector.lambda.data.BlockUtils;
 import com.amazonaws.athena.connector.lambda.domain.Split;
+import com.amazonaws.athena.connector.lambda.domain.TableName;
 import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
 import com.amazonaws.athena.connector.lambda.domain.spill.S3SpillLocation;
 import com.amazonaws.athena.connector.lambda.domain.spill.SpillLocation;
+import com.amazonaws.athena.connector.lambda.metadata.GetTableRequest;
+import com.amazonaws.athena.connector.lambda.metadata.GetTableResponse;
 import com.amazonaws.athena.connector.lambda.records.ReadRecordsRequest;
 import com.amazonaws.athena.connector.lambda.records.ReadRecordsResponse;
 import com.amazonaws.athena.connector.lambda.records.RecordResponse;
@@ -33,18 +36,32 @@ import com.amazonaws.athena.connector.lambda.security.EncryptionKeyFactory;
 import com.amazonaws.athena.connector.lambda.security.LocalKeyFactory;
 import com.amazonaws.services.athena.AmazonAthena;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.glue.AWSGlue;
+import com.amazonaws.services.glue.model.Column;
+import com.amazonaws.services.glue.model.GetTableResult;
+import com.amazonaws.services.glue.model.StorageDescriptor;
+import com.amazonaws.services.glue.model.Table;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.secretsmanager.AWSSecretsManager;
 import com.google.common.collect.ImmutableMap;
+import org.apache.arrow.vector.types.pojo.Schema;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import static com.amazonaws.athena.connector.lambda.handlers.GlueMetadataHandler.COLUMN_NAME_MAPPING_PROPERTY;
+import static com.amazonaws.athena.connector.lambda.handlers.GlueMetadataHandler.SOURCE_TABLE_PROPERTY;
+import static com.amazonaws.athena.connectors.dynamodb.constants.DynamoDBConstants.DEFAULT_SCHEMA;
 import static com.amazonaws.athena.connectors.dynamodb.constants.DynamoDBConstants.EXPRESSION_NAMES_METADATA;
 import static com.amazonaws.athena.connectors.dynamodb.constants.DynamoDBConstants.EXPRESSION_VALUES_METADATA;
 import static com.amazonaws.athena.connectors.dynamodb.constants.DynamoDBConstants.HASH_KEY_NAME_METADATA;
@@ -53,12 +70,16 @@ import static com.amazonaws.athena.connectors.dynamodb.constants.DynamoDBConstan
 import static com.amazonaws.athena.connectors.dynamodb.constants.DynamoDBConstants.SEGMENT_COUNT_METADATA;
 import static com.amazonaws.athena.connectors.dynamodb.constants.DynamoDBConstants.SEGMENT_ID_PROPERTY;
 import static com.amazonaws.athena.connectors.dynamodb.constants.DynamoDBConstants.TABLE_METADATA;
+
 import static com.amazonaws.services.dynamodbv2.document.ItemUtils.toAttributeValue;
 import static com.amazonaws.util.json.Jackson.toJsonString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+@RunWith(MockitoJUnitRunner.class)
 public class DynamoDBRecordHandlerTest
         extends TestBase
 {
@@ -75,12 +96,23 @@ public class DynamoDBRecordHandlerTest
     private BlockAllocator allocator;
     private EncryptionKeyFactory keyFactory = new LocalKeyFactory();
     private DynamoDBRecordHandler handler;
+    private DynamoDBMetadataHandler metadataHandler;
+
+    @Mock
+    private AWSGlue glueClient;
+
+    @Mock
+    private AWSSecretsManager secretsManager;
+
+    @Mock
+    private AmazonAthena athena;
 
     @Before
     public void setup()
     {
         allocator = new BlockAllocatorImpl();
         handler = new DynamoDBRecordHandler(ddbClient, mock(AmazonS3.class), mock(AWSSecretsManager.class), mock(AmazonAthena.class), "source_type");
+        metadataHandler = new DynamoDBMetadataHandler(new LocalKeyFactory(), secretsManager, athena, "spillBucket", "spillPrefix", ddbClient, glueClient);
     }
 
     @After
@@ -245,5 +277,53 @@ public class DynamoDBRecordHandlerTest
         assertEquals(0, response.getRecords().getRowCount());
 
         logger.info("testZeroRowQuery: exit");
+    }
+
+    @Test
+    public void testStructWithNullFromGlueTable() throws Exception
+    {
+        List<Column> columns = new ArrayList<>();
+        columns.add(new Column().withName("col0").withType("string"));
+        columns.add(new Column().withName("col1").withType("struct"));
+        Map<String, String> param = ImmutableMap.of(
+                SOURCE_TABLE_PROPERTY, TEST_TABLE4,
+                COLUMN_NAME_MAPPING_PROPERTY, "col1=Col1,col2=Col2");
+        Table table = new Table()
+                .withParameters(param)
+                .withPartitionKeys()
+                .withStorageDescriptor(new StorageDescriptor().withColumns(columns));
+        GetTableResult mockResult = new GetTableResult().withTable(table);
+        when(glueClient.getTable(any())).thenReturn(mockResult);
+
+        TableName tableName = new TableName(DEFAULT_SCHEMA, TEST_TABLE4);
+        GetTableRequest getTableRequest = new GetTableRequest(TEST_IDENTITY, TEST_QUERY_ID, TEST_CATALOG_NAME, tableName);
+        GetTableResponse getTableResponse = metadataHandler.doGetTable(allocator, getTableRequest);
+        logger.info("testStructWithNullFromGlueTable: GetTableResponse[{}]", getTableResponse);
+        logger.info("testStructWithNullFromGlueTable: GetTableResponse Schema[{}]", getTableResponse.getSchema());
+
+        Schema schema4 = getTableResponse.getSchema();
+
+        Split split = Split.newBuilder(SPILL_LOCATION, keyFactory.create())
+                .add(TABLE_METADATA, TEST_TABLE4)
+                .add(SEGMENT_ID_PROPERTY, "0")
+                .add(SEGMENT_COUNT_METADATA, "1")
+                .build();
+
+        ReadRecordsRequest request = new ReadRecordsRequest(
+                TEST_IDENTITY,
+                TEST_CATALOG_NAME,
+                TEST_QUERY_ID,
+                TEST_TABLE_4_NAME,
+                schema4,
+                split,
+                new Constraints(ImmutableMap.of()),
+                100_000_000_000L, // too big to spill
+                100_000_000_000L);
+
+        RecordResponse rawResponse = handler.doReadRecords(allocator, request);
+        assertTrue(rawResponse instanceof ReadRecordsResponse);
+        ReadRecordsResponse response = (ReadRecordsResponse) rawResponse;
+        logger.info("testStructWithNullFromGlueTable: {}", BlockUtils.rowToString(response.getRecords(), 0));
+
     }
 }

--- a/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/TestBase.java
+++ b/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/TestBase.java
@@ -70,7 +70,7 @@ public class TestBase
 
     protected static AmazonDynamoDB ddbClient;
     protected static Schema schema;
-
+    protected static Table tableDdbNoGlue;
     @BeforeClass
     public static void setupOnce() throws Exception
     {
@@ -175,8 +175,8 @@ public class TestBase
                 .withAttributeDefinitions(attributeDefinitions)
                 .withProvisionedThroughput(provisionedThroughput);
 
-        table = ddb.createTable(createTableRequest);
-        table.waitForActive();
+        tableDdbNoGlue = ddb.createTable(createTableRequest);
+        tableDdbNoGlue.waitForActive();
 
         Map<String, String> col1 = new HashMap<>();
         col1.put("field1", "someField1");

--- a/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/TestBase.java
+++ b/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/TestBase.java
@@ -63,8 +63,10 @@ public class TestBase
     protected static final String TEST_QUERY_ID = "queryId";
     protected static final String TEST_CATALOG_NAME = "default";
     protected static final String TEST_TABLE = "test_table";
+    protected static final String TEST_TABLE4 = "test_table4";
     protected static final TableName TEST_TABLE_NAME = new TableName(DEFAULT_SCHEMA, TEST_TABLE);
     protected static final TableName TEST_TABLE_2_NAME = new TableName(DEFAULT_SCHEMA, "Test_table2");
+    protected static final TableName TEST_TABLE_4_NAME = new TableName(DEFAULT_SCHEMA, "test_table4");
 
     protected static AmazonDynamoDB ddbClient;
     protected static Schema schema;
@@ -159,6 +161,33 @@ public class TestBase
                 .withProvisionedThroughput(provisionedThroughput);
         table = ddb.createTable(createTableRequest);
         table.waitForActive();
+
+        // Table 4
+        attributeDefinitions = new ArrayList<>();
+        attributeDefinitions.add(new AttributeDefinition().withAttributeName("Col0").withAttributeType("S"));
+
+        keySchema = new ArrayList<>();
+        keySchema.add(new KeySchemaElement().withAttributeName("Col0").withKeyType(KeyType.HASH));
+
+        createTableRequest = new CreateTableRequest()
+                .withTableName(TEST_TABLE4)
+                .withKeySchema(keySchema)
+                .withAttributeDefinitions(attributeDefinitions)
+                .withProvisionedThroughput(provisionedThroughput);
+
+        table = ddb.createTable(createTableRequest);
+        table.waitForActive();
+
+        Map<String, String> col1 = new HashMap<>();
+        col1.put("field1", "someField1");
+        col1.put("field2", null);
+
+        tableWriteItems = new TableWriteItems(TEST_TABLE4);
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put("Col0", toAttributeValue("hashVal"));
+        item.put("Col1", toAttributeValue(col1));
+        tableWriteItems.addItemToPut(toItem(item));
+        ddb.batchWriteItem(tableWriteItems);
 
         return client;
     }


### PR DESCRIPTION

*Issue #, if available:*
https://github.com/awslabs/aws-athena-query-federation/issues/118

*Description of changes:*
Currently, If the customer did not register their DDB table with glue, we then peek n rows from the DDB table to infer the table schema. This causes an issue when we come across Struct type, as it can be free formed and we are unable to infer the correct schema. However due to the free-form-ness, we are unable to infer a perfect/correct schema. 

Long term fix is to support map type. However in the short term, we need to address the problem where the query fails if one of the nested fields in the Struct contains NULL type (of value true).

*Testing:*
Created ddb table with nested type with NULLtype (of value true) without registering the table in glue

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
