### PR TITLE
Upgrading Arrow to 3.0.0

### DIFF
--- a/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/EmrClusterTableProviderTest.java
+++ b/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/EmrClusterTableProviderTest.java
@@ -20,6 +20,7 @@
 package com.amazonaws.athena.connectors.aws.cmdb.tables;
 
 import com.amazonaws.athena.connector.lambda.data.Block;
+import com.amazonaws.athena.connector.lambda.data.BlockUtils;
 import com.amazonaws.services.elasticmapreduce.AmazonElasticMapReduce;
 import com.amazonaws.services.elasticmapreduce.model.Application;
 import com.amazonaws.services.elasticmapreduce.model.Cluster;
@@ -34,7 +35,6 @@ import com.amazonaws.services.elasticmapreduce.model.Tag;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.Field;
-import org.joda.time.DateTimeZone;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
@@ -147,7 +147,7 @@ public class EmrClusterTableProviderTest
                 }
                 break;
             case DATEMILLI:
-                assertEquals(100_000, fieldReader.readLocalDateTime().toDateTime(DateTimeZone.UTC).getMillis());
+                assertEquals(100_000, fieldReader.readLocalDateTime().atZone(BlockUtils.UTC_ZONE_ID).toInstant().toEpochMilli());
                 break;
             case BIT:
                 assertTrue(fieldReader.readBoolean());

--- a/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/RdsTableProviderTest.java
+++ b/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/RdsTableProviderTest.java
@@ -20,6 +20,7 @@
 package com.amazonaws.athena.connectors.aws.cmdb.tables;
 
 import com.amazonaws.athena.connector.lambda.data.Block;
+import com.amazonaws.athena.connector.lambda.data.BlockUtils;
 import com.amazonaws.services.elasticmapreduce.AmazonElasticMapReduce;
 import com.amazonaws.services.elasticmapreduce.model.Application;
 import com.amazonaws.services.elasticmapreduce.model.Cluster;
@@ -46,7 +47,6 @@ import com.amazonaws.services.rds.model.Subnet;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.Field;
-import org.joda.time.DateTimeZone;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
@@ -156,7 +156,7 @@ public class RdsTableProviderTest
                     }
                     break;
                 case DATEMILLI:
-                    assertEquals(100_000, fieldReader.readLocalDateTime().toDateTime(DateTimeZone.UTC).getMillis());
+                    assertEquals(100_000, fieldReader.readLocalDateTime().atZone(BlockUtils.UTC_ZONE_ID).toInstant().toEpochMilli());
                     break;
                 case BIT:
                     assertTrue(fieldReader.readBoolean());

--- a/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/ec2/EbsTableProviderTest.java
+++ b/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/ec2/EbsTableProviderTest.java
@@ -20,6 +20,7 @@
 package com.amazonaws.athena.connectors.aws.cmdb.tables.ec2;
 
 import com.amazonaws.athena.connector.lambda.data.Block;
+import com.amazonaws.athena.connector.lambda.data.BlockUtils;
 import com.amazonaws.athena.connectors.aws.cmdb.tables.AbstractTableProviderTest;
 import com.amazonaws.athena.connectors.aws.cmdb.tables.TableProvider;
 import com.amazonaws.services.ec2.AmazonEC2;
@@ -31,7 +32,6 @@ import com.amazonaws.services.ec2.model.VolumeAttachment;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.Field;
-import org.joda.time.DateTimeZone;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
@@ -135,7 +135,7 @@ public class EbsTableProviderTest
                 }
                 break;
             case DATEMILLI:
-                assertEquals(100_000, fieldReader.readLocalDateTime().toDateTime(DateTimeZone.UTC).getMillis());
+                assertEquals(100_000, fieldReader.readLocalDateTime().atZone(BlockUtils.UTC_ZONE_ID).toInstant().toEpochMilli());
                 break;
             case BIT:
                 assertTrue(fieldReader.readBoolean());

--- a/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/ec2/Ec2TableProviderTest.java
+++ b/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/ec2/Ec2TableProviderTest.java
@@ -20,6 +20,7 @@
 package com.amazonaws.athena.connectors.aws.cmdb.tables.ec2;
 
 import com.amazonaws.athena.connector.lambda.data.Block;
+import com.amazonaws.athena.connector.lambda.data.BlockUtils;
 import com.amazonaws.athena.connectors.aws.cmdb.tables.AbstractTableProviderTest;
 import com.amazonaws.athena.connectors.aws.cmdb.tables.TableProvider;
 import com.amazonaws.services.ec2.AmazonEC2;
@@ -36,7 +37,6 @@ import com.amazonaws.services.ec2.model.StateReason;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.Field;
-import org.joda.time.DateTimeZone;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
@@ -137,7 +137,7 @@ public class Ec2TableProviderTest
                 }
                 break;
             case DATEMILLI:
-                assertEquals(100_000, fieldReader.readLocalDateTime().toDateTime(DateTimeZone.UTC).getMillis());
+                assertEquals(100_000, fieldReader.readLocalDateTime().atZone(BlockUtils.UTC_ZONE_ID).toInstant().toEpochMilli());
                 break;
             case BIT:
                 assertTrue(fieldReader.readBoolean());

--- a/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/ec2/ImagesTableProviderTest.java
+++ b/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/ec2/ImagesTableProviderTest.java
@@ -20,6 +20,7 @@
 package com.amazonaws.athena.connectors.aws.cmdb.tables.ec2;
 
 import com.amazonaws.athena.connector.lambda.data.Block;
+import com.amazonaws.athena.connector.lambda.data.BlockUtils;
 import com.amazonaws.athena.connectors.aws.cmdb.tables.AbstractTableProviderTest;
 import com.amazonaws.athena.connectors.aws.cmdb.tables.TableProvider;
 import com.amazonaws.services.ec2.AmazonEC2;
@@ -32,7 +33,6 @@ import com.amazonaws.services.ec2.model.Tag;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.Field;
-import org.joda.time.DateTimeZone;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
@@ -135,7 +135,7 @@ public class ImagesTableProviderTest
                 }
                 break;
             case DATEMILLI:
-                assertEquals(100_000, fieldReader.readLocalDateTime().toDateTime(DateTimeZone.UTC).getMillis());
+                assertEquals(100_000, fieldReader.readLocalDateTime().atZone(BlockUtils.UTC_ZONE_ID).toInstant().toEpochMilli());
                 break;
             case BIT:
                 assertTrue(fieldReader.readBoolean());

--- a/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/ec2/RouteTableProviderTest.java
+++ b/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/ec2/RouteTableProviderTest.java
@@ -20,6 +20,7 @@
 package com.amazonaws.athena.connectors.aws.cmdb.tables.ec2;
 
 import com.amazonaws.athena.connector.lambda.data.Block;
+import com.amazonaws.athena.connector.lambda.data.BlockUtils;
 import com.amazonaws.athena.connectors.aws.cmdb.tables.AbstractTableProviderTest;
 import com.amazonaws.athena.connectors.aws.cmdb.tables.TableProvider;
 import com.amazonaws.services.ec2.AmazonEC2;
@@ -33,7 +34,6 @@ import com.amazonaws.services.ec2.model.Tag;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.Field;
-import org.joda.time.DateTimeZone;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
@@ -136,7 +136,7 @@ public class RouteTableProviderTest
                 }
                 break;
             case DATEMILLI:
-                assertEquals(100_000, fieldReader.readLocalDateTime().toDateTime(DateTimeZone.UTC).getMillis());
+                assertEquals(100_000, fieldReader.readLocalDateTime().atZone(BlockUtils.UTC_ZONE_ID).toInstant().toEpochMilli());
                 break;
             case BIT:
                 assertTrue(fieldReader.readBoolean());

--- a/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/ec2/SecurityGroupsTableProviderTest.java
+++ b/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/ec2/SecurityGroupsTableProviderTest.java
@@ -20,6 +20,7 @@
 package com.amazonaws.athena.connectors.aws.cmdb.tables.ec2;
 
 import com.amazonaws.athena.connector.lambda.data.Block;
+import com.amazonaws.athena.connector.lambda.data.BlockUtils;
 import com.amazonaws.athena.connectors.aws.cmdb.tables.AbstractTableProviderTest;
 import com.amazonaws.athena.connectors.aws.cmdb.tables.TableProvider;
 import com.amazonaws.services.ec2.AmazonEC2;
@@ -34,7 +35,6 @@ import com.amazonaws.services.ec2.model.UserIdGroupPair;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.Field;
-import org.joda.time.DateTimeZone;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
@@ -138,7 +138,7 @@ public class SecurityGroupsTableProviderTest
                 }
                 break;
             case DATEMILLI:
-                assertEquals(100_000, fieldReader.readLocalDateTime().toDateTime(DateTimeZone.UTC).getMillis());
+                assertEquals(100_000, fieldReader.readLocalDateTime().atZone(BlockUtils.UTC_ZONE_ID).toInstant().toEpochMilli());
                 break;
             case BIT:
                 assertTrue(fieldReader.readBoolean());

--- a/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/ec2/SubnetTableProviderTest.java
+++ b/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/ec2/SubnetTableProviderTest.java
@@ -20,6 +20,7 @@
 package com.amazonaws.athena.connectors.aws.cmdb.tables.ec2;
 
 import com.amazonaws.athena.connector.lambda.data.Block;
+import com.amazonaws.athena.connector.lambda.data.BlockUtils;
 import com.amazonaws.athena.connectors.aws.cmdb.tables.AbstractTableProviderTest;
 import com.amazonaws.athena.connectors.aws.cmdb.tables.TableProvider;
 import com.amazonaws.services.ec2.AmazonEC2;
@@ -30,7 +31,6 @@ import com.amazonaws.services.ec2.model.Tag;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.Field;
-import org.joda.time.DateTimeZone;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
@@ -134,7 +134,7 @@ public class SubnetTableProviderTest
                 }
                 break;
             case DATEMILLI:
-                assertEquals(100_000, fieldReader.readLocalDateTime().toDateTime(DateTimeZone.UTC).getMillis());
+                assertEquals(100_000, fieldReader.readLocalDateTime().atZone(BlockUtils.UTC_ZONE_ID).toInstant().toEpochMilli());
                 break;
             case BIT:
                 assertTrue(fieldReader.readBoolean());

--- a/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/ec2/VpcTableProviderTest.java
+++ b/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/ec2/VpcTableProviderTest.java
@@ -20,6 +20,7 @@
 package com.amazonaws.athena.connectors.aws.cmdb.tables.ec2;
 
 import com.amazonaws.athena.connector.lambda.data.Block;
+import com.amazonaws.athena.connector.lambda.data.BlockUtils;
 import com.amazonaws.athena.connectors.aws.cmdb.tables.AbstractTableProviderTest;
 import com.amazonaws.athena.connectors.aws.cmdb.tables.TableProvider;
 import com.amazonaws.services.ec2.AmazonEC2;
@@ -30,7 +31,6 @@ import com.amazonaws.services.ec2.model.Vpc;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.Field;
-import org.joda.time.DateTimeZone;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
@@ -133,7 +133,7 @@ public class VpcTableProviderTest
                 }
                 break;
             case DATEMILLI:
-                assertEquals(100_000, fieldReader.readLocalDateTime().toDateTime(DateTimeZone.UTC).getMillis());
+                assertEquals(100_000, fieldReader.readLocalDateTime().atZone(BlockUtils.UTC_ZONE_ID).toInstant().toEpochMilli());
                 break;
             case BIT:
                 assertTrue(fieldReader.readBoolean());

--- a/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/s3/S3BucketsTableProviderTest.java
+++ b/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/s3/S3BucketsTableProviderTest.java
@@ -20,6 +20,7 @@
 package com.amazonaws.athena.connectors.aws.cmdb.tables.s3;
 
 import com.amazonaws.athena.connector.lambda.data.Block;
+import com.amazonaws.athena.connector.lambda.data.BlockUtils;
 import com.amazonaws.athena.connectors.aws.cmdb.tables.AbstractTableProviderTest;
 import com.amazonaws.athena.connectors.aws.cmdb.tables.TableProvider;
 import com.amazonaws.services.s3.AmazonS3;
@@ -28,7 +29,6 @@ import com.amazonaws.services.s3.model.Owner;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.Field;
-import org.joda.time.DateTimeZone;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.slf4j.Logger;
@@ -120,7 +120,7 @@ public class S3BucketsTableProviderTest
                 }
                 break;
             case DATEMILLI:
-                assertEquals(100_000, fieldReader.readLocalDateTime().toDateTime(DateTimeZone.UTC).getMillis());
+                assertEquals(100_000, fieldReader.readLocalDateTime().atZone(BlockUtils.UTC_ZONE_ID).toInstant().toEpochMilli());
                 break;
             case BIT:
                 assertTrue(fieldReader.readBoolean());

--- a/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/s3/S3ObjectsTableProviderTest.java
+++ b/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/s3/S3ObjectsTableProviderTest.java
@@ -20,6 +20,7 @@
 package com.amazonaws.athena.connectors.aws.cmdb.tables.s3;
 
 import com.amazonaws.athena.connector.lambda.data.Block;
+import com.amazonaws.athena.connector.lambda.data.BlockUtils;
 import com.amazonaws.athena.connectors.aws.cmdb.tables.AbstractTableProviderTest;
 import com.amazonaws.athena.connectors.aws.cmdb.tables.TableProvider;
 import com.amazonaws.services.s3.AmazonS3;
@@ -30,7 +31,6 @@ import com.amazonaws.services.s3.model.S3ObjectSummary;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.Field;
-import org.joda.time.DateTimeZone;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.slf4j.Logger;
@@ -143,7 +143,7 @@ public class S3ObjectsTableProviderTest
                 }
                 break;
             case DATEMILLI:
-                assertEquals(100_000, fieldReader.readLocalDateTime().toDateTime(DateTimeZone.UTC).getMillis());
+                assertEquals(100_000, fieldReader.readLocalDateTime().atZone(BlockUtils.UTC_ZONE_ID).toInstant().toEpochMilli());
                 break;
             case BIT:
                 assertTrue(fieldReader.readBoolean());

--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/util/DDBTypeUtils.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/util/DDBTypeUtils.java
@@ -26,13 +26,13 @@ import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.Text;
 import org.apache.commons.lang3.StringUtils;
-import org.joda.time.DateTimeZone;
-import org.joda.time.LocalDateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -174,11 +174,11 @@ public final class DDBTypeUtils
         }
         else if (object instanceof LocalDateTime) {
             String datetimeFormat = recordMetadata.getDateTimeFormat(columnName);
-            DateTimeZone dtz = DateTimeZone.forID(recordMetadata.getDefaultTimeZone().toString());
+            ZoneId dtz = ZoneId.of(recordMetadata.getDefaultTimeZone().toString());
             if (datetimeFormat != null) {
-                return ((LocalDateTime) object).toDateTime(dtz).toLocalDateTime().toString(datetimeFormat);
+                return ((LocalDateTime) object).atZone(dtz).format(DateTimeFormatter.ofPattern(datetimeFormat));
             }
-            return ((LocalDateTime) object).toDateTime(dtz).getMillis();
+            return ((LocalDateTime) object).atZone(dtz).toInstant().toEpochMilli();
         }
         return object;
     }

--- a/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBMetadataHandlerTest.java
+++ b/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBMetadataHandlerTest.java
@@ -43,7 +43,6 @@ import com.amazonaws.athena.connector.lambda.metadata.ListTablesResponse;
 import com.amazonaws.athena.connector.lambda.metadata.MetadataRequestType;
 import com.amazonaws.athena.connector.lambda.metadata.MetadataResponse;
 import com.amazonaws.athena.connector.lambda.security.LocalKeyFactory;
-import com.amazonaws.athena.connectors.dynamodb.constants.DynamoDBConstants;
 import com.amazonaws.services.athena.AmazonAthena;
 import com.amazonaws.services.dynamodbv2.document.ItemUtils;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
@@ -62,9 +61,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.ArrowType;
-import org.joda.time.Days;
-import org.joda.time.LocalDateTime;
-import org.joda.time.MutableDateTime;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -76,6 +72,10 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -321,14 +321,13 @@ public class DynamoDBMetadataHandlerTest
         Map<String, ValueSet> constraintsMap = new HashMap<>();
         SortedRangeSet.Builder dateValueSet = SortedRangeSet.newBuilder(Types.MinorType.DATEDAY.getType(), false);
         SortedRangeSet.Builder timeValueSet = SortedRangeSet.newBuilder(Types.MinorType.DATEMILLI.getType(), false);
-        LocalDateTime dateTime = new LocalDateTime().withYear(2019).withMonthOfYear(9).withDayOfMonth(23).withHourOfDay(11).withMinuteOfHour(18).withSecondOfMinute(37);
-        MutableDateTime epoch = new MutableDateTime();
-        epoch.setDate(0); //Set to Epoch time
-        dateValueSet.add(Range.equal(allocator, Types.MinorType.DATEDAY.getType(), Days.daysBetween(epoch, dateTime.toDateTime()).getDays()));
+        LocalDateTime dateTime = LocalDateTime.of(2019, 9, 23, 11, 18, 37);
+        Instant epoch = Instant.MIN; //Set to Epoch time
+        dateValueSet.add(Range.equal(allocator, Types.MinorType.DATEDAY.getType(), ChronoUnit.DAYS.between(epoch, dateTime.toInstant(ZoneOffset.UTC))));
         LocalDateTime dateTime2 = dateTime.plusHours(26);
-        dateValueSet.add(Range.equal(allocator, Types.MinorType.DATEDAY.getType(), Days.daysBetween(epoch, dateTime2.toDateTime()).getDays()));
-        long startTime = dateTime.toDateTime().getMillis();
-        long endTime = dateTime2.toDateTime().getMillis();
+        dateValueSet.add(Range.equal(allocator, Types.MinorType.DATEDAY.getType(), ChronoUnit.DAYS.between(epoch, dateTime2.toInstant(ZoneOffset.UTC))));
+        long startTime = dateTime.toInstant(ZoneOffset.UTC).toEpochMilli();
+        long endTime = dateTime2.toInstant(ZoneOffset.UTC).toEpochMilli();
         timeValueSet.add(Range.range(allocator, Types.MinorType.DATEMILLI.getType(), startTime, true,
                 endTime, true));
         constraintsMap.put("col_4", dateValueSet.build());

--- a/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBRecordHandlerTest.java
+++ b/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBRecordHandlerTest.java
@@ -50,7 +50,6 @@ import com.google.common.collect.ImmutableMap;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
-import org.joda.time.LocalDateTime;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -64,6 +63,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -337,7 +337,7 @@ public class DynamoDBRecordHandlerTest
         ReadRecordsResponse response = (ReadRecordsResponse) rawResponse;
 
         LocalDate expectedDate = LocalDate.of(2020, 02, 27);
