### PR TITLE
fix exception thats causing errors to get swallowed and rethrown inco…

### DIFF
--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/domain/spill/SpillLocationVerifier.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/domain/spill/SpillLocationVerifier.java
@@ -21,6 +21,7 @@ package com.amazonaws.athena.connector.lambda.domain.spill;
  */
 
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -95,7 +96,7 @@ public class SpillLocationVerifier
 
             logger.info("The state of bucket {} has been updated to {} from {}", bucket, state, BucketState.UNCHECKED);
         }
-        catch (Exception ex) {
+        catch (AmazonS3Exception ex) {
             throw new RuntimeException("Error while checking bucket ownership for " + bucket, ex);
         }
     }


### PR DESCRIPTION
…rrectly


fixing exception to only throw s3 errors. Currently, errors thrown from connectors get swallowed here, and the user only sees errors related to s3 bucket ownership. 


*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
