### PR TITLE
Added support for ARRAY type - PostGreSQL JDBC connector

### DIFF
--- a/athena-jdbc/README.md
+++ b/athena-jdbc/README.md
@@ -139,8 +139,8 @@ spill_prefix    Spill bucket key prefix. Required.
 |Long|bigint[]|Bigint
 |float|float4[]|Float4
 |Double|float8[]|Float8
-|Date|date[]|Datemilli
-|Timestamp|timestamp[]|Datemilli
+|Date|date[]|DateDay
+|Timestamp|timestamp[]|DateMilli
 |String|text[]|Varchar
 |Bytes|bytea[]|Varbinary
 |BigDecimal|numeric(p,s)[]|Decimal

--- a/athena-jdbc/README.md
+++ b/athena-jdbc/README.md
@@ -130,21 +130,27 @@ spill_prefix    Spill bucket key prefix. Required.
 
 # Data types support
 
-|Jdbc|Arrow|
-| ---|---|
-|Boolean|Bit|
-|Integer|Tiny|
-|Short|Smallint|
-|Integer|Int|
-|Long|Bigint|
-|float|Float4|
-|Double|Float8|
-|Date|DateDay|
-|String|Varchar|
-|Bytes|Varbinary|
-|BigDecimal|Decimal|
+|Jdbc|*PostGreSQL[]|Arrow|
+| ---|---|---|
+|Boolean|boolean[]|Bit
+|Integer|**N/A**|Tiny
+|Short|smallint[]|Smallint
+|Integer|integer[]|Int
+|Long|bigint[]|Bigint
+|float|float4[]|Float4
+|Double|float8[]|Float8
+|Date|date[]|Datemilli
+|Timestamp|timestamp[]|Datemilli
+|String|text[]|Varchar
+|Bytes|bytea[]|Varbinary
+|BigDecimal|numeric(p,s)[]|Decimal
+|**\*ARRAY**|**N/A**|List|
 
 See respective database documentation for conversion between JDBC and database types.
+
+**\*NOTE**: ARRAY type is supported for the PostGreSQL connector with the following constraints:
+* Multi-dimensional arrays (`<data_type>[][]`, or nested arrays) are **NOT** supported.
+* Columns with unsupported ARRAY data-types will be converted to array of string elements (i.e. `array<varchar>`).
 
 # Secrets
 

--- a/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/manager/JdbcArrowTypeConverter.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/manager/JdbcArrowTypeConverter.java
@@ -49,6 +49,15 @@ public final class JdbcArrowTypeConverter
                 new JdbcFieldInfo(jdbcType, precision, scale),
                 null);
 
-        return (arrowType instanceof ArrowType.Timestamp) ? new ArrowType.Date(DateUnit.MILLISECOND) : arrowType;
+        if (arrowType instanceof ArrowType.Date) {
+            // Convert from DateMilli to DateDay
+            return new ArrowType.Date(DateUnit.DAY);
+        }
+        else if (arrowType instanceof ArrowType.Timestamp) {
+            // Convert from Timestamp to DateMilli
+            return new ArrowType.Date(DateUnit.MILLISECOND);
+        }
+
+        return arrowType;
     }
 }

