### PR TITLE
Supplemental Glue metadata definition support for ARRAY<STRUCT<...>> (#184)

### DIFF
--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/metadata/glue/GlueFieldLexer.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/metadata/glue/GlueFieldLexer.java
@@ -95,7 +95,8 @@ public class GlueFieldLexer
         else if (startToken.getValue().toLowerCase().equals(LIST)) {
             GlueTypeParser.Token arrayType = parser.next();
             Field child;
-            if (arrayType.getValue().toLowerCase().equals(STRUCT)) {
+            String type = arrayType.getValue().toLowerCase();
+            if (type.equals(STRUCT) || type.equals(LIST)) {
                 child = lexComplex(name, arrayType, parser, mapper);
             }
             else {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/metadata/glue/GlueFieldLexer.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/metadata/glue/GlueFieldLexer.java
@@ -94,8 +94,14 @@ public class GlueFieldLexer
         }
         else if (startToken.getValue().toLowerCase().equals(LIST)) {
             GlueTypeParser.Token arrayType = parser.next();
-            return FieldBuilder.newBuilder(name, Types.MinorType.LIST.getType())
-                    .addField(mapper.getField(name, arrayType.getValue())).build();
+            Field child;
+            if (arrayType.getValue().toLowerCase().equals(STRUCT)) {
+                child = lexComplex(name, arrayType, parser, mapper);
+            }
+            else {
+                child = mapper.getField(name, arrayType.getValue());
+            }
+            return FieldBuilder.newBuilder(name, Types.MinorType.LIST.getType()).addField(child).build();
         }
         else {
             throw new RuntimeException("Unexpected start type " + startToken.getValue());

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/metadata/glue/GlueFieldLexerTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/metadata/glue/GlueFieldLexerTest.java
@@ -42,6 +42,8 @@ public class GlueFieldLexerTest
 
     private static final String INPUT4 = "ARRAY<STRUCT<last:STRING,mi:STRING,first:STRING>>";
 
+    private static final String INPUT5 = "ARRAY<ARRAY<STRUCT<last:STRING,mi:STRING,first:STRING, aliases:ARRAY<STRING>>>>";
+
     @Test
     public void basicLexTest()
     {
@@ -129,5 +131,38 @@ public class GlueFieldLexerTest
         assertEquals(Types.MinorType.VARCHAR, Types.getMinorTypeForArrowType(child.getChildren().get(2).getType()));
 
         logger.info("arrayOfStructLexComplexTest: exit");
+    }
+
+    @Test
+    public void nestedArrayLexComplexTest() {
+        logger.info("nestedArrayLexComplexTest: enter");
+
+        Field field = GlueFieldLexer.lex("namelist", INPUT5);
+
+        logger.info("lexTest: {}", field);
+
+        assertEquals("namelist", field.getName());
+        assertEquals(Types.MinorType.LIST, Types.getMinorTypeForArrowType(field.getType()));
+
+        Field level1 = field.getChildren().get(0);
+        assertEquals(Types.MinorType.LIST, Types.getMinorTypeForArrowType(level1.getType()));
+
+        Field level2 = level1.getChildren().get(0);
+        assertEquals(Types.MinorType.STRUCT, Types.getMinorTypeForArrowType(level2.getType()));
+        assertEquals(4, level2.getChildren().size());
+        assertEquals("last", level2.getChildren().get(0).getName());
+        assertEquals(Types.MinorType.VARCHAR, Types.getMinorTypeForArrowType(level2.getChildren().get(0).getType()));
+        assertEquals("mi", level2.getChildren().get(1).getName());
+        assertEquals(Types.MinorType.VARCHAR, Types.getMinorTypeForArrowType(level2.getChildren().get(1).getType()));
+        assertEquals("first", level2.getChildren().get(2).getName());
+        assertEquals(Types.MinorType.VARCHAR, Types.getMinorTypeForArrowType(level2.getChildren().get(2).getType()));
+        assertEquals("aliases", level2.getChildren().get(3).getName());
+
+        Field level3 = level2.getChildren().get(3);
+        assertEquals(Types.MinorType.LIST, Types.getMinorTypeForArrowType(level3.getType()));
+        assertEquals("aliases", level3.getChildren().get(0).getName());
+        assertEquals(Types.MinorType.VARCHAR, Types.getMinorTypeForArrowType(level3.getChildren().get(0).getType()));
+
+        logger.info("nestedArrayLexComplexTest: exit");
     }
 }

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/metadata/glue/GlueFieldLexerTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/metadata/glue/GlueFieldLexerTest.java
@@ -40,6 +40,8 @@ public class GlueFieldLexerTest
 
     private static final String INPUT3 = "INT";
 
+    private static final String INPUT4 = "ARRAY<STRUCT<last:STRING,mi:STRING,first:STRING>>";
+
     @Test
     public void basicLexTest()
     {
@@ -104,5 +106,28 @@ public class GlueFieldLexerTest
         assertEquals(Types.MinorType.VARCHAR, Types.getMinorTypeForArrowType(level1.get(2).getChildren().get(0).getType()));
 
         logger.info("lexTest: exit");
+    }
+
+    @Test
+    public void arrayOfStructLexComplexTest() {
+        logger.info("arrayOfStructLexComplexTest: enter");
+
+        Field field = GlueFieldLexer.lex("namelist", INPUT4);
+
+        logger.info("lexTest: {}", field);
+
+        assertEquals("namelist", field.getName());
+        assertEquals(Types.MinorType.LIST, Types.getMinorTypeForArrowType(field.getType()));
+        Field child = field.getChildren().get(0);
+        assertEquals(Types.MinorType.STRUCT, Types.getMinorTypeForArrowType(child.getType()));
+        assertEquals(3, child.getChildren().size());
+        assertEquals("last", child.getChildren().get(0).getName());
+        assertEquals(Types.MinorType.VARCHAR, Types.getMinorTypeForArrowType(child.getChildren().get(0).getType()));
+        assertEquals("mi", child.getChildren().get(1).getName());
+        assertEquals(Types.MinorType.VARCHAR, Types.getMinorTypeForArrowType(child.getChildren().get(1).getType()));
+        assertEquals("first", child.getChildren().get(2).getName());
+        assertEquals(Types.MinorType.VARCHAR, Types.getMinorTypeForArrowType(child.getChildren().get(2).getType()));
+
+        logger.info("arrayOfStructLexComplexTest: exit");
     }
 }


### PR DESCRIPTION
**Issue #, if available:** #184 (and possibly #100)

**Description of changes:**
Added supplemental Glue metadata definition support for ARRAY<STRUCT<...>> and ARRAY<ARRAY<...>> including any nested permutations of the latter and former. Added unit tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
