### PR TITLE
Cut release 2022.24.1

### DIFF
--- a/athena-aws-cmdb/athena-aws-cmdb.yaml
+++ b/athena-aws-cmdb/athena-aws-cmdb.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.23.1
+    SemanticVersion: 2022.24.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AthenaCatalogName:
@@ -47,7 +47,7 @@ Resources:
           spill_prefix: !Ref SpillPrefix
       FunctionName: !Ref AthenaCatalogName
       Handler: "com.amazonaws.athena.connectors.aws.cmdb.AwsCmdbCompositeHandler"
-      CodeUri: "./target/athena-aws-cmdb-2022.23.1.jar"
+      CodeUri: "./target/athena-aws-cmdb-2022.24.1.jar"
       Description: "Enables Amazon Athena to communicate with various AWS Services, making your resource inventories accessible via SQL."
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-aws-cmdb/pom.xml
+++ b/athena-aws-cmdb/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.23.1</version>
+        <version>2022.24.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-aws-cmdb</artifactId>
-    <version>2022.23.1</version>
+    <version>2022.24.1</version>
     <properties>
         <slf4jVersion>1.7.30</slf4jVersion>
     </properties>
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>

--- a/athena-cloudera-hive/athena-cloudera-hive.yaml
+++ b/athena-cloudera-hive/athena-cloudera-hive.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.23.1
+    SemanticVersion: 2022.24.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   LambdaFunctionName:
@@ -60,7 +60,7 @@ Resources:
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.cloudera.HiveMuxCompositeHandler"
-      CodeUri: "./target/athena-cloudera-hive-2022.23.1.jar"
+      CodeUri: "./target/athena-cloudera-hive-2022.24.1.jar"
       Description: "Enables Amazon Athena to communicate with Coludera Hive using JDBC"
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-cloudera-hive/pom.xml
+++ b/athena-cloudera-hive/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.23.1</version>
+        <version>2022.24.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-cloudera-hive</artifactId>
-    <version>2022.23.1</version>
+    <version>2022.24.1</version>
     <properties>
         <slf4jVersion>1.7.30</slf4jVersion>
         <clouderaVersion>2.6.15.1018</clouderaVersion>
@@ -16,13 +16,13 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
         </dependency>
         <dependency>
             <groupId>Hive</groupId>
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/athena-cloudera-impala/athena-cloudera-impala.yaml
+++ b/athena-cloudera-impala/athena-cloudera-impala.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.23.1
+    SemanticVersion: 2022.24.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   LambdaFunctionName:
@@ -60,7 +60,7 @@ Resources:
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.cloudera.ImpalaMuxCompositeHandler"
-      CodeUri: "./target/athena-cloudera-impala-2022.23.1.jar"
+      CodeUri: "./target/athena-cloudera-impala-2022.24.1.jar"
       Description: "Enables Amazon Athena to communicate with Cloudera Impala using JDBC"
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-cloudera-impala/pom.xml
+++ b/athena-cloudera-impala/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.23.1</version>
+        <version>2022.24.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-cloudera-impala</artifactId>
-    <version>2022.23.1</version>
+    <version>2022.24.1</version>
     <properties>
         <slf4jVersion>1.7.30</slf4jVersion>
         <clouderaVersion>2.6.26.1031</clouderaVersion>
@@ -16,13 +16,13 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
         </dependency>
         <dependency>
             <groupId>Impala</groupId>
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/athena-cloudwatch-metrics/athena-cloudwatch-metrics.yaml
+++ b/athena-cloudwatch-metrics/athena-cloudwatch-metrics.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.23.1
+    SemanticVersion: 2022.24.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AthenaCatalogName:
@@ -47,7 +47,7 @@ Resources:
           spill_prefix: !Ref SpillPrefix
       FunctionName: !Ref AthenaCatalogName
       Handler: "com.amazonaws.athena.connectors.cloudwatch.metrics.MetricsCompositeHandler"
-      CodeUri: "./target/athena-cloudwatch-metrics-2022.23.1.jar"
+      CodeUri: "./target/athena-cloudwatch-metrics-2022.24.1.jar"
       Description: "Enables Amazon Athena to communicate with Cloudwatch Metrics, making your metrics data accessible via SQL"
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-cloudwatch-metrics/pom.xml
+++ b/athena-cloudwatch-metrics/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.23.1</version>
+        <version>2022.24.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-cloudwatch-metrics</artifactId>
-    <version>2022.23.1</version>
+    <version>2022.24.1</version>
     <properties>
         <slf4jVersion>1.7.30</slf4jVersion>
     </properties>
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>

