### PR TITLE
Bump log4j from 2.17.0 to 2.17.1 to address CVE-2021-44832

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <fasterxml.jackson.version>2.10.5</fasterxml.jackson.version>
         <aws-cdk.version>1.89.0</aws-cdk.version>
         <surefire.failsafe.version>3.0.0-M5</surefire.failsafe.version>
-        <log4j2Version>2.17.0</log4j2Version>
+        <log4j2Version>2.17.1</log4j2Version>
     </properties>
 
     <organization>


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Hello maintainers. Due to the recent log4j related issue, our organization are very concerned to have the latest secure version of log4j.

Many thanks for the consideration.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