--- a/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/manager/JdbcMetadataHandler.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/manager/JdbcMetadataHandler.java
@@ -236,7 +236,7 @@ public abstract class JdbcMetadataHandler
                 String columnName = resultSet.getString("COLUMN_NAME");
                 if (columnType != null && SupportedTypes.isSupported(columnType)) {
                     if (columnType instanceof ArrowType.List) {
-                        schemaBuilder.addListField(columnName, arrowTypeFromTypeName(
+                        schemaBuilder.addListField(columnName, getArrayArrowTypeFromTypeName(
                                 resultSet.getString("TYPE_NAME"),
                                 resultSet.getInt("COLUMN_SIZE"),
                                 resultSet.getInt("DECIMAL_DIGITS")));
@@ -247,6 +247,8 @@ public abstract class JdbcMetadataHandler
                 }
                 else {
                     // Default to VARCHAR ArrowType
+                    LOGGER.warn("getSchema: Unable to map type for column[" + columnName +
+                            "] to a supported type, attempted " + columnType + " - defaulting type to VARCHAR.");
                     schemaBuilder.addField(FieldBuilder.newBuilder(columnName, new ArrowType.Utf8()).build());
                 }
                 found = true;
@@ -326,15 +328,15 @@ public abstract class JdbcMetadataHandler
     }
 
     /**
-     * Converts an ARRAY column's TYPE_NAME provided by the jdbc metadata to an ArrowType.
+     * Converts an ARRAY column's TYPE_NAME (provided by the jdbc metadata) to an ArrowType.
      * @param typeName The column's TYPE_NAME (e.g. _int4, _text, _float8, etc...)
      * @param precision Used for BigDecimal ArrowType
      * @param scale Used for BigDecimal ArrowType
      * @return Utf8 ArrowType (VARCHAR)
      */
-    protected ArrowType arrowTypeFromTypeName(String typeName, int precision, int scale)
+    protected ArrowType getArrayArrowTypeFromTypeName(String typeName, int precision, int scale)
     {
-        // Default array support is List<Utf8>.
+        // Default ARRAY type is VARCHAR.
         return new ArrowType.Utf8();
     }
 }

--- a/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/manager/JdbcMetadataHandler.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/manager/JdbcMetadataHandler.java
@@ -244,11 +244,12 @@ public abstract class JdbcMetadataHandler
                     else {
                         schemaBuilder.addField(FieldBuilder.newBuilder(columnName, columnType).build());
                     }
-                    found = true;
                 }
                 else {
-                    LOGGER.error("getSchema: Unable to map type for column[" + columnName + "] to a supported type, attempted " + columnType);
+                    // Default to VARCHAR ArrowType
+                    schemaBuilder.addField(FieldBuilder.newBuilder(columnName, new ArrowType.Utf8()).build());
                 }
+                found = true;
             }
 
             if (!found) {

--- a/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/postgresql/PostGreSqlMetadataHandler.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/postgresql/PostGreSqlMetadataHandler.java
@@ -227,14 +227,14 @@ public class PostGreSqlMetadataHandler
     }
 
     /**
-     * Converts an ARRAY column's TYPE_NAME provided by the jdbc metadata to an ArrowType.
+     * Converts an ARRAY column's TYPE_NAME (provided by the jdbc metadata) to an ArrowType.
      * @param typeName The column's TYPE_NAME (e.g. _int4, _text, _float8, etc...)
      * @param precision Used for BigDecimal ArrowType
      * @param scale Used for BigDecimal ArrowType
      * @return ArrowType equivalent of the fieldType.
      */
     @Override
-    protected ArrowType arrowTypeFromTypeName(String typeName, int precision, int scale)
+    protected ArrowType getArrayArrowTypeFromTypeName(String typeName, int precision, int scale)
     {
         switch(typeName) {
             case "_bool":
@@ -256,7 +256,7 @@ public class PostGreSqlMetadataHandler
             case "_numeric":
                 return new ArrowType.Decimal(precision, scale);
             default:
-                return super.arrowTypeFromTypeName(typeName, precision, scale);
+                return super.getArrayArrowTypeFromTypeName(typeName, precision, scale);
         }
     }
 }

--- a/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/postgresql/PostGreSqlMetadataHandler.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/postgresql/PostGreSqlMetadataHandler.java
@@ -41,6 +41,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -223,5 +224,40 @@ public class PostGreSqlMetadataHandler
     private String encodeContinuationToken(int partition)
     {
         return String.valueOf(partition);
+    }
+
+    /**
+     * Converts an ARRAY column's TYPE_NAME provided by the jdbc metadata to an ArrowType.
+     * @param typeName The column's TYPE_NAME (e.g. _int4, _text, _float8, etc...)
+     * @param precision Used for BigDecimal ArrowType
+     * @param scale Used for BigDecimal ArrowType
+     * @return ArrowType equivalent of the fieldType.
+     */
+    @Override
+    protected ArrowType arrowTypeFromTypeName(String typeName, int precision, int scale)
+    {
+        switch(typeName) {
+            case "_bool":
+                return Types.MinorType.BIT.getType();
+            case "_int2":
+                return Types.MinorType.SMALLINT.getType();
+            case "_int4":
+                return Types.MinorType.INT.getType();
+            case "_int8":
+                return Types.MinorType.BIGINT.getType();
+            case "_float4":
+                return Types.MinorType.FLOAT4.getType();
+            case "_float8":
+                return Types.MinorType.FLOAT8.getType();
+            case "_date":
+            case "_timestamp":
+                return Types.MinorType.DATEMILLI.getType();
+            case "_bytea":
+                return Types.MinorType.VARBINARY.getType();
+            case "_numeric":
+                return new ArrowType.Decimal(precision, scale);
+            default:
+                return super.arrowTypeFromTypeName(typeName, precision, scale);
+        }
     }
 }

