### PR TITLE
Elasticsearch parallel scan support

### DIFF
--- a/athena-elasticsearch/README.md
+++ b/athena-elasticsearch/README.md
@@ -66,11 +66,17 @@ endpoint.
     `=` are used by this connector as separators for the domain-endpoint pairs. Therefor, they 
     should **NOT** be used anywhere inside the stored secret.
 
-5. **spill_bucket** - When the data returned by your Lambda function exceeds Lambda’s limits, 
+4. **query_timeout_cluster** - timeout period (in seconds) for Cluster-Health queries used in the
+generation of parallel scans.
+
+5. **query_timeout_search** - timeout period (in seconds) for Search queries used in the retrieval
+of documents from an index.
+
+6. **spill_bucket** - When the data returned by your Lambda function exceeds Lambda’s limits,
 this is the bucket that the data will be written to for Athena to read the excess from (e.g. 
 my_bucket).
 
-6. **spill_prefix** - (Optional) Defaults to sub-folder in your bucket called 
+7. **spill_prefix** - (Optional) Defaults to sub-folder in your bucket called
 'athena-federation-spill'. Used in conjunction with spill_bucket, this is the path within the 
 above bucket where large responses spill. You should configure an S3 lifecycle on this 
 location to delete old spills after X days/hours.

--- a/athena-elasticsearch/README.md
+++ b/athena-elasticsearch/README.md
@@ -175,11 +175,14 @@ will allow users with permission the ability to deploy instances of the connecto
 
 ## Performance
 
-The Athena Elasticsearch Connector does not currently support parallel scans but will attempt 
-to push down predicates as part of its document search queries (parallel scans will be supported 
-in the next development phase).
+The Athena Elasticsearch Connector supports shard-based parallel scans. Using cluster health information
+retrieved from the Elasticsearch instance, the connector generates multiple requests (for a document
+search query) that are split per shard and run concurrently.
 
