### PR TITLE
Fix BUG (Issue #140) with SchemaBuilder

### DIFF
--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/SchemaBuilder.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/SchemaBuilder.java
@@ -28,7 +28,6 @@ import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.types.pojo.Schema;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -39,7 +38,8 @@ import java.util.Map;
  */
 public class SchemaBuilder
 {
-    private final Map<String, Field> fields = new HashMap<>();
+    //Using LinkedHashMap to maintain the order of elements in fields and present consistent schema view.
+    private final Map<String, Field> fields = new LinkedHashMap<>();
     private final ImmutableMap.Builder<String, String> metadata = ImmutableMap.builder();
     //Using LinkedHashMap because Apache Arrow makes field order important so honoring that contract here
     private final Map<String, FieldBuilder> nestedFieldBuilderMap = new LinkedHashMap<>();

--- a/athena-jdbc/src/test/java/com/amazonaws/connectors/athena/jdbc/mysql/MySqlRecordHandlerTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/connectors/athena/jdbc/mysql/MySqlRecordHandlerTest.java
@@ -127,24 +127,24 @@ public class MySqlRecordHandlerTest
                 .put("testCol8", valueSet8)
                 .build());
 
-        String expectedSql = "SELECT `testCol7`, `testCol6`, `testCol8`, `testCol3`, `testCol2`, `testCol5`, `testCol4`, `testCol1` FROM `testSchema`.`testTable` PARTITION(p0)  WHERE (`testCol7` = ?) AND (`testCol6` = ?) AND (`testCol8` = ?) AND ((`testCol3` > ? AND `testCol3` <= ?)) AND ((`testCol2` >= ? AND `testCol2` < ?)) AND (`testCol5` = ?) AND (`testCol4` = ?) AND (`testCol1` IN (?,?))";
+        String expectedSql = "SELECT `testCol1`, `testCol2`, `testCol3`, `testCol4`, `testCol5`, `testCol6`, `testCol7`, `testCol8` FROM `testSchema`.`testTable` PARTITION(p0)  WHERE (`testCol1` IN (?,?)) AND ((`testCol2` >= ? AND `testCol2` < ?)) AND ((`testCol3` > ? AND `testCol3` <= ?)) AND (`testCol4` = ?) AND (`testCol5` = ?) AND (`testCol6` = ?) AND (`testCol7` = ?) AND (`testCol8` = ?)";
         PreparedStatement expectedPreparedStatement = Mockito.mock(PreparedStatement.class);
         Mockito.when(this.connection.prepareStatement(Mockito.eq(expectedSql))).thenReturn(expectedPreparedStatement);
 
         PreparedStatement preparedStatement = this.mySqlRecordHandler.buildSplitSql(this.connection, "testCatalogName", tableName, schema, constraints, split);
 
         Assert.assertEquals(expectedPreparedStatement, preparedStatement);
-        Mockito.verify(preparedStatement, Mockito.times(1)).setInt(10, 1);
-        Mockito.verify(preparedStatement, Mockito.times(1)).setInt(11, 2);
-        Mockito.verify(preparedStatement, Mockito.times(1)).setString(6, "1");
-        Mockito.verify(preparedStatement, Mockito.times(1)).setString(7, "10");
-        Mockito.verify(preparedStatement, Mockito.times(1)).setLong(4, 2L);
-        Mockito.verify(preparedStatement, Mockito.times(1)).setLong(5, 20L);
-        Mockito.verify(preparedStatement, Mockito.times(1)).setFloat(9, 1.1F);
+        Mockito.verify(preparedStatement, Mockito.times(1)).setInt(1, 1);
+        Mockito.verify(preparedStatement, Mockito.times(1)).setInt(2, 2);
+        Mockito.verify(preparedStatement, Mockito.times(1)).setString(3, "1");
+        Mockito.verify(preparedStatement, Mockito.times(1)).setString(4, "10");
+        Mockito.verify(preparedStatement, Mockito.times(1)).setLong(5, 2L);
+        Mockito.verify(preparedStatement, Mockito.times(1)).setLong(6, 20L);
+        Mockito.verify(preparedStatement, Mockito.times(1)).setFloat(7, 1.1F);
         Mockito.verify(preparedStatement, Mockito.times(1)).setShort(8, (short) 1);
-        Mockito.verify(preparedStatement, Mockito.times(1)).setByte(2, (byte) 0);
-        Mockito.verify(preparedStatement, Mockito.times(1)).setDouble(1, 1.2d);
-        Mockito.verify(preparedStatement, Mockito.times(1)).setBoolean(3, true);
+        Mockito.verify(preparedStatement, Mockito.times(1)).setByte(9, (byte) 0);
+        Mockito.verify(preparedStatement, Mockito.times(1)).setDouble(10, 1.2d);
+        Mockito.verify(preparedStatement, Mockito.times(1)).setBoolean(11, true);
     }
 
     private ValueSet getSingleValueSet(Object value) {

--- a/athena-jdbc/src/test/java/com/amazonaws/connectors/athena/jdbc/postgresql/PostGreSqlRecordHandlerTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/connectors/athena/jdbc/postgresql/PostGreSqlRecordHandlerTest.java
@@ -129,24 +129,24 @@ public class PostGreSqlRecordHandlerTest extends TestBase
                 .put("testCol8", valueSet8)
                 .build());
 
