### PR TITLE
Remove reflection code that doesn't work in DDB type inference

### DIFF
--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/util/DDBTypeUtils.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/util/DDBTypeUtils.java
@@ -71,7 +71,7 @@ public final class DDBTypeUtils
      */
     public static Field inferArrowField(String key, Object value)
     {
-        logger.debug("inferArrowField invoked for key {} with value {} of class {}", key, value,
+        logger.debug("inferArrowField invoked for key {} of class {}", key,
                 value != null ? value.getClass() : null);
         if (value == null) {
             return null;

--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/util/DDBTypeUtils.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/util/DDBTypeUtils.java
@@ -71,6 +71,8 @@ public final class DDBTypeUtils
      */
     public static Field inferArrowField(String key, Object value)
     {
+        logger.debug("inferArrowField invoked for key {} with value {} of class {}", key, value,
+                value != null ? value.getClass() : null);
         if (value == null) {
             return null;
         }
@@ -90,14 +92,8 @@ public final class DDBTypeUtils
         else if (value instanceof List || value instanceof Set) {
             Field child = null;
             if (((Collection) value).isEmpty()) {
-                try {
-                    Object subVal = ((Collection) value).getClass()
-                            .getTypeParameters()[0].getGenericDeclaration().newInstance();
-                    child = inferArrowField(key + ".child", subVal);
-                }
-                catch (IllegalAccessException | InstantiationException ex) {
-                    throw new RuntimeException(ex);
-                }
+                logger.warn("Automatic schema inference encountered empty List or Set {}. Unable to determine element types. Falling back to VARCHAR representation", key);
+                child = inferArrowField("", "");
             }
             else {
                 Iterator iterator = ((Collection) value).iterator();


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* If user has an empty List we were trying to infer the element type using reflection, but due to type erasure that would never work, so removed it and added fallback to string/varchar.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
