### PR TITLE
Add support for custom redis db number

### DIFF
--- a/athena-federation-integ-test/src/main/java/com/amazonaws/athena/connector/integ/stacks/ConnectorStack.java
+++ b/athena-federation-integ-test/src/main/java/com/amazonaws/athena/connector/integ/stacks/ConnectorStack.java
@@ -82,16 +82,16 @@ public class ConnectorStack extends Stack
     protected void initialize()
     {
         logger.info("Initializing stack: {}", this.getClass().getSimpleName());
-        createLambdaFunction();
-        createAthenaDataCatalog();
+        Function function = createLambdaFunction();
+        createAthenaDataCatalog(function);
     }
 
     /**
      * Creates the Connector's CloudFormation stack for the lambda function.
      */
-    private void createLambdaFunction()
+    private Function createLambdaFunction()
     {
-        lambdaFunctionBuilder().build();
+        return lambdaFunctionBuilder().build();
     }
 
     /**
@@ -121,21 +121,21 @@ public class ConnectorStack extends Stack
     /**
      * Creates the Connector's Athena data catalog stack resource, and registers the lambda function with Athena.
      */
-    private void createAthenaDataCatalog()
+    private void createAthenaDataCatalog(Function function)
     {
-        athenaDataCatalogBuilder().build();
+        athenaDataCatalogBuilder(function.getFunctionArn()).build();
     }
 
     /**
      * Builds the Athena data catalog stack resource.
      * @return Athena data catalog Builder.
      */
