### PR TITLE
Fixing #397 and #429 by removing deprecated maxScan(...)

### DIFF
--- a/athena-docdb/src/main/java/com/amazonaws/athena/connectors/docdb/SchemaUtils.java
+++ b/athena-docdb/src/main/java/com/amazonaws/athena/connectors/docdb/SchemaUtils.java
@@ -76,7 +76,7 @@ public class SchemaUtils
         int docCount = 0;
         int fieldCount = 0;
         try (MongoCursor<Document> docs = db.getCollection(table.getTableName()).find().batchSize(numObjToSample)
-                .maxScan(numObjToSample).limit(numObjToSample).iterator()) {
+                .limit(numObjToSample).iterator()) {
             if (!docs.hasNext()) {
                 return SchemaBuilder.newBuilder().build();
             }

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/Block.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/Block.java
@@ -88,7 +88,7 @@ public class Block
      * @param schema The schema of the data that can be read/written to the provided VectorSchema.
      * @param vectorSchema Used to read/write values from the Apache Arrow memory buffers owned by this object.
      */
-    protected Block(String allocatorId, Schema schema, VectorSchemaRoot vectorSchema)
+    public Block(String allocatorId, Schema schema, VectorSchemaRoot vectorSchema)
     {
         requireNonNull(allocatorId, "allocatorId is null");
         requireNonNull(schema, "schema is null");


### PR DESCRIPTION
Fixing #397 and #429 by removing deprecated maxScan(...) func call in docdb connector and marking Block constructor as public

*Issue #, if available:*
- #397 
- #429 
 
*Description of changes:*
- removing depricated mongodb client function call
- making Block constructor public to allow for easier integration with sources that already speak Apache Arrow

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
