### PR TITLE
Remove hardcoded partitions

### DIFF
--- a/athena-docdb/athena-docdb.yaml
+++ b/athena-docdb/athena-docdb.yaml
@@ -71,7 +71,7 @@ Resources:
             - Action:
                 - secretsmanager:GetSecretValue
               Effect: Allow
-              Resource: !Sub 'arn:aws:secretsmanager:*:*:secret:${SecretNameOrPrefix}'
+              Resource: !Sub 'arn:${AWS::Partition}:secretsmanager:*:*:secret:${SecretNameOrPrefix}'
           Version: '2012-10-17'
         - Statement:
             - Action:

--- a/athena-elasticsearch/athena-elasticsearch.yaml
+++ b/athena-elasticsearch/athena-elasticsearch.yaml
@@ -21,7 +21,7 @@ Parameters:
     Type: String
     AllowedPattern: ^[a-z0-9-_]{1,64}$
   SecretNamePrefix:
-    Description: 'Used to create resource-based authorization policy for "secretsmanager:GetSecretValue" action. E.g. All Athena Elasticsearch Federation secret names can be prefixed with "AthenaESFederation" and authorization policy will allow "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:AthenaESFederation*". Parameter value in this case should be "AthenaESFederation". If you do not have a prefix, you can manually update the IAM policy to add allow any secret names.'
+    Description: 'Used to create resource-based authorization policy for "secretsmanager:GetSecretValue" action. E.g. All Athena Elasticsearch Federation secret names can be prefixed with "AthenaESFederation" and authorization policy will allow "arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:AthenaESFederation*". Parameter value in this case should be "AthenaESFederation". If you do not have a prefix, you can manually update the IAM policy to add allow any secret names.'
     Type: String
     Default: ""
   SpillBucket:
@@ -84,7 +84,7 @@ Resources:
             - Action:
                 - secretsmanager:GetSecretValue
               Effect: Allow
-              Resource: !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:${SecretNamePrefix}*'
+              Resource: !Sub 'arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:${SecretNamePrefix}*'
           Version: '2012-10-17'
         - Statement:
             - Action:

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/handlers/GlueMetadataHandler.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/handlers/GlueMetadataHandler.java
@@ -111,7 +111,7 @@ public abstract class GlueMetadataHandler
     //Splitter for inline map properties
     private static final Splitter.MapSplitter MAP_SPLITTER = Splitter.on(",").trimResults().withKeyValueSeparator("=");
     //Regex we expect for a table resource ARN
-    private static final Pattern TABLE_ARN_REGEX = Pattern.compile("^arn:aws:[a-z]+:[a-z1-9-]+:[0-9]{12}:table\\/(.+)$");
+    private static final Pattern TABLE_ARN_REGEX = Pattern.compile("^arn:(?:aws|aws-cn|aws-us-gov):[a-z]+:[a-z1-9-]+:[0-9]{12}:table\\/(.+)$");
     //Table property that we expect to contain the source table name
     public static final String SOURCE_TABLE_PROPERTY = "sourceTable";
     //Table property that we expect to contain the column name mapping

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/handlers/GlueMetadataHandlerTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/handlers/GlueMetadataHandlerTest.java
@@ -67,6 +67,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -378,12 +379,15 @@ public class GlueMetadataHandlerTest
     @Test
     public void populateSourceTableFromLocation() {
         Map<String, String> params = new HashMap<>();
-        StorageDescriptor storageDescriptor = new StorageDescriptor().withLocation("arn:aws:dynamodb:us-east-1:012345678910:table/My-Table");
-        Table table = new Table().withParameters(params).withStorageDescriptor(storageDescriptor);
-        SchemaBuilder schemaBuilder = new SchemaBuilder();
-        populateSourceTableNameIfAvailable(table, schemaBuilder);
-        Schema schema = schemaBuilder.build();
-        assertEquals("My-Table", getSourceTableName(schema));
+        List<String> partitions = Arrays.asList("aws", "aws-cn", "aws-us-gov");
+        for (String partition : partitions) {
+            StorageDescriptor storageDescriptor = new StorageDescriptor().withLocation(String.format("arn:%s:dynamodb:us-east-1:012345678910:table/My-Table", partition));
+            Table table = new Table().withParameters(params).withStorageDescriptor(storageDescriptor);
+            SchemaBuilder schemaBuilder = new SchemaBuilder();
+            populateSourceTableNameIfAvailable(table, schemaBuilder);
+            Schema schema = schemaBuilder.build();
+            assertEquals("My-Table", getSourceTableName(schema));
+        }
     }
 
     @Test

