### PR TITLE
S3BlockSpiller: fix double buffering bug

### DIFF
--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/S3BlockSpiller.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/S3BlockSpiller.java
@@ -314,10 +314,16 @@ public class S3BlockSpiller
             totalBytesSpilled.addAndGet(bytes.length);
 
             logger.info("write: Started spilling block of size {} bytes", bytes.length);
+
+            // Set the contentLength otherwise the s3 client will buffer again since it
+            // only sees the InputStream wrapper.
+            ObjectMetadata objMeta = new ObjectMetadata();
+            objMeta.setContentLength(bytes.length);
+
             amazonS3.putObject(spillLocation.getBucket(),
                     spillLocation.getKey(),
                     new ByteArrayInputStream(bytes),
-                    new ObjectMetadata());
+                    objMeta);
             logger.info("write: Completed spilling block of size {} bytes", bytes.length);
 
             return spillLocation;


### PR DESCRIPTION
The content length was not being set before while spilling to s3.
Since the s3 client method putRequest() is seeing an InputStream, it doesn't
know that it is reading from a byte array and it will buffer again to find
the length.

See this: https://docs.aws.amazon.com/codeguru/detector-library/java/s3-object-metadata-content-length-check/


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
