### PR TITLE
Add Redis Integ Tests

### DIFF
--- a/athena-redis/README.md
+++ b/athena-redis/README.md
@@ -59,6 +59,18 @@ Review the "Policies" section of the athena-redis.yaml file for full details on 
 5. CloudWatch Logs - This is a somewhat implicit permission when deploying a Lambda function but it needs access to cloudwatch logs for storing logs.
 1. Athena GetQueryExecution - The connector uses this access to fast-fail when the upstream Athena query has terminated.
 
+### Running Integration Tests
+
+The integration tests in this module are designed to run without the prior need for deploying the connector. Nevertheless,
+the integration tests will not run straight out-of-the-box. Certain build-dependencies are required for them to execute correctly.
+For build commands and step-by-step instructions on building and running the integration tests see the
+[Running Integration Tests](https://github.com/awslabs/aws-athena-query-federation/blob/master/athena-federation-integ-test/README.md#running-integration-tests) README section in the **athena-federation-integ-test** module.
+
+In addition to the build-dependencies, certain test configuration attributes must also be provided in the connector's [test-config.json](./etc/test-config.json) JSON file.
+For additional information about the test configuration file, see the [Test Configuration](https://github.com/awslabs/aws-athena-query-federation/blob/master/athena-federation-integ-test/README.md#test-configuration) README section in the **athena-federation-integ-test** module.
+
+Once all prerequisites have been satisfied, the integration tests can be executed by specifying the following command: `mvn failsafe:integration-test` from the connector's root directory.
+
 ### Deploying The Connector
 
 To use the Amazon Athena Redis Connector in your queries, navigate to AWS Serverless Application Repository and deploy a pre-built version of this connector. Alternatively, you can build and deploy this connector from source follow the below steps or use the more detailed tutorial in the athena-example module:

--- a/athena-redis/etc/test-config.json
+++ b/athena-redis/etc/test-config.json
@@ -1,0 +1,21 @@
+{
+  "athena_work_group" : "FederationIntegrationTests", /* The Athena Workgroup used for running integration tests (default: FederationIntegrationTests) */
+  "secrets_manager_secret" : "<secret name>",         /* Secret name used to retrieve user credentials from SecretsManager. Make sure to enter a dummy value for the username key */
+  "environment_vars" : {                  /* Parameters used by the connector's internal logic */
+    "spill_bucket" : "<spill bucket>",    /* The S3 bucket used for spilling excess data */
+    "spill_prefix" : "athena-spill",      /* The prefix within the S3 spill bucket (default: athena-spill) */
+    "disable_spill_encryption" : "false"  /* If set to true encryption for spilled data is disabled (default: false) */
+  },
+  "vpc_configuration" : {                 /* VPC configuration for Redis instances within a VPC */
+    "vpc_id": "<Enter Value>",                      /* The VPC Id (e.g. vpc-xxx) */
+    "security_group_id": "<Enter Value>",           /* The Security Group Id (e.g. sg-xxx) */
+    "subnet_ids": ["<Subnet 1>", "<Subnet 2>"],     /* A list consisting of at least one Subnet Id (e.g. subnet-xxxx) */
+    "availability_zones": ["<Zone 1>", "<Zone 2>"]  /* A list consisting of at least one AZ (e.g. us-east-1a) */
+  },
+  "user_settings" : {                     /* User customizable settings */
+    "redis_db_name": "<Enter Value>",     /* Name of the Glue Db to create for Redis integration tests */
+    "redis_table_name_prefix": "<Enter Value>",   /* Redis Glue table name prefix*/
+    "redis_port": "<Enter Value>",                /* Port number associated with the Redis cluster endpoint */
+    "redis_instance_prefix": "<Enter Value>"      /* Redis instance name prefix */
+  }
+}

--- a/athena-redis/pom.xml
+++ b/athena-redis/pom.xml
@@ -48,6 +48,32 @@
             <version>${slf4jVersion}</version>
         </dependency>
         <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-elasticache</artifactId>
+            <version>${aws-sdk.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/software.amazon.awscdk/elasticache -->
+        <dependency>
+            <groupId>software.amazon.awscdk</groupId>
+            <artifactId>elasticache</artifactId>
+            <version>${aws-cdk.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/software.amazon.awscdk/glue -->
+        <dependency>
+            <groupId>software.amazon.awscdk</groupId>
+            <artifactId>glue</artifactId>
+            <version>${aws-cdk.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>athena-federation-integ-test</artifactId>
+            <version>${aws-athena-federation-sdk.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
             <version>${log4j2Version}</version>

--- a/athena-redis/src/main/java/com/amazonaws/athena/connectors/redis/integ/RedisIntegTestHandler.java
+++ b/athena-redis/src/main/java/com/amazonaws/athena/connectors/redis/integ/RedisIntegTestHandler.java
@@ -1,0 +1,126 @@
+/*-
+ * #%L
+ * athena-docdb
+ * %%
+ * Copyright (C) 2019 - 2021 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.redis.integ;
+
+import com.amazonaws.athena.connectors.redis.lettuce.RedisCommandsWrapper;
+import com.amazonaws.athena.connectors.redis.lettuce.RedisConnectionFactory;
+import com.amazonaws.athena.connectors.redis.lettuce.RedisConnectionWrapper;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This Lambda function handler is only used within the Redis integration tests. The Lambda function,
+ * when invoked, will insert keys into the Redis instances.
+ * The invocation of the Lambda function must include the following environment variables:
+ * standalone_connection - The connection string used to connect to standalone Redis instance
+ * cluster_connection - The connection string used to connect to clustered Redis instance
+ */
+public class RedisIntegTestHandler
+        implements RequestStreamHandler
+{
+    public static final String HANDLER = "com.amazonaws.athena.connectors.redis.integ.RedisIntegTestHandler";
+
+    private static final Logger logger = LoggerFactory.getLogger(RedisIntegTestHandler.class);
+
+    private final RedisConnectionFactory connectionFactory;
+    private final String standaloneConnectionString;
+    private final String clusterConnectionString;
+
+    public RedisIntegTestHandler()
+    {
+        connectionFactory = new RedisConnectionFactory();
+        standaloneConnectionString = System.getenv("standalone_connection");
+        clusterConnectionString = System.getenv("cluster_connection");
+    }
+
+    @Override
+    public final void handleRequest(InputStream inputStream, OutputStream outputStream, Context context)
+    {
+        logger.info("handleRequest - enter");
+
+        try {
+            RedisConnectionWrapper<String, String> standaloneConnection = connectionFactory.getOrCreateConn(standaloneConnectionString, false, false);
+            RedisConnectionWrapper<String, String> clusterConnection = connectionFactory.getOrCreateConn(clusterConnectionString, true, true);
+
+            insertRedisData(standaloneConnection.sync());
+            insertRedisData(clusterConnection.sync());
+
+            logger.info("Keys inserted successfully.");
+        }
+        catch (Exception e) {
+            logger.error("Error setting up Redis table {}", e.getMessage(), e);
+        }
+
+        logger.info("handleRequest - exit");
+    }
+
+    /**
+     * Insert the necessary keys into the provided Redis instance
+     */
+    private void insertRedisData(RedisCommandsWrapper<String, String> syncCommands)
+    {
+        /**
+         * There are 6 scenarios per redis instance to test:
+         * Data Value Type: Hash, Zset(single col, multiple rows), Literal(single col)
+         * For each above value type, they can be provided 2 ways: prefix, zset
+         */
+        // Hash Data (prefix: customer-hm:* | zset: customer-hm-zset)
+        Map<String, String> redisMap = new HashMap<>();
+        redisMap.put("custkey", "1");
+        redisMap.put("name", "Jon Snow");
+        redisMap.put("acctbal", "1.00");
+        syncCommands.hmset("customer-hm:1", Collections.unmodifiableMap(redisMap));
+
+        redisMap.put("custkey", "2");
+        redisMap.put("name", "Robb Stark");
+        redisMap.put("acctbal", "2.00");
+        syncCommands.hmset("customer-hm:2", Collections.unmodifiableMap(redisMap));
+
+        redisMap.put("custkey", "3");
+        redisMap.put("name", "Eddard Stark");
+        redisMap.put("acctbal", "3.00");
+        syncCommands.hmset("customer-hm:3", Collections.unmodifiableMap(redisMap));
+
+        // Zset Data (prefix: customer-hm-zset* | zset: key-hm-zset)
+        // this zset will also be used to access the hashmap keys above
+        syncCommands.zadd("customer-hm-zset", 1.0, "customer-hm:1");
+        syncCommands.zadd("customer-hm-zset", 2.0, "customer-hm:2");
+        syncCommands.zadd("customer-hm-zset", 3.0, "customer-hm:3");
+        // another zset to access the above zset
+        syncCommands.zadd("key-hm-zset", 1.0, "customer-hm-zset");
+
+        // Literal (prefix: customer-literal:* | zset: key-literal-zset)
+        syncCommands.set("customer-literal:1", "Sansa Stark");
+        syncCommands.set("customer-literal:2", "Daenerys Targaryen");
+        syncCommands.set("customer-literal:3", "Arya Stark");
+        // zset to access the above literals
+        syncCommands.zadd("key-literal-zset", 1.0, "customer-literal:1");
+        syncCommands.zadd("key-literal-zset", 2.0, "customer-literal:2");
+        syncCommands.zadd("key-literal-zset", 3.0, "customer-literal:3");
+    }
+}

--- a/athena-redis/src/main/java/com/amazonaws/athena/connectors/redis/integ/RedisIntegTestHandler.java
+++ b/athena-redis/src/main/java/com/amazonaws/athena/connectors/redis/integ/RedisIntegTestHandler.java
@@ -63,9 +63,11 @@ public class RedisIntegTestHandler
     {
         logger.info("handleRequest - enter");
 
+        RedisConnectionWrapper<String, String> standaloneConnection = null;
+        RedisConnectionWrapper<String, String> clusterConnection = null;
         try {
-            RedisConnectionWrapper<String, String> standaloneConnection = connectionFactory.getOrCreateConn(standaloneConnectionString, false, false);
-            RedisConnectionWrapper<String, String> clusterConnection = connectionFactory.getOrCreateConn(clusterConnectionString, true, true);
+            standaloneConnection = connectionFactory.getOrCreateConn(standaloneConnectionString, false, false);
+            clusterConnection = connectionFactory.getOrCreateConn(clusterConnectionString, true, true);
 
             insertRedisData(standaloneConnection.sync());
             insertRedisData(clusterConnection.sync());
@@ -74,6 +76,14 @@ public class RedisIntegTestHandler
         }
         catch (Exception e) {
             logger.error("Error setting up Redis table {}", e.getMessage(), e);
+        }
+        finally {
+            if (standaloneConnection != null) {
+                standaloneConnection.close();
+            }
+            if (clusterConnection != null) {
+                clusterConnection.close();
+            }
         }
 
         logger.info("handleRequest - exit");

--- a/athena-redis/src/main/java/com/amazonaws/athena/connectors/redis/lettuce/RedisCommandsWrapper.java
+++ b/athena-redis/src/main/java/com/amazonaws/athena/connectors/redis/lettuce/RedisCommandsWrapper.java
@@ -26,6 +26,7 @@ import io.lettuce.core.ScanCursor;
 import io.lettuce.core.ScoredValueScanCursor;
 import io.lettuce.core.api.sync.RedisCommands;
 import io.lettuce.core.cluster.api.sync.RedisAdvancedClusterCommands;
+import org.apache.arrow.util.VisibleForTesting;
 
 import java.util.List;
 import java.util.Map;
@@ -109,6 +110,39 @@ public class RedisCommandsWrapper<K, V>
     }
     else {
       return standaloneCommands.zscan(var1, var2);
+    }
+  }
+
+  @VisibleForTesting
+  public String hmset(K var1, Map<K, V> var2)
+  {
+    if (isCluster) {
+      return clusterCommands.hmset(var1, var2);
+    }
+    else {
+      return standaloneCommands.hmset(var1, var2);
+    }
+  }
+
+  @VisibleForTesting
+  public Long zadd(K var1, double var2, V var3)
+  {
+    if (isCluster) {
+      return clusterCommands.zadd(var1, var2, var3);
+    }
+    else {
+      return standaloneCommands.zadd(var1, var2, var3);
+    }
+  }
+
+  @VisibleForTesting
+  public String set(K var1, V var2)
+  {
+    if (isCluster) {
+      return clusterCommands.set(var1, var2);
+    }
+    else {
+      return standaloneCommands.set(var1, var2);
     }
   }
 }

--- a/athena-redis/src/main/java/com/amazonaws/athena/connectors/redis/lettuce/RedisConnectionWrapper.java
+++ b/athena-redis/src/main/java/com/amazonaws/athena/connectors/redis/lettuce/RedisConnectionWrapper.java
@@ -51,4 +51,14 @@ public class RedisConnectionWrapper<K, V>
   {
     return this.redisCommandsWrapper;
   }
+
+  public void close()
+  {
+    if (isCluster) {
+      clusterConnection.close();
+    }
+    else {
+      standaloneConnection.close();
+    }
+  }
 }

--- a/athena-redis/src/test/java/com/amazonaws/athena/connectors/redis/integ/RedisIntegTest.java
+++ b/athena-redis/src/test/java/com/amazonaws/athena/connectors/redis/integ/RedisIntegTest.java
@@ -1,0 +1,766 @@
+/*-
+ * #%L
+ * athena-redis
+ * %%
+ * Copyright (C) 2019 - 2021 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.redis.integ;
+
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.athena.connector.integ.ConnectorStackFactory;
+import com.amazonaws.athena.connector.integ.IntegrationTestBase;
+import com.amazonaws.athena.connector.integ.clients.CloudFormationClient;
+import com.amazonaws.athena.connector.integ.data.ConnectorPackagingAttributes;
+import com.amazonaws.athena.connector.integ.data.ConnectorStackAttributes;
+import com.amazonaws.athena.connector.integ.data.ConnectorVpcAttributes;
+import com.amazonaws.athena.connector.integ.data.SecretsManagerCredentials;
+import com.amazonaws.athena.connector.integ.providers.ConnectorPackagingAttributesProvider;
+import com.amazonaws.services.athena.model.Row;
+import com.amazonaws.services.elasticache.AmazonElastiCache;
+import com.amazonaws.services.elasticache.AmazonElastiCacheClientBuilder;
+import com.amazonaws.services.elasticache.model.DescribeCacheClustersRequest;
+import com.amazonaws.services.elasticache.model.DescribeCacheClustersResult;
+import com.amazonaws.services.elasticache.model.DescribeReplicationGroupsRequest;
+import com.amazonaws.services.elasticache.model.DescribeReplicationGroupsResult;
+import com.amazonaws.services.elasticache.model.Endpoint;
+import com.amazonaws.services.glue.AWSGlue;
+import com.amazonaws.services.glue.AWSGlueClientBuilder;
+import com.amazonaws.services.glue.model.EntityNotFoundException;
+import com.amazonaws.services.glue.model.GetTableRequest;
+import com.amazonaws.services.glue.model.GetTableResult;
+import com.amazonaws.services.glue.model.TableInput;
+import com.amazonaws.services.glue.model.UpdateTableRequest;
+import com.amazonaws.services.lambda.AWSLambda;
+import com.amazonaws.services.lambda.AWSLambdaClientBuilder;
+import com.amazonaws.services.lambda.model.InvocationType;
+import com.amazonaws.services.lambda.model.InvokeRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.testng.internal.collections.Pair;
+import software.amazon.awscdk.core.App;
+import software.amazon.awscdk.core.Stack;
+import software.amazon.awscdk.services.elasticache.CfnCacheCluster;
+import software.amazon.awscdk.services.elasticache.CfnReplicationGroup;
+import software.amazon.awscdk.services.elasticache.CfnSubnetGroup;
+import software.amazon.awscdk.services.glue.Column;
+import software.amazon.awscdk.services.glue.DataFormat;
+import software.amazon.awscdk.services.glue.Database;
+import software.amazon.awscdk.services.glue.Schema;
+import software.amazon.awscdk.services.glue.Table;
+import software.amazon.awscdk.services.iam.PolicyDocument;
+import software.amazon.awscdk.services.s3.Bucket;
+import software.amazon.awscdk.services.s3.IBucket;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Integration-tests for the Redis connector using the Integration-test module.
+ */
+@Test(singleThreaded = true)
+public class RedisIntegTest extends IntegrationTestBase
+{
+    private static final Logger logger = LoggerFactory.getLogger(RedisIntegTest.class);
+    private static final String STANDALONE_KEY = "standalone";
+    private static final String CLUSTER_KEY = "cluster";
+    private static final int GLUE_TIMEOUT = 250;
+
+    private final App theApp;
+    private final String redisPassword;
+    private final String redisStandaloneName;
+    private final String redisClusterName;
+    private final String redisPort;
+    private final String redisDbName;
+    private final String redisTableNamePrefix;
+    private final String lambdaFunctionName;
+    private final AWSGlue glue;
+    private final String redisStackName;
+    private final Map<String, String> environmentVars;
+
+    private CloudFormationClient cloudFormationClient;
+    private final Map<String, String> redisEndpoints = new HashMap<>();
+
+    public RedisIntegTest()
+    {
+        logger.warn("Entered constructor");
+        theApp = new App();
+        SecretsManagerCredentials secretsManagerCredentials = getSecretCredentials().orElseThrow(() ->
+                new RuntimeException("secrets_manager_secret must be provided in test-config.json file."));
+        redisPassword = secretsManagerCredentials.getPassword();
+        Map<String, Object> userSettings = getUserSettings().orElseThrow(() ->
+                new RuntimeException("user_settings attribute must be provided in test-config.json file."));
+        redisStandaloneName = userSettings.get("redis_instance_prefix") + "-standalone-" + UUID.randomUUID().toString().substring(0, 6);
+        redisClusterName = userSettings.get("redis_instance_prefix") + "-cluster-" + UUID.randomUUID().toString().substring(0, 6);
+        redisPort = (String) userSettings.get("redis_port");
+        redisDbName = (String) userSettings.get("redis_db_name");
+        redisTableNamePrefix = (String) userSettings.get("redis_table_name_prefix");
+        lambdaFunctionName = getLambdaFunctionName();
+        glue = AWSGlueClientBuilder.standard()
+                .withClientConfiguration(new ClientConfiguration().withConnectionTimeout(GLUE_TIMEOUT))
+                .build();
+        redisStackName = "integ-redis-instance-" + UUID.randomUUID();
+        environmentVars = new HashMap<>();
+    }
+
+    /**
+     * Creates a Redis cluster used for the integration tests.
+     */
+    @BeforeClass
+    @Override
+    protected void setUp()
+    {
+        cloudFormationClient = new CloudFormationClient(theApp, getRedisStack());
+        try {
+            // Create the CloudFormation stack for the Redis instances.
+            cloudFormationClient.createStack();
+
+            // Get host and port information
+            Endpoint standaloneEndpoint = getRedisInstanceData(redisStandaloneName, false);
+            logger.info("Got Endpoint: " + standaloneEndpoint.toString());
+            redisEndpoints.put(STANDALONE_KEY, String.format("%s:%s",
+                    standaloneEndpoint.getAddress(), standaloneEndpoint.getPort()));
+
+            Endpoint clusterEndpoint = getRedisInstanceData(redisClusterName, true);
+            logger.info("Got Endpoint: " + clusterEndpoint.toString());
+            redisEndpoints.put(CLUSTER_KEY, String.format("%s:%s:%s",
+                    clusterEndpoint.getAddress(), clusterEndpoint.getPort(), redisPassword));
+
+            // Get endpoint information and set the connection string environment var for Lambda.
+            environmentVars.put("standalone_connection", redisEndpoints.get(STANDALONE_KEY));
+            environmentVars.put("cluster_connection", redisEndpoints.get(CLUSTER_KEY));
+
+            // Invoke the framework's setUp().
+            super.setUp();
+        }
+        catch (Exception e) {
+            // Delete the partially formed CloudFormation stack.
+            cloudFormationClient.deleteStack();
+            throw e;
+        }
+    }
+
+    /**
+     * Deletes a CloudFormation stack for Redis.
+     */
+    @AfterClass
+    @Override
+    protected void cleanUp()
+    {
+        // Invoke the framework's cleanUp().
+        super.cleanUp();
+        // Delete the CloudFormation stack for Redis.
+        cloudFormationClient.deleteStack();
+        // close glue client
+        glue.shutdown();
+    }
+
+    /**
+     * Create and invoke a special Lambda function that sets up the Redis instances used by the integration tests.
+     */
+    @Override
+    protected void setUpTableData()
+    {
+        logger.info("----------------------------------------------------");
+        logger.info("Setting up data for Redis Instances");
+        logger.info("----------------------------------------------------");
+
+        String redisLambdaName = "integ-redis-helper-" + UUID.randomUUID();
+        AWSLambda lambdaClient = AWSLambdaClientBuilder.defaultClient();
+        CloudFormationClient cloudFormationRedisClient = new CloudFormationClient(getRedisLambdaStack(redisLambdaName));
+        try {
+            // Create the Lambda function.
+            cloudFormationRedisClient.createStack();
+            // Invoke the Lambda function.
+            lambdaClient.invoke(new InvokeRequest()
+                    .withFunctionName(redisLambdaName)
+                    .withInvocationType(InvocationType.RequestResponse));
+        }
+        finally {
+            // Delete the Lambda function.
+            cloudFormationRedisClient.deleteStack();
+            lambdaClient.shutdown();
+        }
+    }
+
+    /**
+     * Generates the CloudFormation stack for the Lambda function that inserts the Redis Keys.
+     * @param redisLambdaName The name of the Lambda function.
+     * @return Stack attributes used to create the CloudFormation stack.
+     */
+    private Pair<App, Stack> getRedisLambdaStack(String redisLambdaName)
+    {
+        String redisStackName = "integ-redis-helper-lambda-" + UUID.randomUUID();
+        App redisApp = new App();
+        ConnectorPackagingAttributes packagingAttributes = ConnectorPackagingAttributesProvider.getAttributes();
+        ConnectorPackagingAttributes redisPackagingAttributes =
+                new ConnectorPackagingAttributes(packagingAttributes.getS3Bucket(), packagingAttributes.getS3Key(),
+                        RedisIntegTestHandler.HANDLER);
+        ConnectorStackAttributes redisStackAttributes =
+                new ConnectorStackAttributes(redisApp, redisStackName, redisLambdaName, getConnectorAccessPolicy(),
+                        environmentVars, redisPackagingAttributes, getVpcAttributes());
+        ConnectorStackFactory redisStackFactory = new ConnectorStackFactory(redisStackAttributes);
+
+        return new Pair<>(redisApp, redisStackFactory.createStack());
+    }
+
+    /**
+     * Sets the environment variables for the Lambda function.
+     *
+     * @param environmentVars
+     */
+    @Override
+    protected void setConnectorEnvironmentVars(final Map environmentVars)
+    {
+        environmentVars.putAll(this.environmentVars);
+    }
+
+    /**
+     * Sets up connector-specific Cloud Formation resource.
+     *
+     * @param stack The current CloudFormation stack.
+     */
+    @Override
+    protected void setUpStackData(Stack stack)
+    {
+        //No-op
+    }
+
+    /**
+     * Must be overridden in the extending class to get the lambda function's IAM access policy. The latter sets up
+     * access to multiple connector-specific AWS services (e.g. DynamoDB, Elasticsearch etc...)
+     *
+     * @return A policy document object.
+     */
+    @Override
+    protected Optional<PolicyDocument> getConnectorAccessPolicy()
+    {
+        return Optional.empty();
+    }
+
+    /**
+     * Gets the CloudFormation stack for Redis.
+     * @return Stack object for Redis.
+     */
+    private Stack getRedisStack()
+    {
+        Stack stack = Stack.Builder.create(theApp, redisStackName).build();
+        ConnectorVpcAttributes vpcAttributes = getVpcAttributes()
+                .orElseThrow(() -> new RuntimeException("vpc_configuration must be specified in test-config.json"));
+
+        CfnSubnetGroup redisSubnetGroup = CfnSubnetGroup.Builder.create(stack, "RedisSubnetGroup")
+                .cacheSubnetGroupName("RedisSubnetGroup")
+                .subnetIds(vpcAttributes.getPrivateSubnetIds())
+                .description("RedisSubnetGroup")
+                .build();
+
+        CfnCacheCluster redisStandalone = CfnCacheCluster.Builder.create(stack, "RedisStandalone")
+                .clusterName(redisStandaloneName)
+                .cacheNodeType("cache.t3.micro")
+                .cacheSubnetGroupName(redisSubnetGroup.getCacheSubnetGroupName())
+                .engine("redis")
+                .numCacheNodes(1)
+                .port(Integer.parseInt(redisPort))
+                .vpcSecurityGroupIds(Collections.singletonList(vpcAttributes.getSecurityGroupId()))
+                .build();
+        redisStandalone.addDependsOn(redisSubnetGroup);
+
+        CfnReplicationGroup redisCluster = CfnReplicationGroup.Builder.create(stack, "RedisCluster")
+                .replicationGroupId(redisClusterName)
+                .replicationGroupDescription("RedisCluster")
+                .cacheNodeType("cache.t3.micro")
+                .cacheSubnetGroupName(redisSubnetGroup.getCacheSubnetGroupName())
+                .engine("redis")
+                .replicasPerNodeGroup(1)
+                .numNodeGroups(3)
+                .automaticFailoverEnabled(true)
+                .port(Integer.parseInt(redisPort))
+                .transitEncryptionEnabled(true)
+                .authToken(redisPassword)
+                .build();
+        redisCluster.addDependsOn(redisSubnetGroup);
+
+        IBucket glueTableBucket = Bucket.fromBucketName(stack, "RedisBucket", "fake-bucket");
+        Database redisDb = Database.Builder.create(stack, "RedisDB")
+                .databaseName(redisDbName)
+                .locationUri("s3://fake-bucket?redis-db-flag=redis-db-flag")
+                .build();
+
+        // This Table will be used for hashmap keys
+        List<Column> hashColumns = new ArrayList<>();
+        hashColumns.add(Column.builder().name("custkey").type(Schema.BIG_INT).build());
+        hashColumns.add(Column.builder().name("name").type(Schema.STRING).build());
+        hashColumns.add(Column.builder().name("acctbal").type(Schema.DOUBLE).build());
+
+        Table.Builder.create(stack, "RedisTable1")
+                .database(redisDb)
+                .tableName(redisTableNamePrefix + "_1")
+                .columns(hashColumns)
+                .dataFormat(DataFormat.AVRO)
+                .bucket(glueTableBucket)
+                .build();
+
+        // This Table will be used for Literal and Zset Keys (single column)
+        List<Column> zsetAndLiteralColumns = new ArrayList<>();
+        zsetAndLiteralColumns.add(Column.builder().name("name").type(Schema.STRING).build());
+
+        Table.Builder.create(stack, "RedisTable2")
+                .database(redisDb)
+                .tableName(redisTableNamePrefix + "_2")
+                .columns(zsetAndLiteralColumns)
+                .dataFormat(DataFormat.AVRO)
+                .bucket(glueTableBucket)
+                .build();
+
+        return stack;
+    }
+
+    /**
+     * Gets the Redis server endpoint information.
+     * All exceptions thrown here will be caught in the calling function.
+     */
+    private Endpoint getRedisInstanceData(String redisName, boolean isCluster)
+    {
+        AmazonElastiCache elastiCacheClient = AmazonElastiCacheClientBuilder.defaultClient();
+        try {
+            if (isCluster) {
+                DescribeReplicationGroupsResult describeResult = elastiCacheClient.describeReplicationGroups(new DescribeReplicationGroupsRequest()
+                        .withReplicationGroupId(redisName));
+                return describeResult.getReplicationGroups().get(0).getConfigurationEndpoint();
+            }
+            else {
+                DescribeCacheClustersResult describeResult = elastiCacheClient.describeCacheClusters(new DescribeCacheClustersRequest()
+                        .withCacheClusterId(redisName).withShowCacheNodeInfo(true));
+                return describeResult.getCacheClusters().get(0).getCacheNodes().get(0).getEndpoint();
+            }
+        }
+        finally {
+            elastiCacheClient.shutdown();
+        }
+    }
+
+    /**
+     * This method gets a Table using the given name from Glue Data Catalog.
+     *
+     * @param databaseName
+     * @param tableName
+     * @return Table
+     */
+    private com.amazonaws.services.glue.model.Table getGlueTable(String databaseName, String tableName)
+    {
+        com.amazonaws.services.glue.model.Table table;
+        GetTableRequest getTableRequest = new GetTableRequest();
+        getTableRequest.setDatabaseName(databaseName);
+        getTableRequest.setName(tableName);
+        try {
+            GetTableResult tableResult = glue.getTable(getTableRequest);
+            table = tableResult.getTable();
+        } catch (EntityNotFoundException e) {
+            throw e;
+        }
+        return table;
+    }
+
+    /**
+     * This method creates a TableInput object using Table object
+     *
+     * @param table
+     * @return TableInput
+     */
+    private TableInput createTableInput(com.amazonaws.services.glue.model.Table table) {
+        TableInput tableInput = new TableInput();
+        tableInput.setDescription(table.getDescription());
+        tableInput.setLastAccessTime(table.getLastAccessTime());
+        tableInput.setOwner(table.getOwner());
+        tableInput.setName(table.getName());
+        if (Optional.ofNullable(table.getStorageDescriptor()).isPresent()) {
+            tableInput.setStorageDescriptor(table.getStorageDescriptor());
+            if (Optional.ofNullable(table.getStorageDescriptor().getParameters()).isPresent())
+                tableInput.setParameters(table.getStorageDescriptor().getParameters());
+        }
+        tableInput.setPartitionKeys(table.getPartitionKeys());
+        tableInput.setTableType(table.getTableType());
+        tableInput.setViewExpandedText(table.getViewExpandedText());
+        tableInput.setViewOriginalText(table.getViewOriginalText());
+        tableInput.setParameters(table.getParameters());
+        return tableInput;
+    }
+
+    private void selectHashValue()
+    {
+        String query = String.format("select * from \"%s\".\"%s\".\"%s\";",
+                lambdaFunctionName, redisDbName, redisTableNamePrefix + "_1");
+        List<Row> rows = startQueryExecution(query).getResultSet().getRows();
+        if (!rows.isEmpty()) {
+            // Remove the column-header row
+            rows.remove(0);
+        }
+        List<String> names = new ArrayList<>();
+        rows.forEach(row -> {
+            names.add(row.getData().get(1).getVarCharValue());
+            // redis key is added as an extra col by the connector. so expected #cols is #glue cols + 1
+            assertEquals("Wrong number of columns found", 4, row.getData().size());
+        });
+        logger.info("names: {}", names);
+        assertEquals("Wrong number of DB records found.", 3, names.size());
+        assertTrue("name not found: Jon Snow.", names.contains("Jon Snow"));
+        assertTrue("name not found: Robb Stark.", names.contains("Robb Stark"));
+        assertTrue("name not found: Eddard Stark.", names.contains("Eddard Stark"));
+    }
+
+    private void selectZsetValue()
+    {
+        String query = String.format("select * from \"%s\".\"%s\".\"%s\";",
+                lambdaFunctionName, redisDbName, redisTableNamePrefix + "_2");
+        List<Row> rows = startQueryExecution(query).getResultSet().getRows();
+        if (!rows.isEmpty()) {
+            // Remove the column-header row
+            rows.remove(0);
+        }
+        List<String> names = new ArrayList<>();
+        rows.forEach(row -> {
+            names.add(row.getData().get(0).getVarCharValue());
+            assertEquals("Wrong number of columns found", 2, row.getData().size());
+        });
+        logger.info("names: {}", names);
+        assertEquals("Wrong number of DB records found.", 3, names.size());
+        assertTrue("name not found: customer-hm:1.", names.contains("customer-hm:1"));
+        assertTrue("name not found: customer-hm:2.", names.contains("customer-hm:2"));
+        assertTrue("name not found: customer-hm:3.", names.contains("customer-hm:3"));
+    }
+
+    private void selectLiteralValue()
+    {
+        String query = String.format("select * from \"%s\".\"%s\".\"%s\";",
+                lambdaFunctionName, redisDbName, redisTableNamePrefix + "_2");
+        List<Row> rows = startQueryExecution(query).getResultSet().getRows();
+        if (!rows.isEmpty()) {
+            // Remove the column-header row
+            rows.remove(0);
+        }
+        List<String> names = new ArrayList<>();
+        rows.forEach(row -> {
+            names.add(row.getData().get(0).getVarCharValue());
+            assertEquals("Wrong number of columns found", 2, row.getData().size());
+        });
+        logger.info("names: {}", names);
+        assertEquals("Wrong number of DB records found.", 3, names.size());
+        assertTrue("name not found: Sansa Stark.", names.contains("Sansa Stark"));
+        assertTrue("name not found: Daenerys Targaryen.", names.contains("Daenerys Targaryen"));
+        assertTrue("name not found: Arya Stark.", names.contains("Arya Stark"));
+    }
+
+    @Test
+    public void listDatabasesIntegTest()
+    {
+        logger.info("--------------------------------------");
+        logger.info("Executing listDatabasesIntegTest");
+        logger.info("--------------------------------------");
+
+        List dbNames = listDatabases();
+        logger.info("Databases: {}", dbNames);
+        assertTrue("DB not found.", dbNames.contains(redisDbName));
+    }
+
+    @Test
+    public void listTablesIntegTest()
+    {
+        logger.info("-----------------------------------");
+        logger.info("Executing listTablesIntegTest");
+        logger.info("-----------------------------------");
+
+        List tableNames = listTables(redisDbName);
+        logger.info("Tables: {}", tableNames);
+        assertEquals("Incorrect number of tables found.", 2, tableNames.size());
+        assertTrue(String.format("Table not found: %s.", redisTableNamePrefix + "_1"),
+                tableNames.contains(redisTableNamePrefix + "_1"));
+        assertTrue(String.format("Table not found: %s.", redisTableNamePrefix + "_2"),
+                tableNames.contains(redisTableNamePrefix + "_2"));
+    }
+
+    @Test
+    public void listTableSchemaIntegTest()
+    {
+        logger.info("--------------------------------------");
+        logger.info("Executing listTableSchemaIntegTest");
+        logger.info("--------------------------------------");
+
+        Map schema = describeTable(redisDbName, redisTableNamePrefix + "_1");
+        schema.remove("partition_name");
+        schema.remove("partition_schema_name");
+        logger.info("Schema: {}", schema);
+        assertEquals("Wrong number of columns found.", 4, schema.size());
+
+        assertTrue("Column not found: custkey", schema.containsKey("custkey"));
+        assertEquals("Wrong column type for custkey.", "bigint", schema.get("custkey"));
+        assertTrue("Column not found: name", schema.containsKey("name"));
+        assertEquals("Wrong column type for name.", "varchar", schema.get("name"));
+        assertTrue("Column not found: acctbal", schema.containsKey("acctbal"));
+        assertEquals("Wrong column type for acctbal.", "double", schema.get("acctbal"));
+        assertTrue("Column not found: _key_", schema.containsKey("_key_"));
+        assertEquals("Wrong column type for _key_.", "varchar", schema.get("_key_"));
+    }
+
+    @Test
+    public void standaloneSelectPrefixWithHashValue()
+    {
+        logger.info("--------------------------------------------------");
+        logger.info("Executing standaloneSelectPrefixWithHashValue");
+        logger.info("--------------------------------------------------");
+
+        // Setup Table 1
+        Map<String, String> tableParams = new HashMap<>();
+        tableParams.put("redis-endpoint", redisEndpoints.get(STANDALONE_KEY));
+        tableParams.put("redis-key-prefix", "customer-hm:*"); // prefix
+        tableParams.put("redis-value-type", "hash"); // hash
+        tableParams.put("redis-cluster-flag", "false");
+        tableParams.put("redis-ssl-flag", "false");
+        TableInput tableInput = createTableInput(getGlueTable(redisDbName, redisTableNamePrefix + "_1")).withParameters(tableParams);
+        glue.updateTable(new UpdateTableRequest().withDatabaseName(redisDbName).withTableInput(tableInput));
+
+        selectHashValue();
+    }
+
+    @Test
+    public void standaloneSelectZsetWithHashValue()
+    {
+        logger.info("--------------------------------------------------");
+        logger.info("Executing standaloneSelectZsetWithHashValue");
+        logger.info("--------------------------------------------------");
+
+        // Setup Table 1
+        Map<String, String> tableParams = new HashMap<>();
+        tableParams.put("redis-endpoint", redisEndpoints.get(STANDALONE_KEY));
+        tableParams.put("redis-keys-zset", "customer-hm-zset"); // zset
+        tableParams.put("redis-value-type", "hash"); // hash
+        tableParams.put("redis-cluster-flag", "false");
+        tableParams.put("redis-ssl-flag", "false");
+        TableInput tableInput = createTableInput(getGlueTable(redisDbName, redisTableNamePrefix + "_1")).withParameters(tableParams);
+        glue.updateTable(new UpdateTableRequest().withDatabaseName(redisDbName).withTableInput(tableInput));
+
+        selectHashValue();
+    }
+
+    @Test
+    public void clusterSelectPrefixWithHashValue()
+    {
+        logger.info("--------------------------------------------------");
+        logger.info("Executing clusterSelectPrefixWithHashValue");
+        logger.info("--------------------------------------------------");
+
+        // Setup Table 1
+        Map<String, String> tableParams = new HashMap<>();
+        tableParams.put("redis-endpoint", redisEndpoints.get(CLUSTER_KEY));
+        tableParams.put("redis-key-prefix", "customer-hm:*"); // prefix
+        tableParams.put("redis-value-type", "hash"); // hash
+        tableParams.put("redis-cluster-flag", "true");
+        tableParams.put("redis-ssl-flag", "true");
+        TableInput tableInput = createTableInput(getGlueTable(redisDbName, redisTableNamePrefix + "_1")).withParameters(tableParams);
+        glue.updateTable(new UpdateTableRequest().withDatabaseName(redisDbName).withTableInput(tableInput));
+
+        selectHashValue();
+    }
+
+    @Test
+    public void clusterSelectZsetWithHashValue()
+    {
+        logger.info("--------------------------------------------------");
+        logger.info("Executing clusterSelectZsetWithHashValue");
+        logger.info("--------------------------------------------------");
+
+        // Setup Table 1
+        Map<String, String> tableParams = new HashMap<>();
+        tableParams.put("redis-endpoint", redisEndpoints.get(CLUSTER_KEY));
+        tableParams.put("redis-keys-zset", "customer-hm-zset"); // zset
+        tableParams.put("redis-value-type", "hash"); // hash
+        tableParams.put("redis-cluster-flag", "true");
+        tableParams.put("redis-ssl-flag", "true");
+        TableInput tableInput = createTableInput(getGlueTable(redisDbName, redisTableNamePrefix + "_1")).withParameters(tableParams);
+        glue.updateTable(new UpdateTableRequest().withDatabaseName(redisDbName).withTableInput(tableInput));
+
+        selectHashValue();
+    }
+
+    @Test
+    public void standaloneSelectPrefixWithZsetValue()
+    {
+        logger.info("--------------------------------------------------");
+        logger.info("Executing standaloneSelectPrefixWithZsetValue");
+        logger.info("--------------------------------------------------");
+
+        // Setup Table 2
+        Map<String, String> tableParams = new HashMap<>();
+        tableParams.put("redis-endpoint", redisEndpoints.get(STANDALONE_KEY));
+        tableParams.put("redis-key-prefix", "customer-hm-zset*"); // prefix
+        tableParams.put("redis-value-type", "zset"); // zset
+        tableParams.put("redis-cluster-flag", "false");
+        tableParams.put("redis-ssl-flag", "false");
+        TableInput tableInput = createTableInput(getGlueTable(redisDbName, redisTableNamePrefix + "_2")).withParameters(tableParams);
+        glue.updateTable(new UpdateTableRequest().withDatabaseName(redisDbName).withTableInput(tableInput));
+
+        selectZsetValue();
+    }
+
+    @Test
+    public void standaloneSelectZsetWithZsetValue()
+    {
+        logger.info("--------------------------------------------------");
+        logger.info("Executing standaloneSelectZsetWithZsetValue");
+        logger.info("--------------------------------------------------");
+
+        // Setup Table 2
+        Map<String, String> tableParams = new HashMap<>();
+        tableParams.put("redis-endpoint", redisEndpoints.get(STANDALONE_KEY));
+        tableParams.put("redis-keys-zset", "key-hm-zset"); // zset
+        tableParams.put("redis-value-type", "zset"); // zset
+        tableParams.put("redis-cluster-flag", "false");
+        tableParams.put("redis-ssl-flag", "false");
+        TableInput tableInput = createTableInput(getGlueTable(redisDbName, redisTableNamePrefix + "_2")).withParameters(tableParams);
+        glue.updateTable(new UpdateTableRequest().withDatabaseName(redisDbName).withTableInput(tableInput));
+
+        selectZsetValue();
+    }
+
+    @Test
+    public void clusterSelectPrefixWithZsetValue()
+    {
+        logger.info("--------------------------------------------------");
+        logger.info("Executing clusterSelectPrefixWithZsetValue");
+        logger.info("--------------------------------------------------");
+
+        // Setup Table 2
+        Map<String, String> tableParams = new HashMap<>();
+        tableParams.put("redis-endpoint", redisEndpoints.get(CLUSTER_KEY));
+        tableParams.put("redis-key-prefix", "customer-hm-zset*"); // prefix
+        tableParams.put("redis-value-type", "zset"); // zset
+        tableParams.put("redis-cluster-flag", "true");
+        tableParams.put("redis-ssl-flag", "true");
+        TableInput tableInput = createTableInput(getGlueTable(redisDbName, redisTableNamePrefix + "_2")).withParameters(tableParams);
+        glue.updateTable(new UpdateTableRequest().withDatabaseName(redisDbName).withTableInput(tableInput));
+
+        selectZsetValue();
+    }
+
+    @Test
+    public void clusterSelectZsetWithZsetValue()
+    {
+        logger.info("--------------------------------------------------");
+        logger.info("Executing clusterSelectZsetWithZsetValue");
+        logger.info("--------------------------------------------------");
+
+        // Setup Table 2
+        Map<String, String> tableParams = new HashMap<>();
+        tableParams.put("redis-endpoint", redisEndpoints.get(CLUSTER_KEY));
+        tableParams.put("redis-keys-zset", "key-hm-zset"); // zset
+        tableParams.put("redis-value-type", "zset"); // zset
+        tableParams.put("redis-cluster-flag", "true");
+        tableParams.put("redis-ssl-flag", "true");
+        TableInput tableInput = createTableInput(getGlueTable(redisDbName, redisTableNamePrefix + "_2")).withParameters(tableParams);
+        glue.updateTable(new UpdateTableRequest().withDatabaseName(redisDbName).withTableInput(tableInput));
+
+        selectZsetValue();
+    }
+
+    @Test
+    public void standaloneSelectPrefixWithLiteralValue()
+    {
+        logger.info("--------------------------------------------------");
+        logger.info("Executing standaloneSelectPrefixWithLiteralValue");
+        logger.info("--------------------------------------------------");
+
+        // Setup Table 2
+        Map<String, String> tableParams = new HashMap<>();
+        tableParams.put("redis-endpoint", redisEndpoints.get(STANDALONE_KEY));
+        tableParams.put("redis-key-prefix", "customer-literal:*"); // prefix
+        tableParams.put("redis-value-type", "literal"); // literal
+        tableParams.put("redis-cluster-flag", "false");
+        tableParams.put("redis-ssl-flag", "false");
+        TableInput tableInput = createTableInput(getGlueTable(redisDbName, redisTableNamePrefix + "_2")).withParameters(tableParams);
+        glue.updateTable(new UpdateTableRequest().withDatabaseName(redisDbName).withTableInput(tableInput));
+
+        selectLiteralValue();
+    }
+
+    @Test
+    public void standaloneSelectZsetWithLiteralValue()
+    {
+        logger.info("--------------------------------------------------");
+        logger.info("Executing standaloneSelectZsetWithLiteralValue");
+        logger.info("--------------------------------------------------");
+
+        // Setup Table 2
+        Map<String, String> tableParams = new HashMap<>();
+        tableParams.put("redis-endpoint", redisEndpoints.get(STANDALONE_KEY));
+        tableParams.put("redis-keys-zset", "key-literal-zset"); // zset
+        tableParams.put("redis-value-type", "literal"); // literal
+        tableParams.put("redis-cluster-flag", "false");
+        tableParams.put("redis-ssl-flag", "false");
+        TableInput tableInput = createTableInput(getGlueTable(redisDbName, redisTableNamePrefix + "_2")).withParameters(tableParams);
+        glue.updateTable(new UpdateTableRequest().withDatabaseName(redisDbName).withTableInput(tableInput));
+
+        selectLiteralValue();
+    }
+
+    @Test
+    public void clusterSelectPrefixWithLiteralValue()
+    {
+        logger.info("--------------------------------------------------");
+        logger.info("Executing clusterSelectPrefixWithLiteralValue");
+        logger.info("--------------------------------------------------");
+
+        // Setup Table 2
+        Map<String, String> tableParams = new HashMap<>();
+        tableParams.put("redis-endpoint", redisEndpoints.get(CLUSTER_KEY));
+        tableParams.put("redis-key-prefix", "customer-literal:*"); // prefix
+        tableParams.put("redis-value-type", "literal"); // literal
+        tableParams.put("redis-cluster-flag", "true");
+        tableParams.put("redis-ssl-flag", "true");
+        TableInput tableInput = createTableInput(getGlueTable(redisDbName, redisTableNamePrefix + "_2")).withParameters(tableParams);
+        glue.updateTable(new UpdateTableRequest().withDatabaseName(redisDbName).withTableInput(tableInput));
+
+        selectLiteralValue();
+    }
+
+    @Test
+    public void clusterSelectZsetWithLiteralValue()
+    {
+        logger.info("--------------------------------------------------");
+        logger.info("Executing clusterSelectZsetWithLiteralValue");
+        logger.info("--------------------------------------------------");
+
+        // Setup Table 2
+        Map<String, String> tableParams = new HashMap<>();
+        tableParams.put("redis-endpoint", redisEndpoints.get(CLUSTER_KEY));
+        tableParams.put("redis-keys-zset", "key-literal-zset"); // zset
+        tableParams.put("redis-value-type", "literal"); // literal
+        tableParams.put("redis-cluster-flag", "true");
+        tableParams.put("redis-ssl-flag", "true");
+        TableInput tableInput = createTableInput(getGlueTable(redisDbName, redisTableNamePrefix + "_2")).withParameters(tableParams);
+        glue.updateTable(new UpdateTableRequest().withDatabaseName(redisDbName).withTableInput(tableInput));
+
+        selectLiteralValue();
+    }
+}


### PR DESCRIPTION
*Description of changes:*
Adding Integration Tests for the Redis Connector. 

Two Redis instances (standalone, and clustered) will be deployed. Just like in the DocDB integ tests, an extra helper lambda will be deployed to populate the test data into the Redis instances.
There are 15 tests in total:
```
[INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1,196.281 s - in com.amazonaws.athena.connectors.redis.integ.RedisIntegTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 19:58 min
[INFO] Finished at: 2021-08-18T01:02:51-04:00
```
3 Tests for checking DB, Tables, Schema
6 Tests for each Redis Instance (standalone, and clustered with ssl+password)
- Select Keys provided by Prefix with Hash Value
- Select Keys provided by Prefix with Zset Value
- Select Keys provided by Prefix with Literal Value
- Select Keys provided by Zset with Hash Value
- Select Keys provided by Zset with Zset Value
- Select Keys provided by Zset with Literal Value

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
