### PR TITLE
Fixing issue #433 and #438 for missing javadoc and OOM due to fast pr…

### DIFF
--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/handlers/MetadataHandler.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/handlers/MetadataHandler.java
@@ -187,6 +187,12 @@ public abstract class MetadataHandler
         return (encryptionKeyFactory != null) ? encryptionKeyFactory.create() : null;
     }
 
+    /**
+     * Used to make a spill location for a split. Each split should have a unique spill location, so be sure
+     * to call this method once per split!
+     * @param request 
+     * @return A unique spill location.
+     */
     protected SpillLocation makeSpillLocation(MetadataRequest request)
     {
         return S3SpillLocation.newBuilder()


### PR DESCRIPTION
Fixing issue #433 and #438 for missing javadoc and OOM due to fast producer in S3BlockSpiller

*Issue #, if available:*
#433 , #438

*Description of changes:*
- Adding a bounds to the blocking queue in the S3BlockSpiller's async thread pool.
- Adding missing javadoc to makeSpillLocation(...)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
