### PR TITLE
Fix typo in help message

### DIFF
--- a/tools/publish.sh
+++ b/tools/publish.sh
@@ -38,7 +38,7 @@ if [ "$#" -lt 2 ]; then
     echo "\n\nERROR: Script requires 3 arguments \n"
     echo "\n1. S3_BUCKET used for publishing artifacts to Lambda/Serverless App Repo.\n"
     echo "\n2. The connector module to publish (e.g. athena-exmaple or athena-cloudwatch) \n"
-    echo "\n3. The AS REGION to target (e.g. us-east-1 or us-east-2) \n"
+    echo "\n3. The AWS REGION to target (e.g. us-east-1 or us-east-2) \n"
     echo "\n\n USAGE from the module's directory: ../tools/publish.sh my_s3_bucket athena-example \n"
     exit;
 fi


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Fixes a small typo (`AS REGION` -> `AWS REGION`) in usage message.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