--- a/athena-hbase/athena-hbase.yaml
+++ b/athena-hbase/athena-hbase.yaml
@@ -70,7 +70,7 @@ Resources:
             - Action:
                 - secretsmanager:GetSecretValue
               Effect: Allow
-              Resource: !Sub 'arn:aws:secretsmanager:*:*:secret:${SecretNameOrPrefix}'
+              Resource: !Sub 'arn:${AWS::Partition}:secretsmanager:*:*:secret:${SecretNameOrPrefix}'
           Version: '2012-10-17'
         - Statement:
             - Action:

--- a/athena-jdbc/athena-jdbc.yaml
+++ b/athena-jdbc/athena-jdbc.yaml
@@ -21,7 +21,7 @@ Parameters:
     Description: 'The default connection string is used when catalog is "lambda:${LambdaFunctionName}". Catalog specific Connection Strings can be added later. Format: ${DatabaseType}://${NativeJdbcConnectionString}.'
     Type: String
   SecretNamePrefix:
-      Description: 'Used to create resource-based authorization policy for "secretsmanager:GetSecretValue" action. E.g. All Athena JDBC Federation secret names can be prefixed with "AthenaJdbcFederation" and authorization policy will allow "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:AthenaJdbcFederation*". Parameter value in this case should be "AthenaJdbcFederation". If you do not have a prefix, you can manually update the IAM policy to add allow any secret names.'
+      Description: 'Used to create resource-based authorization policy for "secretsmanager:GetSecretValue" action. E.g. All Athena JDBC Federation secret names can be prefixed with "AthenaJdbcFederation" and authorization policy will allow "arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:AthenaJdbcFederation*". Parameter value in this case should be "AthenaJdbcFederation". If you do not have a prefix, you can manually update the IAM policy to add allow any secret names.'
       Type: String
   SpillBucket:
     Description: 'The name of the bucket where this function can spill data.'
@@ -70,20 +70,20 @@ Resources:
             - Action:
                 - secretsmanager:GetSecretValue
               Effect: Allow
-              Resource: !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:${SecretNamePrefix}*'
+              Resource: !Sub 'arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:${SecretNamePrefix}*'
           Version: '2012-10-17'
         - Statement:
             - Action:
                 - logs:CreateLogGroup
               Effect: Allow
-              Resource: !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*'
+              Resource: !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*'
           Version: '2012-10-17'
         - Statement:
           - Action:
               - logs:CreateLogStream
               - logs:PutLogEvents
             Effect: Allow
-            Resource: !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${LambdaFunctionName}:*'
+            Resource: !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${LambdaFunctionName}:*'
           Version: '2012-10-17'
         - Statement:
           - Action:

--- a/athena-neptune/athena-neptune.yaml
+++ b/athena-neptune/athena-neptune.yaml
@@ -98,7 +98,7 @@ Resources:
                 - neptune-db:*
               Effect: Allow
               #Dynamically construct Neptune Cluster Resource ARN to limit permissions to the specific cluster provided
-              Resource: !Sub 'arn:aws:neptune-db:${AWS::Region}:${AWS::AccountId}:${NeptuneClusterResourceID}/*'
+              Resource: !Sub 'arn:${AWS::Partition}:neptune-db:${AWS::Region}:${AWS::AccountId}:${NeptuneClusterResourceID}/*'
           Version: '2012-10-17'
         #S3CrudPolicy allows our connector to spill large responses to S3. You can optionally replace this pre-made policy
         #with one that is more restrictive and can only 'put' but not read,delete, or overwrite files.

--- a/athena-redis/athena-redis.yaml
+++ b/athena-redis/athena-redis.yaml
@@ -66,7 +66,7 @@ Resources:
             - Action:
                 - secretsmanager:GetSecretValue
               Effect: Allow
-              Resource: !Sub 'arn:aws:secretsmanager:*:*:secret:${SecretNameOrPrefix}'
+              Resource: !Sub 'arn:${AWS::Partition}:secretsmanager:*:*:secret:${SecretNameOrPrefix}'
           Version: '2012-10-17'
         - Statement:
             - Action:

--- a/athena-udfs/athena-udfs.yaml
+++ b/athena-udfs/athena-udfs.yaml
@@ -44,5 +44,5 @@ Resources:
             - Action:
                 - secretsmanager:GetSecretValue
               Effect: Allow
-              Resource: !Sub 'arn:aws:secretsmanager:*:*:secret:${SecretNameOrPrefix}'
+              Resource: !Sub 'arn:${AWS::Partition}:secretsmanager:*:*:secret:${SecretNameOrPrefix}'
           Version: '2012-10-17'

