### PR TITLE
Catching all Athena exceptions in QueryStatusChecker

### DIFF
--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBRecordHandler.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBRecordHandler.java
@@ -297,18 +297,18 @@ public class DynamoDBRecordHandler
                 try {
                     if (request instanceof QueryRequest) {
                         QueryRequest paginatedRequest = ((QueryRequest) request).withExclusiveStartKey(lastKeyEvaluated.get());
-//                        if (logger.isDebugEnabled()) {
-                            logger.info("Invoking DDB with Query request: {}", request);
-//                        }
+                        if (logger.isDebugEnabled()) {
+                            logger.debug("Invoking DDB with Query request: {}", request);
+                        }
                         QueryResult queryResult = invokerCache.get(tableName).invoke(() -> ddbClient.query(paginatedRequest));
                         lastKeyEvaluated.set(queryResult.getLastEvaluatedKey());
                         iterator = queryResult.getItems().iterator();
                     }
                     else {
                         ScanRequest paginatedRequest = ((ScanRequest) request).withExclusiveStartKey(lastKeyEvaluated.get());
-//                        if (logger.isDebugEnabled()) {
-                            logger.info("Invoking DDB with Scan request: {}", request);
-//                        }
+                        if (logger.isDebugEnabled()) {
+                            logger.debug("Invoking DDB with Scan request: {}", request);
+                        }
                         ScanResult scanResult = invokerCache.get(tableName).invoke(() -> ddbClient.scan(paginatedRequest));
                         lastKeyEvaluated.set(scanResult.getLastEvaluatedKey());
                         iterator = scanResult.getItems().iterator();

--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBRecordHandler.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBRecordHandler.java
@@ -297,18 +297,18 @@ public class DynamoDBRecordHandler
                 try {
                     if (request instanceof QueryRequest) {
                         QueryRequest paginatedRequest = ((QueryRequest) request).withExclusiveStartKey(lastKeyEvaluated.get());
-                        if (logger.isDebugEnabled()) {
-                            logger.debug("Invoking DDB with Query request: {}", request);
-                        }
+//                        if (logger.isDebugEnabled()) {
+                            logger.info("Invoking DDB with Query request: {}", request);
+//                        }
                         QueryResult queryResult = invokerCache.get(tableName).invoke(() -> ddbClient.query(paginatedRequest));
                         lastKeyEvaluated.set(queryResult.getLastEvaluatedKey());
                         iterator = queryResult.getItems().iterator();
                     }
                     else {
                         ScanRequest paginatedRequest = ((ScanRequest) request).withExclusiveStartKey(lastKeyEvaluated.get());
-                        if (logger.isDebugEnabled()) {
-                            logger.debug("Invoking DDB with Scan request: {}", request);
-                        }
+//                        if (logger.isDebugEnabled()) {
+                            logger.info("Invoking DDB with Scan request: {}", request);
+//                        }
                         ScanResult scanResult = invokerCache.get(tableName).invoke(() -> ddbClient.scan(paginatedRequest));
                         lastKeyEvaluated.set(scanResult.getLastEvaluatedKey());
                         iterator = scanResult.getItems().iterator();

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/QueryStatusChecker.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/QueryStatusChecker.java
@@ -28,7 +28,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Set;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static java.lang.String.format;

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/QueryStatusChecker.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/QueryStatusChecker.java
@@ -122,7 +122,7 @@ public class QueryStatusChecker
                 isRunning.set(false);
             }
         }
-        catch (RuntimeException | TimeoutException e) {
+        catch (Exception e) {
             logger.warn("Exception {} thrown when calling Athena for query status: {}", e.getClass().getSimpleName(), e.getMessage());
             if (e instanceof InvalidRequestException) {
                 // query does not exist, so no need to keep calling Athena


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* See some query failures due to `Rate exceeded (Service: AmazonAthena; Status Code: 400; Error Code: ThrottlingException)`, so catching all Exceptions instead of just RuntimeException, since I can't think of a reason why we would want to throw any Athena exceptions all the way up.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
