### PR TITLE
GlueFieldLexer: handle Glue set type and fix lexComplex logic

### DIFF
--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/metadata/glue/GlueFieldLexer.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/metadata/glue/GlueFieldLexer.java
@@ -27,6 +27,8 @@ import org.apache.arrow.vector.types.pojo.Field;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Set;
+
 /**
  * Extracts field definitions, including complex types like List and STRUCT, from AWS Glue Data Catalog's
  * definition of a field. This class makes use of GlueTypeParser to tokenize the definition of the field.
@@ -34,11 +36,15 @@ import org.slf4j.LoggerFactory;
  */
 public class GlueFieldLexer
 {
+    // NOTE:
+    // This entire class and file should really be called a parser instead...
+    // The GlueFieldParser should actually be called a GlueFieldLexer and vice versa.
+
     private static final Logger logger = LoggerFactory.getLogger(GlueFieldLexer.class);
 
     private static final String STRUCT = "struct";
-    private static final String ARRAY = "array";
-    private static final String SET = "set";
+
+    private static final Set<String> LIST_EQUIVALENTS = Set.of("array", "set");
 
     private static final BaseTypeMapper DEFAULT_TYPE_MAPPER = (String type) -> DefaultGlueType.toArrowType(type);
 
@@ -60,102 +66,85 @@ public class GlueFieldLexer
 
     public static Field lex(String name, String input)
     {
-        ArrowType typeResult = DEFAULT_TYPE_MAPPER.getType(input);
-        if (typeResult != null) {
-            return FieldBuilder.newBuilder(name, typeResult).build();
-        }
-
-        GlueTypeParser parser = new GlueTypeParser(input);
-        return lexComplex(name, parser.next(), parser, DEFAULT_TYPE_MAPPER);
+        return lex(name, input, DEFAULT_TYPE_MAPPER);
     }
 
     public static Field lex(String name, String input, BaseTypeMapper mapper)
     {
-        Field result = mapper.getField(name, input);
-        if (result != null) {
-            return result;
-        }
-
         GlueTypeParser parser = new GlueTypeParser(input);
-        return lexComplex(name, parser.next(), parser, mapper);
+        return lexInternal(name, parser, mapper);
     }
 
-    private static Field lexComplex(String name, GlueTypeParser.Token startToken, GlueTypeParser parser, BaseTypeMapper mapper)
+    private static Field lexInternal(String name, GlueTypeParser parser, BaseTypeMapper mapper)
     {
-        FieldBuilder fieldBuilder;
-
-        logger.debug("lexComplex: enter - {}", name);
-        if (startToken.getMarker() != GlueTypeParser.FIELD_START) {
-            throw new RuntimeException("Parse error, expected " + GlueTypeParser.FIELD_START
-                    + " but found " + startToken.getMarker());
-        }
-
-        final String startTokenValueLower = startToken.getValue().toLowerCase();
-
-        if (startTokenValueLower.equals(STRUCT)) {
-            fieldBuilder = FieldBuilder.newBuilder(name, Types.MinorType.STRUCT.getType());
-        }
-        else if (startTokenValueLower.equals(ARRAY) || startTokenValueLower.equals(SET)) {
-            GlueTypeParser.Token arrayType = parser.next();
-            Field child;
-            String type = arrayType.getValue().toLowerCase();
-            if (type.equals(STRUCT) || type.equals(ARRAY) || type.equals(SET)) {
-                child = lexComplex(name, arrayType, parser, mapper);
+        logger.debug("lexInternal: enter - {}", name);
+        try {
+            GlueTypeParser.Token typeToken = parser.next();
+            final String typeTokenValueLower = typeToken.getValue().toLowerCase();
+            if (typeTokenValueLower.equals(STRUCT)) {
+                return parseStruct(name, typeToken, parser, mapper);
             }
-            else {
-                child = mapper.getField(name, arrayType.getValue());
+            else if (LIST_EQUIVALENTS.contains(typeTokenValueLower)) {
+                return parseList(name, typeToken, parser, mapper);
             }
-            // Both Glue "array" and "set" get converted to Arrow LIST
-            return FieldBuilder.newBuilder(name, Types.MinorType.LIST.getType()).addField(child).build();
+            // Primitive case
+            expectTokenMarkerIsFieldEnd(typeToken);
+            return mapper.getField(name, typeTokenValueLower);
         }
-        else {
-            throw new RuntimeException("Unexpected start type " + startToken.getValue());
+        finally {
+            logger.debug("lexInternal: exit - {}", name);
         }
+    }
 
-        while (parser.hasNext() && parser.currentToken().getMarker() != GlueTypeParser.FIELD_END) {
-            Field child = lex(parser.next(), parser, mapper);
+    private static Field parseStruct(String name, GlueTypeParser.Token typeToken, GlueTypeParser parser, BaseTypeMapper mapper)
+    {
+        expectTokenMarkerIsFieldStart(typeToken);
+        FieldBuilder fieldBuilder = FieldBuilder.newBuilder(name, Types.MinorType.STRUCT.getType());
+        // Iterate through the child element types of the STRUCT
+        while (parser.hasNext()) {
+            GlueTypeParser.Token childNameToken = parser.next();
+            if (!childNameToken.getMarker().equals(GlueTypeParser.FIELD_DIV)) {
+                // Current token is not a child if it doesn't have a ":" (FIELD_DIV).
+                // Which means we are done with the struct. Just break out and build.
+                break;
+            }
+            // Recursive call to resolve child type
+            Field child = lexInternal(childNameToken.getValue(), parser, mapper);
             fieldBuilder.addField(child);
-            if (Types.getMinorTypeForArrowType(child.getType()) == Types.MinorType.LIST) {
-                // An ARRAY Glue type (LIST in Arrow) within a STRUCT has the same ending token as a STRUCT (">" or
-                // GlueTypeParser.FIELD_END). If allowed to proceed, the Glue parser will misinterpret the end of the
-                // ARRAY to be the end of the STRUCT (which is currently being processed) ending the loop prematurely
-                // and causing all subsequent fields in the STRUCT to be dropped.
-                // Example: movies: STRUCT<actors:ARRAY<STRING>,genre:ARRAY<STRING>>
-                // will result in Field definition: movies: Struct<actors: List<actors: Utf8>>.
-                // In order to prevent that from happening, we must consume an additional token to get past the LIST's
-                // ending token ">".
-                parser.next();
-            }
         }
-        parser.next();
-
-        logger.debug("lexComplex: exit - {}", name);
+        // Expect that we're ending on the closing token
+        expectTokenMarkerIsFieldEnd(parser.currentToken());
         return fieldBuilder.build();
     }
 
-    private static Field lex(GlueTypeParser.Token startToken, GlueTypeParser parser, BaseTypeMapper mapper)
+    private static Field parseList(String name, GlueTypeParser.Token typeToken, GlueTypeParser parser, BaseTypeMapper mapper)
     {
-        GlueTypeParser.Token nameToken = startToken;
-        logger.debug("lex: enter - {}", nameToken.getValue());
-        if (!nameToken.getMarker().equals(GlueTypeParser.FIELD_DIV)) {
-            throw new RuntimeException("Expected Field DIV but found " + nameToken.getMarker() +
-                    " while processing " + nameToken.getValue());
-        }
+        expectTokenMarkerIsFieldStart(typeToken);
+        // Recursive call to resolve child element type
+        Field child = lexInternal(name, parser, mapper);
+        // The next field must always be a closing token since we are building the field here
+        // So consume the closing token for this field
+        GlueTypeParser.Token closingToken = parser.next();
+        // Note that the closing token is , if the enclosing type is a struct
+        // and > if the enclosing type is a list
+        expectTokenMarkerIsFieldEnd(closingToken);
+        return FieldBuilder.newBuilder(name, Types.MinorType.LIST.getType()).addField(child).build();
+    }
 
-        String name = nameToken.getValue();
+    private static void expectTokenMarkerIsFieldStart(GlueTypeParser.Token token)
+    {
+        if (token.getMarker() != GlueTypeParser.FIELD_START) {
+            throw new RuntimeException("Expected field start: but found " + token.toString());
+        }
+    }
 
-        GlueTypeParser.Token typeToken = parser.next();
-        if (typeToken.getMarker().equals(GlueTypeParser.FIELD_START)) {
-            logger.debug("lex: exit - {}", nameToken.getValue());
-            return lexComplex(name, typeToken, parser, mapper);
+    private static void expectTokenMarkerIsFieldEnd(GlueTypeParser.Token token)
+    {
+        boolean isFieldEnd = (token.getMarker() == null ||
+              token.getMarker().equals(GlueTypeParser.FIELD_SEP) ||
+              token.getMarker().equals(GlueTypeParser.FIELD_END));
+        if (!isFieldEnd) {
+            throw new RuntimeException("Expected field ending but found: " + token.toString());
         }
-        else if (typeToken.getMarker().equals(GlueTypeParser.FIELD_SEP) ||
-                typeToken.getMarker().equals(GlueTypeParser.FIELD_END)
-        ) {
-            logger.debug("lex: exit - {}", nameToken.getValue());
-            return mapper.getField(name, typeToken.getValue());
-        }
-        throw new RuntimeException("Unexpected Token " + typeToken.getValue() + "[" + typeToken.getMarker() + "]"
-                + " @ " + typeToken.getPos() + " while processing " + name);
     }
 }

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/metadata/glue/GlueFieldLexerTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/metadata/glue/GlueFieldLexerTest.java
@@ -212,4 +212,71 @@ public class GlueFieldLexerTest
 
         logger.info("lexListOfStructTest: exit");
     }
+
+    @Test
+    public void lexStructListChildAndStructChildTest()
+    {
+        String input = "struct<somearrfield:array<set<string>>,mapinner:struct<numberset_deep:set<bigint>>>";
+        Field field = GlueFieldLexer.lex("testAsdf", input);
+        logger.info("lexStructListChildAndStructChildTest: {}", field);
+
+        assertEquals("testAsdf", field.getName());
+        assertEquals(Types.MinorType.STRUCT, Types.getMinorTypeForArrowType(field.getType()));
+        assertEquals(2, field.getChildren().size());
+
+        List<Field> level1 = field.getChildren();
+        assertEquals("somearrfield", level1.get(0).getName());
+        assertEquals(Types.MinorType.LIST, Types.getMinorTypeForArrowType(level1.get(0).getType()));
+        assertEquals(Types.MinorType.LIST, Types.getMinorTypeForArrowType(level1.get(0).getChildren().get(0).getType()));
+        assertEquals(Types.MinorType.VARCHAR, Types.getMinorTypeForArrowType(level1.get(0).getChildren().get(0).getChildren().get(0).getType()));
+
+        assertEquals("mapinner", level1.get(1).getName());
+        assertEquals(Types.MinorType.STRUCT, Types.getMinorTypeForArrowType(level1.get(1).getType()));
+        assertEquals(Types.MinorType.LIST, Types.getMinorTypeForArrowType(level1.get(1).getChildren().get(0).getType()));
+        assertEquals(Types.MinorType.BIGINT, Types.getMinorTypeForArrowType(level1.get(1).getChildren().get(0).getChildren().get(0).getType()));
+    }
+
+    @Test
+    public void lexExtraInnerClosingFieldsTest()
+    {
+        // Unfortunately we are on Java 11 so we don't have block quotes
+        String input = "struct<" +
+            "somearrfield0:array<set<struct<somefield:string,someset:set<string>>>>," +
+            "mapinner0:struct<numberset_deep:set<bigint>>," +
+            "somearrfield1:array<set<struct<somefield:string,someset:set<string>>>>," +
+            "mapinner1:struct<numberset_deep:set<bigint>>," +
+            "somearrfield2:array<set<struct<somefield:string,someset:set<string>>>>," +
+            "mapinner2:struct<numberset_deep:set<bigint>> >";
+
+        Field field = GlueFieldLexer.lex("testAsdf2", input);
+        logger.info("lexExtraInnerClosingFieldsTest: {}", field);
+
+        assertEquals("testAsdf2", field.getName());
+        assertEquals(Types.MinorType.STRUCT, Types.getMinorTypeForArrowType(field.getType()));
+        assertEquals(6, field.getChildren().size());
+
+        List<Field> level1 = field.getChildren();
+
+        for (int i = 0; i < 3; ++i) {
+            int somearrFieldIdx = i * 2;
+            Field somearrField = level1.get(somearrFieldIdx);
+            assertEquals("somearrfield" + i, somearrField.getName());
+            assertEquals(Types.MinorType.LIST, Types.getMinorTypeForArrowType(somearrField.getType()));
+            assertEquals(Types.MinorType.LIST, Types.getMinorTypeForArrowType(somearrField.getChildren().get(0).getType()));
+            assertEquals(Types.MinorType.STRUCT, Types.getMinorTypeForArrowType(somearrField.getChildren().get(0).getChildren().get(0).getType()));
+
+            Field innerAsdfStruct = somearrField.getChildren().get(0).getChildren().get(0);
+            assertEquals(Types.MinorType.VARCHAR, Types.getMinorTypeForArrowType(innerAsdfStruct.getChildren().get(0).getType()));
+            assertEquals(Types.MinorType.LIST, Types.getMinorTypeForArrowType(innerAsdfStruct.getChildren().get(1).getType()));
+            assertEquals(Types.MinorType.VARCHAR, Types.getMinorTypeForArrowType(innerAsdfStruct.getChildren().get(1).getChildren().get(0).getType()));
+
+            int mapinnerIdx = (i*2) + 1;
+            Field mapinnerField = level1.get(mapinnerIdx);
+            assertEquals("mapinner" + i, mapinnerField.getName());
+            assertEquals(Types.MinorType.STRUCT, Types.getMinorTypeForArrowType(mapinnerField.getType()));
+            assertEquals(Types.MinorType.LIST, Types.getMinorTypeForArrowType(mapinnerField.getChildren().get(0).getType()));
+            assertEquals(Types.MinorType.BIGINT, Types.getMinorTypeForArrowType(mapinnerField.getChildren().get(0).getChildren().get(0).getType()));
+        }
+
+    }
 }


### PR DESCRIPTION
Fix 1:
    GlueFieldLexer: handle Glue set type

    GlueFieldLexer before would fail on the set type, but it should really just be treated as an array would be treated.

Fix 2:
    GlueFieldLexer: refactor and fix lexing logic

    The previous version of the code hardcoded the number of inner end fields (">") to consume in the parent enclosing struct.
    This doesn't work for all situations (see the test added).

    The right way to do this is to actually just consume the closing fields properly whenever we build a complex type.
    This avoids us having to try to figure out how many of these to consume later in an enclosing struct.

    Unified and simplified the calling paths as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
