### PR TITLE
Fixes nullable fields and ranging issues for Elasticsearch connector.

### DIFF
--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/resolver/DynamoDBFieldResolver.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/resolver/DynamoDBFieldResolver.java
@@ -64,7 +64,8 @@ public class DynamoDBFieldResolver
                 fieldValue = ((Map) originalValue).get(fieldName);
             }
             else {
-                throw new RuntimeException("Field not found in DB record: " + fieldName);
+                // Ignore columns that do not exist in the DB record.
+                return null;
             }
         }
         else {

--- a/athena-elasticsearch/src/main/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchFieldResolver.java
+++ b/athena-elasticsearch/src/main/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchFieldResolver.java
@@ -71,7 +71,8 @@ public class ElasticsearchFieldResolver
                 fieldValue = ((Map) originalValue).get(fieldName);
             }
             else {
-                throw new RuntimeException("Field not found in Document: " + fieldName);
+                // Ignore columns that do not exist in the document.
+                return null;
             }
         }
         else {

--- a/athena-elasticsearch/src/test/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchQueryUtilsTest.java
+++ b/athena-elasticsearch/src/test/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchQueryUtilsTest.java
@@ -124,7 +124,7 @@ public class ElasticsearchQueryUtilsTest
                         Range.equal(allocator, Types.MinorType.INT.getType(), 1996),
                         Range.greaterThanOrEqual(allocator, Types.MinorType.INT.getType(), 2010)),
                 false));
-        String expectedPredicate = "(_exists_:year) AND year:((<1950) OR (>1955 AND <=1972) OR (>=2010) OR 1952 OR 1996)";
+        String expectedPredicate = "(_exists_:year) AND year:([* TO 1950} OR {1955 TO 1972] OR [2010 TO *] OR 1952 OR 1996)";
 
         // Get the actual predicate and compare to the expected one.
         QueryBuilder builder = ElasticsearchQueryUtils.getQuery(constraintsMap);

--- a/athena-elasticsearch/src/test/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchRecordHandlerTest.java
+++ b/athena-elasticsearch/src/test/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchRecordHandlerTest.java
@@ -322,7 +322,7 @@ public class ElasticsearchRecordHandlerTest
 
         List<String> expectedProjection = new ArrayList<>();
         mapping.getFields().forEach(field -> expectedProjection.add(field.getName()));
-        String expectedPredicate = "(_exists_:myshort) AND myshort:((>1955 AND <=1972))";
+        String expectedPredicate = "(_exists_:myshort) AND myshort:({1955 TO 1972])";
 
         ReadRecordsRequest request = new ReadRecordsRequest(fakeIdentity(),
                 "elasticsearch",


### PR DESCRIPTION
*Issue #, if available:* #254, #255 

*Description of changes:*
1. Nullable fields - Ignores fields/columns that do not exist in the DB record (fixed for `Elasticsearch` and `DynamoDB`). Closes #254 
2. Ranging - uses the TO operator in combination with [] for inclusive range and {} for exclusive range. Inclusive ranges are specified with square brackets [min TO max] and exclusive ranges with curly brackets {min TO max} - see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html. Closes #255 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
