### PR TITLE
Considering attribute projection when choosing index for AthenaDynamoDBConnector.

### DIFF
--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/model/DynamoDBIndex.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/model/DynamoDBIndex.java
@@ -1,0 +1,98 @@
+/*-
+ * #%L
+ * athena-dynamodb
+ * %%
+ * Copyright (C) 2019 - 2021 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.dynamodb.model;
+
+import com.amazonaws.services.dynamodbv2.model.ProjectionType;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.util.Objects.requireNonNull;
+
+public class DynamoDBIndex
+{
+    private final String name;
+    private final String hashKey;
+    private final Optional<String> rangeKey;
+    private final ProjectionType projectionType;
+    private final List<String> projectionAttributeNames;
+
+    public DynamoDBIndex(String name,
+                         String hashKey,
+                         Optional<String> rangeKey,
+                         ProjectionType projectionType,
+                         List<String> projectionAttributeNames)
+    {
+        checkArgument(!isNullOrEmpty(name), "name is null or is empty");
+        this.name = requireNonNull(name, "name is null");
+        this.hashKey = requireNonNull(hashKey, "hashKey is null");
+        this.rangeKey = requireNonNull(rangeKey, "rangeKey is null");
+        this.projectionType = requireNonNull(projectionType, "projectionType is null");
+        this.projectionAttributeNames = requireNonNull(projectionAttributeNames, "knownAttributeDefinitions is null");
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public String getHashKey()
+    {
+        return hashKey;
+    }
+
+    public Optional<String> getRangeKey()
+    {
+        return rangeKey;
+    }
+
+    public ProjectionType getProjectionType()
+    {
+        return projectionType;
+    }
+
+    public List<String> getProjectionAttributeNames()
+    {
+        return projectionAttributeNames;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+
+        DynamoDBIndex other = (DynamoDBIndex) obj;
+        return Objects.equals(this.name, other.name);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(name);
+    }
+}

--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/model/DynamoDBTable.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/model/DynamoDBTable.java
@@ -39,7 +39,7 @@ public class DynamoDBTable
     private final String hashKey;
     private final Optional<String> rangeKey;
     private final List<AttributeDefinition> knownAttributeDefinitions;
-    private final List<DynamoDBTable> indexes;
+    private final List<DynamoDBIndex> indexes;
     private final long approxTableSizeInBytes;
     private final long approxItemCount;
     private final long provisionedReadCapacity;
@@ -49,7 +49,7 @@ public class DynamoDBTable
             String hashKey,
             Optional<String> rangeKey,
             List<AttributeDefinition> knownAttributeDefinitions,
-            List<DynamoDBTable> indexes,
+            List<DynamoDBIndex> indexes,
             long approxTableSizeInBytes,
             long approxItemCount,
             long provisionedReadCapacity)
@@ -85,7 +85,7 @@ public class DynamoDBTable
         return knownAttributeDefinitions;
     }
 
-    public List<DynamoDBTable> getIndexes()
+    public List<DynamoDBIndex> getIndexes()
     {
         return indexes;
     }

--- a/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DDBPredicateUtilsTest.java
+++ b/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DDBPredicateUtilsTest.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,13 +19,26 @@
  */
 package com.amazonaws.athena.connectors.dynamodb;
 
+import com.amazonaws.athena.connector.lambda.data.BlockAllocatorImpl;
+import com.amazonaws.athena.connector.lambda.domain.predicate.Range;
+import com.amazonaws.athena.connector.lambda.domain.predicate.SortedRangeSet;
+import com.amazonaws.athena.connector.lambda.domain.predicate.ValueSet;
+import com.amazonaws.athena.connectors.dynamodb.model.DynamoDBIndex;
+import com.amazonaws.athena.connectors.dynamodb.model.DynamoDBTable;
 import com.amazonaws.athena.connectors.dynamodb.util.DDBPredicateUtils;
+import com.amazonaws.services.dynamodbv2.model.AttributeDefinition;
+import com.amazonaws.services.dynamodbv2.model.ProjectionType;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Optional;
+
+import static org.apache.arrow.vector.types.Types.MinorType.VARCHAR;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -51,5 +64,131 @@ public class DDBPredicateUtilsTest
                 DDBPredicateUtils.aliasColumn("column-$1`~!@#$%^&*()-=+[]{}\\|;:'\",.<>/?f3F"));
 
         logger.info("testAliasColumn - exit");
