### PR TITLE
Fixing duplicate splits issue in DDB connector

### DIFF
--- a/athena-docdb/src/main/java/com/amazonaws/athena/connectors/docdb/QueryUtils.java
+++ b/athena-docdb/src/main/java/com/amazonaws/athena/connectors/docdb/QueryUtils.java
@@ -148,6 +148,7 @@ public final class QueryUtils
             FieldReader fieldReader = block.getFieldReaders().get(0);
             for (int i = 0; i < block.getRowCount(); i++) {
                 Document nextEqVal = new Document();
+                fieldReader.setPosition(i);
                 Object value = fieldReader.readObject();
                 nextEqVal.put(EQ_OP, convert(value));
                 singleValues.add(singleValues);

--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBRecordHandler.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBRecordHandler.java
@@ -297,18 +297,18 @@ public class DynamoDBRecordHandler
                 try {
                     if (request instanceof QueryRequest) {
                         QueryRequest paginatedRequest = ((QueryRequest) request).withExclusiveStartKey(lastKeyEvaluated.get());
-//                        if (logger.isDebugEnabled()) {
-                            logger.info("Invoking DDB with Query request: {}", request);
-//                        }
+                        if (logger.isDebugEnabled()) {
+                            logger.debug("Invoking DDB with Query request: {}", request);
+                        }
                         QueryResult queryResult = invokerCache.get(tableName).invoke(() -> ddbClient.query(paginatedRequest));
                         lastKeyEvaluated.set(queryResult.getLastEvaluatedKey());
                         iterator = queryResult.getItems().iterator();
                     }
                     else {
                         ScanRequest paginatedRequest = ((ScanRequest) request).withExclusiveStartKey(lastKeyEvaluated.get());
-//                        if (logger.isDebugEnabled()) {
-                            logger.info("Invoking DDB with Scan request: {}", request);
-//                        }
+                        if (logger.isDebugEnabled()) {
+                            logger.debug("Invoking DDB with Scan request: {}", request);
+                        }
                         ScanResult scanResult = invokerCache.get(tableName).invoke(() -> ddbClient.scan(paginatedRequest));
                         lastKeyEvaluated.set(scanResult.getLastEvaluatedKey());
                         iterator = scanResult.getItems().iterator();

--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBRecordHandler.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBRecordHandler.java
@@ -297,18 +297,18 @@ public class DynamoDBRecordHandler
                 try {
                     if (request instanceof QueryRequest) {
                         QueryRequest paginatedRequest = ((QueryRequest) request).withExclusiveStartKey(lastKeyEvaluated.get());
-                        if (logger.isDebugEnabled()) {
-                            logger.debug("Invoking DDB with Query request: {}", request);
-                        }
+//                        if (logger.isDebugEnabled()) {
+                            logger.info("Invoking DDB with Query request: {}", request);
+//                        }
                         QueryResult queryResult = invokerCache.get(tableName).invoke(() -> ddbClient.query(paginatedRequest));
                         lastKeyEvaluated.set(queryResult.getLastEvaluatedKey());
                         iterator = queryResult.getItems().iterator();
                     }
                     else {
                         ScanRequest paginatedRequest = ((ScanRequest) request).withExclusiveStartKey(lastKeyEvaluated.get());
-                        if (logger.isDebugEnabled()) {
-                            logger.debug("Invoking DDB with Scan request: {}", request);
-                        }
+//                        if (logger.isDebugEnabled()) {
+                            logger.info("Invoking DDB with Scan request: {}", request);
+//                        }
                         ScanResult scanResult = invokerCache.get(tableName).invoke(() -> ddbClient.scan(paginatedRequest));
                         lastKeyEvaluated.set(scanResult.getLastEvaluatedKey());
                         iterator = scanResult.getItems().iterator();

--- a/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBMetadataHandlerTest.java
+++ b/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBMetadataHandlerTest.java
@@ -433,6 +433,7 @@ public class DynamoDBMetadataHandlerTest
 
         assertThat(continuationToken, equalTo(String.valueOf(MAX_SPLITS_PER_REQUEST - 1)));
         assertThat(response.getSplits().size(), equalTo(MAX_SPLITS_PER_REQUEST));
+        assertThat(response.getSplits().stream().map(split -> split.getProperty("col_0")).distinct().count(), equalTo((long) MAX_SPLITS_PER_REQUEST));
 
         response = handler.doGetSplits(allocator, new GetSplitsRequest(req, continuationToken));
 
@@ -440,6 +441,7 @@ public class DynamoDBMetadataHandlerTest
 
         assertThat(response.getContinuationToken(), equalTo(null));
         assertThat(response.getSplits().size(), equalTo(MAX_SPLITS_PER_REQUEST));
+        assertThat(response.getSplits().stream().map(split -> split.getProperty("col_0")).distinct().count(), equalTo((long) MAX_SPLITS_PER_REQUEST));
     }
 
     @Test

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/Block.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/Block.java
@@ -506,10 +506,13 @@ public class Block
         for (Field next : this.schema.getFields()) {
             FieldReader thisReader = vectorSchema.getVector(next.getName()).getReader();
             List<String> values = new ArrayList<>();
+            int originalReaderPosition = thisReader.getPosition();
             for (int i = 0; i < rowsToPrint; i++) {
                 thisReader.setPosition(i);
                 values.add(fieldToString(thisReader));
             }
+            // reset the position for other reads
+            thisReader.setPosition(originalReaderPosition);
             helper.add(next.getName(), values);
         }
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Customer raised support case indicating that queries that filter on multiple hash key values resulted in duplicate and missing rows returned.  Turns out that we were using the same split property map for every split, resulting effectively in duplicate splits.  This change creates a new split property map for each split.

Also includes two minor changes:
1. fixed issue where DocDB connector predicate builder wasn't incrementing the FieldReader position when building the value list, resulting in duplicate/missing values
2. Fixed issue where Block's toString was mutating FieldReaders' positions without resetting them (resulted in bizarre/confusing behavior during debugging)

*Testing:* unit tests and uploaded Lambda testing through Athena


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