--- a/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/postgresql/PostGreSqlMetadataHandler.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/postgresql/PostGreSqlMetadataHandler.java
@@ -250,10 +250,9 @@ public class PostGreSqlMetadataHandler
             case "_float8":
                 return Types.MinorType.FLOAT8.getType();
             case "_date":
+                return Types.MinorType.DATEDAY.getType();
             case "_timestamp":
                 return Types.MinorType.DATEMILLI.getType();
-            case "_bytea":
-                return Types.MinorType.VARBINARY.getType();
             case "_numeric":
                 return new ArrowType.Decimal(precision, scale);
             default:

--- a/athena-jdbc/src/test/java/com/amazonaws/connectors/athena/jdbc/manager/JdbcArrowTypeConverterTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/connectors/athena/jdbc/manager/JdbcArrowTypeConverterTest.java
@@ -48,7 +48,7 @@ public class JdbcArrowTypeConverterTest
         Assert.assertEquals(Types.MinorType.VARBINARY.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.BINARY, 0, 0));
         Assert.assertEquals(Types.MinorType.VARBINARY.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.VARBINARY, 0, 0));
         Assert.assertEquals(Types.MinorType.VARBINARY.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.LONGVARBINARY, 0, 0));
-        Assert.assertEquals(Types.MinorType.DATEMILLI.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.DATE, 0, 0));
+        Assert.assertEquals(Types.MinorType.DATEDAY.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.DATE, 0, 0));
         Assert.assertEquals(Types.MinorType.TIMEMILLI.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.TIME, 0, 0));
         Assert.assertEquals(Types.MinorType.DATEMILLI.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.TIMESTAMP, 0, 0));
         Assert.assertEquals(Types.MinorType.LIST.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.ARRAY, 0, 0));

--- a/athena-jdbc/src/test/java/com/amazonaws/connectors/athena/jdbc/manager/JdbcArrowTypeConverterTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/connectors/athena/jdbc/manager/JdbcArrowTypeConverterTest.java
@@ -51,5 +51,6 @@ public class JdbcArrowTypeConverterTest
         Assert.assertEquals(Types.MinorType.DATEMILLI.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.DATE, 0, 0));
         Assert.assertEquals(Types.MinorType.TIMEMILLI.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.TIME, 0, 0));
         Assert.assertEquals(Types.MinorType.DATEMILLI.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.TIMESTAMP, 0, 0));
+        Assert.assertEquals(Types.MinorType.LIST.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.ARRAY, 0, 0));
     }
 }

--- a/athena-jdbc/src/test/java/com/amazonaws/connectors/athena/jdbc/manager/JdbcMetadataHandlerTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/connectors/athena/jdbc/manager/JdbcMetadataHandlerTest.java
@@ -178,6 +178,7 @@ public class JdbcMetadataHandlerTest
         expectedSchemaBuilder.addField(FieldBuilder.newBuilder("testCol1", org.apache.arrow.vector.types.Types.MinorType.INT.getType()).build());
         expectedSchemaBuilder.addField(FieldBuilder.newBuilder("testCol2", org.apache.arrow.vector.types.Types.MinorType.VARCHAR.getType()).build());
         expectedSchemaBuilder.addField(FieldBuilder.newBuilder("testCol3", org.apache.arrow.vector.types.Types.MinorType.DATEMILLI.getType()).build());
+        expectedSchemaBuilder.addField(FieldBuilder.newBuilder("testCol4", org.apache.arrow.vector.types.Types.MinorType.VARCHAR.getType()).build());
         PARTITION_SCHEMA.getFields().forEach(expectedSchemaBuilder::addField);
         Schema expected = expectedSchemaBuilder.build();
 