-    protected CfnDataCatalog.Builder athenaDataCatalogBuilder()
+    protected CfnDataCatalog.Builder athenaDataCatalogBuilder(String functionArn)
     {
         return CfnDataCatalog.Builder.create(this, "AthenaDataCatalog")
                 .name(functionName)
                 .type("LAMBDA")
-                .parameters(ImmutableMap.of("function", "arn:aws:lambda:function:" + functionName));
+                .parameters(ImmutableMap.of("function", functionArn));
     }
 
     /**

--- a/athena-redis/README.md
+++ b/athena-redis/README.md
@@ -29,8 +29,11 @@ To enable a Glue Table for use with Redis, you can set the following properties 
 4. **redis-value-type** - (required) Defines how the value for the keys defined by either redis-key-prefix or redis-keys-zset will be mapped to your table. literal maps to a single column. zset also maps to a single column but each key can essentially store N rows. hash allows for each key to be a row with multiple columns. (e.g. hash or literal or zset)
 5. **redis-ssl-flag** - (optional) Defaults to False, setting this to True will create a redis connection with SSL/TLS. (e.g. True or False)
 6. **redis-cluster-flag** - (optional) Defaults to False, setting this to True will enable support for clustered Redis instances. (e.g. True or False)
+7. **redis-db-number** - (optional, only applies for standalone NOT clustered) Defaults to redis logical database 0, set this to read from a non default redis database. (e.g. 1,2,3,...)**
 
 *To use the Athena Federated Query feature with AWS Secrets Manager, the VPC connected to your Lambda function should have [internet access](https://aws.amazon.com/premiumsupport/knowledge-center/internet-access-lambda-function/) or a [VPC endpoint](https://docs.aws.amazon.com/secretsmanager/latest/userguide/vpc-endpoint-overview.html#vpc-endpoint-create) to connect to Secrets Manager.
+
+**This does not refer to a database in Athena/Glue, but a Redis logical database. Refer to [SELECT index](https://redis.io/commands/select) for more information.
 
 ### Data Types
 

--- a/athena-redis/src/main/java/com/amazonaws/athena/connectors/redis/RedisMetadataHandler.java
+++ b/athena-redis/src/main/java/com/amazonaws/athena/connectors/redis/RedisMetadataHandler.java
@@ -114,6 +114,7 @@ public class RedisMetadataHandler
     protected static final String REDIS_CLUSTER_FLAG = "redis-cluster-flag";
     //Defines the redis database to use
     protected static final String REDIS_DB_NUMBER = "redis-db-number";
+    protected static final String DEFAULT_REDIS_DB_NUMBER = "0";
 
     //Used to filter out Glue tables which lack a redis endpoint.
     private static final TableFilter TABLE_FILTER = (Table table) -> table.getParameters().containsKey(REDIS_ENDPOINT_PROP);
@@ -265,6 +266,10 @@ public class RedisMetadataHandler
             throw new RuntimeException("Table is missing " + VALUE_TYPE_TABLE_PROP + " table property");
         }
 
+        if (dbNumber == null) {
+            dbNumber = DEFAULT_REDIS_DB_NUMBER; // default redis logical database
+        }
+
         logger.info("doGetSplits: Preparing splits for {}", BlockUtils.rowToString(partitions, 0));
 
         KeyType keyType;
@@ -353,7 +358,7 @@ public class RedisMetadataHandler
                     .add(SPLIT_END_INDEX, String.valueOf(endIndex))
                     .add(REDIS_SSL_FLAG, String.valueOf(sslEnabled))
                     .add(REDIS_CLUSTER_FLAG, String.valueOf(isCluster))
-                    .add(REDIS_DB_NUMBER, String.valueOf(dbNumber))
+                    .add(REDIS_DB_NUMBER, dbNumber)
                     .build();
 
             splits.add(split);

--- a/athena-redis/src/main/java/com/amazonaws/athena/connectors/redis/RedisMetadataHandler.java
+++ b/athena-redis/src/main/java/com/amazonaws/athena/connectors/redis/RedisMetadataHandler.java
@@ -114,7 +114,7 @@ public class RedisMetadataHandler
     protected static final String REDIS_CLUSTER_FLAG = "redis-cluster-flag";
     //Defines the redis database to use
     protected static final String REDIS_DB_NUMBER = "redis-db-number";
-    protected static final String DEFAULT_REDIS_DB_NUMBER = "0";
+    public static final String DEFAULT_REDIS_DB_NUMBER = "0";
 
     //Used to filter out Glue tables which lack a redis endpoint.
     private static final TableFilter TABLE_FILTER = (Table table) -> table.getParameters().containsKey(REDIS_ENDPOINT_PROP);

--- a/athena-redis/src/main/java/com/amazonaws/athena/connectors/redis/integ/RedisIntegTestHandler.java
+++ b/athena-redis/src/main/java/com/amazonaws/athena/connectors/redis/integ/RedisIntegTestHandler.java
@@ -47,6 +47,8 @@ public class RedisIntegTestHandler
 
     private static final Logger logger = LoggerFactory.getLogger(RedisIntegTestHandler.class);
 
+    private static final String STANDALONE_REDIS_DB_NUMBER = "10";
+
     private final RedisConnectionFactory connectionFactory;
     private final String standaloneConnectionString;
     private final String clusterConnectionString;
@@ -66,8 +68,8 @@ public class RedisIntegTestHandler
         RedisConnectionWrapper<String, String> standaloneConnection = null;
         RedisConnectionWrapper<String, String> clusterConnection = null;
         try {
-            standaloneConnection = connectionFactory.getOrCreateConn(standaloneConnectionString, false, false);
-            clusterConnection = connectionFactory.getOrCreateConn(clusterConnectionString, true, true);
+            standaloneConnection = connectionFactory.getOrCreateConn(standaloneConnectionString, false, false, STANDALONE_REDIS_DB_NUMBER);
+            clusterConnection = connectionFactory.getOrCreateConn(clusterConnectionString, true, true, null);
 
             insertRedisData(standaloneConnection.sync());
             insertRedisData(clusterConnection.sync());

--- a/athena-redis/src/main/java/com/amazonaws/athena/connectors/redis/integ/RedisIntegTestHandler.java
+++ b/athena-redis/src/main/java/com/amazonaws/athena/connectors/redis/integ/RedisIntegTestHandler.java
@@ -69,7 +69,7 @@ public class RedisIntegTestHandler
         RedisConnectionWrapper<String, String> clusterConnection = null;
         try {
             standaloneConnection = connectionFactory.getOrCreateConn(standaloneConnectionString, false, false, STANDALONE_REDIS_DB_NUMBER);
-            clusterConnection = connectionFactory.getOrCreateConn(clusterConnectionString, true, true, null);
+            clusterConnection = connectionFactory.getOrCreateConn(clusterConnectionString, true, true);
 
             insertRedisData(standaloneConnection.sync());
             insertRedisData(clusterConnection.sync());

--- a/athena-redis/src/main/java/com/amazonaws/athena/connectors/redis/lettuce/RedisConnectionFactory.java
+++ b/athena-redis/src/main/java/com/amazonaws/athena/connectors/redis/lettuce/RedisConnectionFactory.java
@@ -31,6 +31,8 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.amazonaws.athena.connectors.redis.RedisMetadataHandler.DEFAULT_REDIS_DB_NUMBER;
+
 public class RedisConnectionFactory
 {
   private static final Logger logger = LoggerFactory.getLogger(RedisConnectionFactory.class);
@@ -42,7 +44,7 @@ public class RedisConnectionFactory
                                                                              boolean sslEnabled,
                                                                              boolean isCluster)
   {
-    return getOrCreateConn(conStr, sslEnabled, isCluster, "0");
+    return getOrCreateConn(conStr, sslEnabled, isCluster, DEFAULT_REDIS_DB_NUMBER);
   }
 
   public synchronized RedisConnectionWrapper<String, String> getOrCreateConn(String conStr,

--- a/athena-redis/src/main/java/com/amazonaws/athena/connectors/redis/lettuce/RedisConnectionFactory.java
+++ b/athena-redis/src/main/java/com/amazonaws/athena/connectors/redis/lettuce/RedisConnectionFactory.java
@@ -51,7 +51,7 @@ public class RedisConnectionFactory
                                                                              String dbNumber)
   {
     String conKey = conStr + sslEnabled + isCluster;
-    if (!isCluster && dbNumber != null && !"null".equals(dbNumber)) {
+    if (!isCluster && dbNumber != null) {
       conKey += dbNumber;
     }
     RedisConnectionWrapper<String, String> connection = clientCache.get(conKey);
@@ -101,7 +101,7 @@ public class RedisConnectionFactory
     if (passwordToken != null) {
       redisUriBuilder.withPassword(passwordToken.toCharArray());
     }
-    if (dbNumber != null && !"null".equals(dbNumber) && !dbNumber.isEmpty()) {
+    if (dbNumber != null && !dbNumber.isEmpty()) {
       logger.info("getOrCreateCon: With DB Number {}", dbNumber);
       redisUriBuilder.withDatabase(Integer.parseInt(dbNumber));
     }

--- a/athena-redis/src/main/java/com/amazonaws/athena/connectors/redis/lettuce/RedisConnectionFactory.java
+++ b/athena-redis/src/main/java/com/amazonaws/athena/connectors/redis/lettuce/RedisConnectionFactory.java
@@ -40,11 +40,18 @@ public class RedisConnectionFactory
 
   public synchronized RedisConnectionWrapper<String, String> getOrCreateConn(String conStr,
                                                                              boolean sslEnabled,
+                                                                             boolean isCluster)
+  {
+    return getOrCreateConn(conStr, sslEnabled, isCluster, "0");
+  }
+
+  public synchronized RedisConnectionWrapper<String, String> getOrCreateConn(String conStr,
+                                                                             boolean sslEnabled,
                                                                              boolean isCluster,
                                                                              String dbNumber)
   {
     String conKey = conStr + sslEnabled + isCluster;
-    if (dbNumber != null && !"null".equals(dbNumber)) {
+    if (!isCluster && dbNumber != null && !"null".equals(dbNumber)) {
       conKey += dbNumber;
     }
     RedisConnectionWrapper<String, String> connection = clientCache.get(conKey);

--- a/athena-redis/src/test/java/com/amazonaws/athena/connectors/redis/RedisMetadataHandlerTest.java
+++ b/athena-redis/src/test/java/com/amazonaws/athena/connectors/redis/RedisMetadataHandlerTest.java
@@ -66,6 +66,7 @@ import java.util.UUID;
 
 import static com.amazonaws.athena.connectors.redis.RedisMetadataHandler.KEY_PREFIX_TABLE_PROP;
 import static com.amazonaws.athena.connectors.redis.RedisMetadataHandler.REDIS_CLUSTER_FLAG;
+import static com.amazonaws.athena.connectors.redis.RedisMetadataHandler.REDIS_DB_NUMBER;
 import static com.amazonaws.athena.connectors.redis.RedisMetadataHandler.REDIS_ENDPOINT_PROP;
 import static com.amazonaws.athena.connectors.redis.RedisMetadataHandler.REDIS_SSL_FLAG;
 import static com.amazonaws.athena.connectors.redis.RedisMetadataHandler.VALUE_TYPE_TABLE_PROP;
@@ -117,7 +118,7 @@ public class RedisMetadataHandlerTest
     {
         logger.info("{}: enter", testName.getMethodName());
 
-        when(mockFactory.getOrCreateConn(eq(decodedEndpoint), anyBoolean(), anyBoolean())).thenReturn(mockConnection);
+        when(mockFactory.getOrCreateConn(eq(decodedEndpoint), anyBoolean(), anyBoolean(), anyString())).thenReturn(mockConnection);
         when(mockConnection.sync()).thenReturn(mockSyncCommands);
 
         handler = new RedisMetadataHandler(mockGlue, new LocalKeyFactory(), mockSecretsManager, mockAthena, mockFactory, "bucket", "prefix");
@@ -162,7 +163,7 @@ public class RedisMetadataHandlerTest
         }
 
         assertTrue(partitions.getRowCount() > 0);
-        assertEquals(6, partitions.getFields().size());
+        assertEquals(7, partitions.getFields().size());
 
         logger.info("doGetTableLayout: partitions[{}]", partitions.getRowCount());
     }
@@ -210,6 +211,7 @@ public class RedisMetadataHandlerTest
                 .addStringField(ZSET_KEYS_TABLE_PROP)
                 .addStringField(REDIS_SSL_FLAG)
                 .addStringField(REDIS_CLUSTER_FLAG)
+                .addStringField(REDIS_DB_NUMBER)
                 .build();
 
         Block partitions = allocator.createBlock(schema);
@@ -219,6 +221,7 @@ public class RedisMetadataHandlerTest
         partitions.setValue(ZSET_KEYS_TABLE_PROP, 0, prefixes);
         partitions.setValue(REDIS_SSL_FLAG, 0, null);
         partitions.setValue(REDIS_CLUSTER_FLAG, 0, null);
+        partitions.setValue(REDIS_DB_NUMBER, 0, null);
         partitions.setRowCount(1);
 
         String continuationToken = null;
@@ -261,6 +264,7 @@ public class RedisMetadataHandlerTest
                 .addStringField(ZSET_KEYS_TABLE_PROP)
                 .addStringField(REDIS_SSL_FLAG)
                 .addStringField(REDIS_CLUSTER_FLAG)
+                .addStringField(REDIS_DB_NUMBER)
                 .build();
 
         Block partitions = allocator.createBlock(schema);
@@ -270,6 +274,7 @@ public class RedisMetadataHandlerTest
         partitions.setValue(ZSET_KEYS_TABLE_PROP, 0, null);
         partitions.setValue(REDIS_SSL_FLAG, 0, null);
         partitions.setValue(REDIS_CLUSTER_FLAG, 0, null);
+        partitions.setValue(REDIS_DB_NUMBER, 0, null);
         partitions.setRowCount(1);
 
         String continuationToken = null;

--- a/athena-redis/src/test/java/com/amazonaws/athena/connectors/redis/RedisRecordHandlerTest.java
+++ b/athena-redis/src/test/java/com/amazonaws/athena/connectors/redis/RedisRecordHandlerTest.java
@@ -129,7 +129,7 @@ public class RedisRecordHandlerTest
     {
         logger.info("{}: enter", testName.getMethodName());
 
-        when(mockFactory.getOrCreateConn(eq(decodedEndpoint), anyBoolean(), anyBoolean())).thenReturn(mockConnection);
+        when(mockFactory.getOrCreateConn(eq(decodedEndpoint), anyBoolean(), anyBoolean(), anyString())).thenReturn(mockConnection);
         when(mockConnection.sync()).thenReturn(mockSyncCommands);
 
         allocator = new BlockAllocatorImpl();

--- a/athena-redis/src/test/java/com/amazonaws/athena/connectors/redis/integ/RedisIntegTest.java
+++ b/athena-redis/src/test/java/com/amazonaws/athena/connectors/redis/integ/RedisIntegTest.java
@@ -88,6 +88,7 @@ public class RedisIntegTest extends IntegrationTestBase
     private static final String STANDALONE_KEY = "standalone";
     private static final String CLUSTER_KEY = "cluster";
     private static final int GLUE_TIMEOUT = 250;
+    private static final String STANDALONE_REDIS_DB_NUMBER = "10";
 
     private final App theApp;
     private final String redisPassword;
@@ -538,6 +539,7 @@ public class RedisIntegTest extends IntegrationTestBase
         tableParams.put("redis-value-type", "hash"); // hash
         tableParams.put("redis-cluster-flag", "false");
         tableParams.put("redis-ssl-flag", "false");
+        tableParams.put("redis-db-number", STANDALONE_REDIS_DB_NUMBER);
         TableInput tableInput = createTableInput(getGlueTable(redisDbName, redisTableNamePrefix + "_1")).withParameters(tableParams);
         glue.updateTable(new UpdateTableRequest().withDatabaseName(redisDbName).withTableInput(tableInput));
 
@@ -558,6 +560,7 @@ public class RedisIntegTest extends IntegrationTestBase
         tableParams.put("redis-value-type", "hash"); // hash
         tableParams.put("redis-cluster-flag", "false");
         tableParams.put("redis-ssl-flag", "false");
+        tableParams.put("redis-db-number", STANDALONE_REDIS_DB_NUMBER);
         TableInput tableInput = createTableInput(getGlueTable(redisDbName, redisTableNamePrefix + "_1")).withParameters(tableParams);
         glue.updateTable(new UpdateTableRequest().withDatabaseName(redisDbName).withTableInput(tableInput));
 
@@ -618,6 +621,7 @@ public class RedisIntegTest extends IntegrationTestBase
         tableParams.put("redis-value-type", "zset"); // zset
         tableParams.put("redis-cluster-flag", "false");
         tableParams.put("redis-ssl-flag", "false");
+        tableParams.put("redis-db-number", STANDALONE_REDIS_DB_NUMBER);
         TableInput tableInput = createTableInput(getGlueTable(redisDbName, redisTableNamePrefix + "_2")).withParameters(tableParams);
         glue.updateTable(new UpdateTableRequest().withDatabaseName(redisDbName).withTableInput(tableInput));
 
@@ -638,6 +642,7 @@ public class RedisIntegTest extends IntegrationTestBase
         tableParams.put("redis-value-type", "zset"); // zset
         tableParams.put("redis-cluster-flag", "false");
         tableParams.put("redis-ssl-flag", "false");
+        tableParams.put("redis-db-number", STANDALONE_REDIS_DB_NUMBER);
         TableInput tableInput = createTableInput(getGlueTable(redisDbName, redisTableNamePrefix + "_2")).withParameters(tableParams);
         glue.updateTable(new UpdateTableRequest().withDatabaseName(redisDbName).withTableInput(tableInput));
 
@@ -698,6 +703,7 @@ public class RedisIntegTest extends IntegrationTestBase
         tableParams.put("redis-value-type", "literal"); // literal
         tableParams.put("redis-cluster-flag", "false");
         tableParams.put("redis-ssl-flag", "false");
+        tableParams.put("redis-db-number", STANDALONE_REDIS_DB_NUMBER);
         TableInput tableInput = createTableInput(getGlueTable(redisDbName, redisTableNamePrefix + "_2")).withParameters(tableParams);
         glue.updateTable(new UpdateTableRequest().withDatabaseName(redisDbName).withTableInput(tableInput));
 
@@ -718,6 +724,7 @@ public class RedisIntegTest extends IntegrationTestBase
         tableParams.put("redis-value-type", "literal"); // literal
         tableParams.put("redis-cluster-flag", "false");
         tableParams.put("redis-ssl-flag", "false");
+        tableParams.put("redis-db-number", STANDALONE_REDIS_DB_NUMBER);
         TableInput tableInput = createTableInput(getGlueTable(redisDbName, redisTableNamePrefix + "_2")).withParameters(tableParams);
         glue.updateTable(new UpdateTableRequest().withDatabaseName(redisDbName).withTableInput(tableInput));
 


### PR DESCRIPTION
*Description of changes:*
Adding support to Redis Connector to allow input of custom redis logical database number (1,2,3,...) via new glue table property flag `redis-db-number`

Also fixing integ tests. Previous shortened lambda function arn input is no longer valid when creating Athena Catalog.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
