### PR TITLE
fixed issue with span function for null values

### DIFF
--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/domain/predicate/Range.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/domain/predicate/Range.java
@@ -153,9 +153,9 @@ public class Range
 
     public Range span(Range other)
     {
-        Marker lowMarker = Marker.min(low, other.getLow());
-        Marker highMarker = Marker.max(high, other.getHigh());
-
+        Marker lowMarker = low.isNullValue() ? other.getLow() : Marker.min(low, other.getLow());
+        Marker highMarker = other.getHigh().isNullValue() ? high : Marker.max(high, other.getHigh());
+        
         return new Range(lowMarker, highMarker);
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes: When adding multiple ranges to constraints map, the ranges are merged to get correct high and low values. The merge operation has been failing for null values. Final range after merge has both high and low values as null*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
