### PR TITLE
[Fixes] ClassCastException with DATEDAY processing - PostGreSQL connector

### DIFF
--- a/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/manager/JdbcRecordHandler.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/manager/JdbcRecordHandler.java
@@ -72,8 +72,6 @@ import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
-import org.joda.time.DateTime;
-import org.joda.time.Days;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -84,9 +82,9 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Abstracts JDBC record handler and provides common reusable split records handling.
@@ -258,7 +256,7 @@ public abstract class JdbcRecordHandler
                 return (DateDayExtractor) (Object context, NullableDateDayHolder dst) ->
                 {
                     if (resultSet.getDate(fieldName) != null) {
-                        dst.value = Days.daysBetween(EPOCH, new DateTime(((Date) resultSet.getDate(fieldName)).getTime())).getDays();
+                        dst.value = (int) TimeUnit.MILLISECONDS.toDays(resultSet.getDate(fieldName).getTime());
                     }
                     dst.isSet = resultSet.wasNull() ? 0 : 1;
                 };

--- a/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/manager/JdbcSplitQueryBuilder.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/manager/JdbcSplitQueryBuilder.java
@@ -47,6 +47,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 /**
@@ -148,8 +149,8 @@ public abstract class JdbcSplitQueryBuilder
                     statement.setBoolean(i + 1, (boolean) typeAndValue.getValue());
                     break;
                 case DATEDAY:
-                    LocalDateTime dateTime = ((LocalDateTime) typeAndValue.getValue());
-                    statement.setDate(i + 1, new Date(dateTime.toDateTime(DateTimeZone.UTC).getMillis()));
+                    statement.setDate(i + 1,
+                            new Date(TimeUnit.DAYS.toMillis(((Number) typeAndValue.getValue()).longValue())));
                     break;
                 case DATEMILLI:
                     LocalDateTime timestamp = ((LocalDateTime) typeAndValue.getValue());


### PR DESCRIPTION
**Issue #, if available:**
Closes #330.

**Description of changes:**
Queries using the `date()` function in the predicate (e.g. `where mycolumn = date('2021-1-1')`) generate an exception (see below) due to invalid processing of the DATEDAY data type during predicate building. This PR fixes that issue, as well as, the extraction from the DB record that was giving incorrect results.
```
java.lang.Integer cannot be cast to org.joda.time.LocalDateTime: java.lang.ClassCastException
java.lang.ClassCastException: java.lang.Integer cannot be cast to org.joda.time.LocalDateTime
	at com.amazonaws.connectors.athena.jdbc.manager.JdbcSplitQueryBuilder.buildSql(JdbcSplitQueryBuilder.java:151)
	at com.amazonaws.connectors.athena.jdbc.postgresql.PostGreSqlRecordHandler.buildSplitSql(PostGreSqlRecordHandler.java:86)
	at com.amazonaws.connectors.athena.jdbc.manager.JdbcRecordHandler.readWithConstraint(JdbcRecordHandler.java:135)
	at com.amazonaws.connectors.athena.jdbc.MultiplexingJdbcRecordHandler.readWithConstraint(MultiplexingJdbcRecordHandler.java:85)
	at com.amazonaws.athena.connector.lambda.handlers.RecordHandler.doReadRecords(RecordHandler.java:192)
	at com.amazonaws.athena.connector.lambda.handlers.RecordHandler.doHandleRequest(RecordHandler.java:158)
	at com.amazonaws.athena.connector.lambda.handlers.CompositeHandler.handleRequest(CompositeHandler.java:135)
	at com.amazonaws.athena.connector.lambda.handlers.CompositeHandler.handleRequest(CompositeHandler.java:100)
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
