### PR TITLE
Fixed issue with span function for null values

### DIFF
--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/domain/predicate/Range.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/domain/predicate/Range.java
@@ -153,9 +153,9 @@ public class Range
 
     public Range span(Range other)
     {
-        Marker lowMarker = Marker.min(low, other.getLow());
-        Marker highMarker = Marker.max(high, other.getHigh());
-
+        Marker lowMarker = low.isNullValue() ? other.getLow() : Marker.min(low, other.getLow());
+        Marker highMarker = other.getHigh().isNullValue() ? high : Marker.max(high, other.getHigh());
+        
         return new Range(lowMarker, highMarker);
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes: Multiple range values in constraint map are merged to get high and low values. Currently it produces both high and low values as null. Added code to do a null check inside Range.span function*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
