### PR TITLE
Fixes ElasticsearchStatusException when predicate is timestamp for Elasticsearch connector

### DIFF
--- a/athena-elasticsearch/README.md
+++ b/athena-elasticsearch/README.md
@@ -195,7 +195,7 @@ where year >= 1955 and year <= 1962 or year = 1996;
 ```
 **Predicate:**
 ```
-(_exists_:year) AND year:((>=1955 AND <=1962) OR 1996)
+(_exists_:year) AND year:([1955 TO 1962] OR 1996)
 ```
 
 ## Executing SQL Queries


### PR DESCRIPTION
*Description of changes:*

Fixes the following exception when the predicate is column = timestamp (e.g.: select * from mytable where mydate = timestamp '2000-11-11 06:57:44.123'). The resulting push-down predicate when is using the `=` operator on a timestamp, needs to wrapp the timestamp in quotes, e.g.: mydate:("2000-11-11T06:57:44.123")

```
org.elasticsearch.ElasticsearchStatusException: Elasticsearch exception [type=search_phase_execution_exception, reason=all shards failed]
                at org.elasticsearch.rest.BytesRestResponse.errorFromXContent(BytesRestResponse.java:177) ~[task/:?]
                at org.elasticsearch.client.RestHighLevelClient.parseEntity(RestHighLevelClient.java:1706) ~[task/:?]
                at org.elasticsearch.client.RestHighLevelClient.parseResponseException(RestHighLevelClient.java:1683) ~[task/:?]
                at org.elasticsearch.client.RestHighLevelClient.internalPerformRequest(RestHighLevelClient.java:1446) ~[task/:?]
                at org.elasticsearch.client.RestHighLevelClient.performRequest(RestHighLevelClient.java:1403) ~[task/:?]
                at org.elasticsearch.client.RestHighLevelClient.performRequestAndParseEntity(RestHighLevelClient.java:1373) ~[task/:?]
                at org.elasticsearch.client.RestHighLevelClient.search(RestHighLevelClient.java:915) ~[task/:?]
                at com.amazonaws.connectors.athena.elasticsearch.AwsRestHighLevelClient.getDocuments(AwsRestHighLevelClient.java:148) ~[task/:?]
                at com.amazonaws.connectors.athena.elasticsearch.ElasticsearchRecordHandler.readWithConstraint(ElasticsearchRecordHandler.java:162) ~[task/:?]
                at com.amazonaws.athena.connector.lambda.handlers.RecordHandler.doReadRecords(RecordHandler.java:192) ~[task/:?]
                at com.amazonaws.athena.connector.lambda.handlers.RecordHandler.doHandleRequest(RecordHandler.java:158) ~[task/:?]
                at com.amazonaws.athena.connector.lambda.handlers.CompositeHandler.handleRequest(CompositeHandler.java:135) ~[task/:?]
                at com.amazonaws.athena.connector.lambda.handlers.CompositeHandler.handleRequest(CompositeHandler.java:100) [task/:?]
                at lambdainternal.EventHandlerLoader$2.call(EventHandlerLoader.java:902) [LambdaSandboxJava-1.0.jar:?]
                at lambdainternal.AWSLambda.startRuntime(AWSLambda.java:341) [LambdaSandboxJava-1.0.jar:?]
                at lambdainternal.AWSLambda.<clinit>(AWSLambda.java:63) [LambdaSandboxJava-1.0.jar:?]
                at java.lang.Class.forName0(Native Method) ~[?:1.8.0_201]
                at java.lang.Class.forName(Class.java:348) [?:1.8.0_201]
...
{"error":{"root_cause":[{"type":"parse_exception","reason":"parse_exception: Encountered \" \":\" \": \"\" at line 1, column 84.\nWas expecting one of:\n    <AND> ...\n    <OR> ...\n    <NOT> ...\n    \"+\" ...\n    \"-\" ...\n    <BAREOPER> ...\n    \"(\" ...\n    \")\" ...\n    \"*\" ...\n    \"^\" ...\n    <QUOTED> ...\n    <TERM> ...\n    <FUZZY_SLOP> ...\n    <PREFIXTERM> ...\n    <WILDTERM> ...\n    <REGEXPTERM> ...\n    \"[\" ...\n    \"{\" ...\n    <NUMBER> ...\n    "}],"type":"search_phase_execution_exception","reason":"all shards failed"
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
