### PR TITLE
env variable log level for athena-federation-sdk

### DIFF
--- a/athena-aws-cmdb/src/main/resources/log4j2.xml
+++ b/athena-aws-cmdb/src/main/resources/log4j2.xml
@@ -28,7 +28,7 @@
         </Lambda>
     </Appenders>
     <Loggers>
-        <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-info}" />
+        <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Root level="info">
             <AppenderRef ref="Lambda" />
         </Root>

--- a/athena-aws-cmdb/src/main/resources/log4j2.xml
+++ b/athena-aws-cmdb/src/main/resources/log4j2.xml
@@ -28,6 +28,7 @@
         </Lambda>
     </Appenders>
     <Loggers>
+        <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-info}" />
         <Root level="info">
             <AppenderRef ref="Lambda" />
         </Root>

--- a/athena-cloudwatch-metrics/src/main/resources/log4j2.xml
+++ b/athena-cloudwatch-metrics/src/main/resources/log4j2.xml
@@ -28,7 +28,7 @@
         </Lambda>
     </Appenders>
     <Loggers>
-        <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-info}" />
+        <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Root level="info">
             <AppenderRef ref="Lambda" />
         </Root>

--- a/athena-cloudwatch-metrics/src/main/resources/log4j2.xml
+++ b/athena-cloudwatch-metrics/src/main/resources/log4j2.xml
@@ -28,6 +28,7 @@
         </Lambda>
     </Appenders>
     <Loggers>
+        <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-info}" />
         <Root level="info">
             <AppenderRef ref="Lambda" />
         </Root>

--- a/athena-cloudwatch/src/main/resources/log4j2.xml
+++ b/athena-cloudwatch/src/main/resources/log4j2.xml
@@ -28,7 +28,7 @@
         </Lambda>
     </Appenders>
     <Loggers>
-        <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-info}" />
+        <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Root level="info">
             <AppenderRef ref="Lambda" />
         </Root>

--- a/athena-cloudwatch/src/main/resources/log4j2.xml
+++ b/athena-cloudwatch/src/main/resources/log4j2.xml
@@ -28,6 +28,7 @@
         </Lambda>
     </Appenders>
     <Loggers>
+        <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-info}" />
         <Root level="info">
             <AppenderRef ref="Lambda" />
         </Root>

--- a/athena-docdb/src/main/resources/log4j2.xml
+++ b/athena-docdb/src/main/resources/log4j2.xml
@@ -28,7 +28,7 @@
         </Lambda>
     </Appenders>
     <Loggers>
-        <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-info}" />
+        <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Root level="info">
             <AppenderRef ref="Lambda" />
         </Root>

--- a/athena-docdb/src/main/resources/log4j2.xml
+++ b/athena-docdb/src/main/resources/log4j2.xml
@@ -28,6 +28,7 @@
         </Lambda>
     </Appenders>
     <Loggers>
+        <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-info}" />
         <Root level="info">
             <AppenderRef ref="Lambda" />
         </Root>

--- a/athena-dynamodb/src/main/resources/log4j2.xml
+++ b/athena-dynamodb/src/main/resources/log4j2.xml
@@ -28,7 +28,7 @@
         </Lambda>
     </Appenders>
     <Loggers>
-        <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-info}" />
+        <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Root level="info">
             <AppenderRef ref="Lambda" />
         </Root>

--- a/athena-dynamodb/src/main/resources/log4j2.xml
+++ b/athena-dynamodb/src/main/resources/log4j2.xml
@@ -28,6 +28,7 @@
         </Lambda>
     </Appenders>
     <Loggers>
+        <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-info}" />
         <Root level="info">
             <AppenderRef ref="Lambda" />
         </Root>

--- a/athena-elasticsearch/src/main/resources/log4j2.xml
+++ b/athena-elasticsearch/src/main/resources/log4j2.xml
@@ -28,7 +28,7 @@
         </Lambda>
     </Appenders>
     <Loggers>
-        <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-info}" />
+        <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Root level="info">
             <AppenderRef ref="Lambda" />
         </Root>

