### PR TITLE
Feature/teradata datasource

### DIFF
--- a/athena-mysql/pom.xml
+++ b/athena-mysql/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.17</version>
+            <version>8.0.28</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-rds -->
         <dependency>

--- a/athena-snowflake/README.md
+++ b/athena-snowflake/README.md
@@ -56,7 +56,9 @@ Example properties for a Snowflake Mux Lambda function that supports two databas
 |	|	|
 |snowflake_catalog1_connection_string|```snowflake://jdbc:snowflake://snowflake1.host:port/?warehouse=warehousename&db=db1&schema=schema1${Test/RDS/Snowflake1}```|
 |	|	|
-|snowflake_catalog2_connection_string|```snowflake://jdbc:snowflake://snowflake2.host:port/?warehouse=warehousename&db=db1&schema=schema1&user=sample2&password=sample2```|
+|snowflake_catalog2_connection_string|```snowflake://jdbc:snowflake://snowflake1.host:port/?warehouse=warehousename&db=db1${Test/RDS/Snowflake1}```|
+|	|	|
+|snowflake_catalog3_connection_string|```snowflake://jdbc:snowflake://snowflake2.host:port/?warehouse=warehousename&db=db1&schema=schema1&user=sample2&password=sample2```|
 
 Snowflake Connector supports substitution of any string enclosed like *${SecretName}* with *username* and *password* retrieved from AWS Secrets Manager. Example:
 
@@ -73,6 +75,25 @@ snowflake://jdbc:snowflake://snowflake2.host:port/?warehouse=warehousename&db=db
 Secret Name `Test/RDS/Snowflake1` will be used to retrieve secrets.
 
 Currently Snowflake recognizes `user` and `password` JDBC properties.It will take username and password like username/password without any key `user` and `password`
+
+Please note, If user has provided schema details in connection string, the data source will restrict to tables in that particular schema, If user has not provided schema details, then data source
+will display tables present in the database that has been mentioned in connection string Example:
+
+```
+ snowflake://jdbc:snowflake://snowflake1.host:port/?warehouse=warehousename&db=db1&schema=schema1${Test/RDS/Snowflake1}
+```
+Above will load tables present in schema1 and not other schemas present in db1.
+
+```
+snowflake://jdbc:snowflake://snowflake1.host:port/?warehouse=warehousename&db=db1${Test/RDS/Snowflake1}
+```
+Above will load tables present in db1.
+
+### References
+
+```
+https://docs.snowflake.com/en/user-guide/jdbc-configure.html#jdbc-driver-connection-string
+```
 
 ### Single connection handler parameters
 