--- a/athena-cloudwatch/athena-cloudwatch.yaml
+++ b/athena-cloudwatch/athena-cloudwatch.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.23.1
+    SemanticVersion: 2022.24.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AthenaCatalogName:
@@ -56,7 +56,7 @@ Resources:
           kms_key_id: !If [HasKMSKeyId, !Ref KMSKeyId, !Ref "AWS::NoValue"]
       FunctionName: !Ref AthenaCatalogName
       Handler: "com.amazonaws.athena.connectors.cloudwatch.CloudwatchCompositeHandler"
-      CodeUri: "./target/athena-cloudwatch-2022.23.1.jar"
+      CodeUri: "./target/athena-cloudwatch-2022.24.1.jar"
       Description: "Enables Amazon Athena to communicate with Cloudwatch, making your log accessible via SQL"
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-cloudwatch/pom.xml
+++ b/athena-cloudwatch/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.23.1</version>
+        <version>2022.24.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-cloudwatch</artifactId>
-    <version>2022.23.1</version>
+    <version>2022.24.1</version>
     <properties>
         <slf4jVersion>1.7.30</slf4jVersion>
     </properties>
@@ -15,12 +15,12 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awscdk/logs -->

--- a/athena-datalakegen2/athena-datalakegen2.yaml
+++ b/athena-datalakegen2/athena-datalakegen2.yaml
@@ -12,7 +12,7 @@ Metadata:
       - athena-federation
       - jdbc
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.23.1
+    SemanticVersion: 2022.24.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   LambdaFunctionName:
@@ -62,7 +62,7 @@ Resources:
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.datalakegen2.DataLakeGen2MuxCompositeHandler"
-      CodeUri: "./target/athena-datalakegen2-2022.23.1.jar"
+      CodeUri: "./target/athena-datalakegen2-2022.24.1.jar"
       Description: "Enables Amazon Athena to communicate with DataLake Gen2 using JDBC"
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-datalakegen2/pom.xml
+++ b/athena-datalakegen2/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.23.1</version>
+        <version>2022.24.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-datalakegen2</artifactId>
-    <version>2022.23.1</version>
+    <version>2022.24.1</version>
     <properties>
         <slf4jVersion>1.7.30</slf4jVersion>
     </properties>
@@ -15,18 +15,18 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/athena-docdb/athena-docdb.yaml
+++ b/athena-docdb/athena-docdb.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.23.1
+    SemanticVersion: 2022.24.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AthenaCatalogName:
@@ -61,7 +61,7 @@ Resources:
           default_docdb: !Ref DocDBConnectionString
       FunctionName: !Ref AthenaCatalogName
       Handler: "com.amazonaws.athena.connectors.docdb.DocDBCompositeHandler"
-      CodeUri: "./target/athena-docdb-2022.23.1.jar"
+      CodeUri: "./target/athena-docdb-2022.24.1.jar"
       Description: "Enables Amazon Athena to communicate with DocumentDB, making your DocumentDB data accessible via SQL."
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-docdb/pom.xml
+++ b/athena-docdb/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.23.1</version>
+        <version>2022.24.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-docdb</artifactId>
-    <version>2022.23.1</version>
+    <version>2022.24.1</version>
     <properties>
         <slf4jVersion>1.7.30</slf4jVersion>
     </properties>
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
                 <exclusion>
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-docdb -->

--- a/athena-dynamodb/athena-dynamodb.yaml
+++ b/athena-dynamodb/athena-dynamodb.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.23.1
+    SemanticVersion: 2022.24.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AthenaCatalogName:
@@ -56,7 +56,7 @@ Resources:
           kms_key_id: !If [HasKMSKeyId, !Ref KMSKeyId, !Ref "AWS::NoValue"]
       FunctionName: !Ref AthenaCatalogName
       Handler: "com.amazonaws.athena.connectors.dynamodb.DynamoDBCompositeHandler"
