### PR TITLE
 Updated Documentation and the default LambdaMemory

### DIFF
--- a/athena-dynamodb/README.md
+++ b/athena-dynamodb/README.md
@@ -10,15 +10,17 @@ This connector enables Amazon Athena to communicate with DynamoDB, making your t
 
 The Athena DynamoDB Connector exposes several configuration options via Lambda environment variables. More detail on the available parameters can be found below.
 
-1. **spill_bucket** - When the data returned by your Lambda function exceeds Lambda’s limits, this is the bucket that the data will be written to for Athena to read the excess from. (e.g. my_bucket)
-2. **spill_prefix** - (Optional) Defaults to sub-folder in your bucket called 'athena-federation-spill'. Used in conjunction with spill_bucket, this is the path within the above bucket that large
+1. **SpillBucket** - When the data returned by your Lambda function exceeds Lambda’s limits, this is the bucket that the data will be written to for Athena to read the excess from. (e.g. my_bucket)
+2. **SpillPrefix** - (Optional) Defaults to sub-folder in your bucket called 'athena-federation-spill'. Used in conjunction with spill_bucket, this is the path within the above bucket that large
 responses are spilled to. You should configure an S3 lifecycle on this location to delete old spills after X days/Hours.
-3. **kms_key_id** - (Optional) By default any data that is spilled to S3 is encrypted using AES-GCM and a randomly generated key. Setting a KMS Key ID allows your Lambda function to use KMS for key
+3. **KMSKeyId** - (Optional) By default any data that is spilled to S3 is encrypted using AES-GCM and a randomly generated key. Setting a KMS Key ID allows your Lambda function to use KMS for key
 generation for a stronger source of encryption keys. (e.g. a7e63k4b-8loc-40db-a2a1-4d0en2cd8331)
-4. **disable_spill_encryption** - (Optional) Defaults to False so that any data that is spilled to S3 is encrypted using AES-GCM either with a randomly generated key or using KMS to generate keys.
+4. **DisableSpillEncryption** - (Optional) Defaults to False so that any data that is spilled to S3 is encrypted using AES-GCM either with a randomly generated key or using KMS to generate keys.
 Setting this to false will disable spill encryption. You may wish to disable this for improved performance, especially if your spill location in S3 uses S3 Server Side Encryption. (e.g. True or False)
 5. **disable_glue** - (Optional) If present, with any value except false, the connector will no longer attempt to retrieve supplemental metadata from Glue.
 6. **glue_catalog** - (Optional) Can be used to target a cross-account Glue catalog. By default the connector will attempt to get metadata from its own Glue account.
+7. **LambdaMemory** - (Optional) Memory is the amount of memory available to your Lambda function at runtime. Set a value between 128 MB and 10240 MB
+8. **LambdaTimeout** - (Optional)  Amount of time that the Lambda function handler can run for an invocation. Set a value between 1 second and 900 seconds
 
 ### Setting Up Databases & Tables in Glue
 

--- a/athena-dynamodb/athena-dynamodb.yaml
+++ b/athena-dynamodb/athena-dynamodb.yaml
@@ -29,8 +29,8 @@ Parameters:
     Default: 900
     Type: Number
   LambdaMemory:
-    Description: 'Lambda memory in MB (min 128 - 3008 max).'
-    Default: 3008
+    Description: 'Lambda memory in MB (min 128 - 10240 max).'
+    Default: 10240
     Type: Number
   DisableSpillEncryption:
     Description: "WARNING: If set to 'true' encryption for spilled data is disabled."


### PR DESCRIPTION
*Issue #, if available:* #648

*Description of changes:*

1. Updated the default LambdaMemory to 10240 MB from 3008 MB
2. Documentation: "disable_glue" and "glue_catalog" are not seen to be used and hence removed
3. Documentation: Updated Parameter names to match "[athena-dynamodb.yaml](https://github.com/awslabs/aws-athena-query-federation/blob/master/athena-dynamodb/athena-dynamodb.yaml)" parameters

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
