### PR TITLE
Updating FederatedIdentity to include more detailed caller identification for Federated Authorization

### DIFF
--- a/athena-aws-cmdb/athena-aws-cmdb.yaml
+++ b/athena-aws-cmdb/athena-aws-cmdb.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2020.34.1
+    SemanticVersion: 2020.35.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AthenaCatalogName:

--- a/athena-aws-cmdb/pom.xml
+++ b/athena-aws-cmdb/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>${aws-athena-federation-sdk.version}</version>
+            <version>2020.35.1</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>

--- a/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/AwsCmdbMetadataHandlerTest.java
+++ b/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/AwsCmdbMetadataHandlerTest.java
@@ -72,7 +72,7 @@ public class AwsCmdbMetadataHandlerTest
     private String bucket = "bucket";
     private String prefix = "prefix";
     private String queryId = "queryId";
-    private FederatedIdentity identity = new FederatedIdentity("id", "principal", "account");
+    private FederatedIdentity identity = new FederatedIdentity("arn", "account", Collections.emptyMap(), Collections.emptyList());
 
     @Mock
     private AmazonS3 mockS3;

--- a/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/AwsCmdbRecordHandlerTest.java
+++ b/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/AwsCmdbRecordHandlerTest.java
@@ -57,7 +57,7 @@ public class AwsCmdbRecordHandlerTest
     private String bucket = "bucket";
     private String prefix = "prefix";
     private EncryptionKeyFactory keyFactory = new LocalKeyFactory();
-    private FederatedIdentity identity = new FederatedIdentity("id", "principal", "account");
+    private FederatedIdentity identity = new FederatedIdentity("arn", "account", Collections.emptyMap(), Collections.emptyList());
 
     @Mock
     private AmazonS3 mockS3;

--- a/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/AbstractTableProviderTest.java
+++ b/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/AbstractTableProviderTest.java
@@ -63,6 +63,7 @@ import org.slf4j.LoggerFactory;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -81,7 +82,7 @@ public abstract class AbstractTableProviderTest
 
     private BlockAllocator allocator;
 
-    private FederatedIdentity identity = new FederatedIdentity("id", "principal", "account");
+    private FederatedIdentity identity = new FederatedIdentity("arn", "account", Collections.emptyMap(), Collections.emptyList());
     private String idField = getIdField();
     private String idValue = getIdValue();
     private String expectedQuery = "queryId";

--- a/athena-cloudwatch-metrics/athena-cloudwatch-metrics.yaml
+++ b/athena-cloudwatch-metrics/athena-cloudwatch-metrics.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2020.34.1
+    SemanticVersion: 2020.35.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AthenaCatalogName:

--- a/athena-cloudwatch-metrics/pom.xml
+++ b/athena-cloudwatch-metrics/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>${aws-athena-federation-sdk.version}</version>
+            <version>2020.35.1</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>