-      CodeUri: "./target/athena-dynamodb-2022.23.1.jar"
+      CodeUri: "./target/athena-dynamodb-2022.24.1.jar"
       Description: "Enables Amazon Athena to communicate with DynamoDB, making your tables accessible via SQL"
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-dynamodb/pom.xml
+++ b/athena-dynamodb/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.23.1</version>
+        <version>2022.24.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-dynamodb</artifactId>
-    <version>2022.23.1</version>
+    <version>2022.24.1</version>
     <properties>
         <slf4jVersion>1.7.30</slf4jVersion>
     </properties>
@@ -15,12 +15,12 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/athena-elasticsearch/athena-elasticsearch.yaml
+++ b/athena-elasticsearch/athena-elasticsearch.yaml
@@ -10,7 +10,7 @@ Metadata:
     ReadmeUrl: README.md
     Labels: ['athena-federation']
     HomePageUrl: https://github.com/awslabs/aws-athena-query-federation
-    SemanticVersion: 2022.23.1
+    SemanticVersion: 2022.24.1
     SourceCodeUrl: https://github.com/awslabs/aws-athena-query-federation
 
 # Parameters are CloudFormation features to pass input
@@ -93,7 +93,7 @@ Resources:
           query_timeout_search: !Ref QueryTimeoutSearch
       FunctionName: !Sub "${AthenaCatalogName}"
       Handler: "com.amazonaws.athena.connectors.elasticsearch.ElasticsearchCompositeHandler"
-      CodeUri: "./target/athena-elasticsearch-2022.23.1.jar"
+      CodeUri: "./target/athena-elasticsearch-2022.24.1.jar"
       Description: "The Elasticsearch Lambda Connector provides Athena users the ability to query data stored on Elasticsearch clusters."
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-elasticsearch/pom.xml
+++ b/athena-elasticsearch/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.23.1</version>
+        <version>2022.24.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-elasticsearch</artifactId>
-    <version>2022.23.1</version>
+    <version>2022.24.1</version>
     <properties>
         <slf4jVersion>1.7.30</slf4jVersion>
     </properties>
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
                 <exclusion>
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/athena-example/athena-example.yaml
+++ b/athena-example/athena-example.yaml
@@ -10,7 +10,7 @@ Metadata:
     ReadmeUrl: README.md
     Labels: ['athena-federation']
     HomePageUrl: https://github.com/awslabs/aws-athena-query-federation
-    SemanticVersion: 2022.23.1
+    SemanticVersion: 2022.24.1
     SourceCodeUrl: https://github.com/awslabs/aws-athena-query-federation
 
 # Parameters are CloudFormation features to pass input
@@ -55,7 +55,7 @@ Resources:
           data_bucket: !Ref DataBucket
       FunctionName: !Sub "${AthenaCatalogName}"
       Handler: "com.amazonaws.athena.connectors.example.ExampleCompositeHandler"
-      CodeUri: "./target/athena-example-2022.23.1.jar"
+      CodeUri: "./target/athena-example-2022.24.1.jar"
       Description: "A guided example for writing and deploying your own federated Amazon Athena connector for a custom source."
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-example/pom.xml
+++ b/athena-example/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.23.1</version>
+        <version>2022.24.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-example</artifactId>
-    <version>2022.23.1</version>
+    <version>2022.24.1</version>
     <properties>
         <slf4jVersion>1.7.30</slf4jVersion>
     </properties>
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
                 <exclusion>

