### PR TITLE
[Issue-410] Continue query when the nextToken is returned

### DIFF
--- a/athena-timestream/src/test/java/com/amazonaws/connectors/timestream/TimestreamRecordHandlerTest.java
+++ b/athena-timestream/src/test/java/com/amazonaws/connectors/timestream/TimestreamRecordHandlerTest.java
@@ -198,9 +198,7 @@ public class TimestreamRecordHandlerTest
         when(mockClient.query(any(QueryRequest.class)))
                 .thenAnswer((Answer<QueryResult>) invocationOnMock -> {
                             QueryRequest request = (QueryRequest) invocationOnMock.getArguments()[0];
-                            if (request.getNextToken() == null) {
-                                assertEquals(expectedQuery, request.getQueryString().replace("\n", ""));
-                            }
+                            assertEquals(expectedQuery, request.getQueryString().replace("\n", ""));
                             return mockResult;
                         }
                 );
@@ -255,9 +253,7 @@ public class TimestreamRecordHandlerTest
         when(mockClient.query(any(QueryRequest.class)))
                 .thenAnswer((Answer<QueryResult>) invocationOnMock -> {
                             QueryRequest request = (QueryRequest) invocationOnMock.getArguments()[0];
-                            if (request.getNextToken() == null) {
-                                assertEquals(expectedQuery, request.getQueryString().replace("\n", ""));
-                            }
+                            assertEquals(expectedQuery, request.getQueryString().replace("\n", ""));
                             return mockResult;
                         }
                 );
@@ -331,9 +327,7 @@ public class TimestreamRecordHandlerTest
         when(mockClient.query(any(QueryRequest.class)))
                 .thenAnswer((Answer<QueryResult>) invocationOnMock -> {
                             QueryRequest request = (QueryRequest) invocationOnMock.getArguments()[0];
-                            if (request.getNextToken() == null) {
-                                assertEquals(expectedQuery, request.getQueryString().replace("\n", ""));
-                            }
+                            assertEquals(expectedQuery, request.getQueryString().replace("\n", ""));
                             return mockResult;
                         }
                 );
@@ -400,9 +394,7 @@ public class TimestreamRecordHandlerTest
         when(mockClient.query(any(QueryRequest.class)))
                 .thenAnswer((Answer<QueryResult>) invocationOnMock -> {
                             QueryRequest request = (QueryRequest) invocationOnMock.getArguments()[0];
-                            if (request.getNextToken() == null) {
-                                assertEquals("actual: " + request.getQueryString(), expectedQuery, request.getQueryString().replace("\n", ""));
-                            }
+                            assertEquals("actual: " + request.getQueryString(), expectedQuery, request.getQueryString().replace("\n", ""));
                             return mockResult;
                         }
                 );


### PR DESCRIPTION
*Issue #, if available:*
Pagination token is not handled properly in athena-timestream connector which leads to empty query result when the dataset is large. See issue-410

*Description of changes:*
1. Continue the query as long as the pagination token is returned even though the result is empty. TimeStream returns empty result with a pagination token when the query takes a longer time to finish  
2. Pass the query string even the pagination token is supplied because this is required per query API documentation: https://docs.aws.amazon.com/timestream/latest/developerguide/API_query_Query.html#timestream-query_Query-request-QueryString

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

*Test*
I deployed the code to you AWS account and verified the fix