--- a/athena-vertica/athena-vertica.yaml
+++ b/athena-vertica/athena-vertica.yaml
@@ -94,14 +94,14 @@ Resources:
                 - s3:ListBucket
               Effect: Allow
               Resource:
-                - !Sub 'arn:aws:s3:::${VerticaExportBucket}'
-                - !Sub 'arn:aws:s3:::${SpillBucket}'
+                - !Sub 'arn:${AWS::Partition}:s3:::${VerticaExportBucket}'
+                - !Sub 'arn:${AWS::Partition}:s3:::${SpillBucket}'
           Version: '2012-10-17'
         - Statement:
             - Action:
                 - secretsmanager:GetSecretValue
               Effect: Allow
-              Resource: !Sub 'arn:aws:secretsmanager:*:*:secret:${SecretNameOrPrefix}'
+              Resource: !Sub 'arn:${AWS::Partition}:secretsmanager:*:*:secret:${SecretNameOrPrefix}'
         - S3ReadPolicy:
             BucketName:
               Ref: SpillBucket

--- a/tools/publish.sh
+++ b/tools/publish.sh
@@ -39,6 +39,7 @@ if [ "$#" -lt 2 ]; then
     echo "\n1. S3_BUCKET used for publishing artifacts to Lambda/Serverless App Repo.\n"
     echo "\n2. The connector module to publish (e.g. athena-exmaple or athena-cloudwatch) \n"
     echo "\n3. The AWS REGION to target (e.g. us-east-1 or us-east-2) \n"
+    echo "\n4. The AWS PARTITION to target (aws, aws-cn, aws-us-gov) Defaults to aws \n"
     echo "\n\n USAGE from the module's directory: ../tools/publish.sh my_s3_bucket athena-example \n"
     exit;
 fi
@@ -58,6 +59,14 @@ fi
 
 echo "Using AWS Region $REGION"
 
+PARTITION=$4
+if [ -z "$PARTITION" ]
+then
+      REGION="aws"
+fi
+
+echo "Using PARTITION $PARTITION"
+
 
 if ! aws s3api get-bucket-policy --bucket $1 --region $REGION| grep 'Statement' ; then
     echo "No bucket policy is set on $1 , would you like to add a Serverless Application Repository Bucket Policy?"
@@ -75,7 +84,7 @@ if ! aws s3api get-bucket-policy --bucket $1 --region $REGION| grep 'Statement' 
         "Service":  "serverlessrepo.amazonaws.com"
       },
       "Action": "s3:GetObject",
-      "Resource": "arn:aws:s3:::$1/*"
+      "Resource": "arn:$4:s3:::$1/*"
     }
   ]
 }

--- a/tools/publish.sh
+++ b/tools/publish.sh
@@ -62,7 +62,7 @@ echo "Using AWS Region $REGION"
 PARTITION=$4
 if [ -z "$PARTITION" ]
 then
-      REGION="aws"
+      PARTITION="aws"
 fi
 
 echo "Using PARTITION $PARTITION"
@@ -84,7 +84,7 @@ if ! aws s3api get-bucket-policy --bucket $1 --region $REGION| grep 'Statement' 
         "Service":  "serverlessrepo.amazonaws.com"
       },
       "Action": "s3:GetObject",
-      "Resource": "arn:$4:s3:::$1/*"
+      "Resource": "arn:$PARTITION:s3:::$1/*"
     }
   ]
 }

--- a/tools/publish.sh
+++ b/tools/publish.sh
@@ -59,10 +59,12 @@ fi
 
 echo "Using AWS Region $REGION"
 
-PARTITION=$4
-if [ -z "$PARTITION" ]
-then
-      PARTITION="aws"
+if [[ $REGION == cn-* ]]; then
+    PARTITION="aws-cn"
+elif [[ $REGION == us-gov-* ]]; then
+    PARTITION="aws-us-gov"
+else
+  PARTITION="aws"
 fi
 
 echo "Using PARTITION $PARTITION"
@@ -105,4 +107,3 @@ mvn clean install -Dpublishing=true
 
 sam package --template-file $2.yaml --output-template-file packaged.yaml --s3-bucket $1 --region $REGION
 sam publish --template packaged.yaml --region $REGION
-


### PR DESCRIPTION
V2 is now available in the china and govcloud partitions.  The CloudFormation templates and GlueMetadataHandler hardcoded the arn prefix  as `aws`  which was causing deployments to fail in those partitions.  

This updates the CloudFormation templates to use the parameter [AWS::Partition](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/pseudo-parameter-reference.html#cfn-pseudo-param-partition).

I also updated the `TABLE_ARN_REGEX`  in `GlueMetadataHandler` and the publish script.

I tested the publish script and confirmed the JDBC connector was able to be deployed in cn-north-1.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
