### PR TITLE
Fixing ClassCastException for decimal type in athena-jdbc connector

### DIFF
--- a/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/manager/JdbcSplitQueryBuilder.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/manager/JdbcSplitQueryBuilder.java
@@ -163,8 +163,7 @@ public abstract class JdbcSplitQueryBuilder
                     statement.setBytes(i + 1, (byte[]) typeAndValue.getValue());
                     break;
                 case DECIMAL:
-                    ArrowType.Decimal decimalType = (ArrowType.Decimal) typeAndValue.getType();
-                    statement.setBigDecimal(i + 1, BigDecimal.valueOf((long) typeAndValue.getValue(), decimalType.getScale()));
+                    statement.setBigDecimal(i + 1, (BigDecimal) typeAndValue.getValue());
                     break;
                 default:
                     throw new UnsupportedOperationException(String.format("Can't handle type: %s, %s", typeAndValue.getType(), minorTypeForArrowType));


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Bug fixing: athena-jdbc throws ClassCastException when handling filter on decimal type column

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
