### PR TITLE
Fix for External table access issue in Azure Server less environment

### DIFF
--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JDBCUtil.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JDBCUtil.java
@@ -22,19 +22,16 @@ package com.amazonaws.athena.connectors.jdbc.manager;
 import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionConfig;
 import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionConfigBuilder;
 import com.google.common.collect.ImmutableMap;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public final class JDBCUtil
 {
     private static final String DEFAULT_CATALOG_PREFIX = "lambda:";
     private static final String LAMBDA_FUNCTION_NAME_PROPERTY = "AWS_LAMBDA_FUNCTION_NAME";
-    private static final Pattern SYNAPSE_CONN_STRING_PATTERN = Pattern.compile("([a-zA-Z]+)://([^;]+);(.*)");
+
     private JDBCUtil() {}
 
     /**
@@ -131,21 +128,5 @@ public final class JDBCUtil
         }
 
         return recordHandlerMap.build();
-    }
-
-    public static String checkEnvironment(String databaseEngine, String url)
-    {
-        if ("synapse".equals(databaseEngine)) {
-            // checking whether it's Azure serverless environment or not based on host name
-            Matcher m = SYNAPSE_CONN_STRING_PATTERN.matcher(url);
-            String hostName = "";
-            if (m.find() && m.groupCount() == 3) {
-                hostName = m.group(2);
-            }
-            if (StringUtils.isNotBlank(hostName) && hostName.contains("ondemand")) {
-                return "azureServerless";
-            }
-        }
-        return null;
     }
 }

--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JDBCUtil.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JDBCUtil.java
@@ -22,10 +22,13 @@ package com.amazonaws.athena.connectors.jdbc.manager;
 import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionConfig;
 import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionConfigBuilder;
 import com.google.common.collect.ImmutableMap;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public final class JDBCUtil
 {
@@ -127,5 +130,21 @@ public final class JDBCUtil
         }
 
         return recordHandlerMap.build();
+    }
+
+    public static String checkEnvironment(String databaseEngine, String url)
+    {
+        if ("synapse".equals(databaseEngine)) {
+            // checking whether it's Azure serverless environment or not based on host name
+            Matcher m = Pattern.compile("([a-zA-Z]+)://([^;]+);(.*)").matcher(url);
+            String hostName = "";
+            if (m.find() && m.groupCount() == 3) {
+                hostName = m.group(2);
+            }
+            if (StringUtils.isNotBlank(hostName) && hostName.contains("ondemand")) {
+                return "azureServerless";
+            }
+        }
+        return null;
     }
 }

--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JDBCUtil.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JDBCUtil.java
@@ -34,6 +34,7 @@ public final class JDBCUtil
 {
     private static final String DEFAULT_CATALOG_PREFIX = "lambda:";
     private static final String LAMBDA_FUNCTION_NAME_PROPERTY = "AWS_LAMBDA_FUNCTION_NAME";
+    private static final Pattern SYNAPSE_CONN_STRING_PATTERN = Pattern.compile("([a-zA-Z]+)://([^;]+);(.*)");
     private JDBCUtil() {}
 
     /**
@@ -136,7 +137,7 @@ public final class JDBCUtil
     {
         if ("synapse".equals(databaseEngine)) {
             // checking whether it's Azure serverless environment or not based on host name
-            Matcher m = Pattern.compile("([a-zA-Z]+)://([^;]+);(.*)").matcher(url);
+            Matcher m = SYNAPSE_CONN_STRING_PATTERN.matcher(url);
             String hostName = "";
             if (m.find() && m.groupCount() == 3) {
                 hostName = m.group(2);

--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcRecordHandler.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcRecordHandler.java
@@ -86,8 +86,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * Abstracts JDBC record handler and provides common reusable split records handling.
@@ -165,21 +163,8 @@ public abstract class JdbcRecordHandler
                 }
                 LOGGER.info("{} rows returned by database.", rowsReturnedFromDatabase);
 
-                boolean isAzureServerless = false;
-                // checking whether it's Azure serverless environment or not based on host name
-                if("synapse".equals(this.databaseConnectionConfig.getEngine())) {
-                    Matcher m = Pattern.compile("([a-zA-Z]+)://([^;]+);(.*)").matcher(connection.getMetaData().getURL());
-                    String hostName = "";
-                    if (m.find() && m.groupCount() == 3) {
-                        hostName = m.group(2);
-                    }
-                    if(StringUtils.isNotBlank(hostName) && hostName.contains("ondemand")) {
-                        isAzureServerless = true;
-                    }
-                }
-
                 // Not performing commit() in case of Azure serverless environment
-                if (!isAzureServerless) {
+                if (!"azureServerless".equals(JDBCUtil.checkEnvironment(this.databaseConnectionConfig.getEngine(), connection.getMetaData().getURL()))) {
                     connection.commit();
                 }
             }

--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcRecordHandler.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcRecordHandler.java
@@ -120,7 +120,7 @@ public abstract class JdbcRecordHandler
         return jdbcConnectionFactory;
     }
 
-    private JdbcCredentialProvider getCredentialProvider()
+    protected JdbcCredentialProvider getCredentialProvider()
     {
         final String secretName = this.databaseConnectionConfig.getSecret();
         if (StringUtils.isNotBlank(secretName)) {
@@ -163,12 +163,7 @@ public abstract class JdbcRecordHandler
                 }
                 LOGGER.info("{} rows returned by database.", rowsReturnedFromDatabase);
 
-                // SqlServer jdbc driver is using @@TRANCOUNT while performing commit(), it results below RuntimeException.
-                // com.microsoft.sqlserver.jdbc.SQLServerException:  '@@TRANCOUNT' is not supported.
-                // So we are evading this connection.commit(), in case of Azure serverless environment.
-                if (!"azureServerless".equals(JDBCUtil.checkEnvironment(this.databaseConnectionConfig.getEngine(), connection.getMetaData().getURL()))) {
-                    connection.commit();
-                }
+                connection.commit();
             }
         }
         catch (SQLException sqlException) {

--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcRecordHandler.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcRecordHandler.java
@@ -163,7 +163,10 @@ public abstract class JdbcRecordHandler
                 }
                 LOGGER.info("{} rows returned by database.", rowsReturnedFromDatabase);
 
-                connection.commit();
+                String url = connection.getMetaData().getURL();
+                if (!("synapse".equals(this.databaseConnectionConfig.getEngine()) && url.contains("ondemand"))) {
+                    connection.commit();
+                }
             }
         }
         catch (SQLException sqlException) {

--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcRecordHandler.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcRecordHandler.java
@@ -163,7 +163,9 @@ public abstract class JdbcRecordHandler
                 }
                 LOGGER.info("{} rows returned by database.", rowsReturnedFromDatabase);
 
-                // Not performing commit() in case of Azure serverless environment
+                // SqlServer jdbc driver is using @@TRANCOUNT while performing commit(), it results below RuntimeException.
+                // com.microsoft.sqlserver.jdbc.SQLServerException:  '@@TRANCOUNT' is not supported.
+                // So we are evading this connection.commit(), in case of Azure serverless environment.
                 if (!"azureServerless".equals(JDBCUtil.checkEnvironment(this.databaseConnectionConfig.getEngine(), connection.getMetaData().getURL()))) {
                     connection.commit();
                 }

--- a/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseMetadataHandler.java
+++ b/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseMetadataHandler.java
@@ -324,7 +324,7 @@ public class SynapseMetadataHandler extends JdbcMetadataHandler
             }
         }
 
-        if ("azureServerless".equalsIgnoreCase(JDBCUtil.checkEnvironment(SynapseConstants.NAME, jdbcConnection.getMetaData().getURL()))) {
+        if ("azureServerless".equalsIgnoreCase(SynapseUtil.checkEnvironment(jdbcConnection.getMetaData().getURL()))) {
             // getColumns() method from SQL Server driver is causing an exception in case of Azure Serverless environment.
             // so doing explicit data type conversion
             schemaBuilder = doDataTypeConversion(columnNameAndDataTypeMap, tableName.getSchemaName());

--- a/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseUtil.java
+++ b/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseUtil.java
@@ -28,7 +28,6 @@ public class SynapseUtil
 {
     private SynapseUtil()
     {
-
     }
 
     private static final Pattern SYNAPSE_CONN_STRING_PATTERN = Pattern.compile("([a-zA-Z]+)://([^;]+);(.*)");

--- a/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseUtil.java
+++ b/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseUtil.java
@@ -1,0 +1,49 @@
+/*-
+ * #%L
+ * athena-synapse
+ * %%
+ * Copyright (C) 2019 - 2022 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.synapse;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class SynapseUtil
+{
+    private SynapseUtil()
+    {
+
+    }
+
+    private static final Pattern SYNAPSE_CONN_STRING_PATTERN = Pattern.compile("([a-zA-Z]+)://([^;]+);(.*)");
+
+    public static String checkEnvironment(String url)
+    {
+        // checking whether it's Azure serverless environment or not based on host name
+        Matcher m = SYNAPSE_CONN_STRING_PATTERN.matcher(url);
+        String hostName = "";
+        if (m.find() && m.groupCount() == 3) {
+            hostName = m.group(2);
+        }
+        if (StringUtils.isNotBlank(hostName) && hostName.contains("ondemand")) {
+            return "azureServerless";
+        }
+        return null;
+    }
+}

--- a/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/integ/AzureSynapseIntegTest.java
+++ b/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/integ/AzureSynapseIntegTest.java
@@ -21,7 +21,6 @@ package com.amazonaws.athena.connectors.synapse.integ;
 
 import com.amazonaws.athena.connector.integ.IntegrationTestBase;
 import com.amazonaws.athena.connector.integ.data.TestConfig;
-import com.amazonaws.services.athena.model.Row;
 import com.google.common.collect.ImmutableList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;


### PR DESCRIPTION
*Issue # INC00001062 : External Table Access Issue In Azure Server Less Environment (Synapse) (Issue Raised Directly By Client)

The issue has been raised from JDBC Driver when we try to access table metadata, so avoided getColumns() method call in case of Azure Server less environment. 
After fixing this, got another issue from driver i.e @@TRANCOUNT' is not supported
In JdbcRecordHandler, refactored conn.commit() to if condition to resolve it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
