### PR TITLE
Fixes LambdaFunctionException: Unable to create domain map - Elasticsearch connector

### DIFF
--- a/athena-elasticsearch/pom.xml
+++ b/athena-elasticsearch/pom.xml
@@ -79,7 +79,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-elasticsearch</artifactId>
-            <version>1.11.759</version>
+            <version>${aws-sdk.version}</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient -->
         <dependency>

--- a/athena-elasticsearch/src/main/java/com/amazonaws/connectors/athena/elasticsearch/AwsElasticsearchFactory.java
+++ b/athena-elasticsearch/src/main/java/com/amazonaws/connectors/athena/elasticsearch/AwsElasticsearchFactory.java
@@ -1,0 +1,38 @@
+/*-
+ * #%L
+ * athena-elasticsearch
+ * %%
+ * Copyright (C) 2019 - 2020 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.connectors.athena.elasticsearch;
+
+import com.amazonaws.services.elasticsearch.AWSElasticsearch;
+import com.amazonaws.services.elasticsearch.AWSElasticsearchClientBuilder;
+
+/**
+ * This factory class provides an AWS ES Client.
+ */
+public class AwsElasticsearchFactory
+{
+    /**
+     * Gets a default AWS ES client.
+     * @return default AWS ES client.
+     */
+    public AWSElasticsearch getClient()
+    {
+        return AWSElasticsearchClientBuilder.defaultClient();
+    }
+}

--- a/athena-elasticsearch/src/main/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchDomainMapProvider.java
+++ b/athena-elasticsearch/src/main/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchDomainMapProvider.java
@@ -87,7 +87,7 @@ class ElasticsearchDomainMapProvider
     private Map<String, String> getDomainMapFromAmazonElasticsearch()
             throws RuntimeException
     {
-        final AWSElasticsearch awsEsClient = AWSElasticsearchClientBuilder.defaultClient();
+        final AWSElasticsearch awsEsClient = getElasticsearchClient();
         final Map<String, String> domainMap = new HashMap<>();
 
         try {
@@ -125,6 +125,15 @@ class ElasticsearchDomainMapProvider
         finally {
             awsEsClient.shutdown();
         }
+    }
+
+    /**
+     * Gets an Amazon Elasticsearch client.
+     * @return Amazon Elasticsearch client.
+     */
+    protected AWSElasticsearch getElasticsearchClient()
+    {
+        return AWSElasticsearchClientBuilder.defaultClient();
     }
 
     /**

--- a/athena-elasticsearch/src/main/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchMetadataHandler.java
+++ b/athena-elasticsearch/src/main/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchMetadataHandler.java
@@ -164,6 +164,11 @@ public class ElasticsearchMetadataHandler
     {
         logger.debug("doListSchemaNames: enter - " + request);
 
+        if (autoDiscoverEndpoint) {
+            // Refresh Domain Map as new domains could have been added (in Amazon ES), and/or old ones removed...
+            domainMap = domainMapProvider.getDomainMap(null);
+        }
+
         return new ListSchemasResponse(request.getCatalogName(), domainMap.keySet());
     }
 


### PR DESCRIPTION
**Issue #, if available:**
When using Amazon Elasticsearch service as a data-source provider, if the account being used has more than 5 Domain Names defined in Amazon Elasticsearch service, the following error will be observed in Athena for `ListDatabases`/`show databases` requests:
```
java.lang.RuntimeException: com.amazonaws.services.lambda.invoke.LambdaFunctionException: Unable to create domain map: Please provide a maximum of 5 Elasticsearch domain names to describe. (Service: AWSElasticsearch; Status Code: 400;...
```
**Description of changes:**
Since the `DescribeElasticsearchDomains` Elasticsearch API can only process 5 domain names in a single call, the lambda function was modified to generate multiple calls to that API when the list of domain names exceeds 5.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
