### PR TITLE
Alias column name normalization for DynamoDB

### DIFF
--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/util/DDBPredicateUtils.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/util/DDBPredicateUtils.java
@@ -136,7 +136,9 @@ public class DDBPredicateUtils
     }
 
     /**
-     * Generates a simple alias for a column to satisfy filter expressions.
+     * Generates a simple alias for a column to satisfy filter expressions. Uses a regex to convert illegal characters
+     * (any character or combination of characters that are NOT included in [a-zA-Z_0-9]) to underscore.
+     * Example: "column-$1`~!@#$%^&*()-=+[]{}\\|;:'\",.<>/?f3" -> "#column_1_f3"
      *
      * @see <a href="https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.ExpressionAttributeNames.html">
      *     https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.ExpressionAttributeNames.html</a>
@@ -145,7 +147,7 @@ public class DDBPredicateUtils
      */
     public static String aliasColumn(String columnName)
     {
-        return "#" + columnName;
+        return "#" + columnName.replaceAll("\\W+", "_");
     }
 
     /*

--- a/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DDBPredicateUtilsTest.java
+++ b/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DDBPredicateUtilsTest.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * athena-dynamodb
+ * %%
+ * Copyright (C) 2019 - 2020 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.amazonaws.athena.connectors.dynamodb;
 
 import com.amazonaws.athena.connectors.dynamodb.util.DDBPredicateUtils;
@@ -18,9 +37,9 @@ public class DDBPredicateUtilsTest
     private static final Logger logger = LoggerFactory.getLogger(DDBPredicateUtilsTest.class);
 
     @Test
-    public void aliasColumnTest()
+    public void testAliasColumn()
     {
-        logger.info("aliasColumnTest - enter");
+        logger.info("testAliasColumn - enter");
 
         assertEquals("Unexpected alias column value!", "#column_1",
                 DDBPredicateUtils.aliasColumn("column_1"));
@@ -31,6 +50,6 @@ public class DDBPredicateUtilsTest
         assertEquals("Unexpected alias column value!", "#column_1_f3F",
                 DDBPredicateUtils.aliasColumn("column-$1`~!@#$%^&*()-=+[]{}\\|;:'\",.<>/?f3F"));
 
-        logger.info("aliasColumnTest - exit");
+        logger.info("testAliasColumn - exit");
     }
 }

--- a/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DDBPredicateUtilsTest.java
+++ b/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DDBPredicateUtilsTest.java
@@ -1,0 +1,36 @@
+package com.amazonaws.athena.connectors.dynamodb;
+
+import com.amazonaws.athena.connectors.dynamodb.util.DDBPredicateUtils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests DynamoDB utility methods relating to predicate handling.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class DDBPredicateUtilsTest
+{
+    private static final Logger logger = LoggerFactory.getLogger(DDBPredicateUtilsTest.class);
+
+    @Test
+    public void aliasColumnTest()
+    {
+        logger.info("aliasColumnTest - enter");
+
+        assertEquals("Unexpected alias column value!", "#column_1",
+                DDBPredicateUtils.aliasColumn("column_1"));
+        assertEquals("Unexpected alias column value!", "#column__1",
+                DDBPredicateUtils.aliasColumn("column__1"));
+        assertEquals("Unexpected alias column value!", "#column_1",
+                DDBPredicateUtils.aliasColumn("column-1"));
+        assertEquals("Unexpected alias column value!", "#column_1_f3F",
+                DDBPredicateUtils.aliasColumn("column-$1`~!@#$%^&*()-=+[]{}\\|;:'\",.<>/?f3F"));
+
+        logger.info("aliasColumnTest - exit");
+    }
+}


### PR DESCRIPTION
**Issue #, if available:** N/A

**Description of changes:**
This fixes an exception caused by dashes or other special characters in the alias column's name:  
`com.amazonaws.services.dynamodbv2.model.AmazonDynamoDBException: ExpressionAttributeNames contains invalid key: Syntax error; key: "#fle-status" (Service: AmazonDynamoDBv2; Status Code: 400; Error Code: ValidationException;`

**Fix**: Convert illegal characters in the attribute aliases (any character or combination of characters that are NOT included in [a-zA-Z_0-9]) to underscore. 

**Example**: ```"column-$1`~!@#$%^&*()-=+[]{}\\|;:'\",.<>/?f3"``` -> ```"#column_1_f3"```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