--- a/athena-elasticsearch/src/main/resources/log4j2.xml
+++ b/athena-elasticsearch/src/main/resources/log4j2.xml
@@ -28,6 +28,7 @@
         </Lambda>
     </Appenders>
     <Loggers>
+        <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-info}" />
         <Root level="info">
             <AppenderRef ref="Lambda" />
         </Root>

--- a/athena-example/src/main/resources/log4j2.xml
+++ b/athena-example/src/main/resources/log4j2.xml
@@ -28,7 +28,7 @@
         </Lambda>
     </Appenders>
     <Loggers>
-        <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-info}" />
+        <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Root level="info">
             <AppenderRef ref="Lambda" />
         </Root>

--- a/athena-example/src/main/resources/log4j2.xml
+++ b/athena-example/src/main/resources/log4j2.xml
@@ -28,6 +28,7 @@
         </Lambda>
     </Appenders>
     <Loggers>
+        <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-info}" />
         <Root level="info">
             <AppenderRef ref="Lambda" />
         </Root>

--- a/athena-federation-sdk-tools/src/main/resources/log4j2.xml
+++ b/athena-federation-sdk-tools/src/main/resources/log4j2.xml
@@ -8,7 +8,7 @@
         </Console>
     </Appenders>
     <Loggers>
-        <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-info}" />
+        <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Root level="info">
             <AppenderRef ref="Console" />
         </Root>

--- a/athena-federation-sdk-tools/src/main/resources/log4j2.xml
+++ b/athena-federation-sdk-tools/src/main/resources/log4j2.xml
@@ -8,6 +8,7 @@
         </Console>
     </Appenders>
     <Loggers>
+        <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-info}" />
         <Root level="info">
             <AppenderRef ref="Console" />
         </Root>

--- a/athena-federation-sdk/src/test/resources/log4j2-test.xml
+++ b/athena-federation-sdk/src/test/resources/log4j2-test.xml
@@ -28,6 +28,7 @@
         </Lambda>
     </Appenders>
     <Loggers>
+        <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-info}" />
         <Root level="info">
             <AppenderRef ref="Lambda" />
         </Root>

--- a/athena-hbase/src/main/resources/log4j2.xml
+++ b/athena-hbase/src/main/resources/log4j2.xml
@@ -28,7 +28,7 @@
         </Lambda>
     </Appenders>
     <Loggers>
-        <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-info}" />
+        <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Root level="info">
             <AppenderRef ref="Lambda" />
         </Root>

--- a/athena-hbase/src/main/resources/log4j2.xml
+++ b/athena-hbase/src/main/resources/log4j2.xml
@@ -28,6 +28,7 @@
         </Lambda>
     </Appenders>
     <Loggers>
+        <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-info}" />
         <Root level="info">
             <AppenderRef ref="Lambda" />
         </Root>

--- a/athena-jdbc/src/main/resources/log4j2.xml
+++ b/athena-jdbc/src/main/resources/log4j2.xml
@@ -28,7 +28,7 @@
         </Lambda>
     </Appenders>
     <Loggers>
-        <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-info}" />
+        <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Root level="info">
             <AppenderRef ref="Lambda" />
         </Root>

--- a/athena-jdbc/src/main/resources/log4j2.xml
+++ b/athena-jdbc/src/main/resources/log4j2.xml
@@ -28,6 +28,7 @@
         </Lambda>
     </Appenders>
     <Loggers>
+        <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-info}" />
         <Root level="info">
             <AppenderRef ref="Lambda" />
         </Root>

--- a/athena-neptune/src/main/resources/log4j2.xml
+++ b/athena-neptune/src/main/resources/log4j2.xml
@@ -28,7 +28,7 @@
         </Lambda>
     </Appenders>
     <Loggers>
-        <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-info}" />
+        <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Root level="info">
             <AppenderRef ref="Lambda" />
         </Root>

--- a/athena-neptune/src/main/resources/log4j2.xml
+++ b/athena-neptune/src/main/resources/log4j2.xml
@@ -28,6 +28,7 @@
         </Lambda>
     </Appenders>
     <Loggers>