--- a/athena-cloudwatch-metrics/src/test/java/com/amazonaws/athena/connectors/cloudwatch/metrics/MetricUtilsTest.java
+++ b/athena-cloudwatch-metrics/src/test/java/com/amazonaws/athena/connectors/cloudwatch/metrics/MetricUtilsTest.java
@@ -63,7 +63,7 @@ import static org.junit.Assert.*;
 
 public class MetricUtilsTest
 {
-    private FederatedIdentity identity = new FederatedIdentity("id", "principal", "account");
+    private FederatedIdentity identity = new FederatedIdentity("arn", "account", Collections.emptyMap(), Collections.emptyList());
     private String catalog = "default";
     private BlockAllocator allocator;
 

--- a/athena-cloudwatch-metrics/src/test/java/com/amazonaws/athena/connectors/cloudwatch/metrics/MetricsMetadataHandlerTest.java
+++ b/athena-cloudwatch-metrics/src/test/java/com/amazonaws/athena/connectors/cloudwatch/metrics/MetricsMetadataHandlerTest.java
@@ -83,7 +83,7 @@ public class MetricsMetadataHandlerTest
     private static final Logger logger = LoggerFactory.getLogger(MetricsMetadataHandlerTest.class);
 
     private final String defaultSchema = "default";
-    private final FederatedIdentity identity = new FederatedIdentity("id", "principal", "account");
+    private final FederatedIdentity identity = new FederatedIdentity("arn", "account", Collections.emptyMap(), Collections.emptyList());
 
     private MetricsMetadataHandler handler;
     private BlockAllocator allocator;

--- a/athena-cloudwatch-metrics/src/test/java/com/amazonaws/athena/connectors/cloudwatch/metrics/MetricsRecordHandlerTest.java
+++ b/athena-cloudwatch-metrics/src/test/java/com/amazonaws/athena/connectors/cloudwatch/metrics/MetricsRecordHandlerTest.java
@@ -102,7 +102,7 @@ public class MetricsRecordHandlerTest
     private static final TableName METRICS_TABLE_NAME = new TableName("default", METRIC_TABLE.getName());
     private static final TableName METRIC_SAMPLES_TABLE_NAME = new TableName("default", METRIC_DATA_TABLE.getName());
 
-    private FederatedIdentity identity = new FederatedIdentity("id", "principal", "account");
+    private FederatedIdentity identity = new FederatedIdentity("arn", "account", Collections.emptyMap(), Collections.emptyList());
     private List<ByteHolder> mockS3Storage;
     private MetricsRecordHandler handler;
     private S3BlockSpillReader spillReader;

--- a/athena-cloudwatch/athena-cloudwatch.yaml
+++ b/athena-cloudwatch/athena-cloudwatch.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2020.34.1
+    SemanticVersion: 2020.35.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AthenaCatalogName:

--- a/athena-cloudwatch/pom.xml
+++ b/athena-cloudwatch/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>${aws-athena-federation-sdk.version}</version>
+            <version>2020.35.1</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>

--- a/athena-cloudwatch/src/test/java/com/amazonaws/athena/connectors/cloudwatch/CloudwatchMetadataHandlerTest.java
+++ b/athena-cloudwatch/src/test/java/com/amazonaws/athena/connectors/cloudwatch/CloudwatchMetadataHandlerTest.java
@@ -84,7 +84,7 @@ public class CloudwatchMetadataHandlerTest
 {
     private static final Logger logger = LoggerFactory.getLogger(CloudwatchMetadataHandlerTest.class);
 
-    private FederatedIdentity identity = new FederatedIdentity("id", "principal", "account");
+    private FederatedIdentity identity = new FederatedIdentity("arn", "account", Collections.emptyMap(), Collections.emptyList());
     private CloudwatchMetadataHandler handler;
     private BlockAllocator allocator;
 

--- a/athena-cloudwatch/src/test/java/com/amazonaws/athena/connectors/cloudwatch/CloudwatchRecordHandlerTest.java
+++ b/athena-cloudwatch/src/test/java/com/amazonaws/athena/connectors/cloudwatch/CloudwatchRecordHandlerTest.java
@@ -66,6 +66,7 @@ import org.slf4j.LoggerFactory;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -83,7 +84,7 @@ public class CloudwatchRecordHandlerTest
 {
     private static final Logger logger = LoggerFactory.getLogger(CloudwatchRecordHandlerTest.class);
 
-    private FederatedIdentity identity = new FederatedIdentity("id", "principal", "account");
+    private FederatedIdentity identity = new FederatedIdentity("arn", "account", Collections.emptyMap(), Collections.emptyList());
     private List<ByteHolder> mockS3Storage;
     private CloudwatchRecordHandler handler;
     private S3BlockSpillReader spillReader;

--- a/athena-docdb/athena-docdb.yaml
+++ b/athena-docdb/athena-docdb.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2020.34.1
+    SemanticVersion: 2020.35.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AthenaCatalogName:

--- a/athena-docdb/pom.xml
+++ b/athena-docdb/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>${aws-athena-federation-sdk.version}</version>
+            <version>2020.35.1</version>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
                 <exclusion>

--- a/athena-docdb/src/test/java/com/amazonaws/athena/connectors/docdb/DocDBRecordHandlerTest.java
+++ b/athena-docdb/src/test/java/com/amazonaws/athena/connectors/docdb/DocDBRecordHandlerTest.java
@@ -74,6 +74,7 @@ import org.slf4j.LoggerFactory;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/athena-docdb/src/test/java/com/amazonaws/athena/connectors/docdb/TestBase.java
+++ b/athena-docdb/src/test/java/com/amazonaws/athena/connectors/docdb/TestBase.java
@@ -22,8 +22,10 @@ package com.amazonaws.athena.connectors.docdb;
 import com.amazonaws.athena.connector.lambda.domain.TableName;
 import com.amazonaws.athena.connector.lambda.security.FederatedIdentity;
 
+import java.util.Collections;
+
 public class TestBase {
-    protected static final FederatedIdentity IDENTITY = new FederatedIdentity("id", "principal", "account");
+    protected static final FederatedIdentity IDENTITY = new FederatedIdentity("arn", "account", Collections.emptyMap(), Collections.emptyList());
     protected static final String QUERY_ID = "query_id";
     protected static final String PARTITION_ID = "partition_id";
     protected static final String DEFAULT_CATALOG = "default";

--- a/athena-dynamodb/athena-dynamodb.yaml
+++ b/athena-dynamodb/athena-dynamodb.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2020.34.1
+    SemanticVersion: 2020.35.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AthenaCatalogName:

--- a/athena-dynamodb/pom.xml
+++ b/athena-dynamodb/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>${aws-athena-federation-sdk.version}</version>
+            <version>2020.35.1</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>

--- a/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/TestBase.java
+++ b/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/TestBase.java
@@ -50,6 +50,7 @@ import org.junit.BeforeClass;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -60,7 +61,7 @@ import static com.amazonaws.services.dynamodbv2.document.ItemUtils.toItem;
 
 public class TestBase
 {
-    protected FederatedIdentity TEST_IDENTITY = new FederatedIdentity("id", "principal", "account");
+    protected FederatedIdentity TEST_IDENTITY = new FederatedIdentity("arn", "account", Collections.emptyMap(), Collections.emptyList());
     protected static final String TEST_QUERY_ID = "queryId";
     protected static final String TEST_CATALOG_NAME = "default";
     protected static final String TEST_TABLE = "test_table";

--- a/athena-elasticsearch/athena-elasticsearch.yaml
+++ b/athena-elasticsearch/athena-elasticsearch.yaml
@@ -10,7 +10,7 @@ Metadata:
     ReadmeUrl: README.md
     Labels: ['athena-federation']
     HomePageUrl: https://github.com/awslabs/aws-athena-query-federation
-    SemanticVersion: 2020.34.1
+    SemanticVersion: 2020.35.1
     SourceCodeUrl: https://github.com/awslabs/aws-athena-query-federation
 
 # Parameters are CloudFormation features to pass input

--- a/athena-elasticsearch/pom.xml
+++ b/athena-elasticsearch/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>${aws-athena-federation-sdk.version}</version>
+            <version>2020.35.1</version>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
                 <exclusion>

--- a/athena-elasticsearch/src/test/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchMetadataHandlerTest.java
+++ b/athena-elasticsearch/src/test/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchMetadataHandlerTest.java
@@ -442,7 +442,10 @@ public class ElasticsearchMetadataHandlerTest
 
     private static FederatedIdentity fakeIdentity()
     {
-        return new FederatedIdentity("access_key_id", "principle", "account");
+        return new FederatedIdentity("access_key_id",
+            "principle",
+            Collections.emptyMap(),
+            Collections.emptyList());
     }
 
     @Test

--- a/athena-elasticsearch/src/test/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchRecordHandlerTest.java
+++ b/athena-elasticsearch/src/test/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchRecordHandlerTest.java
@@ -440,7 +440,10 @@ public class ElasticsearchRecordHandlerTest
 
     private static FederatedIdentity fakeIdentity()
     {
-        return new FederatedIdentity("access_key_id", "principle", "account");
+        return new FederatedIdentity("access_key_id",
+            "principle",
+            Collections.emptyMap(),
+            Collections.emptyList());
     }
 
     private SpillLocation makeSpillLocation()

--- a/athena-example/athena-example.yaml
+++ b/athena-example/athena-example.yaml
@@ -10,7 +10,7 @@ Metadata:
     ReadmeUrl: README.md
     Labels: ['athena-federation']
     HomePageUrl: https://github.com/awslabs/aws-athena-query-federation
-    SemanticVersion: 2020.34.1
+    SemanticVersion: 2020.35.1
     SourceCodeUrl: https://github.com/awslabs/aws-athena-query-federation
 
 # Parameters are CloudFormation features to pass input

--- a/athena-example/pom.xml
+++ b/athena-example/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>${aws-athena-federation-sdk.version}</version>
+            <version>2020.35.1</version>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
                 <exclusion>

--- a/athena-example/src/test/java/com/amazonaws/connectors/athena/example/ExampleMetadataHandlerTest.java
+++ b/athena-example/src/test/java/com/amazonaws/connectors/athena/example/ExampleMetadataHandlerTest.java
@@ -55,6 +55,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -314,6 +315,6 @@ public class ExampleMetadataHandlerTest
 
     private static FederatedIdentity fakeIdentity()
     {
-        return new FederatedIdentity("access_key_id", "principle", "account");
+        return new FederatedIdentity("arn", "account", Collections.emptyMap(), Collections.emptyList());
     }
 }

--- a/athena-example/src/test/java/com/amazonaws/connectors/athena/example/ExampleRecordHandlerTest.java
+++ b/athena-example/src/test/java/com/amazonaws/connectors/athena/example/ExampleRecordHandlerTest.java
@@ -52,6 +52,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.UnsupportedEncodingException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -190,7 +191,7 @@ public class ExampleRecordHandlerTest
 
     private static FederatedIdentity fakeIdentity()
     {
-        return new FederatedIdentity("access_key_id", "principle", "account");
+        return new FederatedIdentity("arn", "account", Collections.emptyMap(), Collections.emptyList());
     }
 
     private SpillLocation makeSpillLocation()

--- a/athena-federation-sdk-tools/pom.xml
+++ b/athena-federation-sdk-tools/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>${aws-athena-federation-sdk.version}</version>
+            <version>2020.35.1</version>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
                 <exclusion>

--- a/athena-federation-sdk-tools/src/main/java/com/amazonaws/athena/connector/validation/ConnectorValidator.java
+++ b/athena-federation-sdk-tools/src/main/java/com/amazonaws/athena/connector/validation/ConnectorValidator.java
@@ -44,6 +44,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
@@ -400,9 +401,10 @@ public class ConnectorValidator
       this.tableId = tableId;
       this.constraints = constraints;
       this.planningOnly = planningOnly;
-      this.identity = new FederatedIdentity("VALIDATION_ACCESS_KEY",
-                                            "VALIDATION_PRINCIPAL",
-                                            "VALIDATION_ACCOUNT");
+      this.identity = new FederatedIdentity("VALIDATION_ARN",
+                                            "VALIDATION_ACCOUNT",
+                                            Collections.emptyMap(),
+                                            Collections.emptyList());
     }
 
     public FederatedIdentity getIdentity()

--- a/athena-federation-sdk/athena-federation-sdk.yaml
+++ b/athena-federation-sdk/athena-federation-sdk.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2020.34.1
+    SemanticVersion: 2020.35.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AthenaCatalogName:
@@ -47,7 +47,7 @@ Resources:
           spill_prefix: !Ref SpillPrefix
       FunctionName: !Ref AthenaCatalogName
       Handler: "com.amazonaws.athena.connector.lambda.examples.ExampleCompositeHandler"
-      CodeUri: "./target/aws-athena-federation-sdk-2020.34.1-withdep.jar"
+      CodeUri: "./target/aws-athena-federation-sdk-2020.35.1-withdep.jar"
       Description: "This connector enables Amazon Athena to communicate with a randomly generated data source."
       Runtime: java8
       Timeout: !Ref LambdaTimeout

--- a/athena-federation-sdk/pom.xml
+++ b/athena-federation-sdk/pom.xml
@@ -5,9 +5,15 @@
 
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>com.amazonaws</groupId>
+        <artifactId>aws-athena-query-federation</artifactId>
+        <version>1.0</version>
+    </parent>
+
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-athena-federation-sdk</artifactId>
-    <version>2020.34.1</version>
+    <version>2020.35.1</version>
     <packaging>jar</packaging>
     <name>Amazon Athena Query Federation SDK</name>
 

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/examples/ExampleMetadataHandler.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/examples/ExampleMetadataHandler.java
@@ -159,7 +159,7 @@ public class ExampleMetadataHandler
     private void logCaller(FederationRequest request)
     {
         FederatedIdentity identity = request.getIdentity();
-        logger.info("logCaller: account[" + identity.getAccount() + "] id[" + identity.getId() + "]  principal[" + identity.getPrincipal() + "]");
+        logger.info("logCaller: account[" + identity.getAccount() + "] arn[" + identity.getArn() + "]");
     }
 
     /**

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/examples/ExampleRecordHandler.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/examples/ExampleRecordHandler.java
@@ -158,7 +158,7 @@ public class ExampleRecordHandler
     private void logCaller(FederationRequest request)
     {
         FederatedIdentity identity = request.getIdentity();
-        logger.info("logCaller: account[" + identity.getAccount() + "] id[" + identity.getId() + "]  principal[" + identity.getPrincipal() + "]");
+        logger.info("logCaller: account[" + identity.getAccount() + "] arn[" + identity.getArn() + "]");
     }
 
     /**

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/security/FederatedIdentity.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/security/FederatedIdentity.java
@@ -23,41 +23,78 @@ package com.amazonaws.athena.connector.lambda.security;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
 /**
  * Defines the identity of the Athena caller. This is used in many of the SDK's request objects to convey to your
  * connector or UDF the identity of the caller that triggered the subsequent Lambda invocation.
  */
 public class FederatedIdentity
 {
-    public final String id;
-    public final String principal;
-    public final String account;
+    private final String arn;
+    private final String account;
+    private final Map<String, String> principalTags;
+    private final List<String> iamGroups;
 
     @JsonCreator
-    public FederatedIdentity(@JsonProperty("id") String id,
-            @JsonProperty("principal") String principal,
-            @JsonProperty("account") String account)
+    public FederatedIdentity(@JsonProperty("arn") String arn,
+                             @JsonProperty("account") String account,
+                             @JsonProperty("principalTags") Map<String, String> principalTags,
+                             @JsonProperty("iamGroups") List<String> iamGroups)
     {
-        this.id = id;
-        this.principal = principal;
+        this.arn = arn;
         this.account = account;
+        this.principalTags = principalTags;
+        this.iamGroups = iamGroups;
     }
 
-    @JsonProperty("id")
-    public String getId()
+    @JsonProperty("arn")
+    public String getArn()
     {
-        return id;
-    }
-
-    @JsonProperty("principal")
-    public String getPrincipal()
-    {
-        return principal;
+        return arn;
     }
 
     @JsonProperty("account")
     public String getAccount()
     {
         return account;
+    }
+
+    @JsonProperty("principalTags")
+    public Map<String, String> getPrincipalTags()
+    {
+        return principalTags;
+    }
+
+    @JsonProperty("iamGroups")
+    public List<String> getIamGroups()
+    {
+        return iamGroups;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        FederatedIdentity that = (FederatedIdentity) o;
+        return arn.equals(that.arn) &&
+                       account.equals(that.account) &&
+                       principalTags.equals(that.principalTags) &&
+                       iamGroups.equals(that.iamGroups);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(arn, account, principalTags, iamGroups);
     }
 }

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/BaseSerializer.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/BaseSerializer.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Map;
 
 public abstract class BaseSerializer<T> extends StdSerializer<T>
 {
@@ -65,20 +66,39 @@ public abstract class BaseSerializer<T> extends StdSerializer<T>
      * Helper used to help serialize a list of strings.
      *
      * @param jgen The json generator to use.
-     * @param fieldname The name to associated to the resulting json array.
+     * @param fieldName The name to associated to the resulting json array.
      * @param values The values to populate the array with.
      * @throws IOException If an error occurs while writing to the generator.
      */
-    protected void writeStringArray(JsonGenerator jgen, String fieldname, Collection<String> values)
+    protected void writeStringArray(JsonGenerator jgen, String fieldName, Collection<String> values)
             throws IOException
     {
-        jgen.writeArrayFieldStart(fieldname);
+        jgen.writeArrayFieldStart(fieldName);
 
         for (String nextElement : values) {
             jgen.writeString(nextElement);
         }
 
         jgen.writeEndArray();
+    }
+
+    /**
+     * Helper used to help serialize a list of strings.
+     *
+     * @param jgen The json generator to use.
+     * @param fieldName The name to associated to the resulting json array.
+     * @param values The values to populate the array with.
+     * @throws IOException If an error occurs while writing to the generator.
+     */
+    protected void writeStringMap(JsonGenerator jgen, String fieldName, Map<String, String> values) throws IOException
+    {
+        jgen.writeObjectFieldStart(fieldName);
+
+        for (Map.Entry<String, String> entry : values.entrySet()) {
+            jgen.writeStringField(entry.getKey(), entry.getValue());
+        }
+
+        jgen.writeEndObject();
     }
 
     /**

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/security/IdentityUtil.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/security/IdentityUtil.java
@@ -20,12 +20,14 @@ package com.amazonaws.athena.connector.lambda.security;
  * #L%
  */
 
+import java.util.Collections;
+
 public class IdentityUtil
 {
     private IdentityUtil() {}
 
     public static FederatedIdentity fakeIdentity()
     {
-        return new FederatedIdentity("access_key_id", "principle", "account");
+        return new FederatedIdentity("arn", "account", Collections.emptyMap(), Collections.emptyList());
     }
 }

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/serde/ObjectMapperUtil.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/serde/ObjectMapperUtil.java
@@ -25,8 +25,6 @@ import com.amazonaws.athena.connector.lambda.data.BlockAllocatorImpl;
 import com.amazonaws.athena.connector.lambda.request.FederationRequest;
 import com.amazonaws.athena.connector.lambda.request.FederationResponse;
 import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,18 +37,9 @@ import static org.junit.Assert.assertEquals;
 
 public class ObjectMapperUtil
 {
-    private static final Logger logger = LoggerFactory.getLogger(ObjectMapperUtil.class);
-
-    private static JsonFactory jsonFactory = new JsonFactory();
-
     private ObjectMapperUtil() {}
 
     public static <T> void assertSerialization(Object object)
-    {
-        assertSerialization(object, false);
-    }
-
-    public static <T> void assertSerialization(Object object, boolean failOnCompatibilityChecks)
     {
         Class<?> clazz = object.getClass();
         if (object instanceof FederationRequest)
@@ -61,40 +50,10 @@ public class ObjectMapperUtil
         try (BlockAllocator allocator = new BlockAllocatorImpl()){
             // check SerDe write, SerDe read
             ByteArrayOutputStream serDeOut = new ByteArrayOutputStream();
-            JsonGenerator jgen = jsonFactory.createGenerator(serDeOut);
             ObjectMapper serDe = VersionedObjectMapperFactory.create(allocator);
-            serDe.writeValue(jgen, object);
-            jgen.close();
+            serDe.writeValue(serDeOut, object);
             byte[] serDeOutput = serDeOut.toByteArray();
-            JsonParser jparser = jsonFactory.createParser(new ByteArrayInputStream(serDeOutput));
-            assertEquals(object, serDe.readValue(jparser, clazz));
-
-            // TODO remove when ObjectMapper is deprecated
-            ObjectMapper mapper = ObjectMapperFactory.create(allocator);
-            ByteArrayOutputStream mapperOut = new ByteArrayOutputStream();
-            mapper.writeValue(mapperOut, object);
-            byte[] mapperOutput = mapperOut.toByteArray();
-            // also check ObjectMapper write, SerDe read compatibility
-            jparser = jsonFactory.createParser(mapperOutput);
-            try {
-                assertEquals(object, serDe.readValue(jparser, clazz));
-            }
-            catch (Exception e) {
-                if (failOnCompatibilityChecks) {
-                    throw e;
-                }
-                logger.warn("Object serialized with ObjectMapper not deserializable with SerDe", e);
-            }
-            // also check SerDe write, ObjectMapper read compatibility
-            try {
-                assertEquals(object, mapper.readValue(serDeOutput, object.getClass()));
-            }
-            catch (Exception e) {
-                if (failOnCompatibilityChecks) {
-                    throw e;
-                }
-                logger.warn("Object serialized with SerDe not deserializable with ObjectMapper", e);
-            }
+            assertEquals(object, serDe.readValue(new ByteArrayInputStream(serDeOutput), clazz));
         }
         catch (IOException | AssertionError ex) {
             throw new RuntimeException(ex);

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/serde/PingRequestSerDeTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/serde/PingRequestSerDeTest.java
@@ -77,7 +77,7 @@ public class PingRequestSerDeTest extends TypedSerDeTest<FederationRequest>
         logger.info("deserialize: deserialized[{}]", actual);
 
         assertEquals(expected, actual);
-        assertEquals(expected.getIdentity().getId(), actual.getIdentity().getId());
+        assertEquals(expected.getIdentity().getArn(), actual.getIdentity().getArn());
 
         logger.info("deserialize: exit");
     }
@@ -85,7 +85,7 @@ public class PingRequestSerDeTest extends TypedSerDeTest<FederationRequest>
     @Test
     public void testBackwardsCompatibility()
     {
-        ObjectMapperUtil.assertSerialization(expected, true);
+        ObjectMapperUtil.assertSerialization(expected);
     }
 
     @Test
@@ -102,7 +102,7 @@ public class PingRequestSerDeTest extends TypedSerDeTest<FederationRequest>
         logger.info("testForwardsCompatibility: deserialized[{}]", actual);
 
         assertEquals(expected, actual);
-        assertEquals(expected.getIdentity().getId(), actual.getIdentity().getId());
+        assertEquals(expected.getIdentity().getArn(), actual.getIdentity().getArn());
 
         logger.info("testForwardsCompatibility: exit");
     }

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/serde/PingResponseSerDeTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/serde/PingResponseSerDeTest.java
@@ -84,7 +84,7 @@ public class PingResponseSerDeTest extends TypedSerDeTest<FederationResponse>
     @Test
     public void testBackwardsCompatibility()
     {
-        ObjectMapperUtil.assertSerialization(expected, true);
+        ObjectMapperUtil.assertSerialization(expected);
     }
 
     @Test

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/serde/TypedSerDeTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/serde/TypedSerDeTest.java
@@ -29,13 +29,15 @@ import org.junit.After;
 import org.junit.Before;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 
 public abstract class TypedSerDeTest<T>
 {
     protected TestUtils utils = new TestUtils();
     protected BlockAllocator allocator;
     protected ObjectMapper mapper;
-    protected FederatedIdentity federatedIdentity = new FederatedIdentity("test-id", "test-principal", "0123456789");
+    protected FederatedIdentity federatedIdentity = new FederatedIdentity("testArn", "0123456789", Collections.emptyMap(), Collections.emptyList());
     protected String expectedSerDeText;
     protected T expected;
 

--- a/athena-federation-sdk/src/test/resources/serde/PingRequest.json
+++ b/athena-federation-sdk/src/test/resources/serde/PingRequest.json
@@ -1,9 +1,12 @@
 {
   "@type" : "PingRequest",
   "identity" : {
-    "id" : "test-id",
-    "principal" : "test-principal",
-    "account" : "0123456789"
+    "id" : "UNKNOWN",
+    "principal" : "UNKNOWN",
+    "account" : "0123456789",
+    "arn" : "testArn",
+    "tags" : { },
+    "groups" : [ ]
   },
   "catalogName" : "test-catalog",
   "queryId" : "test-query-id"

--- a/athena-federation-sdk/src/test/resources/serde/PingRequestForwardsCompatible.json
+++ b/athena-federation-sdk/src/test/resources/serde/PingRequestForwardsCompatible.json
@@ -1,9 +1,12 @@
 {
   "@type" : "PingRequest",
   "identity" : {
-    "id" : "test-id",
-    "principal" : "test-principal",
+    "id" : "UNKNOWN",
+    "principal" : "UNKNOWN",
     "account" : "0123456789",
+    "arn" : "testArn",
+    "tags" : { },
+    "groups" : [ ],
     "newIdField" : "newIdFieldValue"
   },
   "catalogName" : "test-catalog",

--- a/athena-federation-sdk/src/test/resources/serde/v2/GetSplitsRequest.json
+++ b/athena-federation-sdk/src/test/resources/serde/v2/GetSplitsRequest.json
@@ -1,9 +1,12 @@
 {
   "@type" : "GetSplitsRequest",
   "identity" : {
-    "id" : "test-id",
-    "principal" : "test-principal",
-    "account" : "0123456789"
+    "id" : "UNKNOWN",
+    "principal" : "UNKNOWN",
+    "account" : "0123456789",
+    "arn" : "testArn",
+    "tags" : { },
+    "groups" : [ ]
   },
   "queryId" : "test-query-id",
   "catalogName" : "test-catalog",

--- a/athena-federation-sdk/src/test/resources/serde/v2/GetTableLayoutRequest.json
+++ b/athena-federation-sdk/src/test/resources/serde/v2/GetTableLayoutRequest.json
@@ -1,9 +1,12 @@
 {
   "@type" : "GetTableLayoutRequest",
   "identity" : {
-    "id" : "test-id",
-    "principal" : "test-principal",
-    "account" : "0123456789"
+    "id" : "UNKNOWN",
+    "principal" : "UNKNOWN",
+    "account" : "0123456789",
+    "arn" : "testArn",
+    "tags" : { },
+    "groups" : [ ]
   },
   "queryId" : "test-query-id",
   "catalogName" : "test-catalog",

--- a/athena-federation-sdk/src/test/resources/serde/v2/GetTableRequest.json
+++ b/athena-federation-sdk/src/test/resources/serde/v2/GetTableRequest.json
@@ -1,9 +1,12 @@
 {
   "@type" : "GetTableRequest",
   "identity" : {
-    "id" : "test-id",
-    "principal" : "test-principal",
-    "account" : "0123456789"
+    "id" : "UNKNOWN",
+    "principal" : "UNKNOWN",
+    "account" : "0123456789",
+    "arn" : "testArn",
+    "tags" : { },
+    "groups" : [ ]
   },
   "queryId" : "test-query-id",
   "catalogName" : "test-catalog",

--- a/athena-federation-sdk/src/test/resources/serde/v2/ListSchemasRequest.json
+++ b/athena-federation-sdk/src/test/resources/serde/v2/ListSchemasRequest.json
@@ -1,9 +1,12 @@
 {
   "@type" : "ListSchemasRequest",
   "identity" : {
-    "id" : "test-id",
-    "principal" : "test-principal",
-    "account" : "0123456789"
+    "id" : "UNKNOWN",
+    "principal" : "UNKNOWN",
+    "account" : "0123456789",
+    "arn" : "testArn",
+    "tags" : { },
+    "groups" : [ ]
   },
   "queryId" : "test-query-id",
   "catalogName" : "test-catalog"

--- a/athena-federation-sdk/src/test/resources/serde/v2/ListTablesRequest.json
+++ b/athena-federation-sdk/src/test/resources/serde/v2/ListTablesRequest.json
@@ -1,9 +1,12 @@
 {
   "@type" : "ListTablesRequest",
   "identity" : {
-    "id" : "test-id",
-    "principal" : "test-principal",
-    "account" : "0123456789"
+    "id" : "UNKNOWN",
+    "principal" : "UNKNOWN",
+    "account" : "0123456789",
+    "arn" : "testArn",
+    "tags" : { },
+    "groups" : [ ]
   },
   "queryId" : "test-query-id",
   "catalogName" : "test-catalog",

--- a/athena-federation-sdk/src/test/resources/serde/v2/ReadRecordsRequest.json
+++ b/athena-federation-sdk/src/test/resources/serde/v2/ReadRecordsRequest.json
@@ -1,9 +1,12 @@
 {
   "@type" : "ReadRecordsRequest",
   "identity" : {
-    "id" : "test-id",
-    "principal" : "test-principal",
-    "account" : "0123456789"
+    "id" : "UNKNOWN",
+    "principal" : "UNKNOWN",
+    "account" : "0123456789",
+    "arn" : "testArn",
+    "tags" : { },
+    "groups" : [ ]
   },
   "queryId" : "test-catalog",
   "catalogName" : "test-query-id",

--- a/athena-federation-sdk/src/test/resources/serde/v2/UserDefinedFunctionRequest.json
+++ b/athena-federation-sdk/src/test/resources/serde/v2/UserDefinedFunctionRequest.json
@@ -1,9 +1,12 @@
 {
   "@type" : "UserDefinedFunctionRequest",
   "identity" : {
-    "id" : "test-id",
-    "principal" : "test-principal",
-    "account" : "0123456789"
+    "id" : "UNKNOWN",
+    "principal" : "UNKNOWN",
+    "account" : "0123456789",
+    "arn" : "testArn",
+    "tags" : { },
+    "groups" : [ ]
   },
   "inputRecords" : {
     "aId" : "test-allocator-id",

--- a/athena-hbase/athena-hbase.yaml
+++ b/athena-hbase/athena-hbase.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2020.34.1
+    SemanticVersion: 2020.35.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AthenaCatalogName:

--- a/athena-hbase/pom.xml
+++ b/athena-hbase/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>${aws-athena-federation-sdk.version}</version>
+            <version>2020.35.1</version>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
                 <exclusion>

--- a/athena-hbase/src/main/java/com/amazonaws/athena/connectors/hbase/HbaseConnectionFactory.java
+++ b/athena-hbase/src/main/java/com/amazonaws/athena/connectors/hbase/HbaseConnectionFactory.java
@@ -1,0 +1,156 @@
+/*-
+ * #%L
+ * athena-hbase
+ * %%
+ * Copyright (C) 2019 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.hbase;
+
+import org.apache.arrow.util.VisibleForTesting;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Creates and Caches HBase Connection Instances, using the connection string as the cache key.
+ *
+ * @Note Connection String format is expected to be host:zookeeper_port:master_port
+ */
+public class HbaseConnectionFactory
+{
+    private static final Logger logger = LoggerFactory.getLogger(HbaseConnectionFactory.class);
+
+    private final Map<String, Connection> clientCache = new HashMap<>();
+
+    private final Map<String, String> defaultClientConfig = new HashMap<>();
+
+    public HbaseConnectionFactory()
+    {
+        setClientConfig("hbase.rpc.timeout", "2000");
+        setClientConfig("hbase.client.retries.number", "3");
+        setClientConfig("hbase.client.pause", "500");
+        setClientConfig("zookeeper.recovery.retry", "2");
+    }
+
+    /**
+     * Used to set HBase client config options that should be applied to all future connections.
+     *
+     * @param name The name of the property (e.g. hbase.rpc.timeout).
+     * @param value The value of the property to set on the HBase client config object before construction.
+     */
+    public synchronized void setClientConfig(String name, String value)
+    {
+        defaultClientConfig.put(name, value);
+    }
+
+    /**
+     * Provides access to the current HBase client config options used during connection construction.
+     *
+     * @return Map<String ,   String> where the Key is the config name and the value is the config value.
+     * @note This can be helpful when logging diagnostic info.
+     */
+    public synchronized Map<String, String> getClientConfigs()
+    {
+        return Collections.unmodifiableMap(defaultClientConfig);
+    }
+
+    /**
+     * Gets or Creates an HBase connection for the given connection string.
+     *
+     * @param conStr HBase connection details, format is expected to be host:zookeeper_port:master_port
+     * @return An HBase connection if the connection succeeded, else the function will throw.
+     */
+    public synchronized Connection getOrCreateConn(String conStr)
+    {
+        logger.info("getOrCreateConn: enter");
+        Connection conn = clientCache.get(conStr);
+
+        if (conn == null || !connectionTest(conn)) {
+            String[] endpointParts = conStr.split(":");
+            if (endpointParts.length == 3) {
+                conn = createConnection(endpointParts[0], endpointParts[1], endpointParts[2]);
+                clientCache.put(conStr, conn);
+            }
+            else {
+                throw new IllegalArgumentException("Hbase endpoint format error.");
+            }
+        }
+
+        logger.info("getOrCreateConn: exit");
+        return conn;
+    }
+
+    private Connection createConnection(String host, String masterPort, String zookeeperPort)
+    {
+        try {
+            logger.info("createConnection: enter");
+            Configuration config = HBaseConfiguration.create();
+            config.set("hbase.zookeeper.quorum", host);
+            config.set("hbase.zookeeper.property.clientPort", zookeeperPort);
+            config.set("hbase.master", host + ":" + masterPort);
+            for (Map.Entry<String, String> nextConfig : defaultClientConfig.entrySet()) {
+                logger.info("createConnection: applying client config {}:{}", nextConfig.getKey(), nextConfig.getValue());
+                config.set(nextConfig.getKey(), nextConfig.getValue());
+            }
+            Connection conn = ConnectionFactory.createConnection(config);
+            logger.info("createConnection: hbase.zookeeper.quorum:" + config.get("hbase.zookeeper.quorum"));
+            logger.info("createConnection: hbase.zookeeper.property.clientPort:" + config.get("hbase.zookeeper.property.clientPort"));
+            logger.info("createConnection: hbase.master:" + config.get("hbase.master"));
+            return conn;
+        }
+        catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    /**
+     * Runs a 'quick' test on the connection and then returns it if it passes.
+     */
+    private boolean connectionTest(Connection conn)
+    {
+        try {
+            logger.info("connectionTest: Testing connection started.");
+            conn.getAdmin().listTableNames();
+            logger.info("connectionTest: Testing connection completed - success.");
+            return true;
+        }
+        catch (RuntimeException | IOException ex) {
+            logger.warn("getOrCreateConn: Exception while testing existing connection.", ex);
+        }
+        logger.info("connectionTest: Testing connection completed - fail.");
+        return false;
+    }
+
+    /**
+     * Injects a connection into the client cache.
+     *
+     * @param conStr The connection string (aka the cache key)
+     * @param conn The connection to inject into the client cache, most often a Mock used in testing.
+     */
+    @VisibleForTesting
+    protected synchronized void addConnection(String conStr, Connection conn)
+    {
+        clientCache.put(conStr, conn);
+    }
+}

--- a/athena-hbase/src/test/java/com/amazonaws/athena/connectors/hbase/HbaseConnectionFactoryTest.java
+++ b/athena-hbase/src/test/java/com/amazonaws/athena/connectors/hbase/HbaseConnectionFactoryTest.java
@@ -1,0 +1,62 @@
+/*-
+ * #%L
+ * athena-hbase
+ * %%
+ * Copyright (C) 2019 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.hbase;
+
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.Connection;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class HbaseConnectionFactoryTest
+{
+    private HbaseConnectionFactory connectionFactory;
+
+    @Before
+    public void setUp()
+            throws Exception
+    {
+        connectionFactory = new HbaseConnectionFactory();
+    }
+
+    @Test
+    public void clientCacheHitTest()
+            throws IOException
+    {
+        Connection mockConn = mock(Connection.class);
+        Admin mockAdmin = mock(Admin.class);
+        when(mockConn.getAdmin()).thenReturn(mockAdmin);
+
+        connectionFactory.addConnection("conStr", mockConn);
+        Connection conn = connectionFactory.getOrCreateConn("conStr");
+
+        assertEquals(mockConn, conn);
+        verify(mockConn, times(1)).getAdmin();
+        verify(mockAdmin, times(1)).listTableNames();
+    }
+}

--- a/athena-hbase/src/test/java/com/amazonaws/athena/connectors/hbase/HbaseRecordHandlerTest.java
+++ b/athena-hbase/src/test/java/com/amazonaws/athena/connectors/hbase/HbaseRecordHandlerTest.java
@@ -78,6 +78,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/athena-hbase/src/test/java/com/amazonaws/athena/connectors/hbase/TestBase.java
+++ b/athena-hbase/src/test/java/com/amazonaws/athena/connectors/hbase/TestBase.java
@@ -22,8 +22,10 @@ package com.amazonaws.athena.connectors.hbase;
 import com.amazonaws.athena.connector.lambda.domain.TableName;
 import com.amazonaws.athena.connector.lambda.security.FederatedIdentity;
 
+import java.util.Collections;
+
 public class TestBase {
-    protected static final FederatedIdentity IDENTITY = new FederatedIdentity("id", "principal", "account");
+    protected static final FederatedIdentity IDENTITY = new FederatedIdentity("arn", "account", Collections.emptyMap(), Collections.emptyList());
     protected static final String QUERY_ID = "query_id";
     protected static final String DEFAULT_CATALOG = "default";
     protected static final String TEST_TABLE = "test_table";

--- a/athena-jdbc/athena-jdbc.yaml
+++ b/athena-jdbc/athena-jdbc.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2020.34.1
+    SemanticVersion: 2020.35.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   LambdaFunctionName:

--- a/athena-jdbc/pom.xml
+++ b/athena-jdbc/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>${aws-athena-federation-sdk.version}</version>
+            <version>2020.35.1</version>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
                 <exclusion>

--- a/athena-redis/athena-redis.yaml
+++ b/athena-redis/athena-redis.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2020.34.1
+    SemanticVersion: 2020.35.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AthenaCatalogName:

--- a/athena-redis/pom.xml
+++ b/athena-redis/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>${aws-athena-federation-sdk.version}</version>
+            <version>2020.35.1</version>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
                 <exclusion>

--- a/athena-redis/src/test/java/com/amazonaws/athena/connectors/redis/RedisMetadataHandlerTest.java
+++ b/athena-redis/src/test/java/com/amazonaws/athena/connectors/redis/RedisMetadataHandlerTest.java
@@ -55,6 +55,7 @@ import redis.clients.jedis.ScanParams;
 import redis.clients.jedis.ScanResult;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;

--- a/athena-redis/src/test/java/com/amazonaws/athena/connectors/redis/RedisRecordHandlerTest.java
+++ b/athena-redis/src/test/java/com/amazonaws/athena/connectors/redis/RedisRecordHandlerTest.java
@@ -67,6 +67,7 @@ import redis.clients.jedis.Tuple;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/athena-redis/src/test/java/com/amazonaws/athena/connectors/redis/TestBase.java
+++ b/athena-redis/src/test/java/com/amazonaws/athena/connectors/redis/TestBase.java
@@ -22,8 +22,10 @@ package com.amazonaws.athena.connectors.redis;
 import com.amazonaws.athena.connector.lambda.domain.TableName;
 import com.amazonaws.athena.connector.lambda.security.FederatedIdentity;
 
+import java.util.Collections;
+
 public class TestBase {
-    protected static final FederatedIdentity IDENTITY = new FederatedIdentity("id", "principal", "account");
+    protected static final FederatedIdentity IDENTITY = new FederatedIdentity("arn", "account", Collections.emptyMap(), Collections.emptyList());
     protected static final String QUERY_ID = "query_id";
     protected static final String DEFAULT_CATALOG = "default";
     protected static final String TEST_TABLE = "test_table";

--- a/athena-tpcds/athena-tpcds.yaml
+++ b/athena-tpcds/athena-tpcds.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2020.34.1
+    SemanticVersion: 2020.35.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AthenaCatalogName:

--- a/athena-tpcds/pom.xml
+++ b/athena-tpcds/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>${aws-athena-federation-sdk.version}</version>
+            <version>2020.35.1</version>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
                 <exclusion>

--- a/athena-tpcds/src/test/java/com/amazonaws/athena/connectors/tpcds/TPCDSMetadataHandlerTest.java
+++ b/athena-tpcds/src/test/java/com/amazonaws/athena/connectors/tpcds/TPCDSMetadataHandlerTest.java
@@ -69,7 +69,7 @@ public class TPCDSMetadataHandlerTest
 {
     private static final Logger logger = LoggerFactory.getLogger(TPCDSMetadataHandlerTest.class);
 
-    private FederatedIdentity identity = new FederatedIdentity("id", "principal", "account");
+    private FederatedIdentity identity = new FederatedIdentity("arn", "account", Collections.emptyMap(), Collections.emptyList());
     private TPCDSMetadataHandler handler;
     private BlockAllocator allocator;
 

--- a/athena-tpcds/src/test/java/com/amazonaws/athena/connectors/tpcds/TPCDSRecordHandlerTest.java
+++ b/athena-tpcds/src/test/java/com/amazonaws/athena/connectors/tpcds/TPCDSRecordHandlerTest.java
@@ -65,6 +65,7 @@ import org.slf4j.LoggerFactory;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -84,7 +85,7 @@ public class TPCDSRecordHandlerTest
 {
     private static final Logger logger = LoggerFactory.getLogger(TPCDSRecordHandlerTest.class);
 
-    private FederatedIdentity identity = new FederatedIdentity("id", "principal", "account");
+    private FederatedIdentity identity = new FederatedIdentity("arn", "account", Collections.emptyMap(), Collections.emptyList());
     private List<ByteHolder> mockS3Storage;
     private TPCDSRecordHandler handler;
     private S3BlockSpillReader spillReader;

--- a/athena-udfs/athena-udfs.yaml
+++ b/athena-udfs/athena-udfs.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2020.34.1
+    SemanticVersion: 2020.35.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   LambdaFunctionName:

--- a/athena-udfs/pom.xml
+++ b/athena-udfs/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>${aws-athena-federation-sdk.version}</version>
+            <version>2020.35.1</version>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
                 <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <aws-sdk.version>1.11.490</aws-sdk.version>
-        <aws-athena-federation-sdk.version>2020.34.1</aws-athena-federation-sdk.version>
+        <aws-athena-federation-sdk.version>2020.35.1</aws-athena-federation-sdk.version>
         <aws.lambda-java-core.version>1.2.0</aws.lambda-java-core.version>
         <slf4j-log4j.version>1.7.28</slf4j-log4j.version>
         <mockito.version>1.10.19</mockito.version>


### PR DESCRIPTION

Closes [#26](https://github.com/awslabs/aws-athena-query-federation/issues/26)

This changes the SDK to allow for more useful identity metadata to be propagated to connectors from Athena.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