-        String expectedSql = "SELECT \"testCol7\", \"testCol6\", \"testCol8\", \"testCol3\", \"testCol2\", \"testCol5\", \"testCol4\", \"testCol1\" FROM \"s0\".\"p0\"  WHERE (\"testCol7\" = ?) AND (\"testCol6\" = ?) AND (\"testCol8\" = ?) AND ((\"testCol3\" > ? AND \"testCol3\" <= ?)) AND ((\"testCol2\" >= ? AND \"testCol2\" < ?)) AND (\"testCol5\" = ?) AND (\"testCol4\" = ?) AND (\"testCol1\" IN (?,?))";
+        String expectedSql = "SELECT \"testCol1\", \"testCol2\", \"testCol3\", \"testCol4\", \"testCol5\", \"testCol6\", \"testCol7\", \"testCol8\" FROM \"s0\".\"p0\"  WHERE (\"testCol1\" IN (?,?)) AND ((\"testCol2\" >= ? AND \"testCol2\" < ?)) AND ((\"testCol3\" > ? AND \"testCol3\" <= ?)) AND (\"testCol4\" = ?) AND (\"testCol5\" = ?) AND (\"testCol6\" = ?) AND (\"testCol7\" = ?) AND (\"testCol8\" = ?)";
         PreparedStatement expectedPreparedStatement = Mockito.mock(PreparedStatement.class);
         Mockito.when(this.connection.prepareStatement(Mockito.eq(expectedSql))).thenReturn(expectedPreparedStatement);
 
         PreparedStatement preparedStatement = this.postGreSqlRecordHandler.buildSplitSql(this.connection, "testCatalogName", tableName, schema, constraints, split);
 
         Assert.assertEquals(expectedPreparedStatement, preparedStatement);
-        Mockito.verify(preparedStatement, Mockito.times(1)).setInt(10, 1);
-        Mockito.verify(preparedStatement, Mockito.times(1)).setInt(11, 2);
-        Mockito.verify(preparedStatement, Mockito.times(1)).setString(6, "1");
-        Mockito.verify(preparedStatement, Mockito.times(1)).setString(7, "10");
-        Mockito.verify(preparedStatement, Mockito.times(1)).setLong(4, 2L);
-        Mockito.verify(preparedStatement, Mockito.times(1)).setLong(5, 20L);
-        Mockito.verify(preparedStatement, Mockito.times(1)).setFloat(9, 1.1F);
+        Mockito.verify(preparedStatement, Mockito.times(1)).setInt(1, 1);
+        Mockito.verify(preparedStatement, Mockito.times(1)).setInt(2, 2);
+        Mockito.verify(preparedStatement, Mockito.times(1)).setString(3, "1");
+        Mockito.verify(preparedStatement, Mockito.times(1)).setString(4, "10");
+        Mockito.verify(preparedStatement, Mockito.times(1)).setLong(5, 2L);
+        Mockito.verify(preparedStatement, Mockito.times(1)).setLong(6, 20L);
+        Mockito.verify(preparedStatement, Mockito.times(1)).setFloat(7, 1.1F);
         Mockito.verify(preparedStatement, Mockito.times(1)).setShort(8, (short) 1);
-        Mockito.verify(preparedStatement, Mockito.times(1)).setByte(2, (byte) 0);
-        Mockito.verify(preparedStatement, Mockito.times(1)).setDouble(1, 1.2d);
-        Mockito.verify(preparedStatement, Mockito.times(1)).setBoolean(3, true);
+        Mockito.verify(preparedStatement, Mockito.times(1)).setByte(9, (byte) 0);
+        Mockito.verify(preparedStatement, Mockito.times(1)).setDouble(10, 1.2d);
+        Mockito.verify(preparedStatement, Mockito.times(1)).setBoolean(11, true);
     }
 
     private ValueSet getSingleValueSet(Object value) {


### PR DESCRIPTION
*Issue #, if available:* #140 

*Description of changes:*
Changed fields from HashMap to LinkedHashMap. The latter will maintain the order of the elements inserted and will present a consistent schema view.
Consequently, had to change two tests in the jdbc connector to conform to new SchemaBuider.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
