### PR TITLE
Add support for optional LambdaRole parameter for AthenaDynamoDBConne…

### DIFF
--- a/athena-cloudwatch/athena-cloudwatch.yaml
+++ b/athena-cloudwatch/athena-cloudwatch.yaml
@@ -32,6 +32,10 @@ Parameters:
     Description: 'Lambda memory in MB (min 128 - 3008 max).'
     Default: 3008
     Type: Number
+  LambdaRole:
+    Description: "(Optional) A custom role to be used by the Connector lambda"
+    Type: String
+    Default: ""
   DisableSpillEncryption:
     Description: "WARNING: If set to 'true' encryption for spilled data is disabled."
     Default: 'false'
@@ -43,6 +47,7 @@ Parameters:
 
 Conditions:
  HasKMSKeyId: !Not [!Equals [!Ref KMSKeyId, ""]]
+ HasLambdaRole: !Not [!Equals [!Ref LambdaRole, ""]]
 
 Resources:
   ConnectorConfig:
@@ -61,9 +66,10 @@ Resources:
       Runtime: java11
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
-      Role: !GetAtt FunctionRole.Arn
+      Role: !If [HasLambdaRole, !Ref LambdaRole, !GetAtt FunctionRole.Arn]
 
   FunctionRole:
+    Condition: !Not HasLambdaRole
     Type: AWS::IAM::Role
     Properties:
       ManagedPolicyArns:

--- a/athena-dynamodb/athena-dynamodb.yaml
+++ b/athena-dynamodb/athena-dynamodb.yaml
@@ -32,6 +32,10 @@ Parameters:
     Description: 'Lambda memory in MB (min 128 - 3008 max).'
     Default: 3008
     Type: Number
+  LambdaRole:
+    Description: "(Optional) A custom role to be used by the Connector lambda"
+    Type: String
+    Default: ""
   DisableSpillEncryption:
     Description: "WARNING: If set to 'true' encryption for spilled data is disabled."
     Default: 'false'
@@ -43,6 +47,7 @@ Parameters:
 
 Conditions:
  HasKMSKeyId: !Not [!Equals [!Ref KMSKeyId, ""]]
+ HasLambdaRole: !Not [!Equals [!Ref LambdaRole, ""]]
 
 Resources:
   ConnectorConfig:
@@ -61,9 +66,10 @@ Resources:
       Runtime: java11
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
-      Role: !GetAtt FunctionRole.Arn
+      Role: !If [HasLambdaRole, !Ref LambdaRole, !GetAtt FunctionRole.Arn]
 
   FunctionRole:
+    Condition: !Not HasLambdaRole
     Type: AWS::IAM::Role
     Properties:
       ManagedPolicyArns:


### PR DESCRIPTION
*Issue #, if available:*
- https://github.com/awslabs/aws-athena-query-federation/issues/350
- https://github.com/awslabs/aws-athena-query-federation/issues/365

*Description of changes:*
Add support for optional LambdaRole parameter for AthenaDynamoDBConnector
Adds the LambdaRole optional parameter for AthenaDynamoDBConnector app which will be used as the default execution role by the Connector lambda if provided, otherwise a default role will be created and used like before.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
