### PR TITLE
Publish Federation SDK to Maven Central

### DIFF
--- a/.github/workflows/publish_to_maven_central.yml
+++ b/.github/workflows/publish_to_maven_central.yml
@@ -1,0 +1,34 @@
+name: Release
+
+on:
+  release:
+    types: [ published ]
+
+jobs:
+  release:
+    name: Publish to maven central
+    runs-on: self-hosted
+
+    steps:
+      - name: Checkout Codebase
+        uses: actions/checkout@v2
+
+      - name: Set up Maven Central Repository
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+          server-id: ossrh
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+
+      - name: Publish to Apache Maven Central
+        working-directory: athena-federation-sdk
+        run: mvn clean deploy --batch-mode -P release
+        env:
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+          AWS_REGION: us-east-1

--- a/athena-federation-sdk/pom.xml
+++ b/athena-federation-sdk/pom.xml
@@ -16,6 +16,8 @@
     <version>2021.14.1</version>
     <packaging>jar</packaging>
     <name>Amazon Athena Query Federation SDK</name>
+    <description>The Athena Query Federation SDK defines a set of interfaces and wire protocols that you can implement to enable Athena to delegate portions of it's query execution plan to code that you deploy/write.</description>
+    <url>https://github.com/awslabs/aws-athena-query-federation</url>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
@@ -271,4 +273,86 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <distributionManagement>
+                <snapshotRepository>
+                    <id>ossrh</id>
+                    <url>https://aws.oss.sonatype.org/content/repositories/snapshots</url>
+                </snapshotRepository>
+                <repository>
+                    <id>ossrh</id>
+                    <url>https://aws.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+                </repository>
+            </distributionManagement>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>3.1.1</version>
+                        <configuration>
+                            <failOnError>false</failOnError>
+                            <notimestamp>true</notimestamp>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>3.2.0</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.6</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                                <configuration>
+                                    <!-- Prevent gpg from using pinentry programs https://github.com/actions/setup-java/issues/83-->
+                                    <gpgArguments>
+                                        <arg>--pinentry-mode</arg>
+                                        <arg>loopback</arg>
+                                    </gpgArguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>1.6.8</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <serverId>ossrh</serverId>
+                            <nexusUrl>https://aws.oss.sonatype.org</nexusUrl>
+                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,9 @@
     <artifactId>aws-athena-query-federation</artifactId>
     <packaging>pom</packaging>
     <version>1.0</version>
+    <name>AWS Athena Query Federation</name>
+    <description>The Amazon Athena Query Federation SDK allows you to customize Amazon Athena with your own code.</description>
+    <url>https://github.com/awslabs/aws-athena-query-federation</url>
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
@@ -37,6 +40,17 @@
             <distribution>repo</distribution>
         </license>
     </licenses>
+
+    <developers>
+        <developer>
+            <id>amazonwebservices</id>
+            <organization>Amazon Web Services</organization>
+            <organizationUrl>https://aws.amazon.com</organizationUrl>
+            <roles>
+                <role>developer</role>
+            </roles>
+        </developer>
+    </developers>
 
     <scm>
         <connection>scm:git@github.com:awslabs/aws-athena-query-federation.git</connection>


### PR DESCRIPTION
*Description of changes:*

This adds a git action to publish the Federation SDK to Maven Central for new releases. 
Some additional metadata and plugins had to be added to satisfy the requirements. https://central.sonatype.org/publish/publish-maven/.

All artifacts published to the central repository need to be signed with [PGP](https://central.sonatype.org/publish/requirements/gpg/), which the `maven-gpg-plugin` handles. The private key will be uploaded to github as a [encrypted secret](https://docs.github.com/en/actions/reference/encrypted-secrets) that can then be referenced in the workflow.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
