### PR TITLE
Update maven central action

### DIFF
--- a/.github/workflows/publish_to_maven_central.yml
+++ b/.github/workflows/publish_to_maven_central.yml
@@ -2,7 +2,8 @@ name: Release
 
 on:
   release:
-    types: [ published, workflow_dispatch ]
+    types: [ published ]
+  workflow_dispatch:
 
 jobs:
   release:

--- a/.github/workflows/publish_to_maven_central.yml
+++ b/.github/workflows/publish_to_maven_central.yml
@@ -2,12 +2,12 @@ name: Release
 
 on:
   release:
-    types: [ published ]
+    types: [ published, workflow_dispatch ]
 
 jobs:
   release:
     name: Publish to maven central
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout Codebase


### PR DESCRIPTION
*Description of changes:*
The github action failed to upload the federation sdk to maven-central with the error
`Error: The process '/usr/bin/gpg' failed with exit code 2`. https://github.com/awslabs/aws-athena-query-federation/runs/2461556378?check_suite_focus=true 

From what I've read this looks like to be a permission issue, with gpg not having access to the necessary directory to import the key.  This is currently running on a self-hosted runner.  I tested using a hosted ubuntu runner and its working fine.  We're currently using the same ubuntu-latest runner in [another action](https://github.com/awslabs/aws-athena-query-federation/blob/master/.github/workflows/codeql-analysis.yml#L12).

For more info, you can read about the GPG key and runners [here](https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#Publishing-using-Apache-Maven).

This also adds the ability for admins to run the upload to maven central action without creating a new release. https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
