### PR TITLE
Fix for Sql Server partition issue

### DIFF
--- a/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerMetadataHandler.java
+++ b/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerMetadataHandler.java
@@ -183,7 +183,6 @@ public class SqlServerMetadataHandler extends JdbcMetadataHandler
                  PreparedStatement preparedStatement2 = new PreparedStatementBuilder().withConnection(connection).withQuery(ROW_COUNT_QUERY).withParameters(parameters).build();
                  ResultSet resultSet = preparedStatement.executeQuery();
                  ResultSet resultSet2 = preparedStatement2.executeQuery()) {
-
                 int rowCount = 0;
                 // check whether the table have partitions or not using ROW_COUNT_QUERY
                 if (resultSet2.next()) {

--- a/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerMetadataHandler.java
+++ b/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerMetadataHandler.java
@@ -59,6 +59,7 @@ import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -69,6 +70,8 @@ import java.util.stream.Collectors;
 
 public class SqlServerMetadataHandler extends JdbcMetadataHandler
 {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SqlServerMetadataHandler.class);
+
     static final Map<String, String> JDBC_PROPERTIES = ImmutableMap.of("databaseTerm", "SCHEMA");
     static final String ALL_PARTITIONS = "0";
     static final String PARTITION_NUMBER = "PARTITION_NUMBER";
@@ -85,13 +88,13 @@ public class SqlServerMetadataHandler extends JdbcMetadataHandler
      */
     static final String GET_PARTITIONS_QUERY = "select distinct PARTITION_NUMBER from SYS.DM_DB_PARTITION_STATS where object_id = OBJECT_ID(?) and partition_number > 1 "; //'dbo.MyPartitionTable'
     static final String ROW_COUNT_QUERY = "select count(distinct PARTITION_NUMBER) as row_count from SYS.DM_DB_PARTITION_STATS where object_id = OBJECT_ID(?) and partition_number > 1 ";
-    private static final Logger LOGGER = LoggerFactory.getLogger(SqlServerMetadataHandler.class);
+
     private static final int MAX_SPLITS_PER_REQUEST = 1000_000;
 
     /**
      * Query for retrieving Sql Server table partition details
      */
-    static final String GET_PARTITION_FUNCTION_QUERY = "SELECT " +
+    static final String GET_PARTITION_DETAILS_QUERY = "SELECT " +
             "c.name AS [Partitioning Column], " +
             "       pf.name AS [Partition Function] " +
             "FROM sys.tables AS t   " +
@@ -111,10 +114,6 @@ public class SqlServerMetadataHandler extends JdbcMetadataHandler
             "WHERE t.object_id = (select object_id from sys.objects o where o.name = ? " +
             "and schema_id = (select schema_id from sys.schemas s where s.name = ?))";
     static final String VIEW_CHECK_QUERY = "select TYPE_DESC from sys.objects where name = ? and schema_id = (select schema_id from sys.schemas s where s.name = ?)";
-
-    String partitionFunction;
-    String partitioningColumn;
-    int rowCount;
 
     public SqlServerMetadataHandler()
     {
@@ -162,8 +161,6 @@ public class SqlServerMetadataHandler extends JdbcMetadataHandler
         LOGGER.info("{}: Schema {}, table {}", getTableLayoutRequest.getQueryId(), getTableLayoutRequest.getTableName().getSchemaName(),
                 getTableLayoutRequest.getTableName().getTableName());
         List<String> params = Arrays.asList(getTableLayoutRequest.getTableName().getTableName(), getTableLayoutRequest.getTableName().getSchemaName());
-        List<String> parameters = Arrays.asList(getTableLayoutRequest.getTableName().getSchemaName() + "." +
-                getTableLayoutRequest.getTableName().getTableName());
 
         //check whether the input table is a view or not
         String viewFlag = "N";
@@ -180,10 +177,14 @@ public class SqlServerMetadataHandler extends JdbcMetadataHandler
         }
 
         try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider())) {
+            List<String> parameters = Arrays.asList(getTableLayoutRequest.getTableName().getSchemaName() + "." +
+                    getTableLayoutRequest.getTableName().getTableName());
             try (PreparedStatement preparedStatement = new PreparedStatementBuilder().withConnection(connection).withQuery(GET_PARTITIONS_QUERY).withParameters(parameters).build();
                  PreparedStatement preparedStatement2 = new PreparedStatementBuilder().withConnection(connection).withQuery(ROW_COUNT_QUERY).withParameters(parameters).build();
                  ResultSet resultSet = preparedStatement.executeQuery();
                  ResultSet resultSet2 = preparedStatement2.executeQuery()) {
+
+                int rowCount = 0;
                 // check whether the table have partitions or not using ROW_COUNT_QUERY
                 if (resultSet2.next()) {
                     rowCount = resultSet2.getInt("ROW_COUNT");
@@ -203,12 +204,14 @@ public class SqlServerMetadataHandler extends JdbcMetadataHandler
                 else {
                     LOGGER.debug("Getting data with diff Partitions: ");
                     // get partition details from sql server meta data tables
-                    getPartitionFunction(params);
+                    List<String> partitionDetails = getPartitionDetails(params);
+                    String partitionInfo = (!partitionDetails.isEmpty() && partitionDetails.size() == 2) ?
+                            ":::" + partitionDetails.get(0) + ":::" + partitionDetails.get(1) : "";
 
                     // Include the first partition because it's not retrieved from GET_PARTITIONS_QUERY
                     blockWriter.writeRows((Block block, int rowNum) ->
                     {
-                        block.setValue(PARTITION_NUMBER, rowNum, "1" + ":::" + partitionFunction + ":::" + partitioningColumn);
+                        block.setValue(PARTITION_NUMBER, rowNum, "1" + partitionInfo);
                         return 1;
                     });
                     if (resultSet.next()) {
@@ -218,7 +221,7 @@ public class SqlServerMetadataHandler extends JdbcMetadataHandler
                             // 2. This API is not paginated, we could use order by and limit clause with offsets here.
                             blockWriter.writeRows((Block block, int rowNum) ->
                             {
-                                block.setValue(PARTITION_NUMBER, rowNum, partitionNumber + ":::" + partitionFunction + ":::" + partitioningColumn);
+                                block.setValue(PARTITION_NUMBER, rowNum, partitionNumber + partitionInfo);
                                 //we wrote 1 row so we return 1
                                 return 1;
                             });
@@ -244,6 +247,7 @@ public class SqlServerMetadataHandler extends JdbcMetadataHandler
         LOGGER.info("{}: Catalog {}, table {}", getSplitsRequest.getQueryId(), getSplitsRequest.getTableName().getSchemaName(), getSplitsRequest.getTableName().getTableName());
 
         int partitionContd = decodeContinuationToken(getSplitsRequest);
+        LOGGER.info("partitionContd: {}", partitionContd);
         Set<Split> splits = new HashSet<>();
         Block partitions = getSplitsRequest.getPartitions();
 
@@ -296,21 +300,23 @@ public class SqlServerMetadataHandler extends JdbcMetadataHandler
      * @param parameters
      * @throws SQLException
      */
-    private void getPartitionFunction(List<String> parameters) throws SQLException
+    private List<String> getPartitionDetails(List<String> parameters) throws SQLException
     {
+        List<String> partitionDetails = new ArrayList<>();
         try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider());
-             PreparedStatement preparedStatement = new PreparedStatementBuilder().withConnection(connection).withQuery(GET_PARTITION_FUNCTION_QUERY).withParameters(parameters).build();
+             PreparedStatement preparedStatement = new PreparedStatementBuilder().withConnection(connection).withQuery(GET_PARTITION_DETAILS_QUERY).withParameters(parameters).build();
              ResultSet resultSet = preparedStatement.executeQuery()) {
             if (resultSet.next()) {
-                partitionFunction = resultSet.getString("PARTITION FUNCTION");
-                partitioningColumn = resultSet.getString("PARTITIONING COLUMN");
+                partitionDetails.add(resultSet.getString("PARTITION FUNCTION"));
+                partitionDetails.add(resultSet.getString("PARTITIONING COLUMN"));
+                LOGGER.debug("partitionFunction: {}", partitionDetails.get(0));
+                LOGGER.debug("partitioningColumn: {}", partitionDetails.get(1));
             }
-            LOGGER.debug("partitionFunction: {}", partitionFunction);
-            LOGGER.debug("partitioningColumn: {}", partitioningColumn);
         }
         catch (SQLException sqlException) {
             throw new SQLException(sqlException.getErrorCode() + ": " + sqlException.getMessage(), sqlException);
         }
+        return partitionDetails;
     }
 
     /**

--- a/athena-sqlserver/src/test/java/com/amazonaws/athena/connectors/sqlserver/SqlServerMetadataHandlerTest.java
+++ b/athena-sqlserver/src/test/java/com/amazonaws/athena/connectors/sqlserver/SqlServerMetadataHandlerTest.java
@@ -128,6 +128,11 @@ public class SqlServerMetadataHandlerTest
         ResultSet resultSet = mockResultSet(columns, types, values, new AtomicInteger(-1));
         Mockito.when(preparedStatement.executeQuery()).thenReturn(resultSet);
 
+        PreparedStatement partFuncPreparedStatement = Mockito.mock(PreparedStatement.class);
+        Mockito.when(this.connection.prepareStatement(sqlServerMetadataHandler.GET_PARTITION_FUNCTION_QUERY)).thenReturn(partFuncPreparedStatement);
+        ResultSet partFuncResultSet = mockResultSet(new String[] {"PARTITION FUNCTION", "PARTITIONING COLUMN"}, new int[] {Types.VARCHAR, Types.VARCHAR}, new Object[][] {{"pf", "pc"}}, new AtomicInteger(-1));
+        Mockito.when(partFuncPreparedStatement.executeQuery()).thenReturn(partFuncResultSet);
+
         Mockito.when(this.connection.getMetaData().getSearchStringEscape()).thenReturn(null);
         GetTableLayoutResponse getTableLayoutResponse = this.sqlServerMetadataHandler.doGetTableLayout(blockAllocator, getTableLayoutRequest);
 
@@ -135,7 +140,7 @@ public class SqlServerMetadataHandlerTest
         for (int i = 0; i < getTableLayoutResponse.getPartitions().getRowCount(); i++) {
             actualValues.add(BlockUtils.rowToString(getTableLayoutResponse.getPartitions(), i));
         }
-        Assert.assertEquals(Arrays.asList("[PARTITION_NUMBER : 1]","[PARTITION_NUMBER : 2]","[PARTITION_NUMBER : 3]"), actualValues);
+        Assert.assertEquals(Arrays.asList("[PARTITION_NUMBER : 1:::pf:::pc]","[PARTITION_NUMBER : 2:::pf:::pc]","[PARTITION_NUMBER : 3:::pf:::pc]"), actualValues);
 
         SchemaBuilder expectedSchemaBuilder = SchemaBuilder.newBuilder();
         expectedSchemaBuilder.addField(FieldBuilder.newBuilder(sqlServerMetadataHandler.PARTITION_NUMBER, org.apache.arrow.vector.types.Types.MinorType.VARCHAR.getType()).build());

--- a/athena-sqlserver/src/test/java/com/amazonaws/athena/connectors/sqlserver/SqlServerMetadataHandlerTest.java
+++ b/athena-sqlserver/src/test/java/com/amazonaws/athena/connectors/sqlserver/SqlServerMetadataHandlerTest.java
@@ -129,7 +129,7 @@ public class SqlServerMetadataHandlerTest
         Mockito.when(preparedStatement.executeQuery()).thenReturn(resultSet);
 
         PreparedStatement partFuncPreparedStatement = Mockito.mock(PreparedStatement.class);
-        Mockito.when(this.connection.prepareStatement(sqlServerMetadataHandler.GET_PARTITION_FUNCTION_QUERY)).thenReturn(partFuncPreparedStatement);
+        Mockito.when(this.connection.prepareStatement(sqlServerMetadataHandler.GET_PARTITION_DETAILS_QUERY)).thenReturn(partFuncPreparedStatement);
         ResultSet partFuncResultSet = mockResultSet(new String[] {"PARTITION FUNCTION", "PARTITIONING COLUMN"}, new int[] {Types.VARCHAR, Types.VARCHAR}, new Object[][] {{"pf", "pc"}}, new AtomicInteger(-1));
         Mockito.when(partFuncPreparedStatement.executeQuery()).thenReturn(partFuncResultSet);
 
@@ -245,7 +245,7 @@ public class SqlServerMetadataHandlerTest
         Mockito.when(preparedStatement.executeQuery()).thenReturn(resultSet);
 
         PreparedStatement partFuncPreparedStatement = Mockito.mock(PreparedStatement.class);
-        Mockito.when(this.connection.prepareStatement(sqlServerMetadataHandler.GET_PARTITION_FUNCTION_QUERY)).thenReturn(partFuncPreparedStatement);
+        Mockito.when(this.connection.prepareStatement(sqlServerMetadataHandler.GET_PARTITION_DETAILS_QUERY)).thenReturn(partFuncPreparedStatement);
         ResultSet partFuncResultSet = mockResultSet(new String[] {"PARTITION FUNCTION", "PARTITIONING COLUMN"}, new int[] {Types.VARCHAR, Types.VARCHAR}, new Object[][] {{"pf", "pc"}}, new AtomicInteger(-1));
         Mockito.when(partFuncPreparedStatement.executeQuery()).thenReturn(partFuncResultSet);
 
@@ -351,7 +351,7 @@ public class SqlServerMetadataHandlerTest
         Mockito.when(preparedStatement.executeQuery()).thenReturn(resultSet);
 
         PreparedStatement partFuncPreparedStatement = Mockito.mock(PreparedStatement.class);
-        Mockito.when(this.connection.prepareStatement(sqlServerMetadataHandler.GET_PARTITION_FUNCTION_QUERY)).thenReturn(partFuncPreparedStatement);
+        Mockito.when(this.connection.prepareStatement(sqlServerMetadataHandler.GET_PARTITION_DETAILS_QUERY)).thenReturn(partFuncPreparedStatement);
         ResultSet partFuncResultSet = mockResultSet(new String[] {"PARTITION FUNCTION", "PARTITIONING COLUMN"}, new int[] {Types.VARCHAR, Types.VARCHAR}, new Object[][] {{"pf", "pc"}}, new AtomicInteger(-1));
         Mockito.when(partFuncPreparedStatement.executeQuery()).thenReturn(partFuncResultSet);
 


### PR DESCRIPTION
*Issue #INC00001064, Sqlserver Connector Generating $PARTITION Clauses With Nulls.*

*Included partition information to the block to fix null issue while forming the query for partitioned table,
modified corresponding mockito test case as well.*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
