### PR TITLE
Fix redshift POM

### DIFF
--- a/athena-redshift/pom.xml
+++ b/athena-redshift/pom.xml
@@ -27,6 +27,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.amazon.redshift</groupId>
+            <artifactId>redshift-jdbc42-no-awssdk</artifactId>
+            <version>1.2.34.1058</version>
+        </dependency>
+        <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
             <version>${aws-athena-federation-sdk.version}</version>


### PR DESCRIPTION
We were missing a driver, adding it here. Will cut a new release shortly after. I took the version from the last known good redshift connector from release 2022.4.1.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
