### PR TITLE
mvn stuff: flip the ordering of the deploy

### DIFF
--- a/.github/workflows/publish_to_maven_central.yml
+++ b/.github/workflows/publish_to_maven_central.yml
@@ -26,7 +26,7 @@ jobs:
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
       - name: Publish to Apache Maven Central
-        run: mvn clean deploy --batch-mode -P release -pl ".,athena-federation-sdk"
+        run: mvn clean deploy --batch-mode -P release -pl "athena-federation-sdk,."
         env:
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}


### PR DESCRIPTION
Publish the child sdk project first before publishing the parent.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