-        LocalDateTime expectedDateTime = new LocalDateTime(2020, 2, 27, 9, 12, 27);
+        LocalDateTime expectedDateTime = LocalDateTime.of(2020, 2, 27, 9, 12, 27);
         assertEquals(1, response.getRecords().getRowCount());
         assertEquals(expectedDateTime, response.getRecords().getFieldReader("Col1").readLocalDateTime());
         assertEquals(expectedDateTime, response.getRecords().getFieldReader("Col2").readLocalDateTime());

--- a/athena-federation-integ-test/README.md
+++ b/athena-federation-integ-test/README.md
@@ -36,7 +36,7 @@ in most **pom.xml** files (e.g.
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
-            <version>Current version of the SDK (e.g. 2021.14.1)</version>
+            <version>Current version of the SDK (e.g. 2021.18.1)</version>
             <scope>test</scope>
         </dependency>
 ```

--- a/athena-federation-integ-test/pom.xml
+++ b/athena-federation-integ-test/pom.xml
@@ -119,6 +119,11 @@
             <version>${fasterxml.jackson.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${fasterxml.jackson.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>3.9</version>

--- a/athena-federation-sdk/pom.xml
+++ b/athena-federation-sdk/pom.xml
@@ -67,12 +67,17 @@
         <dependency>
             <groupId>org.apache.arrow</groupId>
             <artifactId>arrow-vector</artifactId>
-            <version>0.11.0</version>
+            <version>3.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.arrow</groupId>
-            <artifactId>arrow-memory</artifactId>
-            <version>0.11.0</version>
+            <artifactId>arrow-memory-core</artifactId>
+            <version>3.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.arrow</groupId>
+            <artifactId>arrow-memory-netty</artifactId>
+            <version>3.0.0</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/ArrowTypeComparator.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/ArrowTypeComparator.java
@@ -25,7 +25,6 @@ import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.bouncycastle.util.Arrays;
 import org.joda.time.DateTimeZone;
-import org.joda.time.LocalDateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -87,7 +86,7 @@ public class ArrowTypeComparator
             case BIT:
                 return Boolean.compare((boolean) lhs, (boolean) rhs);
             case DATEMILLI:
-                return ((LocalDateTime) lhs).compareTo((LocalDateTime) rhs);
+                return ((java.time.LocalDateTime) lhs).compareTo((java.time.LocalDateTime) rhs);
             case DATEDAY:
                 return ((Integer) lhs).compareTo((Integer) rhs);
             case TIMESTAMPMILLITZ:

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/BlockAllocator.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/BlockAllocator.java
@@ -20,7 +20,7 @@ package com.amazonaws.athena.connector.lambda.data;
  * #L%
  */
 
-import io.netty.buffer.ArrowBuf;
+import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.ipc.message.ArrowRecordBatch;
 import org.apache.arrow.vector.types.pojo.Schema;

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/BlockAllocatorImpl.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/BlockAllocatorImpl.java
@@ -20,7 +20,7 @@ package com.amazonaws.athena.connector.lambda.data;
  * #L%
  */
 
-import io.netty.buffer.ArrowBuf;
+import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.util.VisibleForTesting;

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/BlockUtils.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/BlockUtils.java
@@ -20,7 +20,7 @@ package com.amazonaws.athena.connector.lambda.data;
  * #L%
  */
 
-import io.netty.buffer.ArrowBuf;
+import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.util.VisibleForTesting;
 import org.apache.arrow.vector.BigIntVector;
@@ -200,7 +200,7 @@ public class BlockUtils
      *
      * @param vector The FieldVector into which we should write the provided value.
      * @param pos The row number that the value should be written to.
-     * @param rawValue The value to write.
+     * @param value The value to write.
      * @note This method incurs more Object overhead (heap churn) than using Arrow's native interface. Users of this Utility
      * should weigh their performance needs vs. the readability / ease of use.
      */
@@ -795,13 +795,13 @@ public class BlockUtils
                 case VARBINARY:
                     if (value instanceof ArrowBuf) {
                         ArrowBuf buf = (ArrowBuf) value;
-                        writer.varBinary().writeVarBinary(0, buf.capacity(), buf);
+                        writer.varBinary().writeVarBinary(0, (int) (buf.capacity()), buf);
                     }
                     else if (value instanceof byte[]) {
                         byte[] bytes = (byte[]) value;
                         try (ArrowBuf buf = allocator.buffer(bytes.length)) {
                             buf.writeBytes(bytes);
-                            writer.varBinary().writeVarBinary(0, buf.readableBytes(), buf);
+                            writer.varBinary().writeVarBinary(0, (int) (buf.readableBytes()), buf);
                         }
                     }
                     break;
@@ -821,13 +821,13 @@ public class BlockUtils
                 case VARCHAR:
                     if (value instanceof ArrowBuf) {
                         ArrowBuf buf = (ArrowBuf) value;
-                        writer.varChar().writeVarChar(0, buf.readableBytes(), buf);
+                        writer.varChar().writeVarChar(0, (int) (buf.readableBytes()), buf);
                     }
                     else if (value instanceof byte[]) {
                         byte[] bytes = (byte[]) value;
                         try (ArrowBuf buf = allocator.buffer(bytes.length)) {
                             buf.writeBytes(bytes);
-                            writer.varChar().writeVarChar(0, buf.readableBytes(), buf);
+                            writer.varChar().writeVarChar(0, (int) (buf.readableBytes()), buf);
                         }
                     }
                     else {
@@ -835,7 +835,7 @@ public class BlockUtils
                         byte[] bytes = value.toString().getBytes(Charsets.UTF_8);
                         try (ArrowBuf buf = allocator.buffer(bytes.length)) {
                             buf.writeBytes(bytes);
-                            writer.varChar().writeVarChar(0, buf.readableBytes(), buf);
+                            writer.varChar().writeVarChar(0, (int) (buf.readableBytes()), buf);
                         }
                     }
                     break;
@@ -968,13 +968,13 @@ public class BlockUtils
                 case VARBINARY:
                     if (value instanceof ArrowBuf) {
                         ArrowBuf buf = (ArrowBuf) value;
-                        writer.varBinary(field.getName()).writeVarBinary(0, buf.capacity(), buf);
+                        writer.varBinary(field.getName()).writeVarBinary(0, (int) (buf.capacity()), buf);
                     }
                     else if (value instanceof byte[]) {
                         byte[] bytes = (byte[]) value;
                         try (ArrowBuf buf = allocator.buffer(bytes.length)) {
                             buf.writeBytes(bytes);
-                            writer.varBinary(field.getName()).writeVarBinary(0, buf.readableBytes(), buf);
+                            writer.varBinary(field.getName()).writeVarBinary(0, (int) (buf.readableBytes()), buf);
                         }
                     }
                     break;
@@ -996,18 +996,18 @@ public class BlockUtils
                         byte[] bytes = ((String) value).getBytes(Charsets.UTF_8);
                         try (ArrowBuf buf = allocator.buffer(bytes.length)) {
                             buf.writeBytes(bytes);
-                            writer.varChar(field.getName()).writeVarChar(0, buf.readableBytes(), buf);
+                            writer.varChar(field.getName()).writeVarChar(0, (int) (buf.readableBytes()), buf);
                         }
                     }
                     else if (value instanceof ArrowBuf) {
                         ArrowBuf buf = (ArrowBuf) value;
-                        writer.varChar(field.getName()).writeVarChar(0, buf.readableBytes(), buf);
+                        writer.varChar(field.getName()).writeVarChar(0, (int) (buf.readableBytes()), buf);
                     }
                     else if (value instanceof byte[]) {
                         byte[] bytes = (byte[]) value;
                         try (ArrowBuf buf = allocator.buffer(bytes.length)) {
                             buf.writeBytes(bytes);
-                            writer.varChar(field.getName()).writeVarChar(0, buf.readableBytes(), buf);
+                            writer.varChar(field.getName()).writeVarChar(0, (int) (buf.readableBytes()), buf);
                         }
                     }
                     break;

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/RecordBatchSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/RecordBatchSerDe.java
@@ -20,7 +20,6 @@ package com.amazonaws.athena.connector.lambda.data;
  * #L%
  */
 
-import com.amazonaws.athena.connector.lambda.serde.v2.ArrowRecordBatchSerDe;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.ipc.ReadChannel;
 import org.apache.arrow.vector.ipc.WriteChannel;
@@ -37,7 +36,7 @@ import java.nio.channels.Channels;
 /**
  * used to serialize and deserialize ArrowRecordBatch.
  *
- * @deprecated {@link ArrowRecordBatchSerDe} should be used instead
+ * @deprecated {@link com.amazonaws.athena.connector.lambda.serde.v3.ArrowRecordBatchSerDeV3} should be used instead
  */
 @Deprecated
 public class RecordBatchSerDe

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/RecordBatchSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/RecordBatchSerDe.java
@@ -25,7 +25,9 @@ import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.ipc.ReadChannel;
 import org.apache.arrow.vector.ipc.WriteChannel;
 import org.apache.arrow.vector.ipc.message.ArrowRecordBatch;
+import org.apache.arrow.vector.ipc.message.IpcOption;
 import org.apache.arrow.vector.ipc.message.MessageSerializer;
+import org.apache.arrow.vector.types.MetadataVersion;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -59,7 +61,10 @@ public class RecordBatchSerDe
             throws IOException
     {
         try {
-            MessageSerializer.serialize(new WriteChannel(Channels.newChannel(out)), batch);
+            IpcOption option = new IpcOption();
+            option.metadataVersion = MetadataVersion.V4;
+            option.write_legacy_ipc_format = true;
+            MessageSerializer.serialize(new WriteChannel(Channels.newChannel(out)), batch, option);
         }
         finally {
             batch.close();

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/SchemaSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/SchemaSerDe.java
@@ -22,7 +22,9 @@ package com.amazonaws.athena.connector.lambda.data;
 
 import org.apache.arrow.vector.ipc.ReadChannel;
 import org.apache.arrow.vector.ipc.WriteChannel;
+import org.apache.arrow.vector.ipc.message.IpcOption;
 import org.apache.arrow.vector.ipc.message.MessageSerializer;
+import org.apache.arrow.vector.types.MetadataVersion;
 import org.apache.arrow.vector.types.pojo.Schema;
 
 import java.io.IOException;
@@ -33,7 +35,7 @@ import java.nio.channels.Channels;
 /**
  * Used to serialize and deserialize Apache Arrow Schema objects.
  *
- * @deprecated {@link com.amazonaws.athena.connector.lambda.serde.v2.SchemaSerDe} should be used instead
+ * @deprecated {@link SchemaSerDe} should be used instead
  */
 @Deprecated
 public class SchemaSerDe
@@ -48,7 +50,10 @@ public class SchemaSerDe
     public void serialize(Schema schema, OutputStream out)
             throws IOException
     {
-        MessageSerializer.serialize(new WriteChannel(Channels.newChannel(out)), schema);
+        IpcOption option = new IpcOption();
+        option.metadataVersion = MetadataVersion.V4;
+        option.write_legacy_ipc_format = true;
+        MessageSerializer.serialize(new WriteChannel(Channels.newChannel(out)), schema, option);
     }
 
     /**

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/SchemaSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/SchemaSerDe.java
@@ -35,7 +35,7 @@ import java.nio.channels.Channels;
 /**
  * Used to serialize and deserialize Apache Arrow Schema objects.
  *
- * @deprecated {@link SchemaSerDe} should be used instead
+ * @deprecated {@link com.amazonaws.athena.connector.lambda.serde.v3.SchemaSerDeV3} should be used instead
  */
 @Deprecated
 public class SchemaSerDe

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/projectors/ArrowValueProjectorImpl.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/projectors/ArrowValueProjectorImpl.java
@@ -61,7 +61,7 @@ public abstract class ArrowValueProjectorImpl
                     if (Objects.isNull(fieldReader.readLocalDateTime())) {
                         return null;
                     }
-                    long millis = fieldReader.readLocalDateTime().toDateTime(org.joda.time.DateTimeZone.UTC).getMillis();
+                    long millis = fieldReader.readLocalDateTime().atZone(BlockUtils.UTC_ZONE_ID).toInstant().toEpochMilli();
                     return Instant.ofEpochMilli(millis).atZone(BlockUtils.UTC_ZONE_ID).toLocalDateTime();
                 };
             case TINYINT:

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/writers/fieldwriters/DateMilliFieldWriter.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/writers/fieldwriters/DateMilliFieldWriter.java
@@ -23,8 +23,10 @@ import com.amazonaws.athena.connector.lambda.data.writers.extractors.DateMilliEx
 import com.amazonaws.athena.connector.lambda.domain.predicate.ConstraintProjector;
 import org.apache.arrow.vector.DateMilliVector;
 import org.apache.arrow.vector.holders.NullableDateMilliHolder;
-import org.joda.time.DateTimeZone;
-import org.joda.time.LocalDateTime;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 
 /**
  * Used to write a value and apply constraints for a particular column to the row currently being processed.
@@ -56,7 +58,7 @@ public class DateMilliFieldWriter
         this.extractor = extractor;
         this.vector = vector;
         if (rawConstraint != null) {
-            constraint = (NullableDateMilliHolder value) -> rawConstraint.apply(value.isSet == 0 ? null : new LocalDateTime(value.value, DateTimeZone.UTC));
+            constraint = (NullableDateMilliHolder value) -> rawConstraint.apply(value.isSet == 0 ? null : LocalDateTime.ofInstant(Instant.ofEpochMilli(value.value), ZoneOffset.UTC));
         }
         else {
             constraint = (NullableDateMilliHolder value) -> true;

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/examples/ExampleRecordHandler.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/examples/ExampleRecordHandler.java
@@ -56,7 +56,7 @@ import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.secretsmanager.AWSSecretsManager;
 import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
 import com.google.common.base.Charsets;
-import io.netty.buffer.ArrowBuf;
+import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.util.VisibleForTesting;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.complex.ListVector;
@@ -369,7 +369,7 @@ public class ExampleRecordHandler
                                         byte[] bytes = String.valueOf(1000 + i).getBytes(Charsets.UTF_8);
                                         try (ArrowBuf buf = vector.getAllocator().buffer(bytes.length)) {
                                             buf.writeBytes(bytes);
-                                            innerWriter.varChar().writeVarChar(0, buf.readableBytes(), buf);
+                                            innerWriter.varChar().writeVarChar(0, (int) (buf.readableBytes()), buf);
                                         }
                                     }
                                     innerWriter.endList();
@@ -390,7 +390,7 @@ public class ExampleRecordHandler
                                     byte[] bytes = "chars".getBytes(Charsets.UTF_8);
                                     try (ArrowBuf buf = vector.getAllocator().buffer(bytes.length)) {
                                         buf.writeBytes(bytes);
-                                        structWriter.varChar("varchar").writeVarChar(0, buf.readableBytes(), buf);
+                                        structWriter.varChar("varchar").writeVarChar(0, (int) (buf.readableBytes()), buf);
                                     }
                                     structWriter.bigInt("bigint").writeBigInt(100L);
                                     structWriter.end();

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/handlers/FederationCapabilities.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/handlers/FederationCapabilities.java
@@ -29,6 +29,7 @@ package com.amazonaws.athena.connector.lambda.handlers;
  * Version history:
  * 23 - initial preview release
  * 24 - explicit, versioned serialization introduced
+ * 25 - upgraded Arrow to 3.0.0, addressed backwards incompatible changes
  */
 public class FederationCapabilities
 {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/BaseDeserializer.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/BaseDeserializer.java
@@ -35,7 +35,7 @@ import java.util.Map;
 
 import static com.amazonaws.athena.connector.lambda.serde.BaseSerializer.TYPE_FIELD;
 
-public abstract class BaseDeserializer<T> extends StdDeserializer<T>
+public abstract class BaseDeserializer<T> extends StdDeserializer<T> implements VersionedSerDe.Deserializer<T>
 {
     protected BaseDeserializer(Class<T> clazz)
     {
@@ -65,7 +65,7 @@ public abstract class BaseDeserializer<T> extends StdDeserializer<T>
         return deserialize(jp, ctxt);
     }
 
-    protected abstract T doDeserialize(JsonParser jparser, DeserializationContext ctxt)
+    public abstract T doDeserialize(JsonParser jparser, DeserializationContext ctxt)
             throws IOException;
 
     /**

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/BaseSerializer.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/BaseSerializer.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
 
-public abstract class BaseSerializer<T> extends StdSerializer<T>
+public abstract class BaseSerializer<T> extends StdSerializer<T> implements VersionedSerDe.Serializer<T>
 {
     static final String TYPE_FIELD = "@type";
 
@@ -59,7 +59,7 @@ public abstract class BaseSerializer<T> extends StdSerializer<T>
         serialize(value, gen, serializers);
     }
 
-    protected abstract void doSerialize(T value, JsonGenerator jgen, SerializerProvider provider)
+    public abstract void doSerialize(T value, JsonGenerator jgen, SerializerProvider provider)
             throws IOException;
 
     /**

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/BlockDeserializer.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/BlockDeserializer.java
@@ -25,7 +25,6 @@ import com.amazonaws.athena.connector.lambda.data.BlockAllocator;
 import com.amazonaws.athena.connector.lambda.data.BlockAllocatorRegistry;
 import com.amazonaws.athena.connector.lambda.data.RecordBatchSerDe;
 import com.amazonaws.athena.connector.lambda.data.SchemaSerDe;
-import com.amazonaws.athena.connector.lambda.serde.v2.BlockSerDe;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -48,7 +47,7 @@ import java.io.IOException;
  * operations that are required to move a Block around. It also allows you to put tighter control around
  * which parts of your query execution get which memory pool / limit.
  *
- * @deprecated {@link BlockSerDe} should be used instead
+ * @deprecated {@link com.amazonaws.athena.connector.lambda.serde.v3.BlockSerDeV3} should be used instead
  */
 @Deprecated
 public class BlockDeserializer

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/BlockDeserializer.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/BlockDeserializer.java
@@ -25,6 +25,7 @@ import com.amazonaws.athena.connector.lambda.data.BlockAllocator;
 import com.amazonaws.athena.connector.lambda.data.BlockAllocatorRegistry;
 import com.amazonaws.athena.connector.lambda.data.RecordBatchSerDe;
 import com.amazonaws.athena.connector.lambda.data.SchemaSerDe;
+import com.amazonaws.athena.connector.lambda.serde.v2.BlockSerDe;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -47,7 +48,7 @@ import java.io.IOException;
  * operations that are required to move a Block around. It also allows you to put tighter control around
  * which parts of your query execution get which memory pool / limit.
  *
- * @deprecated {@link com.amazonaws.athena.connector.lambda.serde.v2.BlockSerDe} should be used instead
+ * @deprecated {@link BlockSerDe} should be used instead
  */
 @Deprecated
 public class BlockDeserializer

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/BlockSerializer.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/BlockSerializer.java
@@ -23,6 +23,7 @@ package com.amazonaws.athena.connector.lambda.serde;
 import com.amazonaws.athena.connector.lambda.data.Block;
 import com.amazonaws.athena.connector.lambda.data.RecordBatchSerDe;
 import com.amazonaws.athena.connector.lambda.data.SchemaSerDe;
+import com.amazonaws.athena.connector.lambda.serde.v2.BlockSerDe;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
@@ -42,7 +43,7 @@ import java.io.IOException;
  * operations that are required to move a Block around. It also allows you to put tighter control around
  * which parts of your query execution get which memory pool / limit.
  *
- * @deprecated {@link com.amazonaws.athena.connector.lambda.serde.v2.BlockSerDe} should be used instead
+ * @deprecated {@link BlockSerDe} should be used instead
  */
 @Deprecated
 public class BlockSerializer

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/BlockSerializer.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/BlockSerializer.java
@@ -23,7 +23,6 @@ package com.amazonaws.athena.connector.lambda.serde;
 import com.amazonaws.athena.connector.lambda.data.Block;
 import com.amazonaws.athena.connector.lambda.data.RecordBatchSerDe;
 import com.amazonaws.athena.connector.lambda.data.SchemaSerDe;
-import com.amazonaws.athena.connector.lambda.serde.v2.BlockSerDe;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
@@ -43,7 +42,7 @@ import java.io.IOException;
  * operations that are required to move a Block around. It also allows you to put tighter control around
  * which parts of your query execution get which memory pool / limit.
  *
- * @deprecated {@link BlockSerDe} should be used instead
+ * @deprecated {@link com.amazonaws.athena.connector.lambda.serde.v3.BlockSerDeV3} should be used instead
  */
 @Deprecated
 public class BlockSerializer

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/FederatedIdentitySerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/FederatedIdentitySerDe.java
@@ -55,7 +55,7 @@ public final class FederatedIdentitySerDe
         }
 
         @Override
-        protected void doSerialize(FederatedIdentity federatedIdentity, JsonGenerator jgen, SerializerProvider provider)
+        public void doSerialize(FederatedIdentity federatedIdentity, JsonGenerator jgen, SerializerProvider provider)
                 throws IOException
         {
             jgen.writeStringField(ID_FIELD, COMPATIBILITY_ID);
@@ -92,7 +92,7 @@ public final class FederatedIdentitySerDe
         }
 
         @Override
-        protected FederatedIdentity doDeserialize(JsonParser jparser, DeserializationContext ctxt)
+        public FederatedIdentity doDeserialize(JsonParser jparser, DeserializationContext ctxt)
                 throws IOException
         {
             // First, read fields that we no longer care about.

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/SchemaDeserializer.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/SchemaDeserializer.java
@@ -20,7 +20,6 @@ package com.amazonaws.athena.connector.lambda.serde;
  * #L%
  */
 
-import com.amazonaws.athena.connector.lambda.serde.v2.SchemaSerDe;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -34,7 +33,7 @@ import java.io.IOException;
 /**
  * Used to enhance Jackson's stock ObjectMapper with the ability to deserialize Apache Arrow Schema objects.
  *
- * @deprecated {@link SchemaSerDe} should be used instead
+ * @deprecated {@link com.amazonaws.athena.connector.lambda.serde.v3.SchemaSerDeV3} should be used instead
  */
 @Deprecated
 public class SchemaDeserializer

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/SchemaDeserializer.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/SchemaDeserializer.java
@@ -20,7 +20,7 @@ package com.amazonaws.athena.connector.lambda.serde;
  * #L%
  */
 
-import com.amazonaws.athena.connector.lambda.data.SchemaSerDe;
+import com.amazonaws.athena.connector.lambda.serde.v2.SchemaSerDe;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -34,13 +34,13 @@ import java.io.IOException;
 /**
  * Used to enhance Jackson's stock ObjectMapper with the ability to deserialize Apache Arrow Schema objects.
  *
- * @deprecated {@link com.amazonaws.athena.connector.lambda.serde.v2.SchemaSerDe} should be used instead
+ * @deprecated {@link SchemaSerDe} should be used instead
  */
 @Deprecated
 public class SchemaDeserializer
         extends StdDeserializer<Schema>
 {
-    private final SchemaSerDe serDe = new SchemaSerDe();
+    private final com.amazonaws.athena.connector.lambda.data.SchemaSerDe serDe = new com.amazonaws.athena.connector.lambda.data.SchemaSerDe();
 
     public SchemaDeserializer()
     {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/SchemaSerializer.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/SchemaSerializer.java
@@ -20,7 +20,7 @@ package com.amazonaws.athena.connector.lambda.serde;
  * #L%
  */
 
-import com.amazonaws.athena.connector.lambda.data.SchemaSerDe;
+import com.amazonaws.athena.connector.lambda.serde.v2.SchemaSerDe;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
@@ -32,14 +32,14 @@ import java.io.IOException;
 /**
  * Used to enhance Jackson's stock ObjectMapper with the ability to serialize Apache Arrow Schema objects.
  *
- * @deprecated {@link com.amazonaws.athena.connector.lambda.serde.v2.SchemaSerDe} should be used instead
+ * @deprecated {@link SchemaSerDe} should be used instead
  */
 @Deprecated
 public class SchemaSerializer
         extends StdSerializer<Schema>
 {
     public static final String SCHEMA_FIELD_NAME = "schema";
-    private final SchemaSerDe serDe = new SchemaSerDe();
+    private final com.amazonaws.athena.connector.lambda.data.SchemaSerDe serDe = new com.amazonaws.athena.connector.lambda.data.SchemaSerDe();
 
     public SchemaSerializer()
     {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/SchemaSerializer.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/SchemaSerializer.java
@@ -20,7 +20,6 @@ package com.amazonaws.athena.connector.lambda.serde;
  * #L%
  */
 
-import com.amazonaws.athena.connector.lambda.serde.v2.SchemaSerDe;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
@@ -32,7 +31,7 @@ import java.io.IOException;
 /**
  * Used to enhance Jackson's stock ObjectMapper with the ability to serialize Apache Arrow Schema objects.
  *
- * @deprecated {@link SchemaSerDe} should be used instead
+ * @deprecated {@link com.amazonaws.athena.connector.lambda.serde.v3.SchemaSerDeV3} should be used instead
  */
 @Deprecated
 public class SchemaSerializer

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/TypedDeserializer.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/TypedDeserializer.java
@@ -50,7 +50,7 @@ public abstract class TypedDeserializer<T> extends BaseDeserializer<T>
     }
 
     @Override
-    protected T doDeserialize(JsonParser jparser, DeserializationContext ctxt)
+    public T doDeserialize(JsonParser jparser, DeserializationContext ctxt)
             throws IOException
     {
         // parse the type before delegating to implementation

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/VersionedObjectMapperFactory.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/VersionedObjectMapperFactory.java
@@ -22,6 +22,7 @@ package com.amazonaws.athena.connector.lambda.serde;
 import com.amazonaws.athena.connector.lambda.data.BlockAllocator;
 import com.amazonaws.athena.connector.lambda.handlers.SerDeVersion;
 import com.amazonaws.athena.connector.lambda.serde.v2.ObjectMapperFactoryV2;
+import com.amazonaws.athena.connector.lambda.serde.v3.ObjectMapperFactoryV3;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
@@ -56,6 +57,8 @@ public class VersionedObjectMapperFactory
                 return ObjectMapperFactory.create(allocator);
             case 2:
                 return ObjectMapperFactoryV2.create(allocator);
+            case 3:
+                return ObjectMapperFactoryV3.create(allocator);
             default:
                 throw new IllegalArgumentException("No serde version " + version);
         }

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/VersionedSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/VersionedSerDe.java
@@ -2,7 +2,7 @@
  * #%L
  * Amazon Athena Query Federation SDK
  * %%
- * Copyright (C) 2019 - 2020 Amazon Web Services
+ * Copyright (C) 2019 - 2021 Amazon Web Services
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,35 +20,29 @@
 package com.amazonaws.athena.connector.lambda.serde;
 
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.SerializerProvider;
 
 import java.io.IOException;
 
-import static java.util.Objects.requireNonNull;
-
-public abstract class TypedSerializer<T> extends BaseSerializer<T>
+public interface VersionedSerDe
 {
-    private Class<? extends T> subType;
-
-    protected TypedSerializer(Class<T> superType, Class<? extends T> subType)
+    interface Serializer<T>
     {
-        super(superType);
-        this.subType = requireNonNull(subType, "subType is null");
+        void doSerialize(T value, JsonGenerator jgen, SerializerProvider provider)
+                throws IOException;
+
+        void serialize(T value, JsonGenerator jgen, SerializerProvider provider)
+                throws IOException;
     }
 
-    public Class<? extends T> getSubType()
+    interface Deserializer<T>
     {
-        return subType;
-    }
+        T deserialize(JsonParser jparser, DeserializationContext ctxt)
+                throws IOException;
 
-    @Override
-    public void doSerialize(T value, JsonGenerator jgen, SerializerProvider provider)
-            throws IOException
-    {
-        writeType(jgen, subType);
-        doTypedSerialize(value, jgen, provider);
+        T doDeserialize(JsonParser jparser, DeserializationContext ctxt)
+                throws IOException;
     }
-
-    protected abstract void doTypedSerialize(T value, JsonGenerator jgen, SerializerProvider provider)
-            throws IOException;
 }

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/AllOrNoneValueSetSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/AllOrNoneValueSetSerDe.java
@@ -33,7 +33,7 @@ import java.io.IOException;
 
 import static java.util.Objects.requireNonNull;
 
-final class AllOrNoneValueSetSerDe
+public final class AllOrNoneValueSetSerDe
 {
     private static final String TYPE_FIELD = "type";
     private static final String ALL_FIELD = "all";
@@ -41,11 +41,11 @@ final class AllOrNoneValueSetSerDe
 
     private AllOrNoneValueSetSerDe(){}
 
-    static final class Serializer extends TypedSerializer<ValueSet>
+    public static final class Serializer extends TypedSerializer<ValueSet>
     {
         private final ArrowTypeSerDe.Serializer arrowTypeSerializer;
 
-        Serializer(ArrowTypeSerDe.Serializer arrowTypeSerialzer)
+        public Serializer(ArrowTypeSerDe.Serializer arrowTypeSerialzer)
         {
             super(ValueSet.class, AllOrNoneValueSet.class);
             this.arrowTypeSerializer = requireNonNull(arrowTypeSerialzer, "arrowTypeSerialzer is null");
@@ -64,11 +64,11 @@ final class AllOrNoneValueSetSerDe
         }
     }
 
-    static final class Deserializer extends TypedDeserializer<ValueSet>
+    public static final class Deserializer extends TypedDeserializer<ValueSet>
     {
         private final ArrowTypeSerDe.Deserializer arrowTypeDeserializer;
 
-        Deserializer(ArrowTypeSerDe.Deserializer arrowTypeDeserializer)
+        public Deserializer(ArrowTypeSerDe.Deserializer arrowTypeDeserializer)
         {
             super(ValueSet.class, AllOrNoneValueSet.class);
             this.arrowTypeDeserializer = requireNonNull(arrowTypeDeserializer, "arrowTypeSerDe is null");

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/ArrowRecordBatchSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/ArrowRecordBatchSerDe.java
@@ -31,7 +31,9 @@ import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.ipc.ReadChannel;
 import org.apache.arrow.vector.ipc.WriteChannel;
 import org.apache.arrow.vector.ipc.message.ArrowRecordBatch;
+import org.apache.arrow.vector.ipc.message.IpcOption;
 import org.apache.arrow.vector.ipc.message.MessageSerializer;
+import org.apache.arrow.vector.types.MetadataVersion;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -57,8 +59,11 @@ public final class ArrowRecordBatchSerDe
                 throws IOException
         {
             try {
+                IpcOption option = new IpcOption();
+                option.write_legacy_ipc_format = true;
+                option.metadataVersion = MetadataVersion.V4;
                 ByteArrayOutputStream out = new ByteArrayOutputStream();
-                MessageSerializer.serialize(new WriteChannel(Channels.newChannel(out)), arrowRecordBatch);
+                MessageSerializer.serialize(new WriteChannel(Channels.newChannel(out)), arrowRecordBatch, option);
                 jgen.writeBinary(out.toByteArray());
             }
             finally {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/ArrowTypeSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/ArrowTypeSerDe.java
@@ -40,13 +40,13 @@ import org.apache.arrow.vector.types.pojo.ArrowType;
 
 import java.io.IOException;
 
-final class ArrowTypeSerDe
+public final class ArrowTypeSerDe
 {
     private ArrowTypeSerDe(){}
 
-    static final class Serializer extends DelegatingSerializer<ArrowType>
+    public static final class Serializer extends DelegatingSerializer<ArrowType>
     {
-        Serializer()
+        public Serializer()
         {
             super(ArrowType.class, ImmutableSet.<TypedSerializer<ArrowType>>builder()
                     .add(new NullSerDe.Serializer())
@@ -69,9 +69,9 @@ final class ArrowTypeSerDe
         }
     }
 
-    static final class Deserializer extends DelegatingDeserializer<ArrowType>
+    public static final class Deserializer extends DelegatingDeserializer<ArrowType>
     {
-        Deserializer()
+        public Deserializer()
         {
             super(ArrowType.class, ImmutableSet.<TypedDeserializer<ArrowType>>builder()
                     .add(new NullSerDe.Deserializer())

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/BlockSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/BlockSerDe.java
@@ -46,6 +46,9 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.Objects.requireNonNull;
 
+/**
+ *  @deprecated {@link com.amazonaws.athena.connector.lambda.serde.v3.SchemaSerDeV3} should be used instead
+ */
 @Deprecated
 public final class BlockSerDe
 {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/BlockSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/BlockSerDe.java
@@ -32,7 +32,9 @@ import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.ipc.ReadChannel;
 import org.apache.arrow.vector.ipc.WriteChannel;
 import org.apache.arrow.vector.ipc.message.ArrowRecordBatch;
+import org.apache.arrow.vector.ipc.message.IpcOption;
 import org.apache.arrow.vector.ipc.message.MessageSerializer;
+import org.apache.arrow.vector.types.MetadataVersion;
 import org.apache.arrow.vector.types.pojo.Schema;
 
 import java.io.ByteArrayInputStream;
@@ -83,8 +85,11 @@ final class BlockSerDe
                 throws IOException
         {
             try {
+                IpcOption option = new IpcOption();
+                option.write_legacy_ipc_format = true;
+                option.metadataVersion = MetadataVersion.V4;
                 ByteArrayOutputStream out = new ByteArrayOutputStream();
-                MessageSerializer.serialize(new WriteChannel(Channels.newChannel(out)), recordBatch);
+                MessageSerializer.serialize(new WriteChannel(Channels.newChannel(out)), recordBatch, option);
                 return out.toByteArray();
             }
             finally {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/ConstraintsSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/ConstraintsSerDe.java
@@ -35,24 +35,24 @@ import java.util.Map;
 
 import static java.util.Objects.requireNonNull;
 
-final class ConstraintsSerDe
+public final class ConstraintsSerDe
 {
     private static final String SUMMARY_FIELD = "summary";
 
     private ConstraintsSerDe(){}
 
-    static final class Serializer extends BaseSerializer<Constraints>
+    public static final class Serializer extends BaseSerializer<Constraints>
     {
         private final ValueSetSerDe.Serializer valueSetSerializer;
 
-        Serializer(ValueSetSerDe.Serializer valueSetSerializer)
+        public Serializer(ValueSetSerDe.Serializer valueSetSerializer)
         {
             super(Constraints.class);
             this.valueSetSerializer = requireNonNull(valueSetSerializer, "valueSetSerDe is null");
         }
 
         @Override
-        protected void doSerialize(Constraints constraints, JsonGenerator jgen, SerializerProvider provider)
+        public void doSerialize(Constraints constraints, JsonGenerator jgen, SerializerProvider provider)
                 throws IOException
         {
             jgen.writeObjectFieldStart(SUMMARY_FIELD);
@@ -64,18 +64,18 @@ final class ConstraintsSerDe
         }
     }
 
-    static final class Deserializer extends BaseDeserializer<Constraints>
+    public static final class Deserializer extends BaseDeserializer<Constraints>
     {
         private final ValueSetSerDe.Deserializer valueSetDeserializer;
 
-        Deserializer(ValueSetSerDe.Deserializer valueSetDeserializer)
+        public Deserializer(ValueSetSerDe.Deserializer valueSetDeserializer)
         {
             super(Constraints.class);
             this.valueSetDeserializer = requireNonNull(valueSetDeserializer, "valueSetSerDe is null");
         }
 
         @Override
-        protected Constraints doDeserialize(JsonParser jparser, DeserializationContext ctxt)
+        public Constraints doDeserialize(JsonParser jparser, DeserializationContext ctxt)
                 throws IOException
         {
             assertFieldName(jparser, SUMMARY_FIELD);

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/EncryptionKeySerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/EncryptionKeySerDe.java
@@ -29,22 +29,22 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 
 import java.io.IOException;
 
-final class EncryptionKeySerDe
+public final class EncryptionKeySerDe
 {
     private static final String KEY_FIELD = "key";
     private static final String NONCE_FIELD = "nonce";
 
     private EncryptionKeySerDe(){}
 
-    static final class Serializer extends BaseSerializer<EncryptionKey>
+    public static final class Serializer extends BaseSerializer<EncryptionKey>
     {
-        Serializer()
+        public Serializer()
         {
             super(EncryptionKey.class);
         }
 
         @Override
-        protected void doSerialize(EncryptionKey encryptionKey, JsonGenerator jgen, SerializerProvider provider)
+        public void doSerialize(EncryptionKey encryptionKey, JsonGenerator jgen, SerializerProvider provider)
                 throws IOException
         {
             jgen.writeBinaryField(KEY_FIELD, encryptionKey.getKey());
@@ -52,15 +52,15 @@ final class EncryptionKeySerDe
         }
     }
 
-    static final class Deserializer extends BaseDeserializer<EncryptionKey>
+    public static final class Deserializer extends BaseDeserializer<EncryptionKey>
     {
-        Deserializer()
+        public Deserializer()
         {
             super(EncryptionKey.class);
         }
 
         @Override
-        protected EncryptionKey doDeserialize(JsonParser jparser, DeserializationContext ctxt)
+        public EncryptionKey doDeserialize(JsonParser jparser, DeserializationContext ctxt)
                 throws IOException
         {
             byte[] key = getNextBinaryField(jparser, KEY_FIELD);

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/EquatableValueSetSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/EquatableValueSetSerDe.java
@@ -24,6 +24,7 @@ import com.amazonaws.athena.connector.lambda.domain.predicate.EquatableValueSet;
 import com.amazonaws.athena.connector.lambda.domain.predicate.ValueSet;
 import com.amazonaws.athena.connector.lambda.serde.TypedDeserializer;
 import com.amazonaws.athena.connector.lambda.serde.TypedSerializer;
+import com.amazonaws.athena.connector.lambda.serde.VersionedSerDe;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -33,7 +34,7 @@ import java.io.IOException;
 
 import static java.util.Objects.requireNonNull;
 
-final class EquatableValueSetSerDe
+public final class EquatableValueSetSerDe
 {
     private static final String VALUE_BLOCK_FIELD = "valueBlock";
     private static final String WHITELIST_FIELD = "whiteList";
@@ -41,11 +42,11 @@ final class EquatableValueSetSerDe
 
     private EquatableValueSetSerDe(){}
 
-    static final class Serializer extends TypedSerializer<ValueSet>
+    public static final class Serializer extends TypedSerializer<ValueSet>
     {
-        private final BlockSerDe.Serializer blockSerializer;
+        private final VersionedSerDe.Serializer<Block> blockSerializer;
 
-        Serializer(BlockSerDe.Serializer blockSerializer)
+        public Serializer(VersionedSerDe.Serializer<Block> blockSerializer)
         {
             super(ValueSet.class, EquatableValueSet.class);
             this.blockSerializer = requireNonNull(blockSerializer, "blockSerDe is null");
@@ -65,11 +66,11 @@ final class EquatableValueSetSerDe
         }
     }
 
-    static final class Deserializer extends TypedDeserializer<ValueSet>
+    public static final class Deserializer extends TypedDeserializer<ValueSet>
     {
-        private final BlockSerDe.Deserializer blockDeserializer;
+        private final VersionedSerDe.Deserializer<Block> blockDeserializer;
 
-        Deserializer(BlockSerDe.Deserializer blockDeserializer)
+        public Deserializer(VersionedSerDe.Deserializer<Block> blockDeserializer)
         {
             super(ValueSet.class, EquatableValueSet.class);
             this.blockDeserializer = requireNonNull(blockDeserializer, "blockSerDe is null");

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/FederationRequestSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/FederationRequestSerDe.java
@@ -27,13 +27,13 @@ import com.amazonaws.athena.connector.lambda.serde.TypedDeserializer;
 import com.amazonaws.athena.connector.lambda.serde.TypedSerializer;
 import com.google.common.collect.ImmutableSet;
 
-final class FederationRequestSerDe
+public final class FederationRequestSerDe
 {
     private FederationRequestSerDe(){}
 
-    static final class Serializer extends DelegatingSerializer<FederationRequest>
+    public static final class Serializer extends DelegatingSerializer<FederationRequest>
     {
-        Serializer(
+        public Serializer(
                 PingRequestSerDe.Serializer pingSerializer,
                 ListSchemasRequestSerDe.Serializer listSchemasSerializer,
                 ListTablesRequestSerDe.Serializer listTablesSerializer,
@@ -56,9 +56,9 @@ final class FederationRequestSerDe
         }
     }
 
-    static final class Deserializer extends DelegatingDeserializer<FederationRequest>
+    public static final class Deserializer extends DelegatingDeserializer<FederationRequest>
     {
-        Deserializer(
+        public Deserializer(
                 PingRequestSerDe.Deserializer pingDeserializer,
                 ListSchemasRequestSerDe.Deserializer listSchemasDeserializer,
                 ListTablesRequestSerDe.Deserializer listTablesDeserializer,

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/FederationResponseSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/FederationResponseSerDe.java
@@ -27,13 +27,13 @@ import com.amazonaws.athena.connector.lambda.serde.TypedDeserializer;
 import com.amazonaws.athena.connector.lambda.serde.TypedSerializer;
 import com.google.common.collect.ImmutableSet;
 
-final class FederationResponseSerDe
+public final class FederationResponseSerDe
 {
     private FederationResponseSerDe(){}
 
-    static final class Serializer extends DelegatingSerializer<FederationResponse>
+    public static final class Serializer extends DelegatingSerializer<FederationResponse>
     {
-        Serializer(
+        public Serializer(
                 PingResponseSerDe.Serializer pingSerializer,
                 ListSchemasResponseSerDe.Serializer listSchemasSerializer,
                 ListTablesResponseSerDe.Serializer listTablesSerializer,
@@ -58,9 +58,9 @@ final class FederationResponseSerDe
         }
     }
 
-    static final class Deserializer extends DelegatingDeserializer<FederationResponse>
+    public static final class Deserializer extends DelegatingDeserializer<FederationResponse>
     {
-        Deserializer(
+        public Deserializer(
                 PingResponseSerDe.Deserializer pingDeserializer,
                 ListSchemasResponseSerDe.Deserializer listSchemasDeserializer,
                 ListTablesResponseSerDe.Deserializer listTablesDeserializer,

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/GetSplitsRequestSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/GetSplitsRequestSerDe.java
@@ -27,6 +27,7 @@ import com.amazonaws.athena.connector.lambda.metadata.MetadataRequest;
 import com.amazonaws.athena.connector.lambda.request.FederationRequest;
 import com.amazonaws.athena.connector.lambda.security.FederatedIdentity;
 import com.amazonaws.athena.connector.lambda.serde.FederatedIdentitySerDe;
+import com.amazonaws.athena.connector.lambda.serde.VersionedSerDe;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -37,7 +38,7 @@ import java.util.List;
 
 import static java.util.Objects.requireNonNull;
 
-final class GetSplitsRequestSerDe
+public final class GetSplitsRequestSerDe
 {
     private static final String IDENTITY_FIELD = "identity";
     private static final String QUERY_ID_FIELD = "queryId";
@@ -50,17 +51,17 @@ final class GetSplitsRequestSerDe
 
     private GetSplitsRequestSerDe(){}
 
-    static final class Serializer extends MetadataRequestSerializer
+    public static final class Serializer extends MetadataRequestSerializer
     {
         private final FederatedIdentitySerDe.Serializer identitySerializer;
         private final TableNameSerDe.Serializer tableNameSerializer;
-        private final BlockSerDe.Serializer blockSerializer;
+        private final VersionedSerDe.Serializer<Block> blockSerializer;
         private final ConstraintsSerDe.Serializer constraintsSerializer;
 
-        Serializer(
+        public Serializer(
                 FederatedIdentitySerDe.Serializer identitySerializer,
                 TableNameSerDe.Serializer tableNameSerializer,
-                BlockSerDe.Serializer blockSerializer,
+                VersionedSerDe.Serializer<Block> blockSerializer,
                 ConstraintsSerDe.Serializer constraintsSerializer)
         {
             super(GetSplitsRequest.class, identitySerializer);
@@ -91,17 +92,17 @@ final class GetSplitsRequestSerDe
         }
     }
 
-    static final class Deserializer extends MetadataRequestDeserializer
+    public static final class Deserializer extends MetadataRequestDeserializer
     {
         private final FederatedIdentitySerDe.Deserializer identityDeserializer;
         private final TableNameSerDe.Deserializer tableNameDeserializer;
-        private final BlockSerDe.Deserializer blockDeserializer;
+        private final VersionedSerDe.Deserializer<Block> blockDeserializer;
         private final ConstraintsSerDe.Deserializer constraintsDeserializer;
 
-        Deserializer(
+        public Deserializer(
                 FederatedIdentitySerDe.Deserializer identityDeserializer,
                 TableNameSerDe.Deserializer tableNameDeserializer,
-                BlockSerDe.Deserializer blockDeserializer,
+                VersionedSerDe.Deserializer<Block> blockDeserializer,
                 ConstraintsSerDe.Deserializer constraintsDeserializer)
         {
             super(GetSplitsRequest.class, identityDeserializer);

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/GetSplitsResponseSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/GetSplitsResponseSerDe.java
@@ -35,7 +35,7 @@ import java.io.IOException;
 
 import static java.util.Objects.requireNonNull;
 
-final class GetSplitsResponseSerDe
+public final class GetSplitsResponseSerDe
 {
     private static final String CATALOG_NAME_FIELD = "catalogName";
     private static final String SPLITS_FIELD = "splits";
@@ -43,11 +43,11 @@ final class GetSplitsResponseSerDe
 
     private GetSplitsResponseSerDe(){}
 
-    static final class Serializer extends TypedSerializer<FederationResponse>
+    public static final class Serializer extends TypedSerializer<FederationResponse>
     {
         private final SplitSerDe.Serializer splitSerializer;
 
-        Serializer(SplitSerDe.Serializer splitSerializer)
+        public Serializer(SplitSerDe.Serializer splitSerializer)
         {
             super(FederationResponse.class, GetSplitsResponse.class);
             this.splitSerializer = requireNonNull(splitSerializer, "splitSerializer is null");
@@ -71,11 +71,11 @@ final class GetSplitsResponseSerDe
         }
     }
 
-    static final class Deserializer extends TypedDeserializer<FederationResponse>
+    public static final class Deserializer extends TypedDeserializer<FederationResponse>
     {
         private final SplitSerDe.Deserializer splitDeserializer;
 
-        Deserializer(SplitSerDe.Deserializer splitDeserializer)
+        public Deserializer(SplitSerDe.Deserializer splitDeserializer)
         {
             super(FederationResponse.class, GetSplitsResponse.class);
             this.splitDeserializer = requireNonNull(splitDeserializer, "splitDeserializer is null");

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/GetTableLayoutRequestSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/GetTableLayoutRequestSerDe.java
@@ -26,6 +26,7 @@ import com.amazonaws.athena.connector.lambda.metadata.MetadataRequest;
 import com.amazonaws.athena.connector.lambda.request.FederationRequest;
 import com.amazonaws.athena.connector.lambda.security.FederatedIdentity;
 import com.amazonaws.athena.connector.lambda.serde.FederatedIdentitySerDe;
+import com.amazonaws.athena.connector.lambda.serde.VersionedSerDe;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -37,7 +38,7 @@ import java.io.IOException;
 
 import static java.util.Objects.requireNonNull;
 
-final class GetTableLayoutRequestSerDe
+public final class GetTableLayoutRequestSerDe
 {
     private static final String IDENTITY_FIELD = "identity";
     private static final String QUERY_ID_FIELD = "queryId";
@@ -49,18 +50,18 @@ final class GetTableLayoutRequestSerDe
 
     private GetTableLayoutRequestSerDe(){}
 
-    static final class Serializer extends MetadataRequestSerializer
+    public static final class Serializer extends MetadataRequestSerializer
     {
         private final FederatedIdentitySerDe.Serializer identitySerializer;
         private final TableNameSerDe.Serializer tableNameSerializer;
         private final ConstraintsSerDe.Serializer constraintsSerializer;
-        private final SchemaSerDe.Serializer schemaSerializer;
+        private final VersionedSerDe.Serializer<Schema> schemaSerializer;
 
-        Serializer(
+        public Serializer(
                 FederatedIdentitySerDe.Serializer identitySerializer,
                 TableNameSerDe.Serializer tableNameSerializer,
                 ConstraintsSerDe.Serializer constraintsSerializer,
-                SchemaSerDe.Serializer schemaSerializer)
+                VersionedSerDe.Serializer<Schema> schemaSerializer)
         {
             super(GetTableLayoutRequest.class, identitySerializer);
             this.identitySerializer = requireNonNull(identitySerializer, "identitySerializer is null");
@@ -88,18 +89,18 @@ final class GetTableLayoutRequestSerDe
         }
     }
 
-    static final class Deserializer extends MetadataRequestDeserializer
+    public static final class Deserializer extends MetadataRequestDeserializer
     {
         private final FederatedIdentitySerDe.Deserializer identityDeserializer;
         private final TableNameSerDe.Deserializer tableNameDeserializer;
         private final ConstraintsSerDe.Deserializer constraintsDeserializer;
-        private final SchemaSerDe.Deserializer schemaDeserializer;
+        private final VersionedSerDe.Deserializer<Schema> schemaDeserializer;
 
-        Deserializer(
+        public Deserializer(
                 FederatedIdentitySerDe.Deserializer identityDeserializer,
                 TableNameSerDe.Deserializer tableNameDeserializer,
                 ConstraintsSerDe.Deserializer constraintsDeserializer,
-                SchemaSerDe.Deserializer schemaDeserializer)
+                VersionedSerDe.Deserializer<Schema> schemaDeserializer)
         {
             super(GetTableLayoutRequest.class, identityDeserializer);
             this.identityDeserializer = requireNonNull(identityDeserializer, "identityDeserializer is null");

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/GetTableLayoutResponseSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/GetTableLayoutResponseSerDe.java
@@ -25,6 +25,7 @@ import com.amazonaws.athena.connector.lambda.metadata.GetTableLayoutResponse;
 import com.amazonaws.athena.connector.lambda.request.FederationResponse;
 import com.amazonaws.athena.connector.lambda.serde.TypedDeserializer;
 import com.amazonaws.athena.connector.lambda.serde.TypedSerializer;
+import com.amazonaws.athena.connector.lambda.serde.VersionedSerDe;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -34,7 +35,7 @@ import java.io.IOException;
 
 import static java.util.Objects.requireNonNull;
 
-final class GetTableLayoutResponseSerDe
+public final class GetTableLayoutResponseSerDe
 {
     private static final String CATALOG_NAME_FIELD = "catalogName";
     private static final String TABLE_NAME_FIELD = "tableName";
@@ -42,12 +43,12 @@ final class GetTableLayoutResponseSerDe
 
     private GetTableLayoutResponseSerDe(){}
 
-    static final class Serializer extends TypedSerializer<FederationResponse>
+    public static final class Serializer extends TypedSerializer<FederationResponse>
     {
         private final TableNameSerDe.Serializer tableNameSerializer;
-        private final BlockSerDe.Serializer blockSerializer;
+        private final VersionedSerDe.Serializer<Block> blockSerializer;
 
-        protected Serializer(TableNameSerDe.Serializer tableNameSerializer, BlockSerDe.Serializer blockSerializer)
+        public Serializer(TableNameSerDe.Serializer tableNameSerializer, VersionedSerDe.Serializer<Block> blockSerializer)
         {
             super(FederationResponse.class, GetTableLayoutResponse.class);
             this.tableNameSerializer = requireNonNull(tableNameSerializer, "tableNameSerializer is null");
@@ -70,12 +71,12 @@ final class GetTableLayoutResponseSerDe
         }
     }
 
-    static final class Deserializer extends TypedDeserializer<FederationResponse>
+    public static final class Deserializer extends TypedDeserializer<FederationResponse>
     {
         private final TableNameSerDe.Deserializer tableNameDeserializer;
-        private final BlockSerDe.Deserializer blockDeserializer;
+        private final VersionedSerDe.Deserializer<Block> blockDeserializer;
 
-        Deserializer(TableNameSerDe.Deserializer tableNameDeserializer, BlockSerDe.Deserializer blockDeserializer)
+        public Deserializer(TableNameSerDe.Deserializer tableNameDeserializer, VersionedSerDe.Deserializer<Block> blockDeserializer)
         {
             super(FederationResponse.class, GetTableLayoutResponse.class);
             this.tableNameDeserializer = requireNonNull(tableNameDeserializer, "tableNameDeserializer is null");

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/GetTableRequestSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/GetTableRequestSerDe.java
@@ -34,18 +34,18 @@ import java.io.IOException;
 
 import static java.util.Objects.requireNonNull;
 
-final class GetTableRequestSerDe
+public final class GetTableRequestSerDe
 {
     private static final String TABLE_NAME_FIELD = "tableName";
 
     private GetTableRequestSerDe(){}
 
-    static final class Serializer extends MetadataRequestSerializer
+    public static final class Serializer extends MetadataRequestSerializer
     {
         private final FederatedIdentitySerDe.Serializer identitySerializer;
         private final TableNameSerDe.Serializer tableNameSerializer;
 
-        Serializer(FederatedIdentitySerDe.Serializer identitySerializer, TableNameSerDe.Serializer tableNameSerializer)
+        public Serializer(FederatedIdentitySerDe.Serializer identitySerializer, TableNameSerDe.Serializer tableNameSerializer)
         {
             super(GetTableRequest.class, identitySerializer);
             this.identitySerializer = requireNonNull(identitySerializer, "identitySerializer is null");
@@ -63,12 +63,12 @@ final class GetTableRequestSerDe
         }
     }
 
-    static final class Deserializer extends MetadataRequestDeserializer
+    public static final class Deserializer extends MetadataRequestDeserializer
     {
         private final FederatedIdentitySerDe.Deserializer identityDeserializer;
         private final TableNameSerDe.Deserializer tableNameDeserializer;
 
-        Deserializer(FederatedIdentitySerDe.Deserializer identityDeserializer, TableNameSerDe.Deserializer tableNameDeserializer)
+        public Deserializer(FederatedIdentitySerDe.Deserializer identityDeserializer, TableNameSerDe.Deserializer tableNameDeserializer)
         {
             super(GetTableRequest.class, identityDeserializer);
             this.identityDeserializer = requireNonNull(identityDeserializer, "identityDeserializer is null");

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/GetTableResponseSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/GetTableResponseSerDe.java
@@ -24,6 +24,7 @@ import com.amazonaws.athena.connector.lambda.metadata.GetTableResponse;
 import com.amazonaws.athena.connector.lambda.request.FederationResponse;
 import com.amazonaws.athena.connector.lambda.serde.TypedDeserializer;
 import com.amazonaws.athena.connector.lambda.serde.TypedSerializer;
+import com.amazonaws.athena.connector.lambda.serde.VersionedSerDe;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -35,7 +36,7 @@ import java.io.IOException;
 
 import static java.util.Objects.requireNonNull;
 
-final class GetTableResponseSerDe
+public final class GetTableResponseSerDe
 {
     private static final String CATALOG_NAME_FIELD = "catalogName";
     private static final String TABLE_NAME_FIELD = "tableName";
@@ -44,12 +45,12 @@ final class GetTableResponseSerDe
 
     private GetTableResponseSerDe(){}
 
-    static final class Serializer extends TypedSerializer<FederationResponse>
+    public static final class Serializer extends TypedSerializer<FederationResponse>
     {
         private final TableNameSerDe.Serializer tableNameSerializer;
-        private final SchemaSerDe.Serializer schemaSerializer;
+        private final VersionedSerDe.Serializer<Schema> schemaSerializer;
 
-        Serializer(TableNameSerDe.Serializer tableNameSerializer, SchemaSerDe.Serializer schemaSerializer)
+        public Serializer(TableNameSerDe.Serializer tableNameSerializer, VersionedSerDe.Serializer<Schema> schemaSerializer)
         {
             super(FederationResponse.class, GetTableResponse.class);
             this.tableNameSerializer = requireNonNull(tableNameSerializer, "tableNameSerializer is null");
@@ -74,12 +75,12 @@ final class GetTableResponseSerDe
         }
     }
 
-    static final class Deserializer extends TypedDeserializer<FederationResponse>
+    public static final class Deserializer extends TypedDeserializer<FederationResponse>
     {
         private final TableNameSerDe.Deserializer tableNameDeserializer;
-        private final SchemaSerDe.Deserializer schemaDeserializer;
+        private final VersionedSerDe.Deserializer<Schema> schemaDeserializer;
 
-        Deserializer(TableNameSerDe.Deserializer tableNameDeserializer, SchemaSerDe.Deserializer schemaDeserializer)
+        public Deserializer(TableNameSerDe.Deserializer tableNameDeserializer, VersionedSerDe.Deserializer<Schema> schemaDeserializer)
         {
             super(FederationResponse.class, GetTableResponse.class);
             this.tableNameDeserializer = requireNonNull(tableNameDeserializer, "tableNameDeserializer is null");

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/LambdaFunctionExceptionSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/LambdaFunctionExceptionSerDe.java
@@ -46,9 +46,9 @@ public class LambdaFunctionExceptionSerDe
 
     private LambdaFunctionExceptionSerDe(){}
 
-    static final class Deserializer extends BaseDeserializer<LambdaFunctionException>
+    public static final class Deserializer extends BaseDeserializer<LambdaFunctionException>
     {
-        Deserializer()
+        public Deserializer()
         {
             super(LambdaFunctionException.class);
         }
@@ -63,7 +63,7 @@ public class LambdaFunctionExceptionSerDe
         }
 
         @Override
-        protected LambdaFunctionException doDeserialize(JsonParser jparser, DeserializationContext ctxt)
+        public LambdaFunctionException doDeserialize(JsonParser jparser, DeserializationContext ctxt)
                 throws IOException
         {
             JsonNode root = jparser.getCodec().readTree(jparser);

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/ListSchemasRequestSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/ListSchemasRequestSerDe.java
@@ -33,7 +33,7 @@ import java.io.IOException;
 
 import static java.util.Objects.requireNonNull;
 
-final class ListSchemasRequestSerDe
+public final class ListSchemasRequestSerDe
 {
     private static final String IDENTITY_FIELD = "identity";
     private static final String QUERY_ID_FIELD = "queryId";
@@ -41,11 +41,11 @@ final class ListSchemasRequestSerDe
 
     private ListSchemasRequestSerDe(){}
 
-    static final class Serializer extends MetadataRequestSerializer
+    public static final class Serializer extends MetadataRequestSerializer
     {
         private final FederatedIdentitySerDe.Serializer identitySerializer;
 
-        Serializer(FederatedIdentitySerDe.Serializer identitySerializer)
+        public Serializer(FederatedIdentitySerDe.Serializer identitySerializer)
         {
             super(ListSchemasRequest.class, identitySerializer);
             this.identitySerializer = requireNonNull(identitySerializer, "identitySerializer is null");
@@ -59,11 +59,11 @@ final class ListSchemasRequestSerDe
         }
     }
 
-    static final class Deserializer extends MetadataRequestDeserializer
+    public static final class Deserializer extends MetadataRequestDeserializer
     {
         private final FederatedIdentitySerDe.Deserializer identityDeserializer;
 
-        Deserializer(FederatedIdentitySerDe.Deserializer identityDeserializer)
+        public Deserializer(FederatedIdentitySerDe.Deserializer identityDeserializer)
         {
             super(ListSchemasRequest.class, identityDeserializer);
             this.identityDeserializer = requireNonNull(identityDeserializer, "identityDeserializer is null");

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/ListSchemasResponseSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/ListSchemasResponseSerDe.java
@@ -31,16 +31,16 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import java.io.IOException;
 import java.util.Collection;
 
-final class ListSchemasResponseSerDe
+public final class ListSchemasResponseSerDe
 {
     private static final String CATALOG_NAME_FIELD = "catalogName";
     private static final String SCHEMAS_FIELD = "schemas";
 
     private ListSchemasResponseSerDe(){}
 
-    static final class Serializer extends TypedSerializer<FederationResponse>
+    public static final class Serializer extends TypedSerializer<FederationResponse>
     {
-        Serializer()
+        public Serializer()
         {
             super(FederationResponse.class, ListSchemasResponse.class);
         }
@@ -57,9 +57,9 @@ final class ListSchemasResponseSerDe
         }
     }
 
-    static final class Deserializer extends TypedDeserializer<FederationResponse>
+    public static final class Deserializer extends TypedDeserializer<FederationResponse>
     {
-        Deserializer()
+        public Deserializer()
         {
             super(FederationResponse.class, ListSchemasResponse.class);
         }

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/ListTablesRequestSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/ListTablesRequestSerDe.java
@@ -35,7 +35,7 @@ import java.io.IOException;
 import static com.amazonaws.athena.connector.lambda.metadata.ListTablesRequest.UNLIMITED_PAGE_SIZE_VALUE;
 import static java.util.Objects.requireNonNull;
 
-final class ListTablesRequestSerDe
+public final class ListTablesRequestSerDe
 {
     private static final String IDENTITY_FIELD = "identity";
     private static final String QUERY_ID_FIELD = "queryId";
@@ -46,11 +46,11 @@ final class ListTablesRequestSerDe
 
     private ListTablesRequestSerDe(){}
 
-    static final class Serializer extends MetadataRequestSerializer
+    public static final class Serializer extends MetadataRequestSerializer
     {
         private final FederatedIdentitySerDe.Serializer identitySerializer;
 
-        Serializer(FederatedIdentitySerDe.Serializer identitySerializer)
+        public Serializer(FederatedIdentitySerDe.Serializer identitySerializer)
         {
             super(ListTablesRequest.class, identitySerializer);
             this.identitySerializer = requireNonNull(identitySerializer, "identitySerializer is null");
@@ -68,11 +68,11 @@ final class ListTablesRequestSerDe
         }
     }
 
-    static final class Deserializer extends MetadataRequestDeserializer
+    public static final class Deserializer extends MetadataRequestDeserializer
     {
         private final FederatedIdentitySerDe.Deserializer identityDeserializer;
 
-        Deserializer(FederatedIdentitySerDe.Deserializer identityDeserializer)
+        public Deserializer(FederatedIdentitySerDe.Deserializer identityDeserializer)
         {
             super(ListTablesRequest.class, identityDeserializer);
             this.identityDeserializer = requireNonNull(identityDeserializer, "identityDeserializer is null");

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/ListTablesResponseSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/ListTablesResponseSerDe.java
@@ -35,7 +35,7 @@ import java.io.IOException;
 
 import static java.util.Objects.requireNonNull;
 
-final class ListTablesResponseSerDe
+public final class ListTablesResponseSerDe
 {
     private static final String TABLES_FIELD = "tables";
     private static final String CATALOG_NAME_FIELD = "catalogName";
@@ -43,11 +43,11 @@ final class ListTablesResponseSerDe
 
     private ListTablesResponseSerDe(){}
 
-    static final class Serializer extends TypedSerializer<FederationResponse>
+    public static final class Serializer extends TypedSerializer<FederationResponse>
     {
         private final TableNameSerDe.Serializer tableNameSerializer;
 
-        Serializer(TableNameSerDe.Serializer tableNameSerializer)
+        public Serializer(TableNameSerDe.Serializer tableNameSerializer)
         {
             super(FederationResponse.class, ListTablesResponse.class);
             this.tableNameSerializer = requireNonNull(tableNameSerializer, "tableNameSerializer is null");
@@ -69,11 +69,11 @@ final class ListTablesResponseSerDe
         }
     }
 
-    static final class Deserializer extends TypedDeserializer<FederationResponse>
+    public static final class Deserializer extends TypedDeserializer<FederationResponse>
     {
         private final TableNameSerDe.Deserializer tableNameDeserializer;
 
-        Deserializer(TableNameSerDe.Deserializer tableNameDeserializer)
+        public Deserializer(TableNameSerDe.Deserializer tableNameDeserializer)
         {
             super(FederationResponse.class, ListTablesResponse.class);
             this.tableNameDeserializer = requireNonNull(tableNameDeserializer, "tableNameDeserializer is null");

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/MarkerSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/MarkerSerDe.java
@@ -23,6 +23,7 @@ import com.amazonaws.athena.connector.lambda.data.Block;
 import com.amazonaws.athena.connector.lambda.domain.predicate.Marker;
 import com.amazonaws.athena.connector.lambda.serde.BaseDeserializer;
 import com.amazonaws.athena.connector.lambda.serde.BaseSerializer;
+import com.amazonaws.athena.connector.lambda.serde.VersionedSerDe;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -32,7 +33,7 @@ import java.io.IOException;
 
 import static java.util.Objects.requireNonNull;
 
-final class MarkerSerDe
+public final class MarkerSerDe
 {
     private static final String VALUE_BLOCK_FIELD = "valueBlock";
     private static final String BOUND_FIELD = "bound";
@@ -40,18 +41,18 @@ final class MarkerSerDe
 
     private MarkerSerDe(){}
 
-    static final class Serializer extends BaseSerializer<Marker>
+    public static final class Serializer extends BaseSerializer<Marker>
     {
-        private final BlockSerDe.Serializer blockSerializer;
+        private final VersionedSerDe.Serializer<Block> blockSerializer;
 
-        Serializer(BlockSerDe.Serializer blockSerializer)
+        public Serializer(VersionedSerDe.Serializer<Block> blockSerializer)
         {
             super(Marker.class);
             this.blockSerializer = requireNonNull(blockSerializer, "blockSerializer is null");
         }
 
         @Override
-        protected void doSerialize(Marker marker, JsonGenerator jgen, SerializerProvider provider)
+        public void doSerialize(Marker marker, JsonGenerator jgen, SerializerProvider provider)
                 throws IOException
         {
             jgen.writeFieldName(VALUE_BLOCK_FIELD);
@@ -62,18 +63,18 @@ final class MarkerSerDe
         }
     }
 
-    static final class Deserializer extends BaseDeserializer<Marker>
+    public static final class Deserializer extends BaseDeserializer<Marker>
     {
-        private final BlockSerDe.Deserializer blockDeserializer;
+        private final VersionedSerDe.Deserializer<Block> blockDeserializer;
 
-        Deserializer(BlockSerDe.Deserializer blockDeserializer)
+        public Deserializer(VersionedSerDe.Deserializer<Block> blockDeserializer)
         {
             super(Marker.class);
             this.blockDeserializer = requireNonNull(blockDeserializer, "blockDeserializer is null");
         }
 
         @Override
-        protected Marker doDeserialize(JsonParser jparser, DeserializationContext ctxt)
+        public Marker doDeserialize(JsonParser jparser, DeserializationContext ctxt)
                 throws IOException
         {
             assertFieldName(jparser, VALUE_BLOCK_FIELD);

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/RangeSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/RangeSerDe.java
@@ -32,25 +32,25 @@ import java.io.IOException;
 
 import static java.util.Objects.requireNonNull;
 
-final class RangeSerDe
+public final class RangeSerDe
 {
     private static final String LOW_FIELD = "low";
     private static final String HIGH_FIELD = "high";
 
     private RangeSerDe(){}
 
-    static final class Serializer extends BaseSerializer<Range>
+    public static final class Serializer extends BaseSerializer<Range>
     {
         private final MarkerSerDe.Serializer markerSerializer;
 
-        Serializer(MarkerSerDe.Serializer markerSerializer)
+        public Serializer(MarkerSerDe.Serializer markerSerializer)
         {
             super(Range.class);
             this.markerSerializer = requireNonNull(markerSerializer, "markerSerializer is null");
         }
 
         @Override
-        protected void doSerialize(Range range, JsonGenerator jgen, SerializerProvider provider)
+        public void doSerialize(Range range, JsonGenerator jgen, SerializerProvider provider)
                 throws IOException
         {
             jgen.writeFieldName(LOW_FIELD);
@@ -61,18 +61,18 @@ final class RangeSerDe
         }
     }
 
-    static final class Deserializer extends BaseDeserializer<Range>
+    public static final class Deserializer extends BaseDeserializer<Range>
     {
         private final MarkerSerDe.Deserializer markerDeserializer;
 
-        Deserializer(MarkerSerDe.Deserializer markerDeserializer)
+        public Deserializer(MarkerSerDe.Deserializer markerDeserializer)
         {
             super(Range.class);
             this.markerDeserializer = requireNonNull(markerDeserializer, "markerDeserializer is null");
         }
 
         @Override
-        protected Range doDeserialize(JsonParser jparser, DeserializationContext ctxt)
+        public Range doDeserialize(JsonParser jparser, DeserializationContext ctxt)
                 throws IOException
         {
             assertFieldName(jparser, LOW_FIELD);

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/ReadRecordsRequestSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/ReadRecordsRequestSerDe.java
@@ -28,6 +28,7 @@ import com.amazonaws.athena.connector.lambda.security.FederatedIdentity;
 import com.amazonaws.athena.connector.lambda.serde.FederatedIdentitySerDe;
 import com.amazonaws.athena.connector.lambda.serde.TypedDeserializer;
 import com.amazonaws.athena.connector.lambda.serde.TypedSerializer;
+import com.amazonaws.athena.connector.lambda.serde.VersionedSerDe;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -38,7 +39,7 @@ import java.io.IOException;
 
 import static java.util.Objects.requireNonNull;
 
-final class ReadRecordsRequestSerDe
+public final class ReadRecordsRequestSerDe
 {
     private static final String IDENTITY_FIELD = "identity";
     private static final String QUERY_ID_FIELD = "queryId";
@@ -52,19 +53,19 @@ final class ReadRecordsRequestSerDe
 
     private ReadRecordsRequestSerDe(){}
 
-    static final class Serializer extends TypedSerializer<FederationRequest>
+    public static final class Serializer extends TypedSerializer<FederationRequest>
     {
         private final FederatedIdentitySerDe.Serializer identitySerializer;
         private final TableNameSerDe.Serializer tableNameSerializer;
         private final ConstraintsSerDe.Serializer constraintsSerializer;
-        private final SchemaSerDe.Serializer schemaSerializer;
+        private final VersionedSerDe.Serializer<Schema> schemaSerializer;
         private final SplitSerDe.Serializer splitSerializer;
 
-        Serializer(
+        public Serializer(
                 FederatedIdentitySerDe.Serializer identitySerializer,
                 TableNameSerDe.Serializer tableNameSerializer,
                 ConstraintsSerDe.Serializer constraintsSerializer,
-                SchemaSerDe.Serializer schemaSerializer,
+                VersionedSerDe.Serializer<Schema> schemaSerializer,
                 SplitSerDe.Serializer splitSerializer)
         {
             super(FederationRequest.class, ReadRecordsRequest.class);
@@ -104,19 +105,19 @@ final class ReadRecordsRequestSerDe
         }
     }
 
-    static final class Deserializer extends TypedDeserializer<FederationRequest>
+    public static final class Deserializer extends TypedDeserializer<FederationRequest>
     {
         private final FederatedIdentitySerDe.Deserializer identityDeserializer;
         private final TableNameSerDe.Deserializer tableNameDeserializer;
         private final ConstraintsSerDe.Deserializer constraintsDeserializer;
-        private final SchemaSerDe.Deserializer schemaDeserializer;
+        private final VersionedSerDe.Deserializer<Schema> schemaDeserializer;
         private final SplitSerDe.Deserializer splitDeserializer;
 
-        Deserializer(
+        public Deserializer(
                 FederatedIdentitySerDe.Deserializer identityDeserializer,
                 TableNameSerDe.Deserializer tableNameDeserializer,
                 ConstraintsSerDe.Deserializer constraintsDeserializer,
-                SchemaSerDe.Deserializer schemaDeserializer,
+                VersionedSerDe.Deserializer<Schema> schemaDeserializer,
                 SplitSerDe.Deserializer splitDeserializer)
         {
             super(FederationRequest.class, ReadRecordsRequest.class);

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/ReadRecordsResponseSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/ReadRecordsResponseSerDe.java
@@ -24,6 +24,7 @@ import com.amazonaws.athena.connector.lambda.records.ReadRecordsResponse;
 import com.amazonaws.athena.connector.lambda.request.FederationResponse;
 import com.amazonaws.athena.connector.lambda.serde.TypedDeserializer;
 import com.amazonaws.athena.connector.lambda.serde.TypedSerializer;
+import com.amazonaws.athena.connector.lambda.serde.VersionedSerDe;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -33,18 +34,18 @@ import java.io.IOException;
 
 import static java.util.Objects.requireNonNull;
 
-final class ReadRecordsResponseSerDe
+public final class ReadRecordsResponseSerDe
 {
     private static final String CATALOG_NAME_FIELD = "catalogName";
     private static final String RECORDS_FIELD = "records";
 
     private ReadRecordsResponseSerDe(){}
 
-    static final class Serializer extends TypedSerializer<FederationResponse>
+    public static final class Serializer extends TypedSerializer<FederationResponse>
     {
-        private final BlockSerDe.Serializer blockSerializer;
+        private final VersionedSerDe.Serializer<Block> blockSerializer;
 
-        Serializer(BlockSerDe.Serializer blockSerializer)
+        public Serializer(VersionedSerDe.Serializer<Block> blockSerializer)
         {
             super(FederationResponse.class, ReadRecordsResponse.class);
             this.blockSerializer = requireNonNull(blockSerializer, "blockSerializer is null");
@@ -63,11 +64,11 @@ final class ReadRecordsResponseSerDe
         }
     }
 
-    static final class Deserializer extends TypedDeserializer<FederationResponse>
+    public static final class Deserializer extends TypedDeserializer<FederationResponse>
     {
-        private final BlockSerDe.Deserializer blockDeserializer;
+        private final VersionedSerDe.Deserializer<Block> blockDeserializer;
 
-        Deserializer(BlockSerDe.Deserializer blockDeserializer)
+        public Deserializer(VersionedSerDe.Deserializer<Block> blockDeserializer)
         {
             super(FederationResponse.class, ReadRecordsResponse.class);
             this.blockDeserializer = requireNonNull(blockDeserializer, "blockDeserializer is null");

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/RemoteReadRecordsResponseSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/RemoteReadRecordsResponseSerDe.java
@@ -25,6 +25,7 @@ import com.amazonaws.athena.connector.lambda.request.FederationResponse;
 import com.amazonaws.athena.connector.lambda.security.EncryptionKey;
 import com.amazonaws.athena.connector.lambda.serde.TypedDeserializer;
 import com.amazonaws.athena.connector.lambda.serde.TypedSerializer;
+import com.amazonaws.athena.connector.lambda.serde.VersionedSerDe;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
@@ -37,7 +38,7 @@ import java.io.IOException;
 
 import static java.util.Objects.requireNonNull;
 
-final class RemoteReadRecordsResponseSerDe
+public final class RemoteReadRecordsResponseSerDe
 {
     private static final String CATALOG_NAME_FIELD = "catalogName";
     private static final String SCHEMA_FIELD = "schema";
@@ -46,14 +47,14 @@ final class RemoteReadRecordsResponseSerDe
 
     private RemoteReadRecordsResponseSerDe(){}
 
-    static final class Serializer extends TypedSerializer<FederationResponse>
+    public static final class Serializer extends TypedSerializer<FederationResponse>
     {
-        private final SchemaSerDe.Serializer schemaSerializer;
+        private final VersionedSerDe.Serializer<Schema> schemaSerializer;
         private final SpillLocationSerDe.Serializer spillLocationSerializer;
         private final EncryptionKeySerDe.Serializer encryptionKeySerializer;
 
-        Serializer(
-                SchemaSerDe.Serializer schemaSerializer,
+        public Serializer(
+                VersionedSerDe.Serializer<Schema> schemaSerializer,
                 SpillLocationSerDe.Serializer spillLocationSerializer,
                 EncryptionKeySerDe.Serializer encryptionKeySerializer)
         {
@@ -85,14 +86,14 @@ final class RemoteReadRecordsResponseSerDe
         }
     }
 
-    static final class Deserializer extends TypedDeserializer<FederationResponse>
+    public static final class Deserializer extends TypedDeserializer<FederationResponse>
     {
-        private final SchemaSerDe.Deserializer schemaDeserializer;
+        private final VersionedSerDe.Deserializer<Schema> schemaDeserializer;
         private final SpillLocationSerDe.Deserializer spillLocationDeserializer;
         private final EncryptionKeySerDe.Deserializer encryptionKeyDeserializer;
 
-        Deserializer(
-                SchemaSerDe.Deserializer schemaDeserializer,
+        public Deserializer(
+                VersionedSerDe.Deserializer<Schema> schemaDeserializer,
                 SpillLocationSerDe.Deserializer spillLocationDeserializer,
                 EncryptionKeySerDe.Deserializer encryptionKeyDeserializer)
         {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/S3SpillLocationSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/S3SpillLocationSerDe.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 
 import java.io.IOException;
 
-final class S3SpillLocationSerDe
+public final class S3SpillLocationSerDe
 {
     private static final String BUCKET_FIELD = "bucket";
     private static final String KEY_FIELD = "key";
@@ -38,9 +38,9 @@ final class S3SpillLocationSerDe
 
     private S3SpillLocationSerDe(){}
 
-    static final class Serializer extends TypedSerializer<SpillLocation>
+    public static final class Serializer extends TypedSerializer<SpillLocation>
     {
-        Serializer()
+        public Serializer()
         {
             super(SpillLocation.class, S3SpillLocation.class);
         }
@@ -57,9 +57,9 @@ final class S3SpillLocationSerDe
         }
     }
 
-    static final class Deserializer extends TypedDeserializer<SpillLocation>
+    public static final class Deserializer extends TypedDeserializer<SpillLocation>
     {
-        Deserializer()
+        public Deserializer()
         {
             super(SpillLocation.class, S3SpillLocation.class);
         }

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/SchemaSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/SchemaSerDe.java
@@ -28,7 +28,9 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import org.apache.arrow.vector.ipc.ReadChannel;
 import org.apache.arrow.vector.ipc.WriteChannel;
+import org.apache.arrow.vector.ipc.message.IpcOption;
 import org.apache.arrow.vector.ipc.message.MessageSerializer;
+import org.apache.arrow.vector.types.MetadataVersion;
 import org.apache.arrow.vector.types.pojo.Schema;
 
 import java.io.ByteArrayInputStream;
@@ -59,8 +61,11 @@ final class SchemaSerDe
         protected void doSerialize(Schema schema, JsonGenerator jgen, SerializerProvider provider)
                 throws IOException
         {
+            IpcOption option = new IpcOption();
+            option.write_legacy_ipc_format = true;
+            option.metadataVersion = MetadataVersion.V4;
             ByteArrayOutputStream out = new ByteArrayOutputStream();
-            MessageSerializer.serialize(new WriteChannel(Channels.newChannel(out)), schema);
+            MessageSerializer.serialize(new WriteChannel(Channels.newChannel(out)), schema, option);
             jgen.writeBinary(out.toByteArray());
         }
     }

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/SortedRangeSetSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/SortedRangeSetSerDe.java
@@ -36,7 +36,7 @@ import java.io.IOException;
 
 import static java.util.Objects.requireNonNull;
 
-final class SortedRangeSetSerDe
+public final class SortedRangeSetSerDe
 {
     private static final String TYPE_FIELD = "type";
     private static final String RANGES_FIELD = "ranges";
@@ -44,12 +44,12 @@ final class SortedRangeSetSerDe
 
     private SortedRangeSetSerDe(){}
 
-    static final class Serializer extends TypedSerializer<ValueSet>
+    public static final class Serializer extends TypedSerializer<ValueSet>
     {
         private final ArrowTypeSerDe.Serializer arrowTypeSerializer;
         private final RangeSerDe.Serializer rangeSerializer;
 
-        Serializer(ArrowTypeSerDe.Serializer arrowTypeSerializer, RangeSerDe.Serializer rangeSerializer)
+        public Serializer(ArrowTypeSerDe.Serializer arrowTypeSerializer, RangeSerDe.Serializer rangeSerializer)
         {
             super(ValueSet.class, SortedRangeSet.class);
             this.arrowTypeSerializer = requireNonNull(arrowTypeSerializer, "arrowTypeSerializer is null");
@@ -76,12 +76,12 @@ final class SortedRangeSetSerDe
         }
     }
 
-    static final class Deserializer extends TypedDeserializer<ValueSet>
+    public static final class Deserializer extends TypedDeserializer<ValueSet>
     {
         private final ArrowTypeSerDe.Deserializer arrowTypeDeserializer;
         private final RangeSerDe.Deserializer rangeDeserializer;
 
-        Deserializer(ArrowTypeSerDe.Deserializer arrowTypeDeserializer, RangeSerDe.Deserializer rangeDeserializer)
+        public Deserializer(ArrowTypeSerDe.Deserializer arrowTypeDeserializer, RangeSerDe.Deserializer rangeDeserializer)
         {
             super(ValueSet.class, SortedRangeSet.class);
             this.arrowTypeDeserializer = requireNonNull(arrowTypeDeserializer, "arrowTypeDeserializer is null");

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/SpillLocationSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/SpillLocationSerDe.java
@@ -24,21 +24,21 @@ import com.amazonaws.athena.connector.lambda.serde.DelegatingDeserializer;
 import com.amazonaws.athena.connector.lambda.serde.DelegatingSerializer;
 import com.google.common.collect.ImmutableSet;
 
-final class SpillLocationSerDe
+public final class SpillLocationSerDe
 {
     private SpillLocationSerDe(){}
 
-    static final class Serializer extends DelegatingSerializer<SpillLocation>
+    public static final class Serializer extends DelegatingSerializer<SpillLocation>
     {
-        Serializer(S3SpillLocationSerDe.Serializer s3SpillLocationSerializer)
+        public Serializer(S3SpillLocationSerDe.Serializer s3SpillLocationSerializer)
         {
             super(SpillLocation.class, ImmutableSet.of(s3SpillLocationSerializer));
         }
     }
 
-    static final class Deserializer extends DelegatingDeserializer<SpillLocation>
+    public static final class Deserializer extends DelegatingDeserializer<SpillLocation>
     {
-        Deserializer(S3SpillLocationSerDe.Deserializer s3SpillLocationDeserializer)
+        public Deserializer(S3SpillLocationSerDe.Deserializer s3SpillLocationDeserializer)
         {
             super(SpillLocation.class, ImmutableSet.of(s3SpillLocationDeserializer));
         }

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/SplitSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/SplitSerDe.java
@@ -36,7 +36,7 @@ import java.util.Map;
 
 import static java.util.Objects.requireNonNull;
 
-final class SplitSerDe
+public final class SplitSerDe
 {
     private static final String SPILL_LOCATION_FIELD = "spillLocation";
     private static final String ENCRYPTION_KEY_FIELD = "encryptionKey";
@@ -44,12 +44,12 @@ final class SplitSerDe
 
     private SplitSerDe(){}
 
-    static final class Serializer extends BaseSerializer<Split>
+    public static final class Serializer extends BaseSerializer<Split>
     {
         private final SpillLocationSerDe.Serializer spillLocationSerializer;
         private final EncryptionKeySerDe.Serializer encryptionKeySerializer;
 
-        Serializer(SpillLocationSerDe.Serializer spillLocationSerializer, EncryptionKeySerDe.Serializer encryptionKeySerializer)
+        public Serializer(SpillLocationSerDe.Serializer spillLocationSerializer, EncryptionKeySerDe.Serializer encryptionKeySerializer)
         {
             super(Split.class);
             this.spillLocationSerializer = requireNonNull(spillLocationSerializer, "spillLocationSerializer is null");
@@ -57,7 +57,7 @@ final class SplitSerDe
         }
 
         @Override
-        protected void doSerialize(Split split, JsonGenerator jgen, SerializerProvider provider)
+        public void doSerialize(Split split, JsonGenerator jgen, SerializerProvider provider)
                 throws IOException
         {
             jgen.writeFieldName(SPILL_LOCATION_FIELD);
@@ -80,12 +80,12 @@ final class SplitSerDe
         }
     }
 
-    static final class Deserializer extends BaseDeserializer<Split>
+    public static final class Deserializer extends BaseDeserializer<Split>
     {
         private final SpillLocationSerDe.Deserializer spillLocationDeserializer;
         private final EncryptionKeySerDe.Deserializer encryptionKeyDeserializer;
 
-        Deserializer(SpillLocationSerDe.Deserializer spillLocationDeserializer, EncryptionKeySerDe.Deserializer encryptionKeyDeserializer)
+        public Deserializer(SpillLocationSerDe.Deserializer spillLocationDeserializer, EncryptionKeySerDe.Deserializer encryptionKeyDeserializer)
         {
             super(Split.class);
             this.spillLocationDeserializer = requireNonNull(spillLocationDeserializer, "spillLocationDeserializer is null");
@@ -93,7 +93,7 @@ final class SplitSerDe
         }
 
         @Override
-        protected Split doDeserialize(JsonParser jparser, DeserializationContext ctxt)
+        public Split doDeserialize(JsonParser jparser, DeserializationContext ctxt)
                 throws IOException
         {
             assertFieldName(jparser, SPILL_LOCATION_FIELD);

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/TableNameSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/TableNameSerDe.java
@@ -29,22 +29,22 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 
 import java.io.IOException;
 
-final class TableNameSerDe
+public final class TableNameSerDe
 {
     private static final String SCHEMA_NAME_FIELD = "schemaName";
     private static final String TABLE_NAME_FIELD = "tableName";
 
     private TableNameSerDe(){}
 
-    static final class Serializer extends BaseSerializer<TableName>
+    public static final class Serializer extends BaseSerializer<TableName>
     {
-        Serializer()
+        public Serializer()
         {
             super(TableName.class);
         }
 
         @Override
-        protected void doSerialize(TableName tableName, JsonGenerator jgen, SerializerProvider provider)
+        public void doSerialize(TableName tableName, JsonGenerator jgen, SerializerProvider provider)
                 throws IOException
         {
             jgen.writeStringField(SCHEMA_NAME_FIELD, tableName.getSchemaName());
@@ -52,15 +52,15 @@ final class TableNameSerDe
         }
     }
 
-    static final class Deserializer extends BaseDeserializer<TableName>
+    public static final class Deserializer extends BaseDeserializer<TableName>
     {
-        Deserializer()
+        public Deserializer()
         {
             super(TableName.class);
         }
 
         @Override
-        protected TableName doDeserialize(JsonParser jparser, DeserializationContext ctxt)
+        public TableName doDeserialize(JsonParser jparser, DeserializationContext ctxt)
                 throws IOException
         {
             String schemaName = getNextStringField(jparser, SCHEMA_NAME_FIELD);

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/UserDefinedFunctionRequestSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/UserDefinedFunctionRequestSerDe.java
@@ -25,6 +25,7 @@ import com.amazonaws.athena.connector.lambda.security.FederatedIdentity;
 import com.amazonaws.athena.connector.lambda.serde.FederatedIdentitySerDe;
 import com.amazonaws.athena.connector.lambda.serde.TypedDeserializer;
 import com.amazonaws.athena.connector.lambda.serde.TypedSerializer;
+import com.amazonaws.athena.connector.lambda.serde.VersionedSerDe;
 import com.amazonaws.athena.connector.lambda.udf.UserDefinedFunctionRequest;
 import com.amazonaws.athena.connector.lambda.udf.UserDefinedFunctionType;
 import com.fasterxml.jackson.core.JsonGenerator;
@@ -37,7 +38,7 @@ import java.io.IOException;
 
 import static java.util.Objects.requireNonNull;
 
-final class UserDefinedFunctionRequestSerDe
+public final class UserDefinedFunctionRequestSerDe
 {
     private static final String IDENTITY_FIELD = "identity";
     private static final String INPUT_RECORDS_FIELD = "inputRecords";
@@ -47,16 +48,16 @@ final class UserDefinedFunctionRequestSerDe
 
     private UserDefinedFunctionRequestSerDe(){}
 
-    static final class Serializer extends TypedSerializer<FederationRequest>
+    public static final class Serializer extends TypedSerializer<FederationRequest>
     {
         private final FederatedIdentitySerDe.Serializer identitySerializer;
-        private final BlockSerDe.Serializer blockSerializer;
-        private final SchemaSerDe.Serializer schemaSerializer;
+        private final VersionedSerDe.Serializer<Block> blockSerializer;
+        private final VersionedSerDe.Serializer<Schema> schemaSerializer;
 
-        Serializer(
+        public Serializer(
                 FederatedIdentitySerDe.Serializer identitySerializer,
-                BlockSerDe.Serializer blockSerializer,
-                SchemaSerDe.Serializer schemaSerializer)
+                VersionedSerDe.Serializer<Block> blockSerializer,
+                VersionedSerDe.Serializer<Schema> schemaSerializer)
         {
             super(FederationRequest.class, UserDefinedFunctionRequest.class);
             this.identitySerializer = requireNonNull(identitySerializer, "identitySerializer is null");
@@ -84,16 +85,16 @@ final class UserDefinedFunctionRequestSerDe
         }
     }
 
-    static final class Deserializer extends TypedDeserializer<FederationRequest>
+    public static final class Deserializer extends TypedDeserializer<FederationRequest>
     {
         private final FederatedIdentitySerDe.Deserializer identityDeserializer;
-        private final BlockSerDe.Deserializer blockDeserializer;
-        private final SchemaSerDe.Deserializer schemaDeserializer;
+        private final VersionedSerDe.Deserializer<Block> blockDeserializer;
+        private final VersionedSerDe.Deserializer<Schema> schemaDeserializer;
 
-        Deserializer(
+        public Deserializer(
                 FederatedIdentitySerDe.Deserializer identityDeserializer,
-                BlockSerDe.Deserializer blockDeserializer,
-                SchemaSerDe.Deserializer schemaDeserializer)
+                VersionedSerDe.Deserializer<Block> blockDeserializer,
+                VersionedSerDe.Deserializer<Schema> schemaDeserializer)
         {
             super(FederationRequest.class, UserDefinedFunctionRequest.class);
             this.identityDeserializer = requireNonNull(identityDeserializer, "identityDeserializer is null");

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/UserDefinedFunctionResponseSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/UserDefinedFunctionResponseSerDe.java
@@ -23,6 +23,7 @@ import com.amazonaws.athena.connector.lambda.data.Block;
 import com.amazonaws.athena.connector.lambda.request.FederationResponse;
 import com.amazonaws.athena.connector.lambda.serde.TypedDeserializer;
 import com.amazonaws.athena.connector.lambda.serde.TypedSerializer;
+import com.amazonaws.athena.connector.lambda.serde.VersionedSerDe;
 import com.amazonaws.athena.connector.lambda.udf.UserDefinedFunctionResponse;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
@@ -33,18 +34,18 @@ import java.io.IOException;
 
 import static java.util.Objects.requireNonNull;
 
-final class UserDefinedFunctionResponseSerDe
+public final class UserDefinedFunctionResponseSerDe
 {
     private static final String RECORDS_FIELD = "records";
     private static final String METHOD_NAME_FIELD = "methodName";
 
     private UserDefinedFunctionResponseSerDe(){}
 
-    static final class Serializer extends TypedSerializer<FederationResponse>
+    public static final class Serializer extends TypedSerializer<FederationResponse>
     {
-        private final BlockSerDe.Serializer blockSerializer;
+        private final VersionedSerDe.Serializer<Block> blockSerializer;
 
-        Serializer(BlockSerDe.Serializer blockSerializer)
+        public Serializer(VersionedSerDe.Serializer<Block> blockSerializer)
         {
             super(FederationResponse.class, UserDefinedFunctionResponse.class);
             this.blockSerializer = requireNonNull(blockSerializer, "blockSerializer is null");
@@ -63,11 +64,11 @@ final class UserDefinedFunctionResponseSerDe
         }
     }
 
-    static final class Deserializer extends TypedDeserializer<FederationResponse>
+    public static final class Deserializer extends TypedDeserializer<FederationResponse>
     {
-        private final BlockSerDe.Deserializer blockDeserializer;
+        private final VersionedSerDe.Deserializer<Block> blockDeserializer;
 
-        Deserializer(BlockSerDe.Deserializer blockDeserializer)
+        public Deserializer(VersionedSerDe.Deserializer<Block> blockDeserializer)
         {
             super(FederationResponse.class, UserDefinedFunctionResponse.class);
             this.blockDeserializer = requireNonNull(blockDeserializer, "blockDeserializer is null");

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/ValueSetSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/ValueSetSerDe.java
@@ -28,9 +28,9 @@ public class ValueSetSerDe
 {
     private ValueSetSerDe(){}
 
-    static final class Serializer extends DelegatingSerializer<ValueSet>
+    public static final class Serializer extends DelegatingSerializer<ValueSet>
     {
-        Serializer(
+        public Serializer(
                 EquatableValueSetSerDe.Serializer equatableValueSetSerializer,
                 SortedRangeSetSerDe.Serializer sortedRangeSetSerializer,
                 AllOrNoneValueSetSerDe.Serializer allOrNoneValueSetSerializer)
@@ -42,9 +42,9 @@ public class ValueSetSerDe
         }
     }
 
-    static final class Deserializer extends DelegatingDeserializer<ValueSet>
+    public static final class Deserializer extends DelegatingDeserializer<ValueSet>
     {
-        Deserializer(
+        public Deserializer(
                 EquatableValueSetSerDe.Deserializer equatableValueSetDeserializer,
                 SortedRangeSetSerDe.Deserializer sortedRangeSetDeserializer,
                 AllOrNoneValueSetSerDe.Deserializer allOrNoneValueSetDeserializer)

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v3/ArrowRecordBatchSerDeV3.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v3/ArrowRecordBatchSerDeV3.java
@@ -43,7 +43,7 @@ import static java.util.Objects.requireNonNull;
 
 public final class ArrowRecordBatchSerDeV3
 {
-    private ArrowRecordBatchSerDeV3(){}
+    private ArrowRecordBatchSerDeV3() {}
 
     static final class Serializer extends BaseSerializer<ArrowRecordBatch>
     {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v3/ArrowRecordBatchSerDeV3.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v3/ArrowRecordBatchSerDeV3.java
@@ -17,7 +17,7 @@
  * limitations under the License.
  * #L%
  */
-package com.amazonaws.athena.connector.lambda.serde.v2;
+package com.amazonaws.athena.connector.lambda.serde.v3;
 
 import com.amazonaws.athena.connector.lambda.data.BlockAllocator;
 import com.amazonaws.athena.connector.lambda.serde.BaseDeserializer;
@@ -31,9 +31,7 @@ import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.ipc.ReadChannel;
 import org.apache.arrow.vector.ipc.WriteChannel;
 import org.apache.arrow.vector.ipc.message.ArrowRecordBatch;
-import org.apache.arrow.vector.ipc.message.IpcOption;
 import org.apache.arrow.vector.ipc.message.MessageSerializer;
-import org.apache.arrow.vector.types.MetadataVersion;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -43,15 +41,9 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.Objects.requireNonNull;
 
-/**
- * used to serialize and deserialize ArrowRecordBatch.
- *
- * @deprecated {@link com.amazonaws.athena.connector.lambda.serde.v3.ArrowRecordBatchSerDeV3} should be used instead
- */
-@Deprecated
-public final class ArrowRecordBatchSerDe
+public final class ArrowRecordBatchSerDeV3
 {
-    private ArrowRecordBatchSerDe(){}
+    private ArrowRecordBatchSerDeV3(){}
 
     static final class Serializer extends BaseSerializer<ArrowRecordBatch>
     {
@@ -65,11 +57,8 @@ public final class ArrowRecordBatchSerDe
                 throws IOException
         {
             try {
-                IpcOption option = new IpcOption();
-                option.write_legacy_ipc_format = true;
-                option.metadataVersion = MetadataVersion.V4;
                 ByteArrayOutputStream out = new ByteArrayOutputStream();
-                MessageSerializer.serialize(new WriteChannel(Channels.newChannel(out)), arrowRecordBatch, option);
+                MessageSerializer.serialize(new WriteChannel(Channels.newChannel(out)), arrowRecordBatch);
                 jgen.writeBinary(out.toByteArray());
             }
             finally {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v3/BlockSerDeV3.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v3/BlockSerDeV3.java
@@ -17,7 +17,7 @@
  * limitations under the License.
  * #L%
  */
-package com.amazonaws.athena.connector.lambda.serde.v2;
+package com.amazonaws.athena.connector.lambda.serde.v3;
 
 import com.amazonaws.athena.connector.lambda.data.Block;
 import com.amazonaws.athena.connector.lambda.data.BlockAllocator;
@@ -33,9 +33,7 @@ import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.ipc.ReadChannel;
 import org.apache.arrow.vector.ipc.WriteChannel;
 import org.apache.arrow.vector.ipc.message.ArrowRecordBatch;
-import org.apache.arrow.vector.ipc.message.IpcOption;
 import org.apache.arrow.vector.ipc.message.MessageSerializer;
-import org.apache.arrow.vector.types.MetadataVersion;
 import org.apache.arrow.vector.types.pojo.Schema;
 
 import java.io.ByteArrayInputStream;
@@ -46,18 +44,17 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.Objects.requireNonNull;
 
-@Deprecated
-public final class BlockSerDe
+public class BlockSerDeV3
 {
     private static final String ALLOCATOR_ID_FIELD_NAME = "aId";
     private static final String SCHEMA_FIELD_NAME = "schema";
     private static final String BATCH_FIELD_NAME = "records";
 
-    public BlockSerDe(){}
+    public BlockSerDeV3(){}
 
-    public static final class Serializer extends BaseSerializer<Block>
+    public static final class Serializer extends BaseSerializer<Block> implements VersionedSerDe.Serializer<Block>
     {
-        private VersionedSerDe.Serializer<Schema> schemaSerializer;
+        private final VersionedSerDe.Serializer<Schema> schemaSerializer;
 
         public Serializer(VersionedSerDe.Serializer<Schema> schemaSerializer)
         {
@@ -87,11 +84,8 @@ public final class BlockSerDe
                 throws IOException
         {
             try {
-                IpcOption option = new IpcOption();
-                option.metadataVersion = MetadataVersion.V4;
-                option.write_legacy_ipc_format = true;
                 ByteArrayOutputStream out = new ByteArrayOutputStream();
-                MessageSerializer.serialize(new WriteChannel(Channels.newChannel(out)), recordBatch, option);
+                MessageSerializer.serialize(new WriteChannel(Channels.newChannel(out)), recordBatch);
                 return out.toByteArray();
             }
             finally {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v3/BlockSerDeV3.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v3/BlockSerDeV3.java
@@ -50,7 +50,7 @@ public class BlockSerDeV3
     private static final String SCHEMA_FIELD_NAME = "schema";
     private static final String BATCH_FIELD_NAME = "records";
 
-    public BlockSerDeV3(){}
+    public BlockSerDeV3() {}
 
     public static final class Serializer extends BaseSerializer<Block> implements VersionedSerDe.Serializer<Block>
     {

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/data/BlockTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/data/BlockTest.java
@@ -975,7 +975,8 @@ public class BlockTest
         try {
             ByteArrayOutputStream jout = new ByteArrayOutputStream();
             JsonFactory factory = new JsonFactory();
-            JsonGenerator jsonGenerator = factory.createJsonGenerator(jout);
+            JsonGenerator jsonGenerator = factory.createGenerator(jout);
+            jsonGenerator.writeStartObject();
             jsonGenerator.writeBinaryField("field", serializedBlock.toByteArray());
             jsonGenerator.close();
             double overhead = 1 - (((double) serializedBlock.size()) / ((double) jout.size()));

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/data/BlockUtilsTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/data/BlockUtilsTest.java
@@ -24,7 +24,6 @@ import org.apache.arrow.vector.types.DateUnit;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Schema;
-import org.joda.time.LocalDate;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -34,6 +33,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -166,7 +166,7 @@ public class BlockUtilsTest
                 .addField("col1", new ArrowType.Date(DateUnit.DAY))
                 .build();
 
-        Date date = LocalDate.parse("1998-1-1").toDate();
+        LocalDate date = LocalDate.parse("1998-01-01");
 
         Block block = allocator.createBlock(schema);
         BlockUtils.setValue(block.getFieldVector("col1"), 0, date);

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/data/UnitTestBlockUtils.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/data/UnitTestBlockUtils.java
@@ -52,8 +52,8 @@ public class UnitTestBlockUtils
                 if (Objects.isNull(fieldReader.readLocalDateTime())) {
                     return null;
                 }
-                long millis = fieldReader.readLocalDateTime().toDateTime(org.joda.time.DateTimeZone.UTC).getMillis();
-                return Instant.ofEpochMilli(millis).atZone(UTC_ZONE_ID).toLocalDateTime();
+                long millis = fieldReader.readLocalDateTime().atZone(BlockUtils.UTC_ZONE_ID).toInstant().toEpochMilli();
+                return Instant.ofEpochMilli(millis).atZone(BlockUtils.UTC_ZONE_ID).toLocalDateTime();
             case TINYINT:
             case UINT1:
                 return fieldReader.readByte();

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/examples/ExampleMetadataHandlerTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/examples/ExampleMetadataHandlerTest.java
@@ -102,12 +102,8 @@ public class ExampleMetadataHandlerTest
         logger.info("doListSchemas - enter");
         ListSchemasRequest req = new ListSchemasRequest(IdentityUtil.fakeIdentity(), "queryId", "default");
         ObjectMapperUtil.assertSerialization(req);
-        ObjectMapperUtil.assertSerializationBackwardsCompatible(req);
-        ObjectMapperUtil.assertSerializationForwardsCompatible(req);
         ListSchemasResponse res = metadataHandler.doListSchemaNames(allocator, req);
         ObjectMapperUtil.assertSerialization(res);
-        ObjectMapperUtil.assertSerializationBackwardsCompatible(res);
-        ObjectMapperUtil.assertSerializationForwardsCompatible(res);
         logger.info("doListSchemas - {}", res.getSchemas());
         assertFalse(res.getSchemas().isEmpty());
         logger.info("doListSchemas - exit");
@@ -131,12 +127,8 @@ public class ExampleMetadataHandlerTest
                         .add(new TableName("schema", "table5"))
                         .build(), null);
         ObjectMapperUtil.assertSerialization(req);
-        ObjectMapperUtil.assertSerializationBackwardsCompatible(req);
-        ObjectMapperUtil.assertSerializationForwardsCompatible(req);
         ListTablesResponse res = metadataHandler.doListTables(allocator, req);
         ObjectMapperUtil.assertSerialization(res);
-        ObjectMapperUtil.assertSerializationBackwardsCompatible(res);
-        ObjectMapperUtil.assertSerializationForwardsCompatible(res);
         logger.info("doListTables - {}", res);
         assertEquals("Expecting a different response", expectedResponse, res);
 
@@ -151,12 +143,8 @@ public class ExampleMetadataHandlerTest
                         .add(new TableName("schema", "table3"))
                         .build(), "table4");
         ObjectMapperUtil.assertSerialization(req);
-        ObjectMapperUtil.assertSerializationBackwardsCompatible(req);
-        ObjectMapperUtil.assertSerializationForwardsCompatible(req);
         res = metadataHandler.doListTables(allocator, req);
         ObjectMapperUtil.assertSerialization(res);
-        ObjectMapperUtil.assertSerializationBackwardsCompatible(res);
-        ObjectMapperUtil.assertSerializationForwardsCompatible(res);
         logger.info("doListTables - {}", res);
         assertEquals("Expecting a different response", expectedResponse, res);
 
@@ -185,12 +173,8 @@ public class ExampleMetadataHandlerTest
         GetTableRequest req = new GetTableRequest(IdentityUtil.fakeIdentity(), "queryId", "default",
                 new TableName("custom_source", "fake_table"));
         ObjectMapperUtil.assertSerialization(req);
-        ObjectMapperUtil.assertSerializationBackwardsCompatible(req);
-        ObjectMapperUtil.assertSerializationForwardsCompatible(req);
         GetTableResponse res = metadataHandler.doGetTable(allocator, req);
         ObjectMapperUtil.assertSerialization(res);
-        ObjectMapperUtil.assertSerializationBackwardsCompatible(res);
-        ObjectMapperUtil.assertSerializationForwardsCompatible(res);
         assertTrue(res.getSchema().getFields().size() > 0);
         assertTrue(res.getSchema().getCustomMetadata().size() > 0);
         logger.info("doGetTable - {}", res);
@@ -255,13 +239,9 @@ public class ExampleMetadataHandlerTest
                     tableSchema,
                     partitionCols);
             ObjectMapperUtil.assertSerialization(req);
-            ObjectMapperUtil.assertSerializationBackwardsCompatible(req);
-            ObjectMapperUtil.assertSerializationForwardsCompatible(req);
 
             res = metadataHandler.doGetTableLayout(allocator, req);
             ObjectMapperUtil.assertSerialization(res);
-            ObjectMapperUtil.assertSerializationBackwardsCompatible(res);
-            ObjectMapperUtil.assertSerializationForwardsCompatible(res);
 
             logger.info("doGetTableLayout - {}", res);
             Block partitions = res.getPartitions();
@@ -340,8 +320,6 @@ public class ExampleMetadataHandlerTest
         do {
             GetSplitsRequest req = new GetSplitsRequest(originalReq, continuationToken);
             ObjectMapperUtil.assertSerialization(req);
-            ObjectMapperUtil.assertSerializationBackwardsCompatible(req);
-            ObjectMapperUtil.assertSerializationForwardsCompatible(req);
 
             logger.info("doGetSplits: req[{}]", req);
             metadataHandler.setEncryption(numContinuations % 2 == 0);
@@ -349,8 +327,7 @@ public class ExampleMetadataHandlerTest
 
             MetadataResponse rawResponse = metadataHandler.doGetSplits(allocator, req);
             ObjectMapperUtil.assertSerialization(rawResponse);
-            ObjectMapperUtil.assertSerializationBackwardsCompatible(rawResponse);
-            ObjectMapperUtil.assertSerializationForwardsCompatible(rawResponse);
+
             assertEquals(MetadataRequestType.GET_SPLITS, rawResponse.getRequestType());
 
             GetSplitsResponse response = (GetSplitsResponse) rawResponse;

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/examples/ExampleMetadataHandlerTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/examples/ExampleMetadataHandlerTest.java
@@ -102,8 +102,12 @@ public class ExampleMetadataHandlerTest
         logger.info("doListSchemas - enter");
         ListSchemasRequest req = new ListSchemasRequest(IdentityUtil.fakeIdentity(), "queryId", "default");
         ObjectMapperUtil.assertSerialization(req);
+        ObjectMapperUtil.assertSerializationBackwardsCompatible(req);
+        ObjectMapperUtil.assertSerializationForwardsCompatible(req);
         ListSchemasResponse res = metadataHandler.doListSchemaNames(allocator, req);
         ObjectMapperUtil.assertSerialization(res);
+        ObjectMapperUtil.assertSerializationBackwardsCompatible(res);
+        ObjectMapperUtil.assertSerializationForwardsCompatible(res);
         logger.info("doListSchemas - {}", res.getSchemas());
         assertFalse(res.getSchemas().isEmpty());
         logger.info("doListSchemas - exit");
@@ -127,8 +131,12 @@ public class ExampleMetadataHandlerTest
                         .add(new TableName("schema", "table5"))
                         .build(), null);
         ObjectMapperUtil.assertSerialization(req);
+        ObjectMapperUtil.assertSerializationBackwardsCompatible(req);
+        ObjectMapperUtil.assertSerializationForwardsCompatible(req);
         ListTablesResponse res = metadataHandler.doListTables(allocator, req);
         ObjectMapperUtil.assertSerialization(res);
+        ObjectMapperUtil.assertSerializationBackwardsCompatible(res);
+        ObjectMapperUtil.assertSerializationForwardsCompatible(res);
         logger.info("doListTables - {}", res);
         assertEquals("Expecting a different response", expectedResponse, res);
 
@@ -143,8 +151,12 @@ public class ExampleMetadataHandlerTest
                         .add(new TableName("schema", "table3"))
                         .build(), "table4");
         ObjectMapperUtil.assertSerialization(req);
+        ObjectMapperUtil.assertSerializationBackwardsCompatible(req);
+        ObjectMapperUtil.assertSerializationForwardsCompatible(req);
         res = metadataHandler.doListTables(allocator, req);
         ObjectMapperUtil.assertSerialization(res);
+        ObjectMapperUtil.assertSerializationBackwardsCompatible(res);
+        ObjectMapperUtil.assertSerializationForwardsCompatible(res);
         logger.info("doListTables - {}", res);
         assertEquals("Expecting a different response", expectedResponse, res);
 
@@ -173,8 +185,12 @@ public class ExampleMetadataHandlerTest
         GetTableRequest req = new GetTableRequest(IdentityUtil.fakeIdentity(), "queryId", "default",
                 new TableName("custom_source", "fake_table"));
         ObjectMapperUtil.assertSerialization(req);
+        ObjectMapperUtil.assertSerializationBackwardsCompatible(req);
+        ObjectMapperUtil.assertSerializationForwardsCompatible(req);
         GetTableResponse res = metadataHandler.doGetTable(allocator, req);
         ObjectMapperUtil.assertSerialization(res);
+        ObjectMapperUtil.assertSerializationBackwardsCompatible(res);
+        ObjectMapperUtil.assertSerializationForwardsCompatible(res);
         assertTrue(res.getSchema().getFields().size() > 0);
         assertTrue(res.getSchema().getCustomMetadata().size() > 0);
         logger.info("doGetTable - {}", res);
@@ -239,9 +255,13 @@ public class ExampleMetadataHandlerTest
                     tableSchema,
                     partitionCols);
             ObjectMapperUtil.assertSerialization(req);
+            ObjectMapperUtil.assertSerializationBackwardsCompatible(req);
+            ObjectMapperUtil.assertSerializationForwardsCompatible(req);
 
             res = metadataHandler.doGetTableLayout(allocator, req);
             ObjectMapperUtil.assertSerialization(res);
+            ObjectMapperUtil.assertSerializationBackwardsCompatible(res);
+            ObjectMapperUtil.assertSerializationForwardsCompatible(res);
 
             logger.info("doGetTableLayout - {}", res);
             Block partitions = res.getPartitions();
@@ -320,6 +340,8 @@ public class ExampleMetadataHandlerTest
         do {
             GetSplitsRequest req = new GetSplitsRequest(originalReq, continuationToken);
             ObjectMapperUtil.assertSerialization(req);
+            ObjectMapperUtil.assertSerializationBackwardsCompatible(req);
+            ObjectMapperUtil.assertSerializationForwardsCompatible(req);
 
             logger.info("doGetSplits: req[{}]", req);
             metadataHandler.setEncryption(numContinuations % 2 == 0);
@@ -327,6 +349,8 @@ public class ExampleMetadataHandlerTest
 
             MetadataResponse rawResponse = metadataHandler.doGetSplits(allocator, req);
             ObjectMapperUtil.assertSerialization(rawResponse);
+            ObjectMapperUtil.assertSerializationBackwardsCompatible(rawResponse);
+            ObjectMapperUtil.assertSerializationForwardsCompatible(rawResponse);
             assertEquals(MetadataRequestType.GET_SPLITS, rawResponse.getRequestType());
 
             GetSplitsResponse response = (GetSplitsResponse) rawResponse;

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/examples/ExampleRecordHandlerTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/examples/ExampleRecordHandlerTest.java
@@ -208,9 +208,13 @@ public class ExampleRecordHandlerTest
                     100_000_000_000L
             );
             ObjectMapperUtil.assertSerialization(request);
+            ObjectMapperUtil.assertSerializationBackwardsCompatible(request);
+            ObjectMapperUtil.assertSerializationForwardsCompatible(request);
 
             RecordResponse rawResponse = recordService.readRecords(request);
             ObjectMapperUtil.assertSerialization(rawResponse);
+            ObjectMapperUtil.assertSerializationBackwardsCompatible(rawResponse);
+            ObjectMapperUtil.assertSerializationForwardsCompatible(rawResponse);
 
             assertTrue(rawResponse instanceof ReadRecordsResponse);
 
@@ -249,9 +253,13 @@ public class ExampleRecordHandlerTest
                     1000L
             );
             ObjectMapperUtil.assertSerialization(request);
+            ObjectMapperUtil.assertSerializationBackwardsCompatible(request);
+            ObjectMapperUtil.assertSerializationForwardsCompatible(request);
 
             RecordResponse rawResponse = recordService.readRecords(request);
             ObjectMapperUtil.assertSerialization(rawResponse);
+            ObjectMapperUtil.assertSerializationBackwardsCompatible(request);
+            ObjectMapperUtil.assertSerializationForwardsCompatible(request);
 
             assertTrue(rawResponse instanceof RemoteReadRecordsResponse);
 

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/examples/ExampleRecordHandlerTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/examples/ExampleRecordHandlerTest.java
@@ -208,13 +208,9 @@ public class ExampleRecordHandlerTest
                     100_000_000_000L
             );
             ObjectMapperUtil.assertSerialization(request);
-            ObjectMapperUtil.assertSerializationBackwardsCompatible(request);
-            ObjectMapperUtil.assertSerializationForwardsCompatible(request);
 
             RecordResponse rawResponse = recordService.readRecords(request);
             ObjectMapperUtil.assertSerialization(rawResponse);
-            ObjectMapperUtil.assertSerializationBackwardsCompatible(rawResponse);
-            ObjectMapperUtil.assertSerializationForwardsCompatible(rawResponse);
 
             assertTrue(rawResponse instanceof ReadRecordsResponse);
 
@@ -253,13 +249,9 @@ public class ExampleRecordHandlerTest
                     1000L
             );
             ObjectMapperUtil.assertSerialization(request);
-            ObjectMapperUtil.assertSerializationBackwardsCompatible(request);
-            ObjectMapperUtil.assertSerializationForwardsCompatible(request);
 
             RecordResponse rawResponse = recordService.readRecords(request);
             ObjectMapperUtil.assertSerialization(rawResponse);
-            ObjectMapperUtil.assertSerializationBackwardsCompatible(request);
-            ObjectMapperUtil.assertSerializationForwardsCompatible(request);
 
             assertTrue(rawResponse instanceof RemoteReadRecordsResponse);
 

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/examples/ExampleUserDefinedFunctionHandlerTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/examples/ExampleUserDefinedFunctionHandlerTest.java
@@ -202,8 +202,6 @@ public class ExampleUserDefinedFunctionHandlerTest
                 methodName,
                 UserDefinedFunctionType.SCALAR);
         ObjectMapperUtil.assertSerialization(request);
-        ObjectMapperUtil.assertSerializationBackwardsCompatible(request);
-        ObjectMapperUtil.assertSerializationForwardsCompatible(request);
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         mapper.writeValue(out, request);
@@ -214,8 +212,6 @@ public class ExampleUserDefinedFunctionHandlerTest
 
         UserDefinedFunctionResponse udfResponse = (UserDefinedFunctionResponse) mapper.readValue(outputStream.toByteArray(), FederationResponse.class);
         ObjectMapperUtil.assertSerialization(udfResponse);
-        ObjectMapperUtil.assertSerializationBackwardsCompatible(udfResponse);
-        ObjectMapperUtil.assertSerializationForwardsCompatible(udfResponse);
 
         return udfResponse;
     }

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/examples/ExampleUserDefinedFunctionHandlerTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/examples/ExampleUserDefinedFunctionHandlerTest.java
@@ -202,6 +202,8 @@ public class ExampleUserDefinedFunctionHandlerTest
                 methodName,
                 UserDefinedFunctionType.SCALAR);
         ObjectMapperUtil.assertSerialization(request);
+        ObjectMapperUtil.assertSerializationBackwardsCompatible(request);
+        ObjectMapperUtil.assertSerializationForwardsCompatible(request);
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         mapper.writeValue(out, request);
@@ -212,6 +214,8 @@ public class ExampleUserDefinedFunctionHandlerTest
 
         UserDefinedFunctionResponse udfResponse = (UserDefinedFunctionResponse) mapper.readValue(outputStream.toByteArray(), FederationResponse.class);
         ObjectMapperUtil.assertSerialization(udfResponse);
+        ObjectMapperUtil.assertSerializationBackwardsCompatible(udfResponse);
+        ObjectMapperUtil.assertSerializationForwardsCompatible(udfResponse);
 
         return udfResponse;
     }

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/serde/ConstraintSerializationTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/serde/ConstraintSerializationTest.java
@@ -89,6 +89,8 @@ public class ConstraintSerializationTest
                         new HashSet<>())
         ) {
             ObjectMapperUtil.assertSerialization(req);
+            ObjectMapperUtil.assertSerializationBackwardsCompatible(req);
+            ObjectMapperUtil.assertSerializationForwardsCompatible(req);
         }
 
         logger.info("serializationTest - exit");

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/serde/ConstraintSerializationTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/serde/ConstraintSerializationTest.java
@@ -89,8 +89,6 @@ public class ConstraintSerializationTest
                         new HashSet<>())
         ) {
             ObjectMapperUtil.assertSerialization(req);
-            ObjectMapperUtil.assertSerializationBackwardsCompatible(req);
-            ObjectMapperUtil.assertSerializationForwardsCompatible(req);
         }
 
         logger.info("serializationTest - exit");

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/serde/ObjectMapperUtil.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/serde/ObjectMapperUtil.java
@@ -24,15 +24,13 @@ import com.amazonaws.athena.connector.lambda.data.BlockAllocator;
 import com.amazonaws.athena.connector.lambda.data.BlockAllocatorImpl;
 import com.amazonaws.athena.connector.lambda.request.FederationRequest;
 import com.amazonaws.athena.connector.lambda.request.FederationResponse;
-import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
+import static com.amazonaws.athena.connector.lambda.utils.TestUtils.SERDE_VERSION_ONE;
 import static com.amazonaws.athena.connector.lambda.utils.TestUtils.SERDE_VERSION_THREE;
 import static com.amazonaws.athena.connector.lambda.utils.TestUtils.SERDE_VERSION_TWO;
 import static org.junit.Assert.assertEquals;
@@ -42,6 +40,13 @@ public class ObjectMapperUtil
     private ObjectMapperUtil() {}
 
     public static <T> void assertSerialization(Object object)
+    {
+        assertBaseSerialization(object);
+        assertSerializationForwardsCompatibleV2toV3(object);
+        assertSerializationBackwardsCompatibleV3toV2(object);
+    }
+
+    private static <T> void assertBaseSerialization(Object object)
     {
         Class<?> clazz = object.getClass();
         if (object instanceof FederationRequest)
@@ -62,7 +67,7 @@ public class ObjectMapperUtil
         }
     }
 
-    public static <T> void assertSerializationBackwardsCompatible(Object object)
+    private static <T> void assertSerializationBackwardsCompatibleV3toV2(Object object)
     {
         Class<?> clazz = object.getClass();
         if (object instanceof FederationRequest)
@@ -84,7 +89,7 @@ public class ObjectMapperUtil
         }
     }
 
-    public static <T> void assertSerializationForwardsCompatible(Object object)
+    private static <T> void assertSerializationForwardsCompatibleV2toV3(Object object)
     {
         Class<?> clazz = object.getClass();
         if (object instanceof FederationRequest)

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/serde/ObjectMapperUtil.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/serde/ObjectMapperUtil.java
@@ -30,7 +30,6 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
-import static com.amazonaws.athena.connector.lambda.utils.TestUtils.SERDE_VERSION_ONE;
 import static com.amazonaws.athena.connector.lambda.utils.TestUtils.SERDE_VERSION_THREE;
 import static com.amazonaws.athena.connector.lambda.utils.TestUtils.SERDE_VERSION_TWO;
 import static org.junit.Assert.assertEquals;

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/serde/PingRequestSerDeTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/serde/PingRequestSerDeTest.java
@@ -86,6 +86,8 @@ public class PingRequestSerDeTest extends TypedSerDeTest<FederationRequest>
     public void testBackwardsCompatibility()
     {
         ObjectMapperUtil.assertSerialization(expected);
+        ObjectMapperUtil.assertSerializationBackwardsCompatible(expected);
+        ObjectMapperUtil.assertSerializationForwardsCompatible(expected);
     }
 
     @Test

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/serde/PingRequestSerDeTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/serde/PingRequestSerDeTest.java
@@ -86,8 +86,6 @@ public class PingRequestSerDeTest extends TypedSerDeTest<FederationRequest>
     public void testBackwardsCompatibility()
     {
         ObjectMapperUtil.assertSerialization(expected);
-        ObjectMapperUtil.assertSerializationBackwardsCompatible(expected);
-        ObjectMapperUtil.assertSerializationForwardsCompatible(expected);
     }
 
     @Test

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/serde/PingResponseSerDeTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/serde/PingResponseSerDeTest.java
@@ -82,11 +82,9 @@ public class PingResponseSerDeTest extends TypedSerDeTest<FederationResponse>
     }
 
     @Test
-    public void testBackwardsCompatibility()
+    public void testBackwardsAndForwardsCompatibility()
     {
         ObjectMapperUtil.assertSerialization(expected);
-        ObjectMapperUtil.assertSerializationBackwardsCompatible(expected);
-        ObjectMapperUtil.assertSerializationForwardsCompatible(expected);
     }
 
     @Test

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/serde/PingResponseSerDeTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/serde/PingResponseSerDeTest.java
@@ -85,6 +85,8 @@ public class PingResponseSerDeTest extends TypedSerDeTest<FederationResponse>
     public void testBackwardsCompatibility()
     {
         ObjectMapperUtil.assertSerialization(expected);
+        ObjectMapperUtil.assertSerializationBackwardsCompatible(expected);
+        ObjectMapperUtil.assertSerializationForwardsCompatible(expected);
     }
 
     @Test

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/serde/TypedSerDeTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/serde/TypedSerDeTest.java
@@ -32,11 +32,15 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
+import static com.amazonaws.athena.connector.lambda.utils.TestUtils.SERDE_VERSION_THREE;
+import static com.amazonaws.athena.connector.lambda.utils.TestUtils.SERDE_VERSION_TWO;
+
 public abstract class TypedSerDeTest<T>
 {
     protected TestUtils utils = new TestUtils();
     protected BlockAllocator allocator;
     protected ObjectMapper mapper;
+    protected ObjectMapper mapperV3;
     protected FederatedIdentity federatedIdentity = new FederatedIdentity("testArn", "0123456789", Collections.emptyMap(), Collections.emptyList());
     protected String expectedSerDeText;
     protected T expected;
@@ -45,7 +49,8 @@ public abstract class TypedSerDeTest<T>
     public void before()
     {
         allocator = new BlockAllocatorImpl("test-allocator-id");
-        mapper = VersionedObjectMapperFactory.create(allocator);
+        mapper = VersionedObjectMapperFactory.create(allocator, SERDE_VERSION_TWO);
+        mapperV3 = VersionedObjectMapperFactory.create(allocator, SERDE_VERSION_THREE);
         mapper.enable(SerializationFeature.INDENT_OUTPUT);
     }
 

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/serde/v3/ObjectMapperFactoryV3Test.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/serde/v3/ObjectMapperFactoryV3Test.java
@@ -17,7 +17,7 @@
  * limitations under the License.
  * #L%
  */
-package com.amazonaws.athena.connector.lambda.serde.v2;
+package com.amazonaws.athena.connector.lambda.serde.v3;
 
 import com.amazonaws.athena.connector.lambda.data.BlockAllocator;
 import com.amazonaws.athena.connector.lambda.data.BlockAllocatorImpl;
@@ -30,16 +30,17 @@ import org.junit.Test;
 
 import java.io.IOException;
 
+import static com.amazonaws.athena.connector.lambda.utils.TestUtils.SERDE_VERSION_THREE;
 import static com.amazonaws.athena.connector.lambda.utils.TestUtils.SERDE_VERSION_TWO;
 
-public class ObjectMapperFactoryV2Test
+public class ObjectMapperFactoryV3Test
 {
     @Test(expected = JsonMappingException.class)
     public void testStrictSerializer()
             throws JsonProcessingException
     {
         try (BlockAllocator allocator = new BlockAllocatorImpl()) {
-            ObjectMapper mapper = VersionedObjectMapperFactory.create(allocator, SERDE_VERSION_TWO);
+            ObjectMapper mapper = VersionedObjectMapperFactory.create(allocator, SERDE_VERSION_THREE);
             mapper.writeValueAsString(new ArrowType.Null());
         }
     }
@@ -49,7 +50,7 @@ public class ObjectMapperFactoryV2Test
             throws IOException
     {
         try (BlockAllocator allocator = new BlockAllocatorImpl()) {
-            ObjectMapper mapper = VersionedObjectMapperFactory.create(allocator, SERDE_VERSION_TWO);
+            ObjectMapper mapper = VersionedObjectMapperFactory.create(allocator, SERDE_VERSION_THREE);
             mapper.readValue("{\"@type\" : \"FloatingPoint\", \"precision\" : \"DOUBLE\"}", ArrowType.FloatingPoint.class);
         }
     }

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/utils/TestUtils.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/utils/TestUtils.java
@@ -35,6 +35,9 @@ public class TestUtils
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(TestUtils.class);
 
+    public final static int SERDE_VERSION_TWO = 2;
+    public final static int SERDE_VERSION_THREE = 3;
+
     /**
      * Helper to retrieve resources from the class path and enforce they are found
      * @param locationHint Used to help find the resources if a classpath scan isn't working

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/utils/TestUtils.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/utils/TestUtils.java
@@ -35,6 +35,7 @@ public class TestUtils
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(TestUtils.class);
 
+    public final static int SERDE_VERSION_ONE = 1;
     public final static int SERDE_VERSION_TWO = 2;
     public final static int SERDE_VERSION_THREE = 3;
 

--- a/athena-jdbc/pom.xml
+++ b/athena-jdbc/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.apache.arrow</groupId>
             <artifactId>arrow-jdbc</artifactId>
-            <version>0.15.0</version>
+            <version>2.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>

--- a/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/manager/JdbcRecordHandler.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/manager/JdbcRecordHandler.java
@@ -92,7 +92,6 @@ import java.util.concurrent.TimeUnit;
 public abstract class JdbcRecordHandler
         extends RecordHandler
 {
-    public static final org.joda.time.MutableDateTime EPOCH = new org.joda.time.MutableDateTime();
     private static final Logger LOGGER = LoggerFactory.getLogger(JdbcRecordHandler.class);
     private final JdbcConnectionFactory jdbcConnectionFactory;
     private final DatabaseConnectionConfig databaseConnectionConfig;

--- a/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/manager/JdbcSplitQueryBuilder.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/manager/JdbcSplitQueryBuilder.java
@@ -32,8 +32,6 @@ import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.commons.lang3.Validate;
-import org.joda.time.DateTimeZone;
-import org.joda.time.LocalDateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,6 +41,8 @@ import java.sql.Date;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -154,7 +154,7 @@ public abstract class JdbcSplitQueryBuilder
                     break;
                 case DATEMILLI:
                     LocalDateTime timestamp = ((LocalDateTime) typeAndValue.getValue());
-                    statement.setTimestamp(i + 1, new Timestamp(timestamp.toDateTime(DateTimeZone.UTC).getMillis()));
+                    statement.setTimestamp(i + 1, new Timestamp(timestamp.toInstant(ZoneOffset.UTC).toEpochMilli()));
                     break;
                 case VARCHAR:
                     statement.setString(i + 1, String.valueOf(typeAndValue.getValue()));

--- a/athena-tpcds/src/main/java/com/amazonaws/athena/connectors/tpcds/TPCDSRecordHandler.java
+++ b/athena-tpcds/src/main/java/com/amazonaws/athena/connectors/tpcds/TPCDSRecordHandler.java
@@ -40,13 +40,12 @@ import com.teradata.tpcds.column.ColumnType;
 import org.apache.arrow.util.VisibleForTesting;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
-import org.joda.time.LocalDate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.math.BigDecimal;
-import java.util.Date;
+import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -195,7 +194,7 @@ public class TPCDSRecordHandler
                 };
             case DATE:
                 return (Block block, int rowNum, String rawValue) -> {
-                    Date value = (rawValue != null) ? LocalDate.parse(rawValue).toDate() : null;
+                    LocalDate value = (rawValue != null) ? LocalDate.parse(rawValue) : null;
                     return block.setValue(field.getName(), rowNum, value);
                 };
             case DECIMAL:

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <mockito.version>1.10.19</mockito.version>
         <junit.version>4.13.1</junit.version>
         <testng.version>7.0.0</testng.version>
-        <fasterxml.jackson.version>2.11.3</fasterxml.jackson.version>
+        <fasterxml.jackson.version>2.10.5</fasterxml.jackson.version>
         <aws-cdk.version>1.89.0</aws-cdk.version>
         <surefire.failsafe.version>3.0.0-M5</surefire.failsafe.version>
     </properties>


### PR DESCRIPTION
This PR is the first PR for upgrading arrow to version 3.0.0. This PR will specifically handle the implementation of the following:
1. Upgrade arrow to 3.0.0
2. Move from Joda.time to Java.time (arrow moved away from Joda time)
3. fix tests to handle move from joda time
4. Add support for IPC writing to only V4. 


Re 4:
Arrow added backwards incompatible changes. However, in order to fix this, they've added IpcOption class to determine which version to write in. Arrow 0.11.0 is considered V4, and this change forces the V2 serde to write in V4. 

The latest IpcOption version is V5. V5 written formats cannot be read by V4, but V4 written objects can be read by V5. 

In a subsequent PR, I will add the changes to support writing in V5 by creating a new serde version for the affected classes. Please do not merge this PR until the subsequent one is approved. 



Testing:
Unit tests all pass. local testing works as well.