### PR TITLE
Add limitation noting that Athena queries are lower-cased

### DIFF
--- a/athena-jdbc/README.md
+++ b/athena-jdbc/README.md
@@ -210,6 +210,7 @@ For latest version information see [pom.xml](./pom.xml).
 * In Mux setup, spill bucket and prefix is shared across all database instances.
 * Any relevant Lambda Limits. See Lambda documentation.
 * Redshift does not support external partitions so all data will be retrieved every time.
+* Athena converts queries to lower case. MySQL table names need to be in lower case to match. For example, Athena queries against "myTable" will fail.
 
 # Performance tuning
 


### PR DESCRIPTION
Queries will fail if the source table has upper case letters in the name.

Athena queries are converted to lower case. This causes a mismatch between the Athena query and the source database, and returns an error like "table not found".
For example, if you have the MySQL table "myTable", Athena queries will fail. The table must be renamed "mytable" or users could create a view with a lower case name.

*Description of changes:*
Added a point to the Limitations section

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