+    }
+
+    @Test
+    public void testGetBestIndexForPredicatesWithGSIProjectionTypeInclude()
+    {
+        // global secondary index with INCLUDE projection type
+        ValueSet singleValueSet = SortedRangeSet.of(Range.equal(new BlockAllocatorImpl(), VARCHAR.getType(), "value"));
+        DynamoDBTable table = new DynamoDBTable("tableName", "hashKey", Optional.of("sortKey"),
+              ImmutableList.of(
+                    new AttributeDefinition("hashKey", "S"),
+                    new AttributeDefinition("sortKey", "S"),
+                    new AttributeDefinition("col0", "S")),
+              ImmutableList.of(
+                    new DynamoDBIndex("col0-gsi", "col0", Optional.empty(), ProjectionType.INCLUDE, ImmutableList.of("col1"))
+              ), 1000, 10, 5);
+        assertEquals("tableName", DDBPredicateUtils.getBestIndexForPredicates(table, ImmutableList.of("hashKey", "sortKey", "col0", "col1", "col2"), ImmutableMap.of("hashKey", singleValueSet)).getName());
+        assertEquals("tableName", DDBPredicateUtils.getBestIndexForPredicates(table, ImmutableList.of("hashKey", "sortKey", "col0", "col1", "col2"), ImmutableMap.of("sortKey", singleValueSet)).getName());
+        assertEquals("tableName", DDBPredicateUtils.getBestIndexForPredicates(table, ImmutableList.of("hashKey", "sortKey", "col0", "col1", "col2"), ImmutableMap.of("col3", singleValueSet)).getName());
+        assertEquals("tableName", DDBPredicateUtils.getBestIndexForPredicates(table, ImmutableList.of("hashKey", "sortKey", "col0", "col1", "col2"), ImmutableMap.of("col0", singleValueSet)).getName());
+        assertEquals("col0-gsi", DDBPredicateUtils.getBestIndexForPredicates(table, ImmutableList.of("hashKey", "sortKey", "col0", "col1"), ImmutableMap.of("col0", singleValueSet)).getName());
+    }
+
+    @Test
+    public void testGetBestIndexForPredicatesWithGSIProjectionTypeKeysOnly()
+    {
+        // global secondary index with KEYS_ONLY projection type
+        ValueSet singleValueSet = SortedRangeSet.of(Range.equal(new BlockAllocatorImpl(), VARCHAR.getType(), "value"));
+        DynamoDBTable table = new DynamoDBTable("tableName", "hashKey", Optional.of("sortKey"),
+              ImmutableList.of(
+                    new AttributeDefinition("hashKey", "S"),
+                    new AttributeDefinition("sortKey", "S"),
+                    new AttributeDefinition("col0", "S")),
+              ImmutableList.of(
+                    new DynamoDBIndex("col0-gsi", "col0", Optional.empty(), ProjectionType.KEYS_ONLY, ImmutableList.of())
+              ), 1000, 10, 5);
+        assertEquals("tableName", DDBPredicateUtils.getBestIndexForPredicates(table, ImmutableList.of("hashKey", "sortKey", "col0", "col1"), ImmutableMap.of("hashKey", singleValueSet)).getName());
+        assertEquals("tableName", DDBPredicateUtils.getBestIndexForPredicates(table, ImmutableList.of("hashKey", "sortKey", "col0", "col1"), ImmutableMap.of("col0", singleValueSet)).getName());
+        assertEquals("col0-gsi", DDBPredicateUtils.getBestIndexForPredicates(table, ImmutableList.of("hashKey", "sortKey", "col0"), ImmutableMap.of("col0", singleValueSet)).getName());
+    }
+
+    @Test
+    public void testGetBestIndexForPredicatesWithNonEqualityPredicate()
+    {
+        // non-equality conditions for the hash key
+        ValueSet rangeValueSet = SortedRangeSet.of(Range.range(new BlockAllocatorImpl(), VARCHAR.getType(), "aaa", true, "bbb", false));
+        ValueSet singleValueSet = SortedRangeSet.of(Range.equal(new BlockAllocatorImpl(), VARCHAR.getType(), "value"));
+        DynamoDBTable table = new DynamoDBTable("tableName", "hashKey", Optional.of("sortKey"),
+              ImmutableList.of(
+                    new AttributeDefinition("hashKey", "S"),
+                    new AttributeDefinition("sortKey", "S"),
+                    new AttributeDefinition("col0", "S")),
+              ImmutableList.of(
+                    new DynamoDBIndex("col0-gsi", "col0", Optional.empty(), ProjectionType.KEYS_ONLY, ImmutableList.of())
+              ), 1000, 10, 5);
+        assertEquals("tableName", DDBPredicateUtils.getBestIndexForPredicates(table, ImmutableList.of("hashKey", "col0"), ImmutableMap.of("col0", rangeValueSet)).getName());
+        assertEquals("col0-gsi", DDBPredicateUtils.getBestIndexForPredicates(table, ImmutableList.of("hashKey", "col0"), ImmutableMap.of("col0", singleValueSet)).getName());
+    }
+
+    @Test
+    public void testGetBestIndexForPredicatesWithGSIProjectionTypeAll()
+    {
+        // global secondary index with ALL projection type
+        ValueSet singleValueSet = SortedRangeSet.of(Range.equal(new BlockAllocatorImpl(), VARCHAR.getType(), "value"));
+        DynamoDBTable table = new DynamoDBTable("tableName", "hashKey", Optional.of("sortKey"),
+              ImmutableList.of(
+                    new AttributeDefinition("hashKey", "S"),
+                    new AttributeDefinition("sortKey", "S"),
+                    new AttributeDefinition("col0", "S")),
+              ImmutableList.of(
+                    new DynamoDBIndex("col0-gsi", "col0", Optional.of("col1"), ProjectionType.ALL, ImmutableList.of())
+              ), 1000, 10, 5);
+        assertEquals("tableName", DDBPredicateUtils.getBestIndexForPredicates(table, ImmutableList.of("hashKey", "sortKey", "col0", "col1"), ImmutableMap.of("hashKey", singleValueSet)).getName());
+        assertEquals("tableName", DDBPredicateUtils.getBestIndexForPredicates(table, ImmutableList.of("hashKey", "sortKey", "col0", "col1", "col2"), ImmutableMap.of("hashKey", singleValueSet)).getName());
+        assertEquals("col0-gsi", DDBPredicateUtils.getBestIndexForPredicates(table, ImmutableList.of("hashKey", "sortKey", "col0", "col1"), ImmutableMap.of("col0", singleValueSet)).getName());
+        assertEquals("col0-gsi", DDBPredicateUtils.getBestIndexForPredicates(table, ImmutableList.of("hashKey", "sortKey", "col0", "col1", "col2"), ImmutableMap.of("col0", singleValueSet)).getName());
+        assertEquals("col0-gsi", DDBPredicateUtils.getBestIndexForPredicates(table, ImmutableList.of("hashKey", "sortKey", "col0"), ImmutableMap.of("col0", singleValueSet)).getName());
+        assertEquals("col0-gsi", DDBPredicateUtils.getBestIndexForPredicates(table, ImmutableList.of("hashKey", "sortKey", "col0"), ImmutableMap.of("col0", singleValueSet, "col1", singleValueSet)).getName());
+        assertEquals("col0-gsi", DDBPredicateUtils.getBestIndexForPredicates(table, ImmutableList.of("hashKey", "sortKey", "col0"), ImmutableMap.of("col0", singleValueSet, "sortKey", singleValueSet)).getName());
+        assertEquals("tableName", DDBPredicateUtils.getBestIndexForPredicates(table, ImmutableList.of("hashKey", "sortKey", "col0"), ImmutableMap.of("col1", singleValueSet)).getName());
+        assertEquals("tableName", DDBPredicateUtils.getBestIndexForPredicates(table, ImmutableList.of("hashKey", "sortKey", "col0"), ImmutableMap.of("col1", singleValueSet, "hashKey", singleValueSet)).getName());
+
+    }
+
+    @Test
+    public void testGetBestIndexForPredicatesWithLSI()
+    {
+        // local secondary index
+        ValueSet singleValueSet = SortedRangeSet.of(Range.equal(new BlockAllocatorImpl(), VARCHAR.getType(), "value"));
+        DynamoDBTable table = new DynamoDBTable("tableName", "hashKey", Optional.of("sortKey"),
+              ImmutableList.of(
+                    new AttributeDefinition("hashKey", "S"),
+                    new AttributeDefinition("sortKey", "S"),
+                    new AttributeDefinition("col0", "S")),
+              ImmutableList.of(
+                    new DynamoDBIndex("col0-lsi", "hashKey", Optional.of("col0"), ProjectionType.ALL, ImmutableList.of())
+              ), 1000, 10, 5);
+        assertEquals("tableName", DDBPredicateUtils.getBestIndexForPredicates(table, ImmutableList.of("hashKey", "sortKey", "col0", "col1"), ImmutableMap.of("hashKey", singleValueSet)).getName());
+        assertEquals("tableName", DDBPredicateUtils.getBestIndexForPredicates(table, ImmutableList.of("hashKey", "sortKey", "col0", "col1"), ImmutableMap.of("hashKey", singleValueSet, "sortKey", singleValueSet)).getName());
+        assertEquals("col0-lsi", DDBPredicateUtils.getBestIndexForPredicates(table, ImmutableList.of("hashKey", "sortKey", "col0", "col1"), ImmutableMap.of("hashKey", singleValueSet, "col0", singleValueSet)).getName());
+        assertEquals("tableName", DDBPredicateUtils.getBestIndexForPredicates(table, ImmutableList.of("hashKey", "sortKey", "col0", "col1"), ImmutableMap.of("col0", singleValueSet)).getName());
+
+    }
+
+    @Test
+    public void testGetBestIndexForPredicatesWithMultipleIndices()
+    {
+        // multiple indices
+        ValueSet singleValueSet = SortedRangeSet.of(Range.equal(new BlockAllocatorImpl(), VARCHAR.getType(), "value"));
+        DynamoDBTable table = new DynamoDBTable("tableName", "hashKey", Optional.of("sortKey"),
+              ImmutableList.of(
+                    new AttributeDefinition("hashKey", "S"),
+                    new AttributeDefinition("sortKey", "S"),
+                    new AttributeDefinition("col0", "S"),
+                    new AttributeDefinition("col1", "S")),
+              ImmutableList.of(
+                    new DynamoDBIndex("col0-gsi", "col0", Optional.empty(), ProjectionType.INCLUDE, ImmutableList.of("col1")),
+                    new DynamoDBIndex("col1-gsi", "col1", Optional.empty(), ProjectionType.INCLUDE, ImmutableList.of("col2")),
+                    new DynamoDBIndex("col2-lsi", "hashKey", Optional.of("col2"), ProjectionType.ALL, ImmutableList.of())
+              ), 1000, 10, 5);
+        assertEquals("tableName", DDBPredicateUtils.getBestIndexForPredicates(table, ImmutableList.of("hashKey", "col0", "col1", "col2"), ImmutableMap.of("hashKey", singleValueSet)).getName());
+        assertEquals("tableName", DDBPredicateUtils.getBestIndexForPredicates(table, ImmutableList.of("hashKey", "col0", "col1", "col2"), ImmutableMap.of("col0", singleValueSet)).getName());
+        assertEquals("tableName", DDBPredicateUtils.getBestIndexForPredicates(table, ImmutableList.of("hashKey", "col0", "col1", "col2"), ImmutableMap.of("col1", singleValueSet)).getName());
+        assertEquals("tableName", DDBPredicateUtils.getBestIndexForPredicates(table, ImmutableList.of("hashKey", "col0", "col1", "col2"), ImmutableMap.of("col2", singleValueSet)).getName());
+        assertEquals("col0-gsi", DDBPredicateUtils.getBestIndexForPredicates(table, ImmutableList.of("hashKey", "col0", "col1"), ImmutableMap.of("col0", singleValueSet)).getName());
+        assertEquals("col1-gsi", DDBPredicateUtils.getBestIndexForPredicates(table, ImmutableList.of("hashKey", "col1", "col2"), ImmutableMap.of("col1", singleValueSet)).getName());
+        assertEquals("col2-lsi", DDBPredicateUtils.getBestIndexForPredicates(table, ImmutableList.of("hashKey", "col0", "col1"), ImmutableMap.of("hashKey", singleValueSet, "col2", singleValueSet)).getName());
     }
 }


### PR DESCRIPTION
*Issue #, if available: #279

*Description of changes: adding validation to check if projected attributes of an index contails all required attributes of a query when choosing index in AthenaDynamoDBConnector. Fix to issue#279


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
