### PR TITLE
Update the aws-athena-query-federation version

### DIFF
--- a/athena-aws-cmdb/pom.xml
+++ b/athena-aws-cmdb/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>1.1.12</version>
+        <version>${aws-athena-query-federation.version}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/athena-cloudera-hive/pom.xml
+++ b/athena-cloudera-hive/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>1.1.12</version>
+        <version>${aws-athena-query-federation.version}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/athena-cloudera-impala/pom.xml
+++ b/athena-cloudera-impala/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>1.1.12</version>
+        <version>${aws-athena-query-federation.version}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/athena-cloudwatch-metrics/pom.xml
+++ b/athena-cloudwatch-metrics/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>1.1.12</version>
+        <version>${aws-athena-query-federation.version}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/athena-cloudwatch/pom.xml
+++ b/athena-cloudwatch/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>1.1.12</version>
+        <version>${aws-athena-query-federation.version}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/athena-datalakegen2/pom.xml
+++ b/athena-datalakegen2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>1.1.12</version>
+        <version>${aws-athena-query-federation.version}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/athena-docdb/pom.xml
+++ b/athena-docdb/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>1.1.12</version>
+        <version>${aws-athena-query-federation.version}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/athena-dynamodb/pom.xml
+++ b/athena-dynamodb/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>1.1.12</version>
+        <version>${aws-athena-query-federation.version}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/athena-elasticsearch/pom.xml
+++ b/athena-elasticsearch/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>1.1.12</version>
+        <version>${aws-athena-query-federation.version}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/athena-example/pom.xml
+++ b/athena-example/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>1.1.12</version>
+        <version>${aws-athena-query-federation.version}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/athena-federation-integ-test/pom.xml
+++ b/athena-federation-integ-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>1.1.12</version>
+        <version>${aws-athena-query-federation.version}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/athena-federation-sdk-tools/pom.xml
+++ b/athena-federation-sdk-tools/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>1.1.12</version>
+        <version>${aws-athena-query-federation.version}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/athena-federation-sdk/pom.xml
+++ b/athena-federation-sdk/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-athena-query-federation</artifactId>
-        <version>1.1.12</version>
+        <version>${aws-athena-query-federation.version}</version>
     </parent>
 
     <groupId>com.amazonaws</groupId>

--- a/athena-google-bigquery/pom.xml
+++ b/athena-google-bigquery/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>1.1.12</version>
+        <version>${aws-athena-query-federation.version}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/athena-hbase/pom.xml
+++ b/athena-hbase/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>1.1.12</version>
+        <version>${aws-athena-query-federation.version}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/athena-hortonworks-hive/pom.xml
+++ b/athena-hortonworks-hive/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>1.1.12</version>
+        <version>${aws-athena-query-federation.version}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/athena-jdbc/pom.xml
+++ b/athena-jdbc/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>1.1.12</version>
+        <version>${aws-athena-query-federation.version}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/athena-mysql/pom.xml
+++ b/athena-mysql/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>1.1.12</version>
+        <version>${aws-athena-query-federation.version}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/athena-neptune/pom.xml
+++ b/athena-neptune/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>1.1.12</version>
+        <version>${aws-athena-query-federation.version}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/athena-oracle/pom.xml
+++ b/athena-oracle/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>1.1.12</version>
+        <version>${aws-athena-query-federation.version}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/athena-postgresql/pom.xml
+++ b/athena-postgresql/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>1.1.12</version>
+        <version>${aws-athena-query-federation.version}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/athena-redis/pom.xml
+++ b/athena-redis/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>1.1.12</version>
+        <version>${aws-athena-query-federation.version}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/athena-redshift/pom.xml
+++ b/athena-redshift/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>1.1.12</version>
+        <version>${aws-athena-query-federation.version}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/athena-saphana/pom.xml
+++ b/athena-saphana/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>1.1.12</version>
+        <version>${aws-athena-query-federation.version}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/athena-snowflake/pom.xml
+++ b/athena-snowflake/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>1.1.12</version>
+        <version>${aws-athena-query-federation.version}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/athena-sqlserver/pom.xml
+++ b/athena-sqlserver/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>1.1.12</version>
+        <version>${aws-athena-query-federation.version}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/athena-synapse/pom.xml
+++ b/athena-synapse/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>1.1.12</version>
+        <version>${aws-athena-query-federation.version}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/athena-teradata/pom.xml
+++ b/athena-teradata/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>1.1.12</version>
+        <version>${aws-athena-query-federation.version}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/athena-timestream/pom.xml
+++ b/athena-timestream/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>1.1.12</version>
+        <version>${aws-athena-query-federation.version}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/athena-tpcds/pom.xml
+++ b/athena-tpcds/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>1.1.12</version>
+        <version>${aws-athena-query-federation.version}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/athena-udfs/pom.xml
+++ b/athena-udfs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>1.1.12</version>
+        <version>${aws-athena-query-federation.version}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/athena-vertica/pom.xml
+++ b/athena-vertica/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>1.1.12</version>
+        <version>${aws-athena-query-federation.version}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-athena-query-federation</artifactId>
     <packaging>pom</packaging>
-    <version>1.1.12</version>
+    <version>${aws-athena-query-federation.version}</version>
     <name>AWS Athena Query Federation</name>
     <description>The Amazon Athena Query Federation SDK allows you to customize Amazon Athena with your own code.</description>
     <url>https://github.com/awslabs/aws-athena-query-federation</url>
@@ -15,6 +15,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <aws-sdk.version>1.11.800</aws-sdk.version>
+        <aws-athena-query-federation.version>1.1.12</aws-athena-query-federation.version>
         <aws-athena-federation-sdk.version>2022.22.1</aws-athena-federation-sdk.version>
         <aws.lambda-java-core.version>1.2.0</aws.lambda-java-core.version>
         <aws.lambda-java-log4j2.version>1.5.1</aws.lambda-java-log4j2.version>


### PR DESCRIPTION
Also updates child projects pom.xmls to use the newly
defined aws-athena-query-federation.version property.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
