### PR TITLE
GlueFieldLexer: Add decimal support

### DIFF
--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/metadata/glue/DefaultGlueType.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/metadata/glue/DefaultGlueType.java
@@ -24,43 +24,46 @@ import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 
 import java.time.ZoneId;
-import java.util.HashMap;
-import java.util.HashSet;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.util.Map.entry;
 
 /**
  * Defines the default mapping of AWS Glue Data Catalog types to Apache Arrow types. You can override these by
  * overriding convertField(...) on GlueMetadataHandler.
  */
-public enum DefaultGlueType
+public class DefaultGlueType
 {
-    INT("int", Types.MinorType.INT.getType()),
-    VARCHAR("varchar", Types.MinorType.VARCHAR.getType()),
-    STRING("string", Types.MinorType.VARCHAR.getType()),
-    BIGINT("bigint", Types.MinorType.BIGINT.getType()),
-    DOUBLE("double", Types.MinorType.FLOAT8.getType()),
-    FLOAT("float", Types.MinorType.FLOAT4.getType()),
-    SMALLINT("smallint", Types.MinorType.SMALLINT.getType()),
-    TINYINT("tinyint", Types.MinorType.TINYINT.getType()),
-    BIT("boolean", Types.MinorType.BIT.getType()),
-    VARBINARY("binary", Types.MinorType.VARBINARY.getType()),
-    TIMESTAMP("timestamp", Types.MinorType.DATEMILLI.getType()),
-    // ZoneId.systemDefault().getId() is just a place holder, each row will have a TZ value
-    // otherwise fall back to the table configured default TZ
-    TIMESTAMPMILLITZ("timestamptz", new ArrowType.Timestamp(org.apache.arrow.vector.types.TimeUnit.MILLISECOND, ZoneId.systemDefault().getId())),
-    DATE("date", Types.MinorType.DATEDAY.getType());
+    private static final String TIMESTAMPMILLITZ = "timestamptz";
+    private static final Set<String> NON_COMPARABALE_SET = Set.of("TIMESTAMPMILLITZ");
 
-    private static final Map<String, DefaultGlueType> TYPE_MAP = new HashMap<>();
-    private static final Set<String> NON_COMPARABALE_SET = new HashSet<>();
+    private static final Map<String, ArrowType> TYPE_MAP = Map.ofEntries(
+        entry("int", Types.MinorType.INT.getType()),
+        entry("varchar", Types.MinorType.VARCHAR.getType()),
+        entry("string", Types.MinorType.VARCHAR.getType()),
+        entry("bigint", Types.MinorType.BIGINT.getType()),
+        entry("double", Types.MinorType.FLOAT8.getType()),
+        entry("float", Types.MinorType.FLOAT4.getType()),
+        entry("smallint", Types.MinorType.SMALLINT.getType()),
+        entry("tinyint", Types.MinorType.TINYINT.getType()),
+        entry("boolean", Types.MinorType.BIT.getType()),
+        entry("binary", Types.MinorType.VARBINARY.getType()),
+        entry("timestamp", Types.MinorType.DATEMILLI.getType()),
+        entry("date", Types.MinorType.DATEDAY.getType()),
+        // ZoneId.systemDefault().getId() is just a place holder, each row will have a TZ value
+        // otherwise fall back to the table configured default TZ
+        entry(TIMESTAMPMILLITZ, new ArrowType.Timestamp(
+                org.apache.arrow.vector.types.TimeUnit.MILLISECOND, ZoneId.systemDefault().getId())));
 
-    static {
-        for (DefaultGlueType next : DefaultGlueType.values()) {
-            TYPE_MAP.put(next.id, next);
-        }
-
-        NON_COMPARABALE_SET.add(DefaultGlueType.TIMESTAMPMILLITZ.name());
-    }
+    // decimal match examples:
+    // decimal
+    // decimal(1,2)
+    // decimal(3,2,1)
+    private static final Pattern decimalPattern = Pattern.compile("decimal([(](([0-9]+,?){2,3})[)])?");
 
     private String id;
     private ArrowType arrowType;
@@ -71,24 +74,49 @@ public enum DefaultGlueType
         this.arrowType = arrowType;
     }
 
