### PR TITLE
Fix Default Glue Catalog

### DIFF
--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/handlers/CompositeHandler.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/handlers/CompositeHandler.java
@@ -97,6 +97,9 @@ public class CompositeHandler
         try (BlockAllocatorImpl allocator = new BlockAllocatorImpl()) {
             ObjectMapper objectMapper = VersionedObjectMapperFactory.create(allocator);
             try (FederationRequest rawReq = objectMapper.readValue(inputStream, FederationRequest.class)) {
+                if (rawReq instanceof MetadataRequest) {
+                    ((MetadataRequest) rawReq).setContext(context);
+                }
                 handleRequest(allocator, rawReq, outputStream, objectMapper);
             }
         }

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/handlers/MetadataHandler.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/handlers/MetadataHandler.java
@@ -220,6 +220,7 @@ public abstract class MetadataHandler
                 if (!(rawReq instanceof MetadataRequest)) {
                     throw new RuntimeException("Expected a MetadataRequest but found " + rawReq.getClass());
                 }
+                ((MetadataRequest) rawReq).setContext(context);
                 doHandleRequest(allocator, objectMapper, (MetadataRequest) rawReq, outputStream);
             }
             catch (Exception ex) {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/metadata/MetadataRequest.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/metadata/MetadataRequest.java
@@ -22,6 +22,7 @@ package com.amazonaws.athena.connector.lambda.metadata;
 
 import com.amazonaws.athena.connector.lambda.request.FederationRequest;
 import com.amazonaws.athena.connector.lambda.security.FederatedIdentity;
+import com.amazonaws.services.lambda.runtime.Context;
 
 import static java.util.Objects.requireNonNull;
 
@@ -34,6 +35,7 @@ public abstract class MetadataRequest
     private final MetadataRequestType requestType;
     private final String queryId;
     private final String catalogName;
+    private Context context;
 
     /**
      * Constructs a new MetadataRequest object.
@@ -79,5 +81,23 @@ public abstract class MetadataRequest
     public String getQueryId()
     {
         return queryId;
+    }
+
+    /**
+     * Returns Context from Lambda.
+     *
+     * @return The Context of the Lambda
+     */
+    public Context getContext()
+    {
+        return context;
+    }
+
+    /**
+     * Set the Context from Lambda.
+     */
+    public void setContext(Context context)
+    {
+        this.context = context;
     }
 }


### PR DESCRIPTION
*Description of changes:*

If Env variable `glue_catalog` is blank, the glue catalog used should be the account where the lambda function exists. This isn't case for Cross account federated queries:
1. Account A executes cross account federated query to use Account B's function
2. Account B's function will then try to read the glue catalog of Account A by default

This change will update step 2 so that Account B's function, when invoked by Account A, will read Account B's glue catalog by default.
