### PR TITLE
Allow PostGreSqlCompositeHandler to be used as Lambda handler class

### DIFF
--- a/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/postgresql/PostGreSqlCompositeHandler.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/postgresql/PostGreSqlCompositeHandler.java
@@ -20,8 +20,6 @@
 package com.amazonaws.connectors.athena.jdbc.postgresql;
 
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
-import com.amazonaws.athena.connector.lambda.handlers.MetadataHandler;
-import com.amazonaws.athena.connector.lambda.handlers.RecordHandler;
 
 /**
  * Boilerplate composite handler that allows us to use a single Lambda function for both

--- a/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/postgresql/PostGreSqlCompositeHandler.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/postgresql/PostGreSqlCompositeHandler.java
@@ -32,7 +32,7 @@ import com.amazonaws.athena.connector.lambda.handlers.RecordHandler;
 public class PostGreSqlCompositeHandler
         extends CompositeHandler
 {
-    public PostGreSqlCompositeHandler(MetadataHandler metadataHandler, RecordHandler recordHandler)
+    public PostGreSqlCompositeHandler()
     {
         super(new PostGreSqlMetadataHandler(), new PostGreSqlRecordHandler());
     }


### PR DESCRIPTION
Removed unused constructor parameters to allow to use this class as AWS Lambda handler directly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.