### PR TITLE
cutting new release 2021.6.1

### DIFF
--- a/athena-aws-cmdb/athena-aws-cmdb.yaml
+++ b/athena-aws-cmdb/athena-aws-cmdb.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2020.51.1
+    SemanticVersion: 2021.6.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AthenaCatalogName:

--- a/athena-aws-cmdb/pom.xml
+++ b/athena-aws-cmdb/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>2020.51.1</version>
+            <version>2021.6.1</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>

--- a/athena-cloudwatch-metrics/athena-cloudwatch-metrics.yaml
+++ b/athena-cloudwatch-metrics/athena-cloudwatch-metrics.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2020.51.1
+    SemanticVersion: 2021.6.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AthenaCatalogName:

--- a/athena-cloudwatch-metrics/pom.xml
+++ b/athena-cloudwatch-metrics/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>2020.51.1</version>
+            <version>2021.6.1</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>

--- a/athena-cloudwatch/athena-cloudwatch.yaml
+++ b/athena-cloudwatch/athena-cloudwatch.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2020.51.1
+    SemanticVersion: 2021.6.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AthenaCatalogName:

--- a/athena-cloudwatch/pom.xml
+++ b/athena-cloudwatch/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>2020.51.1</version>
+            <version>2021.6.1</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>

--- a/athena-docdb/athena-docdb.yaml
+++ b/athena-docdb/athena-docdb.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2020.51.1
+    SemanticVersion: 2021.6.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AthenaCatalogName:

--- a/athena-docdb/pom.xml
+++ b/athena-docdb/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>2020.51.1</version>
+            <version>2021.6.1</version>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
                 <exclusion>

--- a/athena-dynamodb/athena-dynamodb.yaml
+++ b/athena-dynamodb/athena-dynamodb.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2020.51.1
+    SemanticVersion: 2021.6.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AthenaCatalogName:

--- a/athena-dynamodb/pom.xml
+++ b/athena-dynamodb/pom.xml
@@ -20,12 +20,12 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>2020.51.1</version>
+            <version>2021.6.1</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
-            <version>2020.51.1</version>
+            <version>2021.6.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/athena-elasticsearch/athena-elasticsearch.yaml
+++ b/athena-elasticsearch/athena-elasticsearch.yaml
@@ -10,7 +10,7 @@ Metadata:
     ReadmeUrl: README.md
     Labels: ['athena-federation']
     HomePageUrl: https://github.com/awslabs/aws-athena-query-federation
-    SemanticVersion: 2020.51.1
+    SemanticVersion: 2021.6.1
     SourceCodeUrl: https://github.com/awslabs/aws-athena-query-federation
 
 # Parameters are CloudFormation features to pass input

--- a/athena-elasticsearch/pom.xml
+++ b/athena-elasticsearch/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>2020.51.1</version>
+            <version>2021.6.1</version>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
                 <exclusion>

--- a/athena-example/athena-example.yaml
+++ b/athena-example/athena-example.yaml
@@ -10,7 +10,7 @@ Metadata:
     ReadmeUrl: README.md
     Labels: ['athena-federation']
     HomePageUrl: https://github.com/awslabs/aws-athena-query-federation
-    SemanticVersion: 2020.51.1
+    SemanticVersion: 2021.6.1
     SourceCodeUrl: https://github.com/awslabs/aws-athena-query-federation
 
 # Parameters are CloudFormation features to pass input

--- a/athena-example/pom.xml
+++ b/athena-example/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>2020.51.1</version>
+            <version>2021.6.1</version>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
                 <exclusion>

--- a/athena-federation-integ-test/pom.xml
+++ b/athena-federation-integ-test/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>athena-federation-integ-test</artifactId>
-    <version>2020.51.1</version>
+    <version>2021.6.1</version>
     <packaging>jar</packaging>
     <name>Amazon Athena Query Federation Integ Test</name>
 

--- a/athena-federation-sdk-tools/pom.xml
+++ b/athena-federation-sdk-tools/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>2020.51.1</version>
+            <version>2021.6.1</version>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
                 <exclusion>

--- a/athena-federation-sdk/athena-federation-sdk.yaml
+++ b/athena-federation-sdk/athena-federation-sdk.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2020.51.1
+    SemanticVersion: 2021.6.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AthenaCatalogName:
@@ -47,7 +47,7 @@ Resources:
           spill_prefix: !Ref SpillPrefix
       FunctionName: !Ref AthenaCatalogName
       Handler: "com.amazonaws.athena.connector.lambda.examples.ExampleCompositeHandler"