-The following example demonstrates this connector's ability to utilize predicate push-down.
+**NOTE: Only primary shards that are active at the time of the query will be considered for parallel scans**.
+
+Additionally, the connector will push down predicates as part of its document search queries. The following
+example demonstrates this connector's ability to utilize predicate push-down.
 
 **Query:**
 ```sql

--- a/athena-elasticsearch/README.md
+++ b/athena-elasticsearch/README.md
@@ -185,8 +185,6 @@ The Athena Elasticsearch Connector supports shard-based parallel scans. Using cl
 retrieved from the Elasticsearch instance, the connector generates multiple requests (for a document
 search query) that are split per shard and run concurrently.
 
-**NOTE: Only primary shards that are active at the time of the query will be considered for parallel scans**.
-
 Additionally, the connector will push down predicates as part of its document search queries. The following
 example demonstrates this connector's ability to utilize predicate push-down.
 

--- a/athena-elasticsearch/athena-elasticsearch.yaml
+++ b/athena-elasticsearch/athena-elasticsearch.yaml
@@ -51,6 +51,12 @@ Parameters:
     Description: "List of one or more domain-names and their respective endpoints (including secret credentials) in the format: domain1=endpoint1,domain2=endpoint2,... (e.g. movies=https://${secret-credentials}:www.mymovies.com)."
     Default: ""
     Type: String
+  QueryTimeoutCluster:
+    Description: "timeout period (in seconds) for Cluster-Health queries used in the generation of parallel scans."
+    Type: Number
+  QueryTimeoutSearch:
+    Description: "timeout period (in seconds) for Search queries used in the retrieval of documents from an index."
+    Type: Number
 Resources:
   ConnectorConfig:
     Type: 'AWS::Serverless::Function'
@@ -62,6 +68,8 @@ Resources:
           spill_prefix: !Ref SpillPrefix
           auto_discover_endpoint: !Ref AutoDiscoverEndpoint
           domain_mapping: !Ref DomainMapping
+          query_timeout_cluster: !Ref QueryTimeoutCluster
+          query_timeout_search: !Ref QueryTimeoutSearch
       FunctionName: !Sub "${AthenaCatalogName}"
       Handler: "com.amazonaws.connectors.athena.elasticsearch.ElasticsearchCompositeHandler"
       CodeUri: "./target/athena-elasticsearch-1.0.jar"

--- a/athena-elasticsearch/athena-elasticsearch.yaml
+++ b/athena-elasticsearch/athena-elasticsearch.yaml
@@ -52,10 +52,12 @@ Parameters:
     Default: ""
     Type: String
   QueryTimeoutCluster:
-    Description: "timeout period (in seconds) for Cluster-Health queries used in the generation of parallel scans."
+    Description: "timeout period (in seconds) for Cluster-Health queries used in the generation of parallel scans (default is 10 seconds)."
+    Default: 10
     Type: Number
   QueryTimeoutSearch:
-    Description: "timeout period (in seconds) for Search queries used in the retrieval of documents from an index."
+    Description: "timeout period (in seconds) for Search queries used in the retrieval of documents from an index (default is 12 minutes)."
+    Default: 720
     Type: Number
 Resources:
   ConnectorConfig:

--- a/athena-elasticsearch/pom.xml
+++ b/athena-elasticsearch/pom.xml
@@ -81,6 +81,20 @@
             <artifactId>aws-java-sdk-elasticsearch</artifactId>
             <version>1.11.759</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.mockito/mockito-core -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.3.3</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/junit/junit -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/athena-elasticsearch/pom.xml
+++ b/athena-elasticsearch/pom.xml
@@ -81,6 +81,12 @@
             <artifactId>aws-java-sdk-elasticsearch</artifactId>
             <version>1.11.759</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient -->
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.12</version>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/org.mockito/mockito-core -->
         <dependency>
             <groupId>org.mockito</groupId>

--- a/athena-elasticsearch/src/main/java/com/amazonaws/connectors/athena/elasticsearch/AwsRestHighLevelClient.java
+++ b/athena-elasticsearch/src/main/java/com/amazonaws/connectors/athena/elasticsearch/AwsRestHighLevelClient.java
@@ -118,10 +118,13 @@ public class AwsRestHighLevelClient
         ClusterHealthResponse response = cluster().health(request, RequestOptions.DEFAULT);
 
         if (response.isTimedOut()) {
-            throw new RuntimeException("Request timed out.");
+            throw new RuntimeException("Request timed out for index (" + index + ").");
         }
         else if (response.getActiveShards() == 0) {
-            throw new RuntimeException("There are no active shards.");
+            throw new RuntimeException("There are no active shards for index (" + index + ").");
+        }
+        else if (index == null || !response.getIndices().containsKey(index)) {
+            throw new RuntimeException("Request has an invalid index (" + (index == null ? "null" : index) + ").");
         }
 
         return response.getIndices().get(index).getShards().keySet();

--- a/athena-elasticsearch/src/main/java/com/amazonaws/connectors/athena/elasticsearch/AwsRestHighLevelClient.java
+++ b/athena-elasticsearch/src/main/java/com/amazonaws/connectors/athena/elasticsearch/AwsRestHighLevelClient.java
@@ -118,19 +118,6 @@ public class AwsRestHighLevelClient
     }
 
     /**
-     * Shuts down the client.
-     */
-    public void shutdown()
-    {
-        try {
-            close();
-        }
-        catch (IOException error) {
-            logger.error("Unable to shutdown client:", error);
-        }
-    }
-
-    /**
      * A builder for the AwsRestHighLevelClient class.
      */
     public static class Builder

--- a/athena-elasticsearch/src/main/java/com/amazonaws/connectors/athena/elasticsearch/AwsRestHighLevelClient.java
+++ b/athena-elasticsearch/src/main/java/com/amazonaws/connectors/athena/elasticsearch/AwsRestHighLevelClient.java
@@ -107,11 +107,11 @@ public class AwsRestHighLevelClient
      * if response is not received within 30 seconds.
      * @param index is used to restrict the request to a specified index.
      * @return a Map of cluster Ids with their associated health information.
-     * @throws IOException if an error occurs while sending the request to the Elasticsearch instance, the request
-     * times out, or no active-primary shards are present.
+     * @throws IOException if an error occurs while sending the request to the Elasticsearch instance.
+     * @throws RuntimeException if the request times out, or no active-primary shards are present.
      */
     public Map<Integer, ClusterShardHealth> getShardHealthInfo(String index)
-            throws IOException
+            throws RuntimeException, IOException
     {
         ClusterHealthRequest request = new ClusterHealthRequest(index).timeout(CLUSTER_HEALTH_TIMEOUT);
         // Set request to shard-level details
@@ -120,10 +120,10 @@ public class AwsRestHighLevelClient
         ClusterHealthResponse response = cluster().health(request, RequestOptions.DEFAULT);
 
         if (response.isTimedOut()) {
-            throw new IOException("Request timed out.");
+            throw new RuntimeException("Request timed out.");
         }
         else if (response.getActivePrimaryShards() == 0) {
-            throw new IOException("There are no active primary shards.");
+            throw new RuntimeException("There are no active primary shards.");
         }
 
         return response.getIndices().get(index).getShards();

--- a/athena-elasticsearch/src/main/java/com/amazonaws/connectors/athena/elasticsearch/AwsRestHighLevelClientFactory.java
+++ b/athena-elasticsearch/src/main/java/com/amazonaws/connectors/athena/elasticsearch/AwsRestHighLevelClientFactory.java
@@ -23,8 +23,6 @@ import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -55,7 +53,7 @@ public class AwsRestHighLevelClientFactory
     /**
      * Stored cache of clients accessible via the endpoint.
      */
-    private final Map<String, AwsRestHighLevelClient> clientCache;
+    private final CacheableAwsRestHighLevelClient clientCache = new CacheableAwsRestHighLevelClient();
 
     /**
      * Constructs a new client factory (using a builder) that will create clients injected with credentials.
@@ -65,7 +63,6 @@ public class AwsRestHighLevelClientFactory
     public AwsRestHighLevelClientFactory(boolean useAwsCredentials)
     {
         this.useAwsCredentials = useAwsCredentials;
-        this.clientCache = new HashMap<>();
     }
 
     /**
@@ -75,7 +72,7 @@ public class AwsRestHighLevelClientFactory
      * @param endpoint is the Elasticsearch instance endpoint.
      * @return an Elasticsearch REST client.
      */
-    public synchronized AwsRestHighLevelClient getClient(String endpoint)
+    public synchronized AwsRestHighLevelClient getOrCreateClient(String endpoint)
     {
         AwsRestHighLevelClient client = clientCache.get(endpoint);
 

--- a/athena-elasticsearch/src/main/java/com/amazonaws/connectors/athena/elasticsearch/AwsRestHighLevelClientFactory.java
+++ b/athena-elasticsearch/src/main/java/com/amazonaws/connectors/athena/elasticsearch/AwsRestHighLevelClientFactory.java
@@ -23,6 +23,8 @@ import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -33,8 +35,6 @@ public class AwsRestHighLevelClientFactory
 {
     private static final Logger logger = LoggerFactory.getLogger(AwsRestHighLevelClientFactory.class);
 
-    private final boolean useAwsCredentials;
-
     /**
      * credentialsPattern is used for parsing out the username/password credentials out of the endpoint with the
      * format: "username@password:" (e.g. if the endpoint is http://myusername@mypassword:www.google.com, then this
@@ -43,28 +43,63 @@ public class AwsRestHighLevelClientFactory
     private static final Pattern credentialsPattern = Pattern.compile("[^/@]+@[^:]+:");
 
     /**
+     * A flag indicating how the created clients will authenticate to an Elasticsearch instance.
+     * If useAwsCredentials = true, the client will be injected with AWS credentials.
+     * If useAwsCredentials = false and username/password are extracted using the credentialsPattern, the client
+     * will be injected with username/password credentials.
+     * If useAwsCredentials = false and username/password are not present, the client will be created with no
+     * credentials.
+     */
+    private final boolean useAwsCredentials;
+
+    /**
+     * Stored cache of clients accessible via the endpoint.
+     */
+    private final Map<String, AwsRestHighLevelClient> clientCache;
+
+    /**
      * Constructs a new client factory (using a builder) that will create clients injected with credentials.
      * @param useAwsCredentials if true the factory create clients injected with AWC credentials.
-     *                              If false, it will create clients injected with username/password credentials.
+     *                          If false, it will create clients injected with username/password credentials.
      */
-    protected AwsRestHighLevelClientFactory(boolean useAwsCredentials)
+    public AwsRestHighLevelClientFactory(boolean useAwsCredentials)
     {
         this.useAwsCredentials = useAwsCredentials;
+        this.clientCache = new HashMap<>();
     }
 
     /**
-     * Gets an Elasticsearch REST client injected with credentials.
+     * Attempts to get a REST client from the client cache synchronously using the endpoint as a key. If the client
+     * does not exist in the cache, createClient() is called to create a new client. The newly created client is
+     * then inserted into the cache and stored for later use.
+     * @param endpoint is the Elasticsearch instance endpoint.
+     * @return an Elasticsearch REST client.
+     */
+    public synchronized AwsRestHighLevelClient getClient(String endpoint)
+    {
+        AwsRestHighLevelClient client = clientCache.get(endpoint);
+
+        if (client == null) {
+            client = createClient(endpoint);
+            clientCache.put(endpoint, client);
+        }
+
+        return client;
+    }
+
+    /**
+     * Creates a new Elasticsearch REST client. If useAwsCredentials = true, the client is injected with AWS
+     * credentials. If useAwsCredentials = false and username/password are extracted using the credentialsPattern,
+     * the client is injected with username/password credentials. Otherwise a default client with no credentials is
+     * returned.
      * @param endpoint is the Elasticsearch instance endpoint. The latter may contain username/password credentials
      *                 for Elasticsearch services that are external to Amazon.
      *                 Examples:
-     *                 1) https://search-movies-ne3fcqzfipy6jcrew2wca6kyqu.us-east-1.es.amazonaws.com
+     *                 1) https://search-movies-ne3yqu.us-east-1.es.amazonaws.com
      *                 2) http://myusername@mypassword:www.google.com
-     * @return an Elasticsearch REST client. If useAwsCredentials = true, the client is injected
-     *          with AWS credentials. If useAwsCredentials = false and username/password are extracted using the
-     *          credentialsPattern, it is injected with username/password credentials. Otherwise a default client
-     *          with no credentials is returned.
+     * @return an Elasticsearch REST client.
      */
-    public AwsRestHighLevelClient getClient(String endpoint)
+    private AwsRestHighLevelClient createClient(String endpoint)
     {
         if (useAwsCredentials) {
             return new AwsRestHighLevelClient.Builder(endpoint)

--- a/athena-elasticsearch/src/main/java/com/amazonaws/connectors/athena/elasticsearch/CacheableAwsRestHighLevelClient.java
+++ b/athena-elasticsearch/src/main/java/com/amazonaws/connectors/athena/elasticsearch/CacheableAwsRestHighLevelClient.java
@@ -1,0 +1,219 @@
+/*-
+ * #%L
+ * athena-elasticsearch
+ * %%
+ * Copyright (C) 2019 - 2020 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.connectors.athena.elasticsearch;
+
+import org.apache.arrow.util.VisibleForTesting;
+import org.elasticsearch.client.RequestOptions;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class CacheableAwsRestHighLevelClient
+{
+    /**
+     * The maximum age allowed for stored clients in milliseconds (15 minutes).
+     */
+    protected static final long MAX_CACHE_AGE_MS = 900_000;
+    /**
+     * The maximum number of clients allowed in the cache.
+     */
+    protected static final int MAX_CACHE_SIZE = 10;
+    /**
+     * Stored cache of clients accessible via the endpoint. This cache has a maximum capacity of 10 clients.
+     * The mechanism for removing clients from the cache is outlined in the following eviction policy:
+     * 1) An age test is performed when a client is retrieved from cache, and upon insertion into cache. Clients that
+     *    have aged out (as indicated by MAX_CACHE_AGE_MS), will be removed.
+     * 2) A health test is performed on a client retrieved from cache. A client that fails the test, will be removed.
+     * 3) A cache capacity test is performed upon insertion into cache. The oldest client will be removed when the
+     *    cache size exceeds capacity (as indicated by MAX_CACHE_SIZE).
+     */
+    private final Map<String, CacheEntry> clientCache = new LinkedHashMap<>();
+
+    public CacheableAwsRestHighLevelClient() {}
+
+    /**
+     * Gets a client from the cache keyed on the endpoint. If the client retrieved has aged out, or is unhealthy,
+     * then evict it.
+     * @param endpoint is the http address associated with the client.
+     * @return a client (if one exist, is age-appropriate, and is healthy), or null (if none of the aforementioned
+     * conditions are met).
+     */
+    public AwsRestHighLevelClient get(String endpoint)
+    {
+        CacheEntry cacheEntry = clientCache.get(endpoint);
+
+        if (cacheEntry != null) {
+            if (cacheEntry.getAge() > MAX_CACHE_AGE_MS) {
+                // Gentle eviction of cache based on client age only.
+                evictCache(false);
+                return null;
+            }
+            if (!clientIsHealthy(cacheEntry.getClient())) {
+                // Forceful eviction of unhealthy client.
+                evictCache(endpoint);
+                return null;
+            }
+        }
+
+        return cacheEntry == null ? null : cacheEntry.getClient();
+    }
+
+    /**
+     * Sets a client in the cache keyed on the endpoint and process cache eviction based on cache capacity limit.
+     * @param endpoint is the http address associated with the client.
+     * @param client is a REST client used for communication with an Elasticsearch instance.
+     */
+    public void put(String endpoint, AwsRestHighLevelClient client)
+    {
+        clientCache.put(endpoint, new CacheEntry(client));
+        // Forceful eviction of cache based on client age and cache capacity limit.
+        evictCache(size() > MAX_CACHE_SIZE);
+    }
+
+    /**
+     * Evicts clients that have aged out, or exceeded the cache's capacity limit as indicated by the force argument.
+     * Evicted clients will be closed in order to free up their resources.
+     * @param force is a flag that indicated whether eviction will be handled forcefully (force = true), or more
+     *              gently (force = false). The latter will only evict based on the age of the client, while the
+     *              former will forcefully evict the oldest client if the cache's capacity has been exceeded.
+     */
+    private void evictCache(boolean force)
+    {
+        Iterator<Map.Entry<String, CacheableAwsRestHighLevelClient.CacheEntry>> itr = clientCache.entrySet().iterator();
+        int removed = 0;
+        while (itr.hasNext()) {
+            CacheableAwsRestHighLevelClient.CacheEntry entry = itr.next().getValue();
+            // If age of client is greater than the maximum allowed, remove it.
+            if (entry.getAge() > MAX_CACHE_AGE_MS) {
+                closeClient(entry.getClient());
+                itr.remove();
+                removed++;
+                continue;
+            }
+            // Since a LinkedHashMap is ordered from older to newer, no need to keep looking once we encounter
+            // an age-appropriate client.
+            break;
+        }
+
+        if (removed == 0 && force) {
+            // Remove the oldest entry since we found no expired entries and cache has exceeded capacity.
+            itr = clientCache.entrySet().iterator();
+            if (itr.hasNext()) {
+                closeClient(itr.next().getValue().getClient());
+                itr.remove();
+            }
+        }
+    }
+
+    /**
+     * Forcefully evict a client whose endpoint is specified from the cache. Evicted clients will be closed in order
+     * to free up their resources.
+     * @param endpoint of the client to be evicted.
+     */
+    private void evictCache(String endpoint)
+    {
+        CacheEntry cacheEntry = clientCache.remove(endpoint);
+        closeClient(cacheEntry.getClient());
+    }
+
+    /**
+     * Test the client's connection by pinging the Elasticsearch cluster.
+     * @param client is the REST client to be tested.
+     * @return true if the client's connection is healthy, false otherwise.
+     */
+    private boolean clientIsHealthy(AwsRestHighLevelClient client)
+    {
+        try {
+            return client.ping(RequestOptions.DEFAULT);
+        }
+        catch (IOException error) {
+            return false;
+        }
+    }
+
+    /**
+     * Frees up all resources held by client after its eviction from the cache.
+     * @param client is the REST client who's just been evicted.
+     */
+    private void closeClient(AwsRestHighLevelClient client)
+    {
+        try {
+            client.close();
+        }
+        catch (IOException error) {
+            // Do nothing.
+        }
+    }
+
+    /**
+     * @return the number of clients stored in the cache.
+     */
+    public int size()
+    {
+        return clientCache.size();
+    }
+
+    @VisibleForTesting
+    protected void addClientEntry(String endpoint, AwsRestHighLevelClient client, long createTime)
+    {
+        clientCache.put(endpoint, new CacheEntry(client, createTime));
+    }
+
+    /**
+     * Clients are stored in the cache using a CacheEntry instance which consists of the client as well as the time
+     * of creation. The latter is used for the age test during the eviction from the cache process.
+     */
+    private class CacheEntry
+    {
+        private final AwsRestHighLevelClient client;
+        private final long createTime;
+
+        public CacheEntry(AwsRestHighLevelClient client)
+        {
+            this(client, System.currentTimeMillis());
+        }
+
+        public CacheEntry(AwsRestHighLevelClient client, long createTime)
+        {
+            this.client = client;
+            this.createTime = createTime;
+        }
+
+        /**
+         * Get the client from the cache entry.
+         * @return the REST client.
+         */
+        public AwsRestHighLevelClient getClient()
+        {
+            return client;
+        }
+
+        /**
+         * Gets the age of the client entry in milliseconds.
+         * @return the calculated age (in millisecond) based on the difference between the current time and createdTime.
+         */
+        public long getAge()
+        {
+            return System.currentTimeMillis() - createTime;
+        }
+    }
+}

--- a/athena-elasticsearch/src/main/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchMetadataHandler.java
+++ b/athena-elasticsearch/src/main/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchMetadataHandler.java
@@ -88,7 +88,7 @@ public class ElasticsearchMetadataHandler
 
     // Env. variable that holds the query timeout period for the Cluster-Health queries.
     private static final String QUERY_TIMEOUT_CLUSTER = "query_timeout_cluster";
-    private Long queryTimeout;
+    private final long queryTimeout;
 
     /**
      * Key used to store shard information in the Split's properties map (later used by the Record Handler).
@@ -117,7 +117,7 @@ public class ElasticsearchMetadataHandler
         this.domainMap = domainMapProvider.getDomainMap(resolveSecrets(getEnv(DOMAIN_MAPPING)));
         this.clientFactory = new AwsRestHighLevelClientFactory(this.autoDiscoverEndpoint);
         this.glueTypeMapper = new ElasticsearchGlueTypeMapper();
-        this.queryTimeout = new Long(getEnv(QUERY_TIMEOUT_CLUSTER));
+        this.queryTimeout = Long.parseLong(getEnv(QUERY_TIMEOUT_CLUSTER));
     }
 
     @VisibleForTesting
@@ -128,7 +128,8 @@ public class ElasticsearchMetadataHandler
                                            String spillBucket,
                                            String spillPrefix,
                                            ElasticsearchDomainMapProvider domainMapProvider,
-                                           AwsRestHighLevelClientFactory clientFactory)
+                                           AwsRestHighLevelClientFactory clientFactory,
+                                           long queryTimeout)
     {
         super(awsGlue, keyFactory, awsSecretsManager, athena, SOURCE_TYPE, spillBucket, spillPrefix);
         this.awsGlue = awsGlue;
@@ -136,7 +137,7 @@ public class ElasticsearchMetadataHandler
         this.domainMap = this.domainMapProvider.getDomainMap(null);
         this.clientFactory = clientFactory;
         this.glueTypeMapper = new ElasticsearchGlueTypeMapper();
-        this.queryTimeout = new Long(30);
+        this.queryTimeout = queryTimeout;
     }
 
     /**

--- a/athena-elasticsearch/src/main/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchMetadataHandler.java
+++ b/athena-elasticsearch/src/main/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchMetadataHandler.java
@@ -52,7 +52,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -292,7 +292,7 @@ public class ElasticsearchMetadataHandler
         logger.debug("doGetSplits: enter - " + request);
 
         // Create set of splits
-        Set<Split> splits = new HashSet<>();
+        Set<Split> splits = new LinkedHashSet<>();
         // Get domain
         String domain = request.getTableName().getSchemaName();
         // Get index

--- a/athena-elasticsearch/src/main/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchMetadataHandler.java
+++ b/athena-elasticsearch/src/main/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchMetadataHandler.java
@@ -180,7 +180,7 @@ public class ElasticsearchMetadataHandler
 
         try {
             String endpoint = getDomainEndpoint(request.getSchemaName());
-            AwsRestHighLevelClient client = clientFactory.getClient(endpoint);
+            AwsRestHighLevelClient client = clientFactory.getOrCreateClient(endpoint);
             try {
                 for (String index : client.getAliases()) {
                     // Add all Indices except for kibana.
@@ -241,7 +241,7 @@ public class ElasticsearchMetadataHandler
             String index = request.getTableName().getTableName();
             try {
                 String endpoint = getDomainEndpoint(request.getTableName().getSchemaName());
-                AwsRestHighLevelClient client = clientFactory.getClient(endpoint);
+                AwsRestHighLevelClient client = clientFactory.getOrCreateClient(endpoint);
                 try {
                     Map<String, Object> mappings = client.getMapping(index);
                     schema = ElasticsearchSchemaUtils.parseMapping(mappings);
@@ -300,7 +300,7 @@ public class ElasticsearchMetadataHandler
 
         try {
             String endpoint = getDomainEndpoint(domain);
-            AwsRestHighLevelClient client = clientFactory.getClient(endpoint);
+            AwsRestHighLevelClient client = clientFactory.getOrCreateClient(endpoint);
             try {
                 Map<Integer, ClusterShardHealth> shardHealthInfo = client.getShardHealthInfo(index);
                 for (Map.Entry<Integer, ClusterShardHealth> entry : shardHealthInfo.entrySet()) {

--- a/athena-elasticsearch/src/main/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchMetadataHandler.java
+++ b/athena-elasticsearch/src/main/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchMetadataHandler.java
@@ -90,7 +90,7 @@ public class ElasticsearchMetadataHandler
     /**
      * Key used to store shard information in the Split's properties map (later used by the Record Handler).
      */
-    private static final String SHARD_KEY = "shard";
+    protected static final String SHARD_KEY = "shard";
     /**
      * Value used in combination with the shard ID to store shard information in the Split's properties map (later
      * used by the Record Handler). The completed value is sent as a request preference to retrieve a specific shard
@@ -306,7 +306,7 @@ public class ElasticsearchMetadataHandler
                 for (Map.Entry<Integer, ClusterShardHealth> entry : shardHealthInfo.entrySet()) {
                     Integer shardId = entry.getKey();
                     ClusterShardHealth shardHealth = entry.getValue();
-                    // Process only primary active shards.
+                    // Process only primary active shards. If a shard is not active it is not available for reading.
                     if (shardHealth.isPrimaryActive()) {
                         // Every split must have a unique location if we wish to spill to avoid failures
                         SpillLocation spillLocation = makeSpillLocation(request);

--- a/athena-elasticsearch/src/main/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchMetadataHandler.java
+++ b/athena-elasticsearch/src/main/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchMetadataHandler.java
@@ -179,9 +179,6 @@ public class ElasticsearchMetadataHandler
             catch (IOException error) {
                 throw new RuntimeException("Error retrieving indices: " + error.getMessage(), error);
             }
-            finally {
-                client.shutdown();
-            }
         }
         catch (RuntimeException error) {
             throw new RuntimeException("Error processing request to list indices: " + error.getMessage(), error);
@@ -237,9 +234,6 @@ public class ElasticsearchMetadataHandler
                 catch (IOException error) {
                     throw new RuntimeException("Error retrieving mapping information for index (" +
                             index + "): " + error.getMessage(), error);
-                }
-                finally {
-                    client.shutdown();
                 }
             }
             catch (RuntimeException error) {

--- a/athena-elasticsearch/src/main/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchRecordHandler.java
+++ b/athena-elasticsearch/src/main/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchRecordHandler.java
@@ -166,9 +166,6 @@ public class ElasticsearchRecordHandler
             catch (IOException error) {
                 throw new RuntimeException("Error sending query: " + error.getMessage(), error);
             }
-            finally {
-                client.shutdown();
-            }
         }
 
         logger.info("readWithConstraint: numRows[{}]", numRows);

--- a/athena-elasticsearch/src/main/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchRecordHandler.java
+++ b/athena-elasticsearch/src/main/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchRecordHandler.java
@@ -145,7 +145,7 @@ public class ElasticsearchRecordHandler
         long numRows = 0;
 
         if (queryStatusChecker.isQueryRunning()) {
-            AwsRestHighLevelClient client = clientFactory.getClient(endpoint);
+            AwsRestHighLevelClient client = clientFactory.getOrCreateClient(endpoint);
             try {
                 // Create field extractors for all data types in the schema.
                 GeneratedRowWriter rowWriter = createFieldExtractors(recordsRequest);

--- a/athena-elasticsearch/src/main/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchRecordHandler.java
+++ b/athena-elasticsearch/src/main/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchRecordHandler.java
@@ -70,12 +70,6 @@ public class ElasticsearchRecordHandler
     private static final int QUERY_BATCH_SIZE = 100;
 
     /**
-     * Key used to retrieve shard information from the Split's properties map sent as a request preference to retrieve
-     * a specific shard (e.g. "_shards:5" - retrieve shard number 5).
-     */
-    private static final String SHARD_KEY = "shard";
-
-    /**
      * Timeout period for the search document request (60 seconds).
      */
     private final TimeValue searchDocumentTimeout = new TimeValue(60, TimeUnit.SECONDS);
@@ -141,7 +135,7 @@ public class ElasticsearchRecordHandler
 
         String domain = recordsRequest.getTableName().getSchemaName();
         String endpoint = recordsRequest.getSplit().getProperty(domain);
-        String shard = recordsRequest.getSplit().getProperty(SHARD_KEY);
+        String shard = recordsRequest.getSplit().getProperty(ElasticsearchMetadataHandler.SHARD_KEY);
         long numRows = 0;
 
         if (queryStatusChecker.isQueryRunning()) {

--- a/athena-elasticsearch/src/test/java/com/amazonaws/connectors/athena/elasticsearch/CacheableAwsRestHighLevelClientTest.java
+++ b/athena-elasticsearch/src/test/java/com/amazonaws/connectors/athena/elasticsearch/CacheableAwsRestHighLevelClientTest.java
@@ -1,0 +1,158 @@
+/*-
+ * #%L
+ * athena-elasticsearch
+ * %%
+ * Copyright (C) 2019 - 2020 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.connectors.athena.elasticsearch;
+
+import org.elasticsearch.client.RequestOptions;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * This class is used to test the CacheableAwsRestHighLevelClient class.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class CacheableAwsRestHighLevelClientTest
+{
+    private static final Logger logger = LoggerFactory.getLogger(CacheableAwsRestHighLevelClientTest.class);
+
+    private CacheableAwsRestHighLevelClient clientCache;
+
+    @Mock
+    AwsRestHighLevelClient client1;
+
+    @Mock
+    AwsRestHighLevelClient client2;
+
+    @Before
+    public void setup()
+    {
+        clientCache = new CacheableAwsRestHighLevelClient();
+    }
+
+    /**
+     * Test the cache's ability to return the correct client.
+     */
+    @Test
+    public void getClientSimpleTest()
+            throws IOException
+    {
+        logger.info("getClientSimpleTest - enter");
+
+        clientCache.put("endpoint1", client1);
+        clientCache.put("endpoint2", client2);
+
+        when(client1.ping(RequestOptions.DEFAULT)).thenReturn(true);
+        when(client2.ping(RequestOptions.DEFAULT)).thenReturn(true);
+
+        assertEquals("Cache has wrong number of clients.", 2, clientCache.size());
+        assertNotNull("Cache get() method returned null.", clientCache.get("endpoint1"));
+        assertNotNull("Cache get() method returned null.", clientCache.get("endpoint2"));
+        assertEquals("Wrong client returned from cache.", client1, clientCache.get("endpoint1"));
+        assertEquals("Wrong client returned from cache.", client2, clientCache.get("endpoint2"));
+
+        logger.info("getClientSimpleTest - exit");
+    }
+
+    /**
+     * Test the cache's ability to evict clients that have aged out (as indicated by MAX_CACHE_AGE_MS).
+     */
+    @Test
+    public void evictOldClientTest()
+            throws IOException
+    {
+        logger.info("evictOldClientTest - enter");
+
+        // Test eviction on the get() method.
+        clientCache.addClientEntry("endpoint1", client1, System.currentTimeMillis() -
+                CacheableAwsRestHighLevelClient.MAX_CACHE_AGE_MS - 1);
+
+        assertEquals("Cache has wrong number of clients.", 1, clientCache.size());
+        assertNull("Invalid value returned from cache.", clientCache.get("endpoint1"));
+        assertEquals("Cache has wrong number of clients.", 0, clientCache.size());
+
+        // Test eviction on the put() method.
+        when(client2.ping(any())).thenReturn(true);
+        clientCache.addClientEntry("endpoint1", client1, System.currentTimeMillis() -
+                CacheableAwsRestHighLevelClient.MAX_CACHE_AGE_MS - 1);
+
+        assertEquals("Cache has wrong number of clients.", 1, clientCache.size());
+
+        clientCache.put("endpoint2", client2);
+
+        assertEquals("Cache has wrong number of clients.", 1, clientCache.size());
+        assertNotNull("Cache get() method returned null.", clientCache.get("endpoint2"));
+        assertEquals("Wrong client returned from cache.", client2, clientCache.get("endpoint2"));
+
+        logger.info("evictOldClientTest - exit");
+    }
+
+    /**
+     * Test the cache's ability to evict unhealthy clients.
+     */
+    @Test
+    public void evictUnhealthyClientTest()
+            throws IOException
+    {
+        logger.info("evictUnhealthyClientTest - enter");
+
+        when(client1.ping(any())).thenReturn(false);
+        clientCache.put("endpoint1", client1);
+
+        assertEquals("Cache has wrong number of clients.", 1, clientCache.size());
+        assertNull("Invalid value returned from cache.", clientCache.get("endpoint1"));
+        assertEquals("Cache has wrong number of clients.", 0, clientCache.size());
+
+        logger.info("evictUnhealthyClientTest - exit");
+    }
+
+    /**
+     * Test the cache's ability to evict the oldest clients when the cache's capacity is exceeded (as indicated by
+     * MAX_CACHE_SIZE).
+     */
+    @Test
+    public void evictExceededCapacityClientTest()
+    {
+        logger.info("evictExceededCapacityClientTest - enter");
+
+        clientCache.put("endpoint1", client1);
+        for (int i = 0; i < CacheableAwsRestHighLevelClient.MAX_CACHE_SIZE; ++i) {
+            String endpoint = "newendpoint" + i;
+            clientCache.put(endpoint, client2);
+        }
+
+        assertEquals("Cache has wrong number of clients.",
+                CacheableAwsRestHighLevelClient.MAX_CACHE_SIZE, clientCache.size());
+        assertNull("Invalid value returned from cache.", clientCache.get("endpoint1"));
+
+        logger.info("evictExceededCapacityClientTest - exit");
+    }
+}

--- a/athena-elasticsearch/src/test/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchDomainMapProviderTest.java
+++ b/athena-elasticsearch/src/test/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchDomainMapProviderTest.java
@@ -21,7 +21,7 @@ package com.amazonaws.connectors.athena.elasticsearch;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/athena-elasticsearch/src/test/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchFieldResolverTest.java
+++ b/athena-elasticsearch/src/test/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchFieldResolverTest.java
@@ -30,7 +30,7 @@ import org.apache.arrow.vector.types.pojo.Schema;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/athena-elasticsearch/src/test/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchGlueTypeMapperTest.java
+++ b/athena-elasticsearch/src/test/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchGlueTypeMapperTest.java
@@ -19,7 +19,6 @@
  */
 package com.amazonaws.connectors.athena.elasticsearch;
 
-import com.amazonaws.athena.connector.lambda.security.LocalKeyFactory;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.junit.Test;

--- a/athena-elasticsearch/src/test/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchGlueTypeMapperTest.java
+++ b/athena-elasticsearch/src/test/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchGlueTypeMapperTest.java
@@ -24,7 +24,7 @@ import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/athena-elasticsearch/src/test/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchMetadataHandlerTest.java
+++ b/athena-elasticsearch/src/test/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchMetadataHandlerTest.java
@@ -120,8 +120,8 @@ public class ElasticsearchMetadataHandlerTest
         when(domainMapProvider.getDomainMap(null)).thenReturn(ImmutableMap.of("domain1", "endpoint1",
                 "domain2", "endpoint2","domain3", "endpoint3"));
 
-        handler = new ElasticsearchMetadataHandler(awsGlue, new LocalKeyFactory(), awsSecretsManager,
-                amazonAthena, "spill-bucket", "spill-prefix", domainMapProvider, clientFactory);
+        handler = new ElasticsearchMetadataHandler(awsGlue, new LocalKeyFactory(), awsSecretsManager, amazonAthena,
+                "spill-bucket", "spill-prefix", domainMapProvider, clientFactory, 10);
 
         ListSchemasRequest req = new ListSchemasRequest(fakeIdentity(), "queryId", "elasticsearch");
         ListSchemasResponse realDomains = handler.doListSchemaNames(allocator, req);
@@ -182,8 +182,8 @@ public class ElasticsearchMetadataHandlerTest
         // Get real indices.
         when(domainMapProvider.getDomainMap(null)).thenReturn(ImmutableMap.of("movies",
                 "https://search-movies-ne3fcqzfipy6jcrew2wca6kyqu.us-east-1.es.amazonaws.com"));
-        handler = new ElasticsearchMetadataHandler(awsGlue, new LocalKeyFactory(), awsSecretsManager,
-                amazonAthena, "spill-bucket", "spill-prefix", domainMapProvider, clientFactory);
+        handler = new ElasticsearchMetadataHandler(awsGlue, new LocalKeyFactory(), awsSecretsManager, amazonAthena,
+                "spill-bucket", "spill-prefix", domainMapProvider, clientFactory, 10);
         when(mockClient.getAliases()).thenReturn(ImmutableSet.of("movies", ".kibana_1", "customer"));
 
         ListTablesRequest req = new ListTablesRequest(fakeIdentity(),
@@ -354,8 +354,8 @@ public class ElasticsearchMetadataHandlerTest
         // Get real mapping.
         when(domainMapProvider.getDomainMap(null)).thenReturn(ImmutableMap.of("movies",
                 "https://search-movies-ne3fcqzfipy6jcrew2wca6kyqu.us-east-1.es.amazonaws.com"));
-        handler = new ElasticsearchMetadataHandler(awsGlue, new LocalKeyFactory(), awsSecretsManager,
-                amazonAthena, "spill-bucket", "spill-prefix", domainMapProvider, clientFactory);
+        handler = new ElasticsearchMetadataHandler(awsGlue, new LocalKeyFactory(), awsSecretsManager, amazonAthena,
+                "spill-bucket", "spill-prefix", domainMapProvider, clientFactory,10);
         GetTableRequest req = new GetTableRequest(fakeIdentity(), "queryId", "elasticsearch",
                 new TableName("movies", "mishmash"));
         GetTableResponse res = handler.doGetTable(allocator, req);
@@ -408,8 +408,8 @@ public class ElasticsearchMetadataHandlerTest
                 .of(new Integer(0), new Integer(1), new Integer(2)));
 
         // Instantiate handler
-        handler = new ElasticsearchMetadataHandler(awsGlue, new LocalKeyFactory(), awsSecretsManager,
-                amazonAthena, "spill-bucket", "spill-prefix", domainMapProvider, clientFactory);
+        handler = new ElasticsearchMetadataHandler(awsGlue, new LocalKeyFactory(), awsSecretsManager, amazonAthena,
+                "spill-bucket", "spill-prefix", domainMapProvider, clientFactory, 10);
 
         // Call doGetSplits()
         MetadataResponse rawResponse = handler.doGetSplits(allocator, req);
@@ -450,8 +450,8 @@ public class ElasticsearchMetadataHandlerTest
     {
         logger.info("convertFieldTest: enter");
 
-        handler = new ElasticsearchMetadataHandler(awsGlue, new LocalKeyFactory(), awsSecretsManager,
-                amazonAthena, "spill-bucket", "spill-prefix", domainMapProvider, clientFactory);
+        handler = new ElasticsearchMetadataHandler(awsGlue, new LocalKeyFactory(), awsSecretsManager, amazonAthena,
+                "spill-bucket", "spill-prefix", domainMapProvider, clientFactory, 10);
 
         Field field = handler.convertField("myscaled", "SCALED_FLOAT(10.51)");
 

--- a/athena-elasticsearch/src/test/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchMetadataHandlerTest.java
+++ b/athena-elasticsearch/src/test/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchMetadataHandlerTest.java
@@ -95,7 +95,7 @@ public class ElasticsearchMetadataHandlerTest
         logger.info("setUpBefore - enter");
 
         allocator = new BlockAllocatorImpl();
-        when(clientFactory.getClient(anyString())).thenReturn(mockClient);
+        when(clientFactory.getOrCreateClient(anyString())).thenReturn(mockClient);
 
         logger.info("setUpBefore - exit");
     }

--- a/athena-elasticsearch/src/test/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchQueryUtilsTest.java
+++ b/athena-elasticsearch/src/test/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchQueryUtilsTest.java
@@ -33,7 +33,7 @@ import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/athena-elasticsearch/src/test/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchRecordHandlerTest.java
+++ b/athena-elasticsearch/src/test/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchRecordHandlerTest.java
@@ -291,7 +291,7 @@ public class ElasticsearchRecordHandlerTest
         when(mockClient.getDocuments(any())).thenReturn(mockResponse);
         when(mockClient.getDocument(any())).thenReturn(document1, document2);
 
-        handler = new ElasticsearchRecordHandler(amazonS3, awsSecretsManager, athena, clientFactory);
+        handler = new ElasticsearchRecordHandler(amazonS3, awsSecretsManager, athena, clientFactory, 720);
 
         logger.info("setUpBefore - exit");
     }

--- a/athena-elasticsearch/src/test/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchRecordHandlerTest.java
+++ b/athena-elasticsearch/src/test/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchRecordHandlerTest.java
@@ -81,8 +81,8 @@ import java.util.UUID;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 
@@ -249,7 +249,7 @@ public class ElasticsearchRecordHandlerTest
 
         allocator = new BlockAllocatorImpl();
 
-        when(amazonS3.putObject(anyObject(), anyObject(), anyObject(), anyObject()))
+        when(amazonS3.putObject(any(), any(), any(), any()))
                 .thenAnswer(new Answer<Object>()
                 {
                     @Override
@@ -287,9 +287,9 @@ public class ElasticsearchRecordHandlerTest
                 .add("movies", "https://search-movies-ne3fcqzfipy6jcrew2wca6kyqu.us-east-1.es.amazonaws.com")
                 .build();
 
-        when(clientFactory.getClient(anyString())).thenReturn(mockClient);
-        when(mockClient.getDocuments(anyObject())).thenReturn(mockResponse);
-        when(mockClient.getDocument(anyObject())).thenReturn(document1, document2);
+        when(clientFactory.getOrCreateClient(anyString())).thenReturn(mockClient);
+        when(mockClient.getDocuments(any())).thenReturn(mockResponse);
+        when(mockClient.getDocument(any())).thenReturn(document1, document2);
 
         handler = new ElasticsearchRecordHandler(amazonS3, awsSecretsManager, athena, clientFactory);
 

--- a/athena-elasticsearch/src/test/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchRecordHandlerTest.java
+++ b/athena-elasticsearch/src/test/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchRecordHandlerTest.java
@@ -63,7 +63,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/athena-elasticsearch/src/test/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchSchemaUtilsTest.java
+++ b/athena-elasticsearch/src/test/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchSchemaUtilsTest.java
@@ -30,7 +30,7 @@ import org.apache.arrow.vector.types.pojo.Schema;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/athena-elasticsearch/src/test/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchTypeUtilsTest.java
+++ b/athena-elasticsearch/src/test/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchTypeUtilsTest.java
@@ -47,7 +47,7 @@ import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/athena-elasticsearch/src/test/resources/mockito-extensions/README.md
+++ b/athena-elasticsearch/src/test/resources/mockito-extensions/README.md
@@ -1,4 +1,4 @@
-#Mockito Configuration
+# Mockito Configuration
 
 The file `org.mockito.plugins.MockMaker` contains a configuration (**mock-maker-inline**) allowing Mockito to mock
 methods and objects declared `final`.

--- a/athena-elasticsearch/src/test/resources/mockito-extensions/README.md
+++ b/athena-elasticsearch/src/test/resources/mockito-extensions/README.md
@@ -1,0 +1,12 @@
+#Mockito Configuration
+
+The file `org.mockito.plugins.MockMaker` contains a configuration (**mock-maker-inline**) allowing Mockito to mock
+methods and objects declared `final`.
+
+**NOTE: Failure to include this configuration will result in a runtime error when attempting to mock final methods
+and objects:**
+
+```
+Mockito cannot mock/spy because :
+– final class
+```

--- a/athena-elasticsearch/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/athena-elasticsearch/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
*Issue #, if available:*
#180 #77 
*Description of changes:*
1. Added support for parallel scans.

1. Added a client cache for client reusability.

1. Upgraded the testing platform.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