--- a/athena-jdbc/src/test/java/com/amazonaws/connectors/athena/jdbc/postgresql/PostGreSqlMetadataHandlerTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/connectors/athena/jdbc/postgresql/PostGreSqlMetadataHandlerTest.java
@@ -301,7 +301,7 @@ public class PostGreSqlMetadataHandlerTest
                 {Types.ARRAY, "binary_array", 0, 0, "_bytea"},
                 {Types.ARRAY, "decimal_array", 38, 2, "_numeric"},
                 {Types.ARRAY, "string_array", 0, 0, "_text"},
-                {Types.ARRAY, "default_array", 0, 0, "_unsupported"}
+                {Types.ARRAY, "uuid_array", 0, 0, "_uuid"}
         };
         AtomicInteger rowNumber = new AtomicInteger(-1);
         ResultSet resultSet = mockResultSet(schema, values, rowNumber);
@@ -319,7 +319,7 @@ public class PostGreSqlMetadataHandlerTest
                 .addListField("binary_array", new ArrowType.Utf8())
                 .addListField("decimal_array", new ArrowType.Decimal(38, 2))
                 .addListField("string_array", new ArrowType.Utf8())
-                .addListField("default_array", new ArrowType.Utf8());
+                .addListField("uuid_array", new ArrowType.Utf8());
         postGreSqlMetadataHandler.getPartitionSchema("testCatalog").getFields()
                 .forEach(expectedSchemaBuilder::addField);
         Schema expected = expectedSchemaBuilder.build();

--- a/athena-jdbc/src/test/java/com/amazonaws/connectors/athena/jdbc/postgresql/PostGreSqlMetadataHandlerTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/connectors/athena/jdbc/postgresql/PostGreSqlMetadataHandlerTest.java
@@ -314,9 +314,9 @@ public class PostGreSqlMetadataHandlerTest
                 .addListField("bigint_array", new ArrowType.Int(64, true))
                 .addListField("float_array", new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE))
                 .addListField("double_array", new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE))
-                .addListField("date_array", new ArrowType.Date(DateUnit.MILLISECOND))
+                .addListField("date_array", new ArrowType.Date(DateUnit.DAY))
                 .addListField("timestamp_array", new ArrowType.Date(DateUnit.MILLISECOND))
-                .addListField("binary_array", new ArrowType.Binary())
+                .addListField("binary_array", new ArrowType.Utf8())
                 .addListField("decimal_array", new ArrowType.Decimal(38, 2))
                 .addListField("string_array", new ArrowType.Utf8())
                 .addListField("default_array", new ArrowType.Utf8());

--- a/athena-jdbc/src/test/java/com/amazonaws/connectors/athena/jdbc/postgresql/PostGreSqlMetadataHandlerTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/connectors/athena/jdbc/postgresql/PostGreSqlMetadataHandlerTest.java
@@ -31,24 +31,29 @@ import com.amazonaws.athena.connector.lambda.metadata.GetSplitsRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetSplitsResponse;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableLayoutRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableLayoutResponse;
+import com.amazonaws.athena.connector.lambda.metadata.GetTableRequest;
+import com.amazonaws.athena.connector.lambda.metadata.GetTableResponse;
 import com.amazonaws.athena.connector.lambda.security.FederatedIdentity;
 import com.amazonaws.connectors.athena.jdbc.TestBase;
 import com.amazonaws.connectors.athena.jdbc.connection.DatabaseConnectionConfig;
 import com.amazonaws.connectors.athena.jdbc.connection.JdbcConnectionFactory;
 import com.amazonaws.connectors.athena.jdbc.connection.JdbcCredentialProvider;
-import com.amazonaws.connectors.athena.jdbc.manager.JdbcMetadataHandler;
-import com.amazonaws.connectors.athena.jdbc.mysql.MySqlMetadataHandler;
 import com.amazonaws.services.athena.AmazonAthena;
 import com.amazonaws.services.secretsmanager.AWSSecretsManager;
 import com.amazonaws.services.secretsmanager.model.GetSecretValueRequest;
 import com.amazonaws.services.secretsmanager.model.GetSecretValueResult;
 import com.google.common.collect.ImmutableMap;
+import org.apache.arrow.vector.types.DateUnit;
+import org.apache.arrow.vector.types.FloatingPointPrecision;
+import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -61,7 +66,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -69,6 +73,8 @@ import java.util.stream.Collectors;
 public class PostGreSqlMetadataHandlerTest
         extends TestBase
 {
+    private static final Logger logger = LoggerFactory.getLogger(PostGreSqlMetadataHandlerTest.class);
+
     private DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", JdbcConnectionFactory.DatabaseEngine.MYSQL,
             "mysql://jdbc:mysql://hostname/user=A&password=B");
     private PostGreSqlMetadataHandler postGreSqlMetadataHandler;