-    public static DefaultGlueType fromId(String id)
+    private static ArrowType getDecimalArrowType(String in)
     {
-        DefaultGlueType result = TYPE_MAP.get(id.toLowerCase());
+        Matcher decimalMatcher = decimalPattern.matcher(in);
+        if (!decimalMatcher.matches()) {
+            return null;
+        }
+        try {
+            int[] params = Arrays.stream(decimalMatcher.group(2).split(","))
+                    .mapToInt(Integer::parseInt).toArray();
+            if (params.length == 2) {
+                return new ArrowType.Decimal(params[0], params[1]);
+            }
+            // else this must be 3 because of the regex
+            return new ArrowType.Decimal(params[0], params[1], params[2]);
+        }
+        catch (java.lang.NullPointerException e) {
+            // This is the case where it is only "decimal" with no parameters
+            // Using the default precision and scale that spark sql defaults
+            // to when no parameters are specified.
+            // NOTE: I would prefer to check the decimalMatcher.groupCount() above
+            // rather than a try catch but decimalMatcher.groupCount() always returns
+            // 3 for some reason...
+            return new ArrowType.Decimal(38, 18);
+        }
+    }
+
+    public static ArrowType fromId(String id)
+    {
+        ArrowType result = toArrowType(id);
         if (result == null) {
             throw new IllegalArgumentException("Unknown DefaultGlueType for id: " + id);
         }
-
         return result;
     }
 
     public static ArrowType toArrowType(String id)
     {
-        DefaultGlueType result = TYPE_MAP.get(id.toLowerCase());
+        ArrowType result = TYPE_MAP.get(id.toLowerCase());
         if (result == null) {
-            return null;
+            return getDecimalArrowType(id);
         }
 
-        return result.getArrowType();
+        return result;
     }
 
     public ArrowType getArrowType()

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/metadata/glue/GlueFieldLexerTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/metadata/glue/GlueFieldLexerTest.java
@@ -21,6 +21,7 @@ package com.amazonaws.athena.connector.lambda.metadata.glue;
  */
 
 import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -278,5 +279,47 @@ public class GlueFieldLexerTest
             assertEquals(Types.MinorType.BIGINT, Types.getMinorTypeForArrowType(mapinnerField.getChildren().get(0).getChildren().get(0).getType()));
         }
 
+    }
+
+    @Test
+    public void basicLexDecimalTest()
+    {
+        logger.info("basicLexDecimalTest: enter");
+        String input1 = "DECIMAL(13,7)";
+        Field field1 = GlueFieldLexer.lex("testField1", input1);
+        // 128 bits is the default for Arrow Decimal if not specified
+        assertEquals("testField1: Decimal(13, 7, 128)", field1.toString());
+
+        String input2 = "DECIMAL(13,7,8)";
+        Field field2 = GlueFieldLexer.lex("testField2", input2);
+        assertEquals("testField2: Decimal(13, 7, 8)", field2.toString());
+
+        String input3 = "DECIMAL";
+        Field field3 = GlueFieldLexer.lex("testField3", input3);
+        // This is what the default params are
+        assertEquals("testField3: Decimal(38, 18, 128)", field3.toString());
+    }
+
+    @Test
+    public void lexExtraInnerClosingFieldsDecimalsTest()
+    {
+        // Unfortunately we are on Java 11 so we don't have block quotes
+        String input = "struct<" +
+            "somearrfield0:array<set<struct<somefield:decimal(38,9),someset:set<decimal(11,7)>>>>," +
+            "mapinner0:struct<numberset_deep:set<decimal(23,3,8)>>," +
+            "somearrfield1:array<set<struct<somefield:decimal(38,9),someset:set<decimal(11,7)>>>>," +
+            "mapinner1:struct<numberset_deep:set<decimal(23,3,16)>>," +
+            "somearrfield2:array<set<struct<somefield:decimal(38,9),someset:set<decimal(11,7)>>>>," +
+            "mapinner2:struct<numberset_deep:set<decimal(23,3,32)>>>";
+
+        Field field = GlueFieldLexer.lex("testAsdf2", input);
+
+        String expectedFieldToString = "testAsdf2: " +
+            "Struct<somearrfield0: List<somearrfield0: List<somearrfield0: Struct<somefield: Decimal(38, 9, 128), someset: List<someset: Decimal(11, 7, 128)>>>>, mapinner0: Struct<numberset_deep: List<numberset_deep: Decimal(23, 3, 8)>>, " +
+            "somearrfield1: List<somearrfield1: List<somearrfield1: Struct<somefield: Decimal(38, 9, 128), someset: List<someset: Decimal(11, 7, 128)>>>>, mapinner1: Struct<numberset_deep: List<numberset_deep: Decimal(23, 3, 16)>>, " +
+            "somearrfield2: List<somearrfield2: List<somearrfield2: Struct<somefield: Decimal(38, 9, 128), someset: List<someset: Decimal(11, 7, 128)>>>>, mapinner2: Struct<numberset_deep: List<numberset_deep: Decimal(23, 3, 32)>>>";
+
+        // Just directly compare against the string, its pointless to write code to compare the fields individually
+        assertEquals(expectedFieldToString, field.toString());
     }
 }

--- a/athena-redis/src/main/java/com/amazonaws/athena/connectors/redis/RedisMetadataHandler.java
+++ b/athena-redis/src/main/java/com/amazonaws/athena/connectors/redis/RedisMetadataHandler.java
@@ -399,7 +399,7 @@ public class RedisMetadataHandler
     @Override
     protected Field convertField(String name, String type)
     {
-        return FieldBuilder.newBuilder(name, DefaultGlueType.fromId(type).getArrowType()).build();
+        return FieldBuilder.newBuilder(name, DefaultGlueType.fromId(type)).build();
     }
 
     private String getValue(Block block, int row, String fieldName)


### PR DESCRIPTION
Adds support for all of the following forms of decimal:
"decimal"
"decimal(12,123)"
"decimal(23,111,128)"

This change required a refactoring of DefaultGlueType that removes its use of enum.
The usage was enum seemed to be only for the purposes of the static initialization of the hash map, which is not necessary since we can just use Map.of which achieves the same thing with less code.

An extra level of indirection is also removed now that we just return "ArrowType"s from the DefaultGlueType methods rather than returning "DefaultGlueType".

Issue #664

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
