### PR TITLE
Updating Guava dependency due to CVE-2018-10237

### DIFF
--- a/athena-federation-sdk/pom.xml
+++ b/athena-federation-sdk/pom.xml
@@ -89,7 +89,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>21.0</version>
+            <version>24.1.1-jre</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/athena-udfs/pom.xml
+++ b/athena-udfs/pom.xml
@@ -31,11 +31,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>21.0</version>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${slf4jVersion}</version>


### PR DESCRIPTION
*Issue #, if available:* #191 

*Description of changes:*
Updating Guava dependency due to CVE-2018-10237

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
