### PR TITLE
Add PartitionLimit option to configure the snowflake connector via SAR

### DIFF
--- a/athena-snowflake/README.md
+++ b/athena-snowflake/README.md
@@ -106,10 +106,23 @@ spill_bucket    Spill bucket name. Required.
 spill_prefix    Spill bucket key prefix. Required.
 ```
 
+### PageCount parameter
+Limits the number of records per partition
+
+The default value is 500000
+
+### PartitionLimit parameter
+Limits the number of partitions. A large number may cause a time-out issue. Please reset to a lower value if you encounter a time-out error
+
+The default value is 10
+
 # Data types support
 
-
 |Jdbc|Arrow|
+Limit on number of partitions. A large number may cause time-out issue during running the query. Please reset to a lower value if you encounter a time-out error.
+
+Default partition limit is 10
+
 | ---|---|
 |Boolean|Bit|
 |Integer|Tiny|

--- a/athena-snowflake/athena-snowflake.yaml
+++ b/athena-snowflake/athena-snowflake.yaml
@@ -49,13 +49,13 @@ Parameters:
     Description: 'One or more Subnet IDs corresponding to the Subnet that the Lambda function can use to access you data source. (e.g. subnet1,subnet2)'
     Type: 'List<AWS::EC2::Subnet::Id>'
   PageCount:
-    Description: 'Limit on number of records per partition'
+    Description: 'Limits the number of records per partition'
     Type: Number
     Default: 500000
   PartitionLimit:
-    Description: 'Limit on number of partitions. A large number may cause time-out issue. Please reset to a lower value if you encounter a time-out error '
+    Description: 'Limits the number of partitions. A large number may cause a time-out issue. Please reset to a lower value if you encounter a time-out error'
     Type: Number
-    Default: 1000
+    Default: 10
 Resources:
   JdbcConnectorConfig:
     Type: 'AWS::Serverless::Function'

--- a/athena-snowflake/athena-snowflake.yaml
+++ b/athena-snowflake/athena-snowflake.yaml
@@ -52,6 +52,10 @@ Parameters:
     Description: 'Limit on number of records per partition'
     Type: Number
     Default: 500000
+  PartitionLimit:
+    Description: 'Limit on number of partitions. A large number may cause time-out issue. Please reset to a lower value if you encounter a time-out error '
+    Type: Number
+    Default: 1000
 Resources:
   JdbcConnectorConfig:
     Type: 'AWS::Serverless::Function'
@@ -63,6 +67,7 @@ Resources:
           spill_prefix: !Ref SpillPrefix
           default: !Ref DefaultConnectionString
           pagecount: !Ref PageCount
+          partitionlimit: !Ref PartitionLimit
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.snowflake.SnowflakeMuxCompositeHandler"
       CodeUri: "./target/athena-snowflake-2022.10.1.jar"


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
In a recently deployed [AthenaSnowflakeConnector](https://us-east-1.console.aws.amazon.com/lambda/home?region=us-east-1#/create/app?applicationId=arn:aws:serverlessrepo:us-east-1:292517598671:applications/AthenaSnowflakeConnector), there is no option named **PartitionLimit**, which is a required option to run queries from Athena Query Console. 

This option takes an integer value to limit the number of partitions and sets it to an environment variable named **partitionlimit** in the lambda configuration. 

In the PR, the issue is fixed and tested.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