@@ -275,4 +281,62 @@ public class PostGreSqlMetadataHandlerTest
         Set<Map<String, String>> actualSplits = getSplitsResponse.getSplits().stream().map(Split::getProperties).collect(Collectors.toSet());
         Assert.assertEquals(expectedSplits, actualSplits);
     }
+
+    @Test
+    public void doGetTableWithArrayColumns()
+            throws Exception
+    {
+        logger.info("doGetTableWithArrayColumns - enter");
+
+        String[] schema = {"DATA_TYPE", "COLUMN_NAME",  "COLUMN_SIZE", "DECIMAL_DIGITS", "TYPE_NAME"};
+        Object[][] values = {
+                {Types.ARRAY, "bool_array", 0, 0, "_bool"},
+                {Types.ARRAY, "smallint_array", 0, 0, "_int2"},
+                {Types.ARRAY, "int_array", 0, 0, "_int4"},
+                {Types.ARRAY, "bigint_array", 0, 0, "_int8"},
+                {Types.ARRAY, "float_array", 0, 0, "_float4"},
+                {Types.ARRAY, "double_array", 0, 0, "_float8"},
+                {Types.ARRAY, "date_array", 0, 0, "_date"},
+                {Types.ARRAY, "timestamp_array", 0, 0, "_timestamp"},
+                {Types.ARRAY, "binary_array", 0, 0, "_bytea"},
+                {Types.ARRAY, "decimal_array", 38, 2, "_numeric"},
+                {Types.ARRAY, "string_array", 0, 0, "_text"},
+                {Types.ARRAY, "default_array", 0, 0, "_unsupported"}
+        };
+        AtomicInteger rowNumber = new AtomicInteger(-1);
+        ResultSet resultSet = mockResultSet(schema, values, rowNumber);
+
+        SchemaBuilder expectedSchemaBuilder = SchemaBuilder.newBuilder();
+        expectedSchemaBuilder
+                .addListField("bool_array", new ArrowType.Bool())
+                .addListField("smallint_array", new ArrowType.Int(16, true))
+                .addListField("int_array", new ArrowType.Int(32, true))
+                .addListField("bigint_array", new ArrowType.Int(64, true))
+                .addListField("float_array", new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE))
+                .addListField("double_array", new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE))
+                .addListField("date_array", new ArrowType.Date(DateUnit.MILLISECOND))
+                .addListField("timestamp_array", new ArrowType.Date(DateUnit.MILLISECOND))
+                .addListField("binary_array", new ArrowType.Binary())
+                .addListField("decimal_array", new ArrowType.Decimal(38, 2))
+                .addListField("string_array", new ArrowType.Utf8())
+                .addListField("default_array", new ArrowType.Utf8());
+        postGreSqlMetadataHandler.getPartitionSchema("testCatalog").getFields()
+                .forEach(expectedSchemaBuilder::addField);
+        Schema expected = expectedSchemaBuilder.build();
+
+        TableName inputTableName = new TableName("testSchema", "testTable");
+        Mockito.when(connection.getMetaData().getColumns("testCatalog", inputTableName.getSchemaName(), inputTableName.getTableName(), null)).thenReturn(resultSet);
+        Mockito.when(connection.getCatalog()).thenReturn("testCatalog");
+
+        GetTableResponse getTableResponse = this.postGreSqlMetadataHandler.doGetTable(new BlockAllocatorImpl(),
+                new GetTableRequest(this.federatedIdentity, "testQueryId", "testCatalog", inputTableName));
+
+        logger.info("Schema: {}", getTableResponse.getSchema());
+
+        Assert.assertEquals(expected, getTableResponse.getSchema());
+        Assert.assertEquals(inputTableName, getTableResponse.getTableName());
+        Assert.assertEquals("testCatalog", getTableResponse.getCatalogName());
+
+        logger.info("doGetTableWithArrayColumns - exit");
+   }
 }


### PR DESCRIPTION
**Issue #, if available:**
Closes #186 

**Description of changes:**
Add support for ARRAY type to the PostGreSQL connector and made all unsupported types default to Varchar to support types such as UUID, etc...

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
