### PR TITLE
support ARN format in secret pattern

### DIFF
--- a/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/connection/DatabaseConnectionConfigBuilder.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/connection/DatabaseConnectionConfigBuilder.java
@@ -40,7 +40,7 @@ public class DatabaseConnectionConfigBuilder
 
     private static final String CONNECTION_STRING_REGEX = "([a-zA-Z]+)://(.*)";
     private static final Pattern CONNECTION_STRING_PATTERN = Pattern.compile(CONNECTION_STRING_REGEX);
-    private static final String SECRET_PATTERN_STRING = "\\$\\{([a-zA-Z0-9/_+=.@-]+)}";
+    private static final String SECRET_PATTERN_STRING = "\\$\\{([a-zA-Z0-9:/_+=.@-]+)}";
     public static final Pattern SECRET_PATTERN = Pattern.compile(SECRET_PATTERN_STRING);
 
     private Map<String, String> properties;

--- a/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/connection/GenericJdbcConnectionFactory.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/connectors/athena/jdbc/connection/GenericJdbcConnectionFactory.java
@@ -56,7 +56,7 @@ public class GenericJdbcConnectionFactory
     private static final String REDSHIFT_DRIVER_CLASS = "com.amazon.redshift.jdbc.Driver";
     private static final int REDSHIFT_DEFAULT_PORT = 5439;
 
-    private static final String SECRET_NAME_PATTERN_STRING = "(\\$\\{[a-zA-Z0-9/_+=.@-]+})";
+    private static final String SECRET_NAME_PATTERN_STRING = "(\\$\\{[a-zA-Z0-9:/_+=.@-]+})";
     public static final Pattern SECRET_NAME_PATTERN = Pattern.compile(SECRET_NAME_PATTERN_STRING);
 
     private static final ImmutableMap<DatabaseEngine, DatabaseConnectionInfo> CONNECTION_INFO = ImmutableMap.of(

--- a/athena-jdbc/src/test/java/com/amazonaws/connectors/athena/jdbc/connection/DatabaseConnectionConfigBuilderTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/connectors/athena/jdbc/connection/DatabaseConnectionConfigBuilderTest.java
@@ -31,6 +31,7 @@ public class DatabaseConnectionConfigBuilderTest
 {
     private static final String CONNECTION_STRING1 = "mysql://jdbc:mysql://hostname/${testSecret}";
     private static final String CONNECTION_STRING2 = "postgres://jdbc:postgresql://hostname/user=testUser&password=testPassword";
+    private static final String CONNECTION_STRING3 = "redshift://jdbc:redshift://hostname:5439/dev?${arn:aws:secretsmanager:us-east-1:1234567890:secret:redshift/user/secret}";
 
     @Test
     public void build()
@@ -39,6 +40,8 @@ public class DatabaseConnectionConfigBuilderTest
                 "jdbc:mysql://hostname/${testSecret}", "testSecret");
         DatabaseConnectionConfig expectedDatabase2 = new DatabaseConnectionConfig("testCatalog2", JdbcConnectionFactory.DatabaseEngine.POSTGRES,
                 "jdbc:postgresql://hostname/user=testUser&password=testPassword");
+        DatabaseConnectionConfig expectedDatabase3 = new DatabaseConnectionConfig("testCatalog3", JdbcConnectionFactory.DatabaseEngine.REDSHIFT,
+                "jdbc:redshift://hostname:5439/dev?${arn:aws:secretsmanager:us-east-1:1234567890:secret:redshift/user/secret}", "arn:aws:secretsmanager:us-east-1:1234567890:secret:redshift/user/secret");
         DatabaseConnectionConfig defaultConnection = new DatabaseConnectionConfig("default", JdbcConnectionFactory.DatabaseEngine.POSTGRES,
                 "jdbc:postgresql://hostname/user=testUser&password=testPassword");
 
@@ -46,10 +49,11 @@ public class DatabaseConnectionConfigBuilderTest
                 .properties(ImmutableMap.of(
                         "default", CONNECTION_STRING2,
                         "testCatalog1_connection_string", CONNECTION_STRING1,
-                        "testCatalog2_connection_string", CONNECTION_STRING2))
+                        "testCatalog2_connection_string", CONNECTION_STRING2,
+                        "testCatalog3_connection_string", CONNECTION_STRING3))
                 .build();
 
-        Assert.assertEquals(Arrays.asList(defaultConnection, expectedDatabase1, expectedDatabase2), databaseConnectionConfigs);
+        Assert.assertEquals(Arrays.asList(defaultConnection, expectedDatabase1, expectedDatabase2, expectedDatabase3), databaseConnectionConfigs);
     }
 
     @Test(expected = RuntimeException.class)


### PR DESCRIPTION
GetSecretValueRequest do support using ARN as secret id, but currently the secret pattern used to extract secret name can't accept ARN format name, such as `${arn:aws:secretsmanager:us-east-1:1234567890:secret:redshift/user/secret}`.

This commit updated the secret pattern string to support ARN format.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