-      CodeUri: "./target/aws-athena-federation-sdk-2020.51.1-withdep.jar"
+      CodeUri: "./target/aws-athena-federation-sdk-2021.6.1-withdep.jar"
       Description: "This connector enables Amazon Athena to communicate with a randomly generated data source."
       Runtime: java8
       Timeout: !Ref LambdaTimeout

--- a/athena-federation-sdk/pom.xml
+++ b/athena-federation-sdk/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-athena-federation-sdk</artifactId>
-    <version>2020.51.1</version>
+    <version>2021.6.1</version>
     <packaging>jar</packaging>
     <name>Amazon Athena Query Federation SDK</name>
 

--- a/athena-hbase/athena-hbase.yaml
+++ b/athena-hbase/athena-hbase.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2020.51.1
+    SemanticVersion: 2021.6.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AthenaCatalogName:

--- a/athena-hbase/pom.xml
+++ b/athena-hbase/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>2020.51.1</version>
+            <version>2021.6.1</version>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
                 <exclusion>

--- a/athena-jdbc/athena-jdbc.yaml
+++ b/athena-jdbc/athena-jdbc.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2020.51.1
+    SemanticVersion: 2021.6.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   LambdaFunctionName:

--- a/athena-jdbc/pom.xml
+++ b/athena-jdbc/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>2020.51.1</version>
+            <version>2021.6.1</version>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
                 <exclusion>

--- a/athena-neptune/athena-neptune.yaml
+++ b/athena-neptune/athena-neptune.yaml
@@ -10,7 +10,7 @@ Metadata:
     ReadmeUrl: README.md
     Labels: ['athena-federation','athena-neptune','neptune']
     HomePageUrl: https://github.com/awslabs/aws-athena-query-federation
-    SemanticVersion: 2020.51.1
+    SemanticVersion: 2021.6.1
     SourceCodeUrl: https://github.com/awslabs/aws-athena-query-federation
 
 Parameters:

--- a/athena-neptune/pom.xml
+++ b/athena-neptune/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>2020.51.1</version>
+            <version>2021.6.1</version>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
                 <exclusion>

--- a/athena-redis/athena-redis.yaml
+++ b/athena-redis/athena-redis.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2020.51.1
+    SemanticVersion: 2021.6.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AthenaCatalogName:

--- a/athena-redis/pom.xml
+++ b/athena-redis/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>2020.51.1</version>
+            <version>2021.6.1</version>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
                 <exclusion>

--- a/athena-timestream/athena-timestream.yaml
+++ b/athena-timestream/athena-timestream.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2020.51.1
+    SemanticVersion: 2021.6.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AthenaCatalogName:

--- a/athena-timestream/pom.xml
+++ b/athena-timestream/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>2020.51.1</version>
+            <version>2021.6.1</version>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
                 <exclusion>

--- a/athena-tpcds/athena-tpcds.yaml
+++ b/athena-tpcds/athena-tpcds.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2020.51.1
+    SemanticVersion: 2021.6.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AthenaCatalogName:

--- a/athena-tpcds/pom.xml
+++ b/athena-tpcds/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>2020.51.1</version>
+            <version>2021.6.1</version>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
                 <exclusion>

--- a/athena-udfs/athena-udfs.yaml
+++ b/athena-udfs/athena-udfs.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2020.51.1
+    SemanticVersion: 2021.6.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   LambdaFunctionName:

--- a/athena-udfs/pom.xml
+++ b/athena-udfs/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>2020.51.1</version>
+            <version>2021.6.1</version>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
                 <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <aws-sdk.version>1.11.800</aws-sdk.version>
-        <aws-athena-federation-sdk.version>2020.51.1</aws-athena-federation-sdk.version>
+        <aws-athena-federation-sdk.version>2021.6.1</aws-athena-federation-sdk.version>
         <aws.lambda-java-core.version>1.2.0</aws.lambda-java-core.version>
         <slf4j-log4j.version>1.7.28</slf4j-log4j.version>
         <mockito.version>1.10.19</mockito.version>


### PR DESCRIPTION
This PR is to cut a new release in order to add latest functionalities to the SAR deployed connectors. This release includes the following bug fixes:

    * Miscalculation in JDBC connector where dates were offset incorrectly, and will fix a classcast issue for dates as well
    * Fixed classcast exception for decimal types in JDBC connector
    * Adds support for Global Secondary Indexes in the Dynamo connector
    * Addressed bug in JDBC connector where duplicate splits are returned to Presto



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
