### PR TITLE
Fixed the issue of type conversion from TPCDS TIME type column to numeric type

### DIFF
--- a/athena-tpcds/src/main/java/com/amazonaws/athena/connectors/tpcds/TPCDSRecordHandler.java
+++ b/athena-tpcds/src/main/java/com/amazonaws/athena/connectors/tpcds/TPCDSRecordHandler.java
@@ -181,7 +181,6 @@ public class TPCDSRecordHandler
     {
         ColumnType type = column.getType();
         switch (type.getBase()) {
-            case TIME:
             case IDENTIFIER:
                 return (Block block, int rowNum, String rawValue) -> {
                     Long value = (rawValue != null) ? Long.parseLong(rawValue) : null;
@@ -202,6 +201,7 @@ public class TPCDSRecordHandler
                     BigDecimal value = (rawValue != null) ? new BigDecimal(rawValue) : null;
                     return block.setValue(field.getName(), rowNum, value);
                 };
+            case TIME:
             case CHAR:
             case VARCHAR:
                 return (Block block, int rowNum, String rawValue) -> {

--- a/athena-tpcds/src/main/java/com/amazonaws/athena/connectors/tpcds/TPCDSUtils.java
+++ b/athena-tpcds/src/main/java/com/amazonaws/athena/connectors/tpcds/TPCDSUtils.java
@@ -48,7 +48,6 @@ public class TPCDSUtils
     {
         ColumnType type = column.getType();
         switch (type.getBase()) {
-            case TIME:
             case IDENTIFIER:
                 return FieldBuilder.newBuilder(column.getName(), Types.MinorType.BIGINT.getType()).build();
             case INTEGER:
@@ -58,6 +57,7 @@ public class TPCDSUtils
             case DECIMAL:
                 ArrowType arrowType = new ArrowType.Decimal(type.getPrecision().get(), type.getScale().get());
                 return FieldBuilder.newBuilder(column.getName(), arrowType).build();
+            case TIME:
             case CHAR:
             case VARCHAR:
                 return FieldBuilder.newBuilder(column.getName(), Types.MinorType.VARCHAR.getType()).build();


### PR DESCRIPTION
*Issue #, if available:* no opened issues

## Issue details
When running query for `dbgen_version` , the query fails with `java.lang.NumberFormatException`. The following output is one of the examples.

```
// Query: SELECT * FROM "athena_tpcds"."tpcds1"."dbgen_version"

Your query has the following error(s):

GENERIC_USER_ERROR: Encountered an exception[java.lang.NumberFormatException] from your LambdaFunction[arn:aws:lambda:us-east-1:885940531297:function:athena_tpcds] executed in context[S3SpillLocation{bucket='garbage-collection', key='athena-spill/ddbca176-e99f-4ddf-a5df-4f85d9af9783/900f3a8f-cf70-4919-8ee0-96483d950ab8', directory=true}] with message[For input string: "08:46:37"]
```

## Description of changes:
* Before: TPCDS `TIME` type is converted to `BigInt`. (This conversion fails and throws `java.lang.NumberFormatException`)
* After:  TPCDS `TIME` type is converted to `String`

The `TIME` type is only generated in `dbgen_version` table in all tables of TPCDS. And this type data has the format as `HH:mm:ss` (e.g. `19:05:35`). Java time/date related modules are hard to handle this value. Thus, handling this type of column as String looks better than handling it as numeric type.

## Test result:

```
➜  athena-tpcds git:(tpcds_typecast) ✗ mvn test -Dtest=TPCDSRecordHandlerTest#doReadRecordForTPCDSTIMETypeColumn
...
[INFO] 
[INFO] --- maven-surefire-plugin:3.0.0-M5:test (default-test) @ athena-tpcds ---
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running com.amazonaws.athena.connectors.tpcds.TPCDSRecordHandlerTest
2021-06-07 15:47:19  INFO  BaseAllocator:58 - Debug mode enabled.
2021-06-07 15:47:19  INFO  DefaultAllocationManagerOption:97 - allocation manager type not specified, using netty as the default type
2021-06-07 15:47:19  INFO  CheckAllocator:73 - Using DefaultAllocationManager at memory-netty/3.0.0/arrow-memory-netty-3.0.0.jar!/org/apache/arrow/memory/DefaultAllocationManagerFactory.class
2021-06-07 15:47:19  INFO  TPCDSRecordHandlerTest:305 - doReadRecordForTPCDSTIMETypeColumn: [dv_version : 2.0.0], [dv_create_date : 18785], [dv_create_time : 15:47:19], [dv_cmdline_args : --table dbgen_version --no-sexism --parallelism 1000]
2021-06-07 15:47:19  INFO  TPCDSRecordHandlerTest:308 - doReadRecordForTPCDSTIMETypeColumn: exit
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.375 s - in com.amazonaws.athena.connectors.tpcds.TPCDSRecordHandlerTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco-maven-plugin:0.8.4:report (report) @ athena-tpcds ---
[INFO] Loading execution data file /home/aws-athena-query-federation/athena-tpcds/target/jacoco.exec
[INFO] Analyzed bundle 'athena-tpcds' with 4 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  9.590 s
[INFO] Finished at: 2021-06-07T15:47:20+09:00
[INFO] ------------------------------------------------------------------------

```

---


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
