### PR TITLE
[#231] Glue lex support for multi-array struct STRUCT<ARRAY<>, ARRAY<>>.

### DIFF
--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/metadata/glue/GlueFieldLexer.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/metadata/glue/GlueFieldLexer.java
@@ -112,6 +112,14 @@ public class GlueFieldLexer
             Field child = lex(parser.next(), parser, mapper);
             fieldBuilder.addField(child);
             if (Types.getMinorTypeForArrowType(child.getType()) == Types.MinorType.LIST) {
+                // An ARRAY Glue type (LIST in Arrow) within a STRUCT has the same ending token as a STRUCT (">" or
+                // GlueTypeParser.FIELD_END). If allowed to proceed, the Glue parser will misinterpret the end of the
+                // ARRAY to be the end of the STRUCT (which is currently being processed) ending the loop prematurely
+                // and causing all subsequent fields in the STRUCT to be dropped.
+                // Example: movies: STRUCT<actors:ARRAY<STRING>,genre:ARRAY<STRING>>
+                // will result in Field definition: movies: Struct<actors: List<actors: Utf8>>.
+                // In order to prevent that from happening, we must consume an additional token to get past the LIST's
+                // ending token ">".
                 parser.next();
             }
         }

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/metadata/glue/GlueFieldLexer.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/metadata/glue/GlueFieldLexer.java
@@ -111,6 +111,9 @@ public class GlueFieldLexer
         while (parser.hasNext() && parser.currentToken().getMarker() != GlueTypeParser.FIELD_END) {
             Field child = lex(parser.next(), parser, mapper);
             fieldBuilder.addField(child);
+            if (Types.getMinorTypeForArrowType(child.getType()) == Types.MinorType.LIST) {
+                parser.next();
+            }
         }
         parser.next();
 

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/metadata/glue/GlueFieldLexerTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/metadata/glue/GlueFieldLexerTest.java
@@ -113,7 +113,8 @@ public class GlueFieldLexerTest
     }
 
     @Test
-    public void arrayOfStructLexComplexTest() {
+    public void arrayOfStructLexComplexTest()
+    {
         logger.info("arrayOfStructLexComplexTest: enter");
 
         Field field = GlueFieldLexer.lex("namelist", INPUT4);
@@ -136,7 +137,8 @@ public class GlueFieldLexerTest
     }
 
     @Test
-    public void nestedArrayLexComplexTest() {
+    public void nestedArrayLexComplexTest()
+    {
         logger.info("nestedArrayLexComplexTest: enter");
 
         Field field = GlueFieldLexer.lex("namelist", INPUT5);
@@ -169,8 +171,9 @@ public class GlueFieldLexerTest
     }
 
     @Test
-    public void multiArrayStructLexComplexTest() {
-        logger.info("nestedArrayLexComplexTest: enter");
+    public void multiArrayStructLexComplexTest()
+    {
+        logger.info("multiArrayStructLexComplexTest: enter");
 
         Field field = GlueFieldLexer.lex("movie_info", INPUT6);
 
@@ -187,5 +190,7 @@ public class GlueFieldLexerTest
         Field array2 = field.getChildren().get(1);
         assertEquals(Types.MinorType.LIST, Types.getMinorTypeForArrowType(array2.getType()));
         assertEquals("genre", array2.getChildren().get(0).getName());
+
+        logger.info("multiArrayStructLexComplexTest: exit");
     }
 }

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/metadata/glue/GlueFieldLexerTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/metadata/glue/GlueFieldLexerTest.java
@@ -44,6 +44,8 @@ public class GlueFieldLexerTest
 
     private static final String INPUT5 = "ARRAY<ARRAY<STRUCT<last:STRING,mi:STRING,first:STRING, aliases:ARRAY<STRING>>>>";
 
+    private static final String INPUT6 = "STRUCT<actors:ARRAY<STRING>,genre:ARRAY<STRING>>";
+
     @Test
     public void basicLexTest()
     {
@@ -164,5 +166,26 @@ public class GlueFieldLexerTest
         assertEquals(Types.MinorType.VARCHAR, Types.getMinorTypeForArrowType(level3.getChildren().get(0).getType()));
 
         logger.info("nestedArrayLexComplexTest: exit");
+    }
+
+    @Test
+    public void multiArrayStructLexComplexTest() {
+        logger.info("nestedArrayLexComplexTest: enter");
+
+        Field field = GlueFieldLexer.lex("movie_info", INPUT6);
+
+        logger.info("lexTest: {}", field);
+
+        assertEquals(Types.MinorType.STRUCT, Types.getMinorTypeForArrowType(field.getType()));
+        assertEquals("movie_info", field.getName());
+        assertEquals(2, field.getChildren().size());
+
+        Field array1 = field.getChildren().get(0);
+        assertEquals(Types.MinorType.LIST, Types.getMinorTypeForArrowType(array1.getType()));
+        assertEquals("actors", array1.getChildren().get(0).getName());
+
+        Field array2 = field.getChildren().get(1);
+        assertEquals(Types.MinorType.LIST, Types.getMinorTypeForArrowType(array2.getType()));
+        assertEquals("genre", array2.getChildren().get(0).getName());
     }
 }


### PR DESCRIPTION
**Issue #, if available:** #231

**Description of changes:** Added support for supplemental Glue metadata when parsing a field defined as a STRUCT containing multiple arrays attributes (e.g. `STRUCT<actors:ARRAY<STRING>,genre:ARRAY<STRING>>`).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