--- a/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMetadataHandler.java
+++ b/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMetadataHandler.java
@@ -525,20 +525,18 @@ public class SnowflakeMetadataHandler extends JdbcMetadataHandler
     {
         try (ResultSet resultSet = jdbcConnection.getMetaData().getSchemas()) {
             ImmutableSet.Builder<String> schemaNames = ImmutableSet.builder();
-            ImmutableSet.Builder<String> catalogNames = ImmutableSet.builder();
             String inputCatalogName = jdbcConnection.getCatalog();
             String inputSchemaName = jdbcConnection.getSchema();
             while (resultSet.next()) {
                 String schemaName = resultSet.getString("TABLE_SCHEM");
                 String catalogName = resultSet.getString("TABLE_CATALOG");
                 // skip internal schemas
-                if (inputSchemaName != null && schemaName.equals(inputSchemaName)  && !schemaName.equals("information_schema") && catalogName.equals(inputCatalogName)) {
+                boolean shouldAddSchema =
+                        ((inputSchemaName == null) || schemaName.equals(inputSchemaName)) &&
+                                (!schemaName.equals("information_schema") && catalogName.equals(inputCatalogName));
+
+                if (shouldAddSchema) {
                     schemaNames.add(schemaName);
-                    catalogNames.add(catalogName);
-                }
-                else if (inputSchemaName == null && !schemaName.equals("information_schema") && catalogName.equals(inputCatalogName)) {
-                    schemaNames.add(schemaName);
-                    catalogNames.add(catalogName);
                 }
             }
             return schemaNames.build();

--- a/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMetadataHandler.java
+++ b/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMetadataHandler.java
@@ -36,6 +36,8 @@ import com.amazonaws.athena.connector.lambda.metadata.GetSplitsResponse;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableLayoutRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableResponse;
+import com.amazonaws.athena.connector.lambda.metadata.ListSchemasRequest;
+import com.amazonaws.athena.connector.lambda.metadata.ListSchemasResponse;
 import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionConfig;
 import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionInfo;
 import com.amazonaws.athena.connectors.jdbc.connection.GenericJdbcConnectionFactory;
@@ -48,6 +50,7 @@ import com.amazonaws.services.athena.AmazonAthena;
 import com.amazonaws.services.secretsmanager.AWSSecretsManager;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.ArrowType;
@@ -505,5 +508,40 @@ public class SnowflakeMetadataHandler extends JdbcMetadataHandler
             }
         }
         return tableName;
+    }
+    @Override
+    public ListSchemasResponse doListSchemaNames(final BlockAllocator blockAllocator, final ListSchemasRequest listSchemasRequest)
+    {
+        try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider())) {
+            LOGGER.info("{}: List schema names for Catalog {}", listSchemasRequest.getQueryId(), listSchemasRequest.getCatalogName());
+            return new ListSchemasResponse(listSchemasRequest.getCatalogName(), listDatabaseNames(connection));
+        }
+        catch (SQLException sqlException) {
+            throw new RuntimeException(sqlException.getErrorCode() + ": " + sqlException.getMessage());
+        }
+    }
+    protected static Set<String>  listDatabaseNames(final Connection jdbcConnection)
+            throws SQLException
+    {
+        try (ResultSet resultSet = jdbcConnection.getMetaData().getSchemas()) {
+            ImmutableSet.Builder<String> schemaNames = ImmutableSet.builder();
+            ImmutableSet.Builder<String> catalogNames = ImmutableSet.builder();
+            String inputCatalogName = jdbcConnection.getCatalog();
+            String inputSchemaName = jdbcConnection.getSchema();
+            while (resultSet.next()) {
+                String schemaName = resultSet.getString("TABLE_SCHEM");
+                String catalogName = resultSet.getString("TABLE_CATALOG");
+                // skip internal schemas
+                if (inputSchemaName != null && schemaName.equals(inputSchemaName)  && !schemaName.equals("information_schema") && catalogName.equals(inputCatalogName)) {
+                    schemaNames.add(schemaName);
+                    catalogNames.add(catalogName);
+                }
+                else if (inputSchemaName == null && !schemaName.equals("information_schema") && catalogName.equals(inputCatalogName)) {
+                    schemaNames.add(schemaName);
+                    catalogNames.add(catalogName);
+                }
+            }
+            return schemaNames.build();
+        }
     }
 }

