### PR TITLE
Fixes fasterxml.jackson-annotations dependency.

### DIFF
--- a/athena-dynamodb/pom.xml
+++ b/athena-dynamodb/pom.xml
@@ -112,7 +112,7 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
             <version>${fasterxml.jackson.version}</version>
-            <scope>test</scope>
+            <scope>runtime</scope>
         </dependency>
     </dependencies>
 

--- a/athena-federation-sdk-tools/pom.xml
+++ b/athena-federation-sdk-tools/pom.xml
@@ -84,6 +84,13 @@
             <version>${aws-sdk.version}</version>
             <scope>provided</scope>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-annotations -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${fasterxml.jackson.version}</version>
+            <scope>runtime</scope>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awscdk/core -->
         <dependency>
             <groupId>software.amazon.awscdk</groupId>

--- a/athena-federation-sdk-tools/src/main/java/com/amazonaws/athena/connector/integration/README.md
+++ b/athena-federation-sdk-tools/src/main/java/com/amazonaws/athena/connector/integration/README.md
@@ -48,7 +48,7 @@ Include the following dependencies in the specific connector's `pom.xml` file:
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
             <version>${fasterxml.jackson.version}</version>
-            <scope>test</scope>
+            <scope>runtime</scope>
         </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -88,13 +88,6 @@
             <version>${testng.version}</version>
             <scope>test</scope>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/software.amazon.awscdk/core -->
-        <dependency>
-            <groupId>software.amazon.awscdk</groupId>
-            <artifactId>core</artifactId>
-            <version>${aws-cdk.version}</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
*Description of changes:*
Removed awscdk:core dependency from main pom.xml which pulled in a conflicting version of the fasterxml-jackson artifacts. Added fasterxml:jackson-annotations artifact as runtime dependency for the dynamodb connector to complement version of other fasterxml-jackson artifacts pulled in by awscdk (needed for integ-tests).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
