### PR TITLE
Swallowing exceptions and moving on when trying to split keyspace in …

### DIFF
--- a/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/manager/JdbcMetadataHandler.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/manager/JdbcMetadataHandler.java
@@ -309,9 +309,6 @@ public abstract class JdbcMetadataHandler
                 }
             }
         }
-        catch (SQLException sqlException) {
-            throw new RuntimeException(sqlException.getErrorCode() + ": " + sqlException.getMessage(), sqlException);
-        }
         catch (Exception ex) {
             LOGGER.warn("Unable to split data.", ex);
         }


### PR DESCRIPTION
…JDBC connector

*Issue #, if available:* N/A

*Description of changes:* It's possible for a primary key to be a non-comparable type (e.g. UUID) in which case an exception is thrown by the underlying DB that there is no min function available for the type (e.g. `function min(uuid) does not exist`) when trying to split the keyspace for parallelization.  This change will bypass splitting when any exception is thrown during in this keyspace splitting method, since it is only an optional optimization anyway.

*Testing:* existing unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