+        <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-info}" />
         <Root level="info">
             <AppenderRef ref="Lambda" />
         </Root>

--- a/athena-redis/src/main/resources/log4j2.xml
+++ b/athena-redis/src/main/resources/log4j2.xml
@@ -28,7 +28,7 @@
         </Lambda>
     </Appenders>
     <Loggers>
-        <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-info}" />
+        <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Root level="info">
             <AppenderRef ref="Lambda" />
         </Root>

--- a/athena-redis/src/main/resources/log4j2.xml
+++ b/athena-redis/src/main/resources/log4j2.xml
@@ -28,6 +28,7 @@
         </Lambda>
     </Appenders>
     <Loggers>
+        <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-info}" />
         <Root level="info">
             <AppenderRef ref="Lambda" />
         </Root>

--- a/athena-timestream/src/main/resources/log4j2.xml
+++ b/athena-timestream/src/main/resources/log4j2.xml
@@ -28,7 +28,7 @@
         </Lambda>
     </Appenders>
     <Loggers>
-        <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-info}" />
+        <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Root level="info">
             <AppenderRef ref="Lambda" />
         </Root>

--- a/athena-timestream/src/main/resources/log4j2.xml
+++ b/athena-timestream/src/main/resources/log4j2.xml
@@ -28,6 +28,7 @@
         </Lambda>
     </Appenders>
     <Loggers>
+        <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-info}" />
         <Root level="info">
             <AppenderRef ref="Lambda" />
         </Root>

--- a/athena-tpcds/src/main/resources/log4j2.xml
+++ b/athena-tpcds/src/main/resources/log4j2.xml
@@ -28,7 +28,7 @@
         </Lambda>
     </Appenders>
     <Loggers>
-        <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-info}" />
+        <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Root level="info">
             <AppenderRef ref="Lambda" />
         </Root>

--- a/athena-tpcds/src/main/resources/log4j2.xml
+++ b/athena-tpcds/src/main/resources/log4j2.xml
@@ -28,6 +28,7 @@
         </Lambda>
     </Appenders>
     <Loggers>
+        <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-info}" />
         <Root level="info">
             <AppenderRef ref="Lambda" />
         </Root>

--- a/athena-udfs/src/main/resources/log4j2.xml
+++ b/athena-udfs/src/main/resources/log4j2.xml
@@ -28,7 +28,7 @@
         </Lambda>
     </Appenders>
     <Loggers>
-        <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-info}" />
+        <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Root level="info">
             <AppenderRef ref="Lambda" />
         </Root>

--- a/athena-udfs/src/main/resources/log4j2.xml
+++ b/athena-udfs/src/main/resources/log4j2.xml
@@ -28,6 +28,7 @@
         </Lambda>
     </Appenders>
     <Loggers>
+        <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-info}" />
         <Root level="info">
             <AppenderRef ref="Lambda" />
         </Root>


### PR DESCRIPTION
*Description of changes:*
This is a suggestion on providing more control over logging. In its current state, the athena-federation-sdk uses log level `INFO` to log full requests e.g.
https://github.com/awslabs/aws-athena-query-federation/blob/master/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/handlers/MetadataHandler.java#L232
https://github.com/awslabs/aws-athena-query-federation/blob/master/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/handlers/RecordHandler.java#L154
This includes potentially sensitive information if stored within Split metadata or records written back to Athena after `READ_RECORDS`. It can also be incredibly verbose if there is a lot of data being processed. While this defaults to `INFO`, an env variable can be specified during runtime to limit logging to `warn` or up to not expose the sensitive info e.g. `ATHENA_FEDERATION_SDK_LOG_LEVEL=warn`

For custom connectors, the log4j2 conf can be modified appropriately but for existing connectors deployed from SAM, this provides a bit more control.

*Testing:*
* Compared results from `AWS_REGION=us-west-2 mvn test` and `AWS_REGION=us-west-2 ATHENA_FEDERATION_SDK_LOG_LEVEL=ERROR mvn test` within `athena-aws-cmdb`. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
