### PR TITLE
Return elasticsearch domain endpoints for clusters in a vpc

### DIFF
--- a/athena-elasticsearch/src/main/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchDomainMapProvider.java
+++ b/athena-elasticsearch/src/main/java/com/amazonaws/connectors/athena/elasticsearch/ElasticsearchDomainMapProvider.java
@@ -117,8 +117,15 @@ class ElasticsearchDomainMapProvider
                         .withDomainNames(domainNames.subList(startDomainNameIndex, endDomainNameIndex));
                 DescribeElasticsearchDomainsResult describeDomainsResult =
                         awsEsClient.describeElasticsearchDomains(describeDomainsRequest);
-                describeDomainsResult.getDomainStatusList().forEach(domainStatus ->
-                        domainMap.put(domainStatus.getDomainName(), endpointPrefix + domainStatus.getEndpoint()));
+                describeDomainsResult.getDomainStatusList().forEach(domainStatus -> {
+                    String endpoint = domainStatus.getEndpoint();
+                    if (endpoint == null) {
+                        endpoint = domainStatus.getEndpoints().get("vpc");
+                    }
+
+                    domainMap.put(domainStatus.getDomainName(), endpointPrefix + endpoint);
+                });
+
                 startDomainNameIndex = endDomainNameIndex;
             }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

`getDomainMapFromAmazonElasticsearch` Currently does not work with domains within a VPC

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
