### PR TITLE
Ignore all system indices starting with period for Elasticsearch connector

### DIFF
--- a/athena-elasticsearch/src/main/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchMetadataHandler.java
+++ b/athena-elasticsearch/src/main/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchMetadataHandler.java
@@ -189,8 +189,9 @@ public class ElasticsearchMetadataHandler
             AwsRestHighLevelClient client = clientFactory.getOrCreateClient(endpoint);
             try {
                 for (String index : client.getAliases()) {
-                    // Add all Indices except for kibana.
-                    if (index.contains("kibana")) {
+                    // Ignore all system indices starting with period `.` (e.g. .kibana, .tasks, etc...)
+                    if (index.startsWith(".")) {
+                        logger.info("Ignoring system index: {}", index);
                         continue;
                     }
 


### PR DESCRIPTION
*Issue #, if available: N/A

*Description of changes:*
Ignore all system indices starting with period `.` (e.g. .kibana, .tasks, etc...)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