--- a/athena-federation-integ-test/README.md
+++ b/athena-federation-integ-test/README.md
@@ -36,7 +36,7 @@ in most **pom.xml** files (e.g.
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
-            <version>Current version of the SDK (e.g. 2022.23.1)</version>
+            <version>Current version of the SDK (e.g. 2022.24.1)</version>
             <scope>test</scope>
         </dependency>
 ```

--- a/athena-federation-integ-test/pom.xml
+++ b/athena-federation-integ-test/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.23.1</version>
+        <version>2022.24.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-federation-integ-test</artifactId>
-    <version>2022.23.1</version>
+    <version>2022.24.1</version>
     <packaging>jar</packaging>
     <name>Amazon Athena Query Federation Integ Test</name>
     <properties>

--- a/athena-federation-sdk-tools/pom.xml
+++ b/athena-federation-sdk-tools/pom.xml
@@ -3,13 +3,13 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.23.1</version>
+        <version>2022.24.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-federation-sdk-tools</artifactId>
     <packaging>jar</packaging>
     <name>Amazon Athena Query Federation SDK Tools</name>
-    <version>2022.23.1</version>
+    <version>2022.24.1</version>
     <properties>
         <slf4jVersion>1.7.30</slf4jVersion>
     </properties>
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
                 <exclusion>

--- a/athena-federation-sdk/athena-federation-sdk.yaml
+++ b/athena-federation-sdk/athena-federation-sdk.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.23.1
+    SemanticVersion: 2022.24.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AthenaCatalogName:
@@ -47,7 +47,7 @@ Resources:
           spill_prefix: !Ref SpillPrefix
       FunctionName: !Ref AthenaCatalogName
       Handler: "com.amazonaws.athena.connector.lambda.examples.ExampleCompositeHandler"
-      CodeUri: "./target/aws-athena-federation-sdk-2022.23.1-withdep.jar"
+      CodeUri: "./target/aws-athena-federation-sdk-2022.24.1-withdep.jar"
       Description: "This connector enables Amazon Athena to communicate with a randomly generated data source."
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-federation-sdk/pom.xml
+++ b/athena-federation-sdk/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-athena-query-federation</artifactId>
-        <version>2022.23.1</version>
+        <version>2022.24.1</version>
     </parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-athena-federation-sdk</artifactId>
-    <version>2022.23.1</version>
+    <version>2022.24.1</version>
     <packaging>jar</packaging>
     <name>Amazon Athena Query Federation SDK</name>
     <description>The Athena Query Federation SDK defines a set of interfaces and wire protocols that you can implement to enable Athena to delegate portions of it's query execution plan to code that you deploy/write.</description>

--- a/athena-google-bigquery/athena-google-bigquery.yaml
+++ b/athena-google-bigquery/athena-google-bigquery.yaml
@@ -13,7 +13,7 @@ Metadata:
       - Athena-Federation
       - Google-SDK
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.23.1
+    SemanticVersion: 2022.24.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   LambdaFunctionName:
@@ -71,7 +71,7 @@ Resources:
           concurrencyLimit: !Ref ConcurrencyLimit
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.google.bigquery.BigQueryCompositeHandler"
-      CodeUri: "./target/athena-google-bigquery-2022.23.1.jar"
+      CodeUri: "./target/athena-google-bigquery-2022.24.1.jar"
       Description: "Enables Amazon Athena to communicate with BigQuery using Google SDK"
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-google-bigquery/pom.xml
+++ b/athena-google-bigquery/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.23.1</version>
+        <version>2022.24.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-google-bigquery</artifactId>
-    <version>2022.23.1</version>
+    <version>2022.24.1</version>
     <properties>
         <slf4jVersion>1.7.30</slf4jVersion>
     </properties>
@@ -15,18 +15,18 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/athena-hbase/athena-hbase.yaml
+++ b/athena-hbase/athena-hbase.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.23.1
+    SemanticVersion: 2022.24.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AthenaCatalogName:
@@ -60,7 +60,7 @@ Resources:
           default_hbase: !Ref HBaseConnectionString
       FunctionName: !Ref AthenaCatalogName
       Handler: "com.amazonaws.athena.connectors.hbase.HbaseCompositeHandler"
-      CodeUri: "./target/athena-hbase-2022.23.1.jar"
+      CodeUri: "./target/athena-hbase-2022.24.1.jar"
       Description: "Enables Amazon Athena to communicate with HBase, making your HBase data accessible via SQL"
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-hbase/pom.xml
+++ b/athena-hbase/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.23.1</version>
+        <version>2022.24.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-hbase</artifactId>
-    <version>2022.23.1</version>
+    <version>2022.24.1</version>
     <properties>
         <slf4jVersion>1.7.30</slf4jVersion>
     </properties>
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
                 <exclusion>
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awscdk/emr -->

--- a/athena-hortonworks-hive/athena-hortonworks-hive.yaml
+++ b/athena-hortonworks-hive/athena-hortonworks-hive.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.23.1
+    SemanticVersion: 2022.24.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   LambdaFunctionName:
@@ -60,7 +60,7 @@ Resources:
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.hortonworks.HiveMuxCompositeHandler"
-      CodeUri: "./target/athena-hortonworks-hive-2022.23.1.jar"
+      CodeUri: "./target/athena-hortonworks-hive-2022.24.1.jar"
       Description: "Enables Amazon Athena to communicate with Hortonworks Hive using JDBC"
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-hortonworks-hive/pom.xml
+++ b/athena-hortonworks-hive/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.23.1</version>
+        <version>2022.24.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-hortonworks-hive</artifactId>
-    <version>2022.23.1</version>
+    <version>2022.24.1</version>
     <properties>
         <slf4jVersion>1.7.30</slf4jVersion>
         <clouderaVersion>2.6.15.1018</clouderaVersion>
@@ -16,13 +16,13 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
         </dependency>
         <dependency>
             <groupId>Hive</groupId>
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/athena-jdbc/pom.xml
+++ b/athena-jdbc/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.23.1</version>
+        <version>2022.24.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-jdbc</artifactId>
-    <version>2022.23.1</version>
+    <version>2022.24.1</version>
     <properties>
         <slf4jVersion>1.7.30</slf4jVersion>
     </properties>
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
                 <exclusion>
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/athena-mysql/athena-mysql.yaml
+++ b/athena-mysql/athena-mysql.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.23.1
+    SemanticVersion: 2022.24.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   LambdaFunctionName:
@@ -60,7 +60,7 @@ Resources:
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.mysql.MySqlMuxCompositeHandler"
-      CodeUri: "./target/athena-mysql-2022.23.1.jar"
+      CodeUri: "./target/athena-mysql-2022.24.1.jar"
       Description: "Enables Amazon Athena to communicate with MySQL using JDBC"
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-mysql/pom.xml
+++ b/athena-mysql/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.23.1</version>
+        <version>2022.24.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-mysql</artifactId>
-    <version>2022.23.1</version>
+    <version>2022.24.1</version>
     <properties>
         <slf4jVersion>1.7.30</slf4jVersion>
     </properties>
@@ -15,18 +15,18 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/athena-neptune/athena-neptune.yaml
+++ b/athena-neptune/athena-neptune.yaml
@@ -10,7 +10,7 @@ Metadata:
     ReadmeUrl: README.md
     Labels: ['athena-federation','athena-neptune','neptune']
     HomePageUrl: https://github.com/awslabs/aws-athena-query-federation
-    SemanticVersion: 2022.23.1
+    SemanticVersion: 2022.24.1
     SourceCodeUrl: https://github.com/awslabs/aws-athena-query-federation
 
 Parameters:
@@ -84,7 +84,7 @@ Resources:
           SERVICE_REGION: !Ref AWS::Region
       FunctionName: !Ref AthenaCatalogName
       Handler: "com.amazonaws.athena.connectors.neptune.NeptuneCompositeHandler"
-      CodeUri: "./target/athena-neptune-2022.23.1.jar"
+      CodeUri: "./target/athena-neptune-2022.24.1.jar"
       Description: "Enables Amazon Athena to communicate with Neptune, making your Neptune graph data accessible via SQL."
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-neptune/pom.xml
+++ b/athena-neptune/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.23.1</version>
+        <version>2022.24.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-neptune</artifactId>
-    <version>2022.23.1</version>
+    <version>2022.24.1</version>
     <properties>
         <slf4jVersion>1.7.30</slf4jVersion>
         <gremlinDriverVersion>3.4.8</gremlinDriverVersion>
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
                 <exclusion>

--- a/athena-oracle/athena-oracle.yaml
+++ b/athena-oracle/athena-oracle.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.23.1
+    SemanticVersion: 2022.24.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   LambdaFunctionName:
@@ -60,7 +60,7 @@ Resources:
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.oracle.OracleMuxCompositeHandler"
-      CodeUri: "./target/athena-oracle-2022.23.1.jar"
+      CodeUri: "./target/athena-oracle-2022.24.1.jar"
       Description: "Enables Amazon Athena to communicate with ORACLE using JDBC"
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-oracle/pom.xml
+++ b/athena-oracle/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.23.1</version>
+        <version>2022.24.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-oracle</artifactId>
-    <version>2022.23.1</version>
+    <version>2022.24.1</version>
     <properties>
         <slf4jVersion>1.7.30</slf4jVersion>
     </properties>
@@ -15,18 +15,18 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/athena-postgresql/athena-postgresql.yaml
+++ b/athena-postgresql/athena-postgresql.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.23.1
+    SemanticVersion: 2022.24.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   LambdaFunctionName:
@@ -60,7 +60,7 @@ Resources:
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.postgresql.PostGreSqlMuxCompositeHandler"
-      CodeUri: "./target/athena-postgresql-2022.23.1.jar"
+      CodeUri: "./target/athena-postgresql-2022.24.1.jar"
       Description: "Enables Amazon Athena to communicate with PostgreSQL using JDBC"
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-postgresql/pom.xml
+++ b/athena-postgresql/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.23.1</version>
+        <version>2022.24.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-postgresql</artifactId>
-    <version>2022.23.1</version>
+    <version>2022.24.1</version>
     <packaging>jar</packaging>
     <properties>
         <slf4jVersion>1.7.30</slf4jVersion>
@@ -16,18 +16,18 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/athena-redis/athena-redis.yaml
+++ b/athena-redis/athena-redis.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.23.1
+    SemanticVersion: 2022.24.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AthenaCatalogName:
@@ -56,7 +56,7 @@ Resources:
           spill_prefix: !Ref SpillPrefix
       FunctionName: !Ref AthenaCatalogName
       Handler: "com.amazonaws.athena.connectors.redis.RedisCompositeHandler"
-      CodeUri: "./target/athena-redis-2022.23.1.jar"
+      CodeUri: "./target/athena-redis-2022.24.1.jar"
       Description: "Enables Amazon Athena to communicate with Redis, making your Redis data accessible via SQL"
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-redis/pom.xml
+++ b/athena-redis/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.23.1</version>
+        <version>2022.24.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-redis</artifactId>
-    <version>2022.23.1</version>
+    <version>2022.24.1</version>
     <properties>
         <slf4jVersion>1.7.30</slf4jVersion>
     </properties>
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
                 <exclusion>
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/athena-redshift/athena-redshift.yaml
+++ b/athena-redshift/athena-redshift.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.23.1
+    SemanticVersion: 2022.24.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   LambdaFunctionName:
@@ -60,7 +60,7 @@ Resources:
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.redshift.RedshiftMuxCompositeHandler"
-      CodeUri: "./target/athena-redshift-2022.23.1.jar"
+      CodeUri: "./target/athena-redshift-2022.24.1.jar"
       Description: "Enables Amazon Athena to communicate with Redshift using JDBC"
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-redshift/pom.xml
+++ b/athena-redshift/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.23.1</version>
+        <version>2022.24.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-redshift</artifactId>
-    <version>2022.23.1</version>
+    <version>2022.24.1</version>
     <properties>
         <slf4jVersion>1.7.30</slf4jVersion>
     </properties>
@@ -15,12 +15,12 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-postgresql</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/athena-saphana/athena-saphana.yaml
+++ b/athena-saphana/athena-saphana.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.23.1
+    SemanticVersion: 2022.24.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   LambdaFunctionName:

--- a/athena-saphana/pom.xml
+++ b/athena-saphana/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.23.1</version>
+        <version>2022.24.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-saphana</artifactId>
-    <version>2022.23.1</version>
+    <version>2022.24.1</version>
     <properties>
         <slf4jVersion>1.7.30</slf4jVersion>
     </properties>
@@ -15,18 +15,18 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/athena-snowflake/athena-snowflake.yaml
+++ b/athena-snowflake/athena-snowflake.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.23.1
+    SemanticVersion: 2022.24.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   LambdaFunctionName:
@@ -70,7 +70,7 @@ Resources:
           partitionlimit: !Ref PartitionLimit
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.snowflake.SnowflakeMuxCompositeHandler"
-      CodeUri: "./target/athena-snowflake-2022.23.1.jar"
+      CodeUri: "./target/athena-snowflake-2022.24.1.jar"
       Description: "Enables Amazon Athena to communicate with Snowflake using JDBC"
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-snowflake/pom.xml
+++ b/athena-snowflake/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.23.1</version>
+        <version>2022.24.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-snowflake</artifactId>
-    <version>2022.23.1</version>
+    <version>2022.24.1</version>
     <properties>
         <slf4jVersion>1.7.30</slf4jVersion>
     </properties>
@@ -15,18 +15,18 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/athena-sqlserver/athena-sqlserver.yaml
+++ b/athena-sqlserver/athena-sqlserver.yaml
@@ -12,7 +12,7 @@ Metadata:
       - athena-federation
       - jdbc
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.23.1
+    SemanticVersion: 2022.24.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   LambdaFunctionName:
@@ -62,7 +62,7 @@ Resources:
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.sqlserver.SqlServerMuxCompositeHandler"
-      CodeUri: "./target/athena-sqlserver-2022.23.1.jar"
+      CodeUri: "./target/athena-sqlserver-2022.24.1.jar"
       Description: "Enables Amazon Athena to communicate with SQLSERVER using JDBC"
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-sqlserver/pom.xml
+++ b/athena-sqlserver/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.23.1</version>
+        <version>2022.24.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-sqlserver</artifactId>
-    <version>2022.23.1</version>
+    <version>2022.24.1</version>
     <properties>
         <slf4jVersion>1.7.30</slf4jVersion>
     </properties>
@@ -15,18 +15,18 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/athena-synapse/athena-synapse.yaml
+++ b/athena-synapse/athena-synapse.yaml
@@ -12,7 +12,7 @@ Metadata:
       - athena-federation
       - jdbc
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.23.1
+    SemanticVersion: 2022.24.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   LambdaFunctionName:
@@ -62,7 +62,7 @@ Resources:
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.synapse.SynapseMuxCompositeHandler"
-      CodeUri: "./target/athena-synapse-2022.23.1.jar"
+      CodeUri: "./target/athena-synapse-2022.24.1.jar"
       Description: "Enables Amazon Athena to communicate with SYNPASE using JDBC"
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-synapse/pom.xml
+++ b/athena-synapse/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.23.1</version>
+        <version>2022.24.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-synapse</artifactId>
-    <version>2022.23.1</version>
+    <version>2022.24.1</version>
     <properties>
         <slf4jVersion>1.7.30</slf4jVersion>
     </properties>
@@ -15,18 +15,18 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/athena-teradata/athena-teradata.yaml
+++ b/athena-teradata/athena-teradata.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.23.1
+    SemanticVersion: 2022.24.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   LambdaFunctionName:
@@ -70,7 +70,7 @@ Resources:
       Handler: "com.amazonaws.athena.connectors.teradata.TeradataMuxCompositeHandler"
       Layers:
         - !Ref LambdaJDBCLayername
-      CodeUri: "./target/athena-teradata-2022.23.1.jar"
+      CodeUri: "./target/athena-teradata-2022.24.1.jar"
       Description: "Enables Amazon Athena to communicate with Teradata using JDBC"
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-teradata/pom.xml
+++ b/athena-teradata/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.23.1</version>
+        <version>2022.24.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-teradata</artifactId>
-    <version>2022.23.1</version>
+    <version>2022.24.1</version>
     <properties>
         <slf4jVersion>1.7.30</slf4jVersion>
     </properties>
@@ -15,18 +15,18 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/athena-timestream/athena-timestream.yaml
+++ b/athena-timestream/athena-timestream.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.23.1
+    SemanticVersion: 2022.24.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AthenaCatalogName:
@@ -47,7 +47,7 @@ Resources:
           spill_prefix: !Ref SpillPrefix
       FunctionName: !Ref AthenaCatalogName
       Handler: "com.amazonaws.athena.connectors.timestream.TimestreamCompositeHandler"
-      CodeUri: "./target/athena-timestream-2022.23.1.jar"
+      CodeUri: "./target/athena-timestream-2022.24.1.jar"
       Description: "Enables Amazon Athena to communicate with Amazon Timestream, making your time series data accessible from Athena."
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-timestream/pom.xml
+++ b/athena-timestream/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.23.1</version>
+        <version>2022.24.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-timestream</artifactId>
-    <version>2022.23.1</version>
+    <version>2022.24.1</version>
     <properties>
         <slf4jVersion>1.7.30</slf4jVersion>
     </properties>
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
                 <exclusion>
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awscdk/timestream -->

--- a/athena-tpcds/athena-tpcds.yaml
+++ b/athena-tpcds/athena-tpcds.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.23.1
+    SemanticVersion: 2022.24.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AthenaCatalogName:
@@ -47,7 +47,7 @@ Resources:
           spill_prefix: !Ref SpillPrefix
       FunctionName: !Ref AthenaCatalogName
       Handler: "com.amazonaws.athena.connectors.tpcds.TPCDSCompositeHandler"
-      CodeUri: "./target/athena-tpcds-2022.23.1.jar"
+      CodeUri: "./target/athena-tpcds-2022.24.1.jar"
       Description: "This connector enables Amazon Athena to communicate with a randomly generated TPC-DS data source."
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-tpcds/pom.xml
+++ b/athena-tpcds/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.23.1</version>
+        <version>2022.24.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-tpcds</artifactId>
-    <version>2022.23.1</version>
+    <version>2022.24.1</version>
     <properties>
         <slf4jVersion>1.7.30</slf4jVersion>
     </properties>
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
                 <exclusion>

--- a/athena-udfs/athena-udfs.yaml
+++ b/athena-udfs/athena-udfs.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.23.1
+    SemanticVersion: 2022.24.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   LambdaFunctionName:
@@ -34,7 +34,7 @@ Resources:
     Properties:
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.udfs.AthenaUDFHandler"
-      CodeUri: "./target/athena-udfs-2022.23.1.jar"
+      CodeUri: "./target/athena-udfs-2022.24.1.jar"
       Description: "This connector enables Amazon Athena to leverage common UDFs made available via Lambda."
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-udfs/pom.xml
+++ b/athena-udfs/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.23.1</version>
+        <version>2022.24.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-udfs</artifactId>
-    <version>2022.23.1</version>
+    <version>2022.24.1</version>
     <properties>
         <slf4jVersion>1.7.30</slf4jVersion>
     </properties>
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
                 <exclusion>

--- a/athena-vertica/athena-vertica.yaml
+++ b/athena-vertica/athena-vertica.yaml
@@ -10,7 +10,7 @@ Metadata:
     ReadmeUrl: README.md
     Labels: ['athena-federation']
     HomePageUrl: https://github.com/awslabs/aws-athena-query-federation
-    SemanticVersion: 2022.23.1
+    SemanticVersion: 2022.24.1
     SourceCodeUrl: https://github.com/awslabs/aws-athena-query-federation
 
 # Parameters are CloudFormation features to pass input
@@ -76,7 +76,7 @@ Resources:
 
       FunctionName: !Sub "${AthenaCatalogName}"
       Handler: "com.amazonaws.athena.connectors.vertica.VerticaCompositeHandler"
-      CodeUri: "./target/athena-vertica-2022.23.1.jar"
+      CodeUri: "./target/athena-vertica-2022.24.1.jar"
       Description: "Amazon Athena Vertica Connector"
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-vertica/pom.xml
+++ b/athena-vertica/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.23.1</version>
+        <version>2022.24.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-vertica</artifactId>
-    <version>2022.23.1</version>
+    <version>2022.24.1</version>
     <properties>
         <slf4jVersion>1.7.30</slf4jVersion>
     </properties>
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>2022.23.1</version>
+            <version>2022.24.1</version>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
                 <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-athena-query-federation</artifactId>
     <packaging>pom</packaging>
-    <version>2022.23.1</version>
+    <version>2022.24.1</version>
     <name>AWS Athena Query Federation</name>
     <description>The Amazon Athena Query Federation SDK allows you to customize Amazon Athena with your own code.</description>
     <url>https://github.com/awslabs/aws-athena-query-federation</url>

--- a/tools/validate_connector.sh
+++ b/tools/validate_connector.sh
@@ -41,7 +41,7 @@ dir=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 
 cd "$dir/../athena-federation-sdk-tools"
 
-if test -f "target/athena-federation-sdk-tools-2022.23.1.jar"; then
+if test -f "target/athena-federation-sdk-tools-2022.24.1.jar"; then
     echo "athena-federation-sdk-tools is already built, skipping compilation."
 else
     mvn clean install


### PR DESCRIPTION
Added `spill_put_request_headers` environment variable.
S3BlockSpiller: fix double buffering bug
Added fix to show only user defined schemas in Athena Data window



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
