### PR TITLE
[Bug-Fix]: Duplicate splits generated when splits are continued

### DIFF
--- a/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/mysql/MySqlMetadataHandler.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/mysql/MySqlMetadataHandler.java
@@ -171,7 +171,7 @@ public class MySqlMetadataHandler
 
             if (splits.size() >= MAX_SPLITS_PER_REQUEST) {
                 //We exceeded the number of split we want to return in a single request, return and provide a continuation token.
-                return new GetSplitsResponse(getSplitsRequest.getCatalogName(), splits, encodeContinuationToken(curPartition));
+                return new GetSplitsResponse(getSplitsRequest.getCatalogName(), splits, encodeContinuationToken(curPartition + 1));
             }
         }
 

--- a/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/postgresql/PostGreSqlMetadataHandler.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/postgresql/PostGreSqlMetadataHandler.java
@@ -203,7 +203,7 @@ public class PostGreSqlMetadataHandler
 
                 if (splits.size() >= MAX_SPLITS_PER_REQUEST) {
                     //We exceeded the number of split we want to return in a single request, return and provide a continuation token.
-                    return new GetSplitsResponse(getSplitsRequest.getCatalogName(), splits, encodeContinuationToken(curPartition));
+                    return new GetSplitsResponse(getSplitsRequest.getCatalogName(), splits, encodeContinuationToken(curPartition + 1));
                 }
             }
         }


### PR DESCRIPTION
*Description of changes:*
This MR addresses duplicate splits bug in the current implementation for athena-jdbc connectors.  I believe that the issue here is that when the number of splits is too large, the continuation token encoded should be next **unprocessed** partition.  Otherwise, the each partition at the partition boundary (MAX_SPLIT_PER_REQUEST) gets included twice in the current implementation.  One time when the MAX_SPLIT_PER_REQUEST is reached, and another time when the next request resumes from the partition that was just processed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
