### PR TITLE
[Issue #117] Improving HBase connector's client reuse logic by adding…

### DIFF
--- a/athena-hbase/src/main/java/com/amazonaws/athena/connectors/hbase/connection/HBaseConnection.java
+++ b/athena-hbase/src/main/java/com/amazonaws/athena/connectors/hbase/connection/HBaseConnection.java
@@ -1,0 +1,268 @@
+/*-
+ * #%L
+ * athena-hbase
+ * %%
+ * Copyright (C) 2019 - 2020 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.hbase.connection;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HRegionInfo;
+import org.apache.hadoop.hbase.NamespaceDescriptor;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
+import org.apache.hadoop.hbase.client.ResultScanner;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.client.Table;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+/**
+ * This class wraps Hbase's Connection construct and provides both a simplified facade for common operations
+ * but also automatic retry and reconnect logic to make client reuse simpler. Some specific cases that this
+ * construct handles are: replacement of an HBase region server, replacement of HBase master server, other
+ * transient errors while communicating with HBase.
+ */
+public class HBaseConnection
+{
+    private static final Logger logger = LoggerFactory.getLogger(HBaseConnection.class);
+
+    private final Configuration config;
+    private final int maxRetries;
+    private int retries = 0;
+    private Connection connection;
+
+    /**
+     * Used by HBaseConnectionFactory to construct new connections.
+     *
+     * @param config The HBase config to use for this connection.
+     * @param maxRetries The max retries this connection will allow before marking itself unhealthy.
+     */
+    protected HBaseConnection(Configuration config, int maxRetries)
+    {
+        this.config = config;
+        this.maxRetries = maxRetries;
+        this.connection = connect(config);
+    }
+
+    /**
+     * Used to facilitate testing by allowing for injection of the underlying HBase connection.
+     *
+     * @param connection The actual Hbase connection to use.
+     * @param maxRetries The max retries this connection will allow before marking itself unhealthy.
+     */
+    @VisibleForTesting
+    protected HBaseConnection(Connection connection, int maxRetries)
+    {
+        this.config = null;
+        this.maxRetries = maxRetries;
+        this.connection = connection;
+    }
+
+    /**
+     * Used to determine if this connection can be reused or if it is unhealthy.
+     *
+     * @return True if the connection can be safely reused, false otherwise.
+     */
+    public synchronized boolean isHealthy()
+    {
+        return retries < maxRetries;
+    }
+
+    /**
+     * Lists the available namespaces in the HBase instance.
+     *
+     * @return Array of NamespaceDescriptor representing the available namespaces in the HBase instance.
+     * @throws IOException
+     */
+    public NamespaceDescriptor[] listNamespaceDescriptors()
+            throws IOException
+    {
+        return callWithReconnectAndRetry(() -> {
+            Admin admin = getConnection().getAdmin();
+            return admin.listNamespaceDescriptors();
+        });
+    }
+
+    /**
+     * Lists the table names present in the given schema (aka namespace)
+     *
+     * @param schemaName The schema name (aka hbase namespace) to list table names from.
+     * @return An array of hbase TableName objects for the given schema name.
+     */
+    public TableName[] listTableNamesByNamespace(String schemaName)
+    {
+        return callWithReconnectAndRetry(() -> {
+            Admin admin = getConnection().getAdmin();
+            return admin.listTableNamesByNamespace(schemaName);
+        });
+    }
+
+    /**
+     * Retreieves the regions for the requested TableName.
+     *
+     * @param tableName The fully qualified HBase TableName for which we should obtain region info.
+     * @return List of HRegionInfo representing the regions hosting the requested table.
+     */
+    public List<HRegionInfo> getTableRegions(TableName tableName)
+    {
+        return callWithReconnectAndRetry(() -> {
+            Admin admin = getConnection().getAdmin();
+            return admin.getTableRegions(tableName);
+        });
+    }
+
+    /**
+     * Used to perform a scan of the given table, scan, and resultProcessor.
+     *
+     * @param tableName The HBase table to scan.
+     * @param scan The HBase scan (filters, etc...) to run.
+     * @param resultProcessor The ResultProcessor that will be used to process the results of the scan.
+     * @param <T> The return type of the ResultProcessor and this this method.
+     * @return The result produced by the resultProcessor when it has completed processing all results of the scan.
+     */
+    public <T> T scanTable(TableName tableName, Scan scan, ResultProcessor<T> resultProcessor)
+    {
+        return callWithReconnectAndRetry(() -> {
+            try (Table table = connection.getTable(tableName);
+                    ResultScanner scanner = table.getScanner(scan)) {
+                try {
+                    return resultProcessor.scan(scanner);
+                }
+                catch (RuntimeException ex) {
+                    throw new UnrecoverableException("Scanner threw exception - " + ex.getMessage(), ex);
+                }
+            }
+        });
+    }
+
+    /**
+     * Used to close this connection by closing the underlying HBase Connection.
+     */
+    protected void close()
+    {
+        try {
+            if (connection != null) {
+                connection.close();
+            }
+        }
+        catch (IOException | RuntimeException ex) {
+            logger.warn("close: Exception while closing connection.");
+        }
+    }
+
+    @VisibleForTesting
+    protected int getRetries()
+    {
+        return retries;
+    }
+
+    /**
+     * Used to invoke operations with HBase reconnect and retry logic.
+     *
+     * @param callable The callable to invoke and monitor for errors.
+     * @param <T> The return type of the callable.
+     * @return The result of the callable, if it was successfull.
+     * @note This retry logic needs to be adjusted for 'write' usecases.
+     */
+    private <T> T callWithReconnectAndRetry(Callable<T> callable)
+    {
+        while (isHealthy()) {
+            try {
+                return callable.call();
+            }
+            catch (RuntimeException ex) {
+                logger.warn("Exception while calling hbase, will attempt to reconnect and retry.", ex);
+                reconnect();
+            }
+            catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(ex);
+            }
+            catch (UnrecoverableException ex) {
+                throw new RuntimeException(ex);
+            }
+            catch (Exception ex) {
+                throw new RuntimeException(ex);
+            }
+        }
+        throw new RuntimeException("Exhausted hbase retries...");
+    }
+
+    /**
+     * Creates a new HBase connection using the provided config.
+     *
+     * @param config The config to use for the new HBase connection.
+     * @return The new connection.
+     */
+    @VisibleForTesting
+    protected synchronized Connection connect(Configuration config)
+    {
+        try {
+            Connection conn = ConnectionFactory.createConnection(config);
+            logger.info("connect: hbase.zookeeper.quorum:" + config.get("hbase.zookeeper.quorum"));
+            logger.info("connect: hbase.zookeeper.property.clientPort:" + config.get("hbase.zookeeper.property.clientPort"));
+            logger.info("connect: hbase.master:" + config.get("hbase.master"));
+            return conn;
+        }
+        catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    /**
+     * Used to reconnect to HBase by freeing existing connection resources, incrementing retry metrics, and ultimately
+     * creating the new connection.
+     *
+     * @return The new connection.
+     */
+    private synchronized Connection reconnect()
+    {
+        retries++;
+        close();
+
+        try {
+            connection = connect(config);
+        }
+        catch (RuntimeException ex) {
+            logger.warn("reConnect: Exception while reconnecting, marking connection as unhealthy and throwing.", ex);
+            retries = maxRetries;
+            throw ex;
+        }
+
+        return connection;
+    }
+
+    /**
+     * Provides access to the current connection if present and healthy.
+     *
+     * @return The underlying HBase connection.
+     */
+    private synchronized Connection getConnection()
+    {
+        if (connection == null || !isHealthy()) {
+            throw new RuntimeException("Invalid connection");
+        }
+        return connection;
+    }
+}

--- a/athena-hbase/src/main/java/com/amazonaws/athena/connectors/hbase/connection/ResultProcessor.java
+++ b/athena-hbase/src/main/java/com/amazonaws/athena/connectors/hbase/connection/ResultProcessor.java
@@ -1,0 +1,38 @@
+/*-
+ * #%L
+ * athena-hbase
+ * %%
+ * Copyright (C) 2019 - 2020 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.hbase.connection;
+
+import org.apache.hadoop.hbase.client.ResultScanner;
+
+/**
+ * Used to define a class which is capable of processing entries returned from an HBase scan operation.
+ *
+ * @param <T> The type that the ResultProcessor will return.
+ */
+public interface ResultProcessor<T>
+{
+    /**
+     * Used to process results from an HBase ResultScanner (aka iterator of results).
+     *
+     * @param scanner The iterable results from an HBase scan.
+     * @return The result from the ResultProcessor.
+     */
+    T scan(ResultScanner scanner);
+}

--- a/athena-hbase/src/main/java/com/amazonaws/athena/connectors/hbase/connection/UnrecoverableException.java
+++ b/athena-hbase/src/main/java/com/amazonaws/athena/connectors/hbase/connection/UnrecoverableException.java
@@ -1,0 +1,33 @@
+/*-
+ * #%L
+ * athena-hbase
+ * %%
+ * Copyright (C) 2019 - 2020 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.hbase.connection;
+
+/**
+ * Used to indicate that a particular exception is not recoverable and thus not retriable by our HBaseConnection's
+ * automatic retry and reconnect logic.
+ */
+public class UnrecoverableException
+        extends Exception
+{
+    public UnrecoverableException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+}

--- a/athena-hbase/src/test/java/com/amazonaws/athena/connectors/hbase/connection/HBaseConnectionTest.java
+++ b/athena-hbase/src/test/java/com/amazonaws/athena/connectors/hbase/connection/HBaseConnectionTest.java
@@ -1,0 +1,396 @@
+/*-
+ * #%L
+ * athena-hbase
+ * %%
+ * Copyright (C) 2019 - 2020 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.hbase.connection;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HRegionInfo;
+import org.apache.hadoop.hbase.NamespaceDescriptor;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.ResultScanner;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.client.Table;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class HBaseConnectionTest
+{
+    private static final Logger logger = LoggerFactory.getLogger(HBaseConnectionTest.class);
+
+    private int maxRetries = 3;
+    private Connection mockConnection;
+    private Admin mockAdmin;
+    private Table mockTable;
+    private ResultScanner mockScanner;
+    private HBaseConnection connection;
+
+    @Before
+    public void setUp()
+            throws Exception
+    {
+        mockConnection = mock(Connection.class);
+        mockAdmin = mock(Admin.class);
+        mockTable = mock(Table.class);
+        mockScanner = mock(ResultScanner.class);
+        connection = new HBaseConnectionStub(mockConnection, maxRetries);
+    }
+
+    @Test
+    public void listNamespaceDescriptors()
+            throws IOException
+    {
+        logger.info("listNamespaceDescriptors: enter");
+        when(mockConnection.getAdmin()).thenReturn(mockAdmin);
+        when(mockAdmin.listNamespaceDescriptors()).thenReturn(new NamespaceDescriptor[] {});
+
+        NamespaceDescriptor[] result = connection.listNamespaceDescriptors();
+        assertNotNull(result);
+        assertTrue(connection.isHealthy());
+        assertEquals(0, connection.getRetries());
+        verify(mockConnection, atLeastOnce()).getAdmin();
+        verify(mockAdmin, atLeastOnce()).listNamespaceDescriptors();
+        logger.info("listNamespaceDescriptors: exit");
+    }
+
+    @Test
+    public void listNamespaceDescriptorsWithRetry()
+            throws IOException
+    {
+        logger.info("listNamespaceDescriptorsWithRetry: enter");
+        when(mockConnection.getAdmin()).thenAnswer(new Answer()
+        {
+            private int count = 0;
+
+            public Object answer(InvocationOnMock invocation)
+            {
+                if (++count == 1) {
+                    //first invocation should throw
+                    return new RuntimeException("Retryable");
+                }
+
+                return mockAdmin;
+            }
+        });
+        when(mockAdmin.listNamespaceDescriptors()).thenReturn(new NamespaceDescriptor[] {});
+
+        NamespaceDescriptor[] result = connection.listNamespaceDescriptors();
+        assertNotNull(result);
+        assertTrue(connection.isHealthy());
+        assertEquals(1, connection.getRetries());
+        verify(mockConnection, atLeastOnce()).getAdmin();
+        verify(mockAdmin, atLeastOnce()).listNamespaceDescriptors();
+        logger.info("listNamespaceDescriptorsWithRetry: exit");
+    }
+
+    @Test
+    public void listNamespaceDescriptorsRetryExhausted()
+            throws IOException
+    {
+        logger.info("listNamespaceDescriptorsRetryExhausted: enter");
+        when(mockConnection.getAdmin()).thenThrow(new RuntimeException("Retryable"));
+        try {
+            connection.listNamespaceDescriptors();
+            fail("Should not reach this line because retries should be exhausted.");
+        }
+        catch (RuntimeException ex) {
+            logger.info("listNamespaceDescriptorsRetryExhausted: Encountered expected exception.", ex);
+        }
+        assertFalse(connection.isHealthy());
+        assertEquals(3, connection.getRetries());
+        logger.info("listNamespaceDescriptorsRetryExhausted: exit");
+    }
+
+    @Test
+    public void listTableNamesByNamespace()
+            throws IOException
+    {
+        logger.info("listTableNamesByNamespace: enter");
+        when(mockConnection.getAdmin()).thenReturn(mockAdmin);
+        when(mockAdmin.listTableNamesByNamespace(anyString())).thenReturn(new TableName[] {});
+
+        TableName[] result = connection.listTableNamesByNamespace("schemaName");
+        assertNotNull(result);
+        assertTrue(connection.isHealthy());
+        assertEquals(0, connection.getRetries());
+        verify(mockConnection, atLeastOnce()).getAdmin();
+        verify(mockAdmin, atLeastOnce()).listTableNamesByNamespace(anyObject());
+        logger.info("listTableNamesByNamespace: exit");
+    }
+
+    @Test
+    public void listTableNamesByNamespaceWithRetry()
+            throws IOException
+    {
+        logger.info("listTableNamesByNamespaceWithRetry: enter");
+        when(mockConnection.getAdmin()).thenAnswer(new Answer()
+        {
+            private int count = 0;
+
+            public Object answer(InvocationOnMock invocation)
+            {
+                if (++count == 1) {
+                    //first invocation should throw
+                    return new RuntimeException("Retryable");
+                }
+
+                return mockAdmin;
+            }
+        });
+        when(mockAdmin.listTableNamesByNamespace(anyString())).thenReturn(new TableName[] {});
+
+        TableName[] result = connection.listTableNamesByNamespace("schemaName");
+        assertNotNull(result);
+        assertTrue(connection.isHealthy());
+        assertEquals(1, connection.getRetries());
+        verify(mockConnection, atLeastOnce()).getAdmin();
+        verify(mockAdmin, atLeastOnce()).listTableNamesByNamespace(anyObject());
+        logger.info("listTableNamesByNamespaceWithRetry: exit");
+    }
+
+    @Test
+    public void listTableNamesByNamespaceRetryExhausted()
+            throws IOException
+    {
+        logger.info("listTableNamesByNamespaceRetryExhausted: enter");
+        when(mockConnection.getAdmin()).thenThrow(new RuntimeException("Retryable"));
+        try {
+            connection.listTableNamesByNamespace("schemaName");
+            fail("Should not reach this line because retries should be exhausted.");
+        }
+        catch (RuntimeException ex) {
+            logger.info("listTableNamesByNamespaceRetryExhausted: Encountered expected exception.", ex);
+        }
+        assertFalse(connection.isHealthy());
+        assertEquals(3, connection.getRetries());
+        logger.info("listTableNamesByNamespaceRetryExhausted: exit");
+    }
+
+    @Test
+    public void getTableRegions()
+            throws IOException
+    {
+        logger.info("getTableRegions: enter");
+        when(mockConnection.getAdmin()).thenReturn(mockAdmin);
+        when(mockAdmin.getTableRegions(anyObject())).thenReturn(new ArrayList<>());
+
+        List<HRegionInfo> result = connection.getTableRegions(null);
+        assertNotNull(result);
+        assertTrue(connection.isHealthy());
+        assertEquals(0, connection.getRetries());
+        verify(mockConnection, atLeastOnce()).getAdmin();
+        verify(mockAdmin, atLeastOnce()).getTableRegions(anyObject());
+        logger.info("getTableRegions: exit");
+    }
+
+    @Test
+    public void getTableRegionsWithRetry()
+            throws IOException
+    {
+        logger.info("getTableRegionsWithRetry: enter");
+        when(mockConnection.getAdmin()).thenAnswer(new Answer()
+        {
+            private int count = 0;
+
+            public Object answer(InvocationOnMock invocation)
+            {
+                if (++count == 1) {
+                    //first invocation should throw
+                    return new RuntimeException("Retryable");
+                }
+
+                return mockAdmin;
+            }
+        });
+        when(mockAdmin.getTableRegions(anyObject())).thenReturn(new ArrayList<>());
+
+        List<HRegionInfo> result = connection.getTableRegions(null);
+        assertNotNull(result);
+        assertTrue(connection.isHealthy());
+        assertEquals(1, connection.getRetries());
+        verify(mockConnection, atLeastOnce()).getAdmin();
+        verify(mockAdmin, atLeastOnce()).getTableRegions(anyObject());
+        logger.info("getTableRegionsWithRetry: exit");
+    }
+
+    @Test
+    public void getTableRegionsRetryExhausted()
+            throws IOException
+    {
+        logger.info("getTableRegionsRetryExhausted: enter");
+        when(mockConnection.getAdmin()).thenThrow(new RuntimeException("Retryable"));
+        try {
+            connection.getTableRegions(null);
+            fail("Should not reach this line because retries should be exhausted.");
+        }
+        catch (RuntimeException ex) {
+            logger.info("listTableNamesByNamespaceRetryExhausted: Encountered expected exception.", ex);
+        }
+        assertFalse(connection.isHealthy());
+        assertEquals(3, connection.getRetries());
+        logger.info("getTableRegionsRetryExhausted: exit");
+    }
+
+    @Test
+    public void scanTable()
+            throws IOException
+    {
+        logger.info("scanTable: enter");
+        when(mockConnection.getTable(any(org.apache.hadoop.hbase.TableName.class))).thenReturn(mockTable);
+        when(mockTable.getScanner(any(Scan.class))).thenReturn(mockScanner);
+
+        TableName tableName = org.apache.hadoop.hbase.TableName.valueOf("schema1", "table1");
+        boolean result = connection.scanTable(tableName, mock(Scan.class), (ResultScanner scanner) -> scanner != null);
+
+        assertTrue(result);
+        assertTrue(connection.isHealthy());
+        assertEquals(0, connection.getRetries());
+        verify(mockConnection, atLeastOnce()).getTable(anyObject());
+        verify(mockTable, atLeastOnce()).getScanner(any(Scan.class));
+        logger.info("scanTable: exit");
+    }
+
+    @Test
+    public void scanTableWithRetry()
+            throws IOException
+    {
+        logger.info("scanTableWithRetry: enter");
+        when(mockConnection.getTable(any(org.apache.hadoop.hbase.TableName.class))).thenReturn(mockTable);
+        when(mockTable.getScanner(any(Scan.class))).thenAnswer(new Answer()
+        {
+            private int count = 0;
+
+            public Object answer(InvocationOnMock invocation)
+            {
+                if (++count == 1) {
+                    //first invocation should throw
+                    return new RuntimeException("Retryable");
+                }
+
+                return mockScanner;
+            }
+        });
+
+        TableName tableName = org.apache.hadoop.hbase.TableName.valueOf("schema1", "table1");
+        boolean result = connection.scanTable(tableName, mock(Scan.class), (ResultScanner scanner) -> scanner != null);
+
+        assertTrue(result);
+        assertTrue(connection.isHealthy());
+        assertEquals(1, connection.getRetries());
+        verify(mockConnection, atLeastOnce()).getTable(anyObject());
+        verify(mockTable, atLeastOnce()).getScanner(any(Scan.class));
+        logger.info("scanTableWithRetry: exit");
+    }
+
+    @Test
+    public void scanTableRetriesExhausted()
+            throws IOException
+    {
+        logger.info("scanTableRetriesExhausted: enter");
+        when(mockConnection.getTable(any(org.apache.hadoop.hbase.TableName.class))).thenReturn(mockTable);
+        when(mockTable.getScanner(any(Scan.class))).thenThrow(new RuntimeException("Retryable"));
+        TableName tableName = org.apache.hadoop.hbase.TableName.valueOf("schema1", "table1");
+
+        try {
+            connection.scanTable(tableName, mock(Scan.class), (ResultScanner scanner) -> scanner != null);
+        }
+        catch (RuntimeException ex) {
+            logger.info("listTableNamesByNamespaceRetryExhausted: Encountered expected exception.", ex);
+        }
+
+        assertFalse(connection.isHealthy());
+        assertEquals(3, connection.getRetries());
+        verify(mockConnection, atLeastOnce()).getTable(anyObject());
+        verify(mockTable, atLeastOnce()).getScanner(any(Scan.class));
+        logger.info("scanTableRetriesExhausted: exit");
+    }
+
+    @Test
+    public void scanTableWithCallerException()
+            throws IOException
+    {
+        logger.info("scanTable: enter");
+        when(mockConnection.getTable(any(org.apache.hadoop.hbase.TableName.class))).thenReturn(mockTable);
+        when(mockTable.getScanner(any(Scan.class))).thenReturn(mockScanner);
+
+        TableName tableName = org.apache.hadoop.hbase.TableName.valueOf("schema1", "table1");
+        try {
+            connection.scanTable(tableName, mock(Scan.class), (ResultScanner scanner) -> {
+                throw new RuntimeException("Do not retry!");
+            });
+        }
+        catch (RuntimeException ex) {
+            assertTrue(UnrecoverableException.class.equals(ex.getCause().getClass()));
+            logger.info("listTableNamesByNamespaceRetryExhausted: Encountered expected exception.", ex);
+        }
+
+        assertTrue(connection.isHealthy());
+        assertEquals(0, connection.getRetries());
+        verify(mockConnection, atLeastOnce()).getTable(anyObject());
+        verify(mockTable, atLeastOnce()).getScanner(any(Scan.class));
+        logger.info("scanTable: exit");
+    }
+
+    @Test
+    public void close()
+            throws IOException
+    {
+        connection.close();
+        verify(mockConnection, times(1)).close();
+    }
+
+    /**
+     * This stub is used to intercept and reroute calls to connect to HBase itself.
+     */
+    public class HBaseConnectionStub
+            extends HBaseConnection
+    {
+        public HBaseConnectionStub(Connection connection, int maxRetries)
+        {
+            super(connection, maxRetries);
+        }
+
+        @Override
+        protected synchronized Connection connect(Configuration config)
+        {
+            return mockConnection;
+        }
+    }
+}

--- a/athena-hbase/src/test/java/com/amazonaws/athena/connectors/hbase/connection/HbaseConnectionFactoryTest.java
+++ b/athena-hbase/src/test/java/com/amazonaws/athena/connectors/hbase/connection/HbaseConnectionFactoryTest.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,13 +17,13 @@
  * limitations under the License.
  * #L%
  */
-package com.amazonaws.athena.connectors.hbase;
+package com.amazonaws.athena.connectors.hbase.connection;
 
-import org.apache.hadoop.hbase.client.Admin;
-import org.apache.hadoop.hbase.client.Connection;
-import org.junit.After;
+import org.apache.hadoop.hbase.NamespaceDescriptor;
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
@@ -35,6 +35,8 @@ import static org.mockito.Mockito.when;
 
 public class HbaseConnectionFactoryTest
 {
+    private static final Logger logger = LoggerFactory.getLogger(HbaseConnectionFactoryTest.class);
+
     private HbaseConnectionFactory connectionFactory;
 
     @Before
@@ -48,15 +50,17 @@ public class HbaseConnectionFactoryTest
     public void clientCacheHitTest()
             throws IOException
     {
-        Connection mockConn = mock(Connection.class);
-        Admin mockAdmin = mock(Admin.class);
-        when(mockConn.getAdmin()).thenReturn(mockAdmin);
+        logger.info("clientCacheHitTest: enter");
+        HBaseConnection mockConn = mock(HBaseConnection.class);
+        when(mockConn.listNamespaceDescriptors()).thenReturn(new NamespaceDescriptor[] {});
+        when(mockConn.isHealthy()).thenReturn(true);
 
         connectionFactory.addConnection("conStr", mockConn);
-        Connection conn = connectionFactory.getOrCreateConn("conStr");
+        HBaseConnection conn = connectionFactory.getOrCreateConn("conStr");
 
         assertEquals(mockConn, conn);
-        verify(mockConn, times(1)).getAdmin();
-        verify(mockAdmin, times(1)).listTableNames();
+        verify(mockConn, times(1)).listNamespaceDescriptors();
+        verify(mockConn, times(1)).isHealthy();
+        logger.info("clientCacheHitTest: exit");
     }
 }


### PR DESCRIPTION
… support for error aware retry and reconnect.

*Issue #, if available:*
Related to #117 and #120, specifically the fact that we are too aggressive about reusing the hbase client. 

*Description of changes:*
Wrapped the HBase client with an error aware facade that can trigger retry/reconnect for specific types or errors.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
