### PR TITLE
Adding RequestLimitExceededException to throttling invoker

### DIFF
--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/throttling/DynamoDBExceptionFilter.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/throttling/DynamoDBExceptionFilter.java
@@ -22,6 +22,7 @@ package com.amazonaws.athena.connectors.dynamodb.throttling;
 import com.amazonaws.athena.connector.lambda.ThrottlingInvoker;
 import com.amazonaws.services.dynamodbv2.model.LimitExceededException;
 import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughputExceededException;
+import com.amazonaws.services.dynamodbv2.model.RequestLimitExceededException;
 
 /**
  * Used by {@link ThrottlingInvoker} to determine which DynamoDB exceptions are thrown for throttling.
@@ -37,6 +38,7 @@ public class DynamoDBExceptionFilter
     public boolean isMatch(Exception ex)
     {
         return ex instanceof LimitExceededException
-                || ex instanceof ProvisionedThroughputExceededException;
+                || ex instanceof ProvisionedThroughputExceededException
+                || ex instanceof RequestLimitExceededException;
     }
 }


### PR DESCRIPTION
Queries that have fast producers may be able to spill faster than the amount of time it takes to spill to S3. In this case, the query fails as below:

```
GENERIC_USER_ERROR: Encountered an exception[java.util.concurrent.RejectedExecutionException] from your LambdaFunction[arn:aws:lambda:us-east-1:373919111989:function:dynamo] executed in 

context[S3SpillLocation{bucket='burhan-test', key='athena-spill/c369cc8e-5379-4d5b-8cb1-7e71b763ad2c/34e58ca1-4ad5-4e53-acfe-40277b464d11', directory=true}] 

with message[Task java.util.concurrent.FutureTask@376a312c[Not completed, task = java.util.concurrent.Executors$RunnableAdapter@58e6d4b8[Wrapped task = com.amazonaws.athena.connector.lambda.data.S3BlockSpiller$$Lambda$146/0x0000000840362c40@1de5f0ef]] 

rejected from java.util.concurrent.ThreadPoolExecutor@28d6290[Running, pool size = 2, active threads = 2, queued tasks = 2, completed tasks = 7]]
```

After adding this change, the error did not show up again. 