### PR TITLE
Fixes JDBC Timestamp not showing up in results - JDBC Redshift connectors.

### DIFF
--- a/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/manager/JdbcArrowTypeConverter.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/manager/JdbcArrowTypeConverter.java
@@ -21,6 +21,7 @@ package com.amazonaws.connectors.athena.jdbc.manager;
 
 import org.apache.arrow.adapter.jdbc.JdbcFieldInfo;
 import org.apache.arrow.adapter.jdbc.JdbcToArrowUtils;
+import org.apache.arrow.vector.types.DateUnit;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,8 +45,10 @@ public final class JdbcArrowTypeConverter
      */
     public static ArrowType toArrowType(final int jdbcType, final int precision, final int scale)
     {
-        return JdbcToArrowUtils.getArrowTypeForJdbcField(
+        ArrowType arrowType = JdbcToArrowUtils.getArrowTypeForJdbcField(
                 new JdbcFieldInfo(jdbcType, precision, scale),
                 null);
+
+        return (arrowType instanceof ArrowType.Timestamp) ? new ArrowType.Date(DateUnit.MILLISECOND) : arrowType;
     }
 }

--- a/athena-jdbc/src/test/java/com/amazonaws/connectors/athena/jdbc/manager/JdbcArrowTypeConverterTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/connectors/athena/jdbc/manager/JdbcArrowTypeConverterTest.java
@@ -50,6 +50,6 @@ public class JdbcArrowTypeConverterTest
         Assert.assertEquals(Types.MinorType.VARBINARY.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.LONGVARBINARY, 0, 0));
         Assert.assertEquals(Types.MinorType.DATEMILLI.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.DATE, 0, 0));
         Assert.assertEquals(Types.MinorType.TIMEMILLI.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.TIME, 0, 0));
-        Assert.assertEquals(Types.MinorType.TIMESTAMPMILLI.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.TIMESTAMP, 0, 0));
+        Assert.assertEquals(Types.MinorType.DATEMILLI.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.TIMESTAMP, 0, 0));
     }
 }

--- a/athena-jdbc/src/test/java/com/amazonaws/connectors/athena/jdbc/manager/JdbcMetadataHandlerTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/connectors/athena/jdbc/manager/JdbcMetadataHandlerTest.java
@@ -177,6 +177,7 @@ public class JdbcMetadataHandlerTest
         SchemaBuilder expectedSchemaBuilder = SchemaBuilder.newBuilder();
         expectedSchemaBuilder.addField(FieldBuilder.newBuilder("testCol1", org.apache.arrow.vector.types.Types.MinorType.INT.getType()).build());
         expectedSchemaBuilder.addField(FieldBuilder.newBuilder("testCol2", org.apache.arrow.vector.types.Types.MinorType.VARCHAR.getType()).build());
+        expectedSchemaBuilder.addField(FieldBuilder.newBuilder("testCol3", org.apache.arrow.vector.types.Types.MinorType.DATEMILLI.getType()).build());
         PARTITION_SCHEMA.getFields().forEach(expectedSchemaBuilder::addField);
         Schema expected = expectedSchemaBuilder.build();
 


### PR DESCRIPTION
**Issue #, if available:**
Cx is using Athena to query Redshift DB tables containing timestamp columns. The latter do not show up in Athena in either the table's schema or in the results of the select statements.

**Description of changes:**
Converted JDBC Timestamp to Arrow DATEMILLI type.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