--- a/athena-teradata/src/main/java/com/amazonaws/athena/connectors/teradata/TeradataMetadataHandler.java
+++ b/athena-teradata/src/main/java/com/amazonaws/athena/connectors/teradata/TeradataMetadataHandler.java
@@ -348,6 +348,8 @@ public class TeradataMetadataHandler extends JdbcMetadataHandler
                     LOGGER.info("Column Name: " + columnName);
                     if (columnType != null) {
                         LOGGER.info("Column Type: " + columnType.getTypeID());
+                    }else {
+                        LOGGER.warn("Column Type is null for Column Name" + columnName);
                     }
 
                     /**

--- a/athena-teradata/src/main/java/com/amazonaws/athena/connectors/teradata/TeradataMetadataHandler.java
+++ b/athena-teradata/src/main/java/com/amazonaws/athena/connectors/teradata/TeradataMetadataHandler.java
@@ -44,7 +44,6 @@ import com.amazonaws.athena.connectors.jdbc.manager.PreparedStatementBuilder;
 import com.amazonaws.services.athena.AmazonAthena;
 import com.amazonaws.services.secretsmanager.AWSSecretsManager;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableMap;
 import org.apache.arrow.adapter.jdbc.JdbcFieldInfo;
 import org.apache.arrow.adapter.jdbc.JdbcToArrowUtils;
 import org.apache.arrow.vector.complex.reader.FieldReader;
@@ -64,7 +63,6 @@ import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -74,7 +72,6 @@ import java.util.stream.Collectors;
  */
 public class TeradataMetadataHandler extends JdbcMetadataHandler
 {
-    static final Map<String, String> JDBC_PROPERTIES = ImmutableMap.of("databaseTerm", "SCHEMA");
     static final String ALL_PARTITIONS = "*";
     static final String BLOCK_PARTITION_COLUMN_NAME = "partition";
 
@@ -99,7 +96,7 @@ public class TeradataMetadataHandler extends JdbcMetadataHandler
      */
     public TeradataMetadataHandler(final DatabaseConnectionConfig databaseConnectionConfig)
     {
-       this(databaseConnectionConfig, new GenericJdbcConnectionFactory(databaseConnectionConfig, JDBC_PROPERTIES, new DatabaseConnectionInfo(TeradataConstants.TERADATA_DRIVER_CLASS, TeradataConstants.TERADATA_DEFAULT_PORT)));
+       this(databaseConnectionConfig, new GenericJdbcConnectionFactory(databaseConnectionConfig, null, new DatabaseConnectionInfo(TeradataConstants.TERADATA_DRIVER_CLASS, TeradataConstants.TERADATA_DEFAULT_PORT)));
     }
 
     public TeradataMetadataHandler(final DatabaseConnectionConfig databaseConnectionConfig, final JdbcConnectionFactory jdbcConnectionFactory)
@@ -349,7 +346,9 @@ public class TeradataMetadataHandler extends JdbcMetadataHandler
                     String columnName = resultSet.getString("COLUMN_NAME");
 
                     LOGGER.info("Column Name: " + columnName);
-                    LOGGER.info("Column Type: " + columnType.getTypeID());
+                    if (columnType != null) {
+                        LOGGER.info("Column Type: " + columnType.getTypeID());
+                    }
 
                     /**
                      * Convert decimal into BigInt

--- a/athena-teradata/src/main/java/com/amazonaws/athena/connectors/teradata/TeradataMetadataHandler.java
+++ b/athena-teradata/src/main/java/com/amazonaws/athena/connectors/teradata/TeradataMetadataHandler.java
@@ -348,7 +348,7 @@ public class TeradataMetadataHandler extends JdbcMetadataHandler
                     LOGGER.info("Column Name: " + columnName);
                     if (columnType != null) {
                         LOGGER.info("Column Type: " + columnType.getTypeID());
-                    }else {
+                    } else {
                         LOGGER.warn("Column Type is null for Column Name" + columnName);
                     }
 

--- a/athena-teradata/src/main/java/com/amazonaws/athena/connectors/teradata/TeradataMetadataHandler.java
+++ b/athena-teradata/src/main/java/com/amazonaws/athena/connectors/teradata/TeradataMetadataHandler.java
@@ -348,7 +348,8 @@ public class TeradataMetadataHandler extends JdbcMetadataHandler
                     LOGGER.info("Column Name: " + columnName);
                     if (columnType != null) {
                         LOGGER.info("Column Type: " + columnType.getTypeID());
-                    } else {
+                    }
+                    else {
                         LOGGER.warn("Column Type is null for Column Name" + columnName);
                     }
 

--- a/athena-teradata/src/main/java/com/amazonaws/athena/connectors/teradata/TeradataRecordHandler.java
+++ b/athena-teradata/src/main/java/com/amazonaws/athena/connectors/teradata/TeradataRecordHandler.java
@@ -54,7 +54,7 @@ public class TeradataRecordHandler extends JdbcRecordHandler
     }
     public TeradataRecordHandler(final DatabaseConnectionConfig databaseConnectionConfig)
     {
-        this(databaseConnectionConfig, new GenericJdbcConnectionFactory(databaseConnectionConfig, TeradataMetadataHandler.JDBC_PROPERTIES, new DatabaseConnectionInfo(TeradataConstants.TERADATA_DRIVER_CLASS, TeradataConstants.TERADATA_DEFAULT_PORT)));
+        this(databaseConnectionConfig, new GenericJdbcConnectionFactory(databaseConnectionConfig, null, new DatabaseConnectionInfo(TeradataConstants.TERADATA_DRIVER_CLASS, TeradataConstants.TERADATA_DEFAULT_PORT)));
     }
 
     public TeradataRecordHandler(final DatabaseConnectionConfig databaseConnectionConfig, final JdbcConnectionFactory jdbcConnectionFactory)


### PR DESCRIPTION
*Issue #, if available:*
1.Teradata Connector Errors On Non-Existent DatabaseTerm Parameter In JDBC String
2.Snowflake Connector Doesn't Respect Schema Definition In JDBC String (Snowflake) (Issue Raised Directly By Client)
*Description of changes:*
Issue 1. There was an extra default parameter added in jdbcproperties which was causing the issue. The issue was coming only above 17.x.x.x jdbc version of java.
Issue 2.The issue was after adding snowflake data source, all other schemas present were coming in the database dropdown. Now we have restricted this as per the connection string, if user is selecting specific schema, then only that schema will be available in database dropdown. If no schema has been chosen, then schemas present in the database mentioned in connection string will be available.
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
