### PR TITLE
Fixes UnsupportedOperationException when inferring Glue date column format for DynamoDB connector.

### DIFF
--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/util/DDBRecordMetadata.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/util/DDBRecordMetadata.java
@@ -28,7 +28,6 @@ import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
 
 import java.time.ZoneId;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -185,7 +184,7 @@ public class DDBRecordMetadata
                 return new HashMap<>(MAP_SPLITTER.split(datetimeFormatMappingParam));
             }
         }
-        return Collections.emptyMap();
+        return new HashMap<>();
     }
 
     /**


### PR DESCRIPTION
*Description of changes:*
Fixes the following exception when a date column defined as `String` in a DynamoDB table is defined as `date` in the Glue metadata definitions:

``` 
2020-10-14 21:24:26 c8827898-8436-4fd4-b697-7bc4f798a998 INFO  DDBTypeUtils:239 - Date format not in cache for column LastUpdatedDate. Trying to infer format...
2020-10-14 21:24:26 c8827898-8436-4fd4-b697-7bc4f798a998 INFO  DateTimeFormatterUtil:186 - Inferred format yyyy-MM-dd for value 2020-09-08
2020-10-14 21:24:26 c8827898-8436-4fd4-b697-7bc4f798a998 INFO  DDBTypeUtils:242 - Adding datetime format yyyy-MM-dd for column LastUpdatedDate to cache
Error while processing field data: java.lang.RuntimeException
java.lang.RuntimeException: Error while processing field data
	at com.amazonaws.athena.connectors.dynamodb.DynamoDBRecordHandler.lambda$readWithConstraint$0(DynamoDBRecordHandler.java:193)
	at com.amazonaws.athena.connector.lambda.data.S3BlockSpiller.writeRows(S3BlockSpiller.java:174)
	at com.amazonaws.athena.connectors.dynamodb.DynamoDBRecordHandler.readWithConstraint(DynamoDBRecordHandler.java:149)
	at com.amazonaws.athena.connector.lambda.handlers.RecordHandler.doReadRecords(RecordHandler.java:192)
	at com.amazonaws.athena.connector.lambda.handlers.RecordHandler.doHandleRequest(RecordHandler.java:158)
	at com.amazonaws.athena.connector.lambda.handlers.CompositeHandler.handleRequest(CompositeHandler.java:135)
	at com.amazonaws.athena.connector.lambda.handlers.CompositeHandler.handleRequest(CompositeHandler.java:100)
Caused by: java.lang.UnsupportedOperationException
	at java.util.AbstractMap.put(AbstractMap.java:209)
	at com.amazonaws.athena.connectors.dynamodb.util.DDBRecordMetadata.setDateTimeFormat(DDBRecordMetadata.java:162)
	at com.amazonaws.athena.connectors.dynamodb.util.DDBTypeUtils.coerceValueToExpectedType(DDBTypeUtils.java:243)
	at com.amazonaws.athena.connectors.dynamodb.resolver.DynamoDBFieldResolver.getFieldValue(DynamoDBFieldResolver.java:91)
	at com.amazonaws.athena.connector.lambda.data.BlockUtils.writeStruct(BlockUtils.java:617)
	at com.amazonaws.athena.connector.lambda.data.BlockUtils.setComplexValue(BlockUtils.java:185)
	at com.amazonaws.athena.connector.lambda.data.Block.offerComplexValue(Block.java:218)
	at com.amazonaws.athena.connectors.dynamodb.DynamoDBRecordHandler.lambda$readWithConstraint$0(DynamoDBRecordHandler.java:178)
	... 6 more
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
