### PR TITLE
[#172] Fixing DocumentDB schema inference StackOverFlow on empty list…

### DIFF
--- a/athena-docdb/src/test/java/com/amazonaws/athena/connectors/docdb/SchemaUtilsTest.java
+++ b/athena-docdb/src/test/java/com/amazonaws/athena/connectors/docdb/SchemaUtilsTest.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -144,5 +144,51 @@ public class SchemaUtilsTest
         assertEquals(Types.MinorType.VARCHAR, Types.getMinorTypeForArrowType(fields.get("col6").getChildren().get(1).getType()));
         assertEquals(Types.MinorType.VARCHAR, Types.getMinorTypeForArrowType(fields.get("col6").getChildren().get(2).getType()));
         assertEquals(Types.MinorType.FLOAT4, Types.getMinorTypeForArrowType(fields.get("col6").getChildren().get(3).getType()));
+    }
+
+    @Test
+    public void emptyListTest()
+    {
+        List<Document> docs = new ArrayList<>();
+        Document doc1 = new Document();
+        List<String> emptyList = new ArrayList<>();
+        doc1.put("col1", 1);
+        doc1.put("col2", "string");
+        doc1.put("col3", 1.0D);
+        doc1.put("col4", emptyList);
+        docs.add(doc1);
+
+        Document doc2 = new Document();
+        List<Integer> list2 = new ArrayList<>();
+        list2.add(100);
+        doc2.put("col1", 1);
+        doc2.put("col2", "string");
+        doc2.put("col3", 1.0D);
+        doc2.put("col4", list2);
+        docs.add(doc2);
+
+        MongoClient mockClient = mock(MongoClient.class);
+        MongoDatabase mockDatabase = mock(MongoDatabase.class);
+        MongoCollection mockCollection = mock(MongoCollection.class);
+        FindIterable mockIterable = mock(FindIterable.class);
+        when(mockClient.getDatabase(anyObject())).thenReturn(mockDatabase);
+        when(mockDatabase.getCollection(anyObject())).thenReturn(mockCollection);
+        when(mockCollection.find()).thenReturn(mockIterable);
+        when(mockIterable.limit(anyInt())).thenReturn(mockIterable);
+        when(mockIterable.maxScan(anyInt())).thenReturn(mockIterable);
+        when(mockIterable.batchSize(anyInt())).thenReturn(mockIterable);
+        when(mockIterable.iterator()).thenReturn(new StubbingCursor(docs.iterator()));
+
+        Schema schema = SchemaUtils.inferSchema(mockClient, new TableName("test", "test"), 10);
+        assertEquals(4, schema.getFields().size());
+
+        Map<String, Field> fields = new HashMap<>();
+        schema.getFields().stream().forEach(next -> fields.put(next.getName(), next));
+
+        assertEquals(Types.MinorType.INT, Types.getMinorTypeForArrowType(fields.get("col1").getType()));
+        assertEquals(Types.MinorType.VARCHAR, Types.getMinorTypeForArrowType(fields.get("col2").getType()));
+        assertEquals(Types.MinorType.FLOAT8, Types.getMinorTypeForArrowType(fields.get("col3").getType()));
+        assertEquals(Types.MinorType.LIST, Types.getMinorTypeForArrowType(fields.get("col4").getType()));
+        assertEquals(Types.MinorType.VARCHAR, Types.getMinorTypeForArrowType(fields.get("col4").getChildren().get(0).getType()));
     }
 }


### PR DESCRIPTION
… field

*Issue #, if available:* #172 

*Description of changes:*
Fixing DocumentDB schema inference StackOverFlow on empty list by enhancing SchemaUtils to properly handle type erasure by using a fail-safe type (VARCHAR). Also improved logging of schema inference anomalies.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
