### PR TITLE
Adding User Agent field to Timestream SDKs (Query and Write)

### DIFF
--- a/athena-timestream/src/main/java/com/amazonaws/athena/connectors/timestream/TimestreamClientBuilder.java
+++ b/athena-timestream/src/main/java/com/amazonaws/athena/connectors/timestream/TimestreamClientBuilder.java
@@ -1,0 +1,56 @@
+/*-
+ * #%L
+ * athena-timestream
+ * %%
+ * Copyright (C) 2019 - 2022 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.timestream;
+
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.services.timestreamquery.AmazonTimestreamQuery;
+import com.amazonaws.services.timestreamquery.AmazonTimestreamQueryClientBuilder;
+import com.amazonaws.services.timestreamwrite.AmazonTimestreamWrite;
+import com.amazonaws.services.timestreamwrite.AmazonTimestreamWriteClientBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TimestreamClientBuilder
+{
+  private static final Logger logger = LoggerFactory.getLogger(TimestreamClientBuilder.class);
+
+  private TimestreamClientBuilder()
+  {
+    // prevent instantiation with private constructor
+  }
+
+  public static AmazonTimestreamQuery buildQueryClient(String sourceType)
+  {
+    return AmazonTimestreamQueryClientBuilder.standard().withClientConfiguration(buildClientConfiguration(sourceType)).build();
+  }
+
+  public static AmazonTimestreamWrite buildWriteClient(String sourceType)
+  {
+    return AmazonTimestreamWriteClientBuilder.standard().withClientConfiguration(buildClientConfiguration(sourceType)).build();
+  }
+
+  static ClientConfiguration buildClientConfiguration(String sourceType)
+  {
+    String userAgent = "aws-athena-" + sourceType + "-connector";
+    ClientConfiguration clientConfiguration = new ClientConfiguration().withUserAgentPrefix(userAgent);
+    logger.info("Created client configuration with user agent {} for Timestream SDK", clientConfiguration.getUserAgentPrefix());
+    return clientConfiguration;
+  }
+}

--- a/athena-timestream/src/main/java/com/amazonaws/athena/connectors/timestream/TimestreamMetadataHandler.java
+++ b/athena-timestream/src/main/java/com/amazonaws/athena/connectors/timestream/TimestreamMetadataHandler.java
@@ -42,13 +42,11 @@ import com.amazonaws.services.glue.AWSGlue;
 import com.amazonaws.services.glue.model.Table;
 import com.amazonaws.services.secretsmanager.AWSSecretsManager;
 import com.amazonaws.services.timestreamquery.AmazonTimestreamQuery;
-import com.amazonaws.services.timestreamquery.AmazonTimestreamQueryClientBuilder;
 import com.amazonaws.services.timestreamquery.model.Datum;
 import com.amazonaws.services.timestreamquery.model.QueryRequest;
 import com.amazonaws.services.timestreamquery.model.QueryResult;
 import com.amazonaws.services.timestreamquery.model.Row;
 import com.amazonaws.services.timestreamwrite.AmazonTimestreamWrite;
-import com.amazonaws.services.timestreamwrite.AmazonTimestreamWriteClientBuilder;
 import com.amazonaws.services.timestreamwrite.model.Database;
 import com.amazonaws.services.timestreamwrite.model.ListDatabasesRequest;
 import com.amazonaws.services.timestreamwrite.model.ListDatabasesResult;
@@ -90,8 +88,8 @@ public class TimestreamMetadataHandler
         //Disable Glue if the env var is present and not explicitly set to "false"
         super((System.getenv(GLUE_ENV) != null && !"false".equalsIgnoreCase(System.getenv(GLUE_ENV))), SOURCE_TYPE);
         glue = getAwsGlue();
-        tsQuery = AmazonTimestreamQueryClientBuilder.standard().build();
-        tsMeta = AmazonTimestreamWriteClientBuilder.standard().build();
+        tsQuery = TimestreamClientBuilder.buildQueryClient(SOURCE_TYPE);
+        tsMeta = TimestreamClientBuilder.buildWriteClient(SOURCE_TYPE);
     }
 
     @VisibleForTesting

--- a/athena-timestream/src/main/java/com/amazonaws/athena/connectors/timestream/TimestreamRecordHandler.java
+++ b/athena-timestream/src/main/java/com/amazonaws/athena/connectors/timestream/TimestreamRecordHandler.java
@@ -46,7 +46,6 @@ import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.secretsmanager.AWSSecretsManager;
 import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
 import com.amazonaws.services.timestreamquery.AmazonTimestreamQuery;
-import com.amazonaws.services.timestreamquery.AmazonTimestreamQueryClientBuilder;
 import com.amazonaws.services.timestreamquery.model.Datum;
 import com.amazonaws.services.timestreamquery.model.QueryRequest;
 import com.amazonaws.services.timestreamquery.model.QueryResult;
@@ -86,7 +85,7 @@ public class TimestreamRecordHandler
         this(AmazonS3ClientBuilder.defaultClient(),
                 AWSSecretsManagerClientBuilder.defaultClient(),
                 AmazonAthenaClientBuilder.defaultClient(),
-                AmazonTimestreamQueryClientBuilder.standard().build());
+                TimestreamClientBuilder.buildQueryClient(SOURCE_TYPE));
     }
 
     @VisibleForTesting

--- a/athena-timestream/src/test/java/com/amazonaws/athena/connectors/timestream/TimestreamClientBuilderTest.java
+++ b/athena-timestream/src/test/java/com/amazonaws/athena/connectors/timestream/TimestreamClientBuilderTest.java
@@ -1,0 +1,16 @@
+package com.amazonaws.athena.connectors.timestream;
+
+import com.amazonaws.ClientConfiguration;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class TimestreamClientBuilderTest {
+
+  @Test
+  public void testUserAgentField()
+  {
+    ClientConfiguration clientConfiguration = TimestreamClientBuilder.buildClientConfiguration("timestream");
+    assertEquals("aws-athena-timestream-connector", clientConfiguration.getUserAgentPrefix());
+  }
+}

--- a/athena-timestream/src/test/java/com/amazonaws/athena/connectors/timestream/integ/TimestreamIntegTest.java
+++ b/athena-timestream/src/test/java/com/amazonaws/athena/connectors/timestream/integ/TimestreamIntegTest.java
@@ -20,9 +20,9 @@
 package com.amazonaws.athena.connectors.timestream.integ;
 
 import com.amazonaws.athena.connector.integ.IntegrationTestBase;
+import com.amazonaws.athena.connectors.timestream.TimestreamClientBuilder;
 import com.amazonaws.services.athena.model.Row;
 import com.amazonaws.services.timestreamwrite.AmazonTimestreamWrite;
-import com.amazonaws.services.timestreamwrite.AmazonTimestreamWriteClientBuilder;
 import com.amazonaws.services.timestreamwrite.model.CreateTableRequest;
 import com.amazonaws.services.timestreamwrite.model.DeleteTableRequest;
 import com.amazonaws.services.timestreamwrite.model.MeasureValueType;
@@ -75,7 +75,7 @@ public class TimestreamIntegTest extends IntegrationTestBase
                 currentTimeMillis + 14_000L, currentTimeMillis + 16_000L, currentTimeMillis + 18_000L,
                 currentTimeMillis + 20_000L, currentTimeMillis + 22_000L, currentTimeMillis + 24_000L,
                 currentTimeMillis + 26_000L};
-        timestreamWriteClient = AmazonTimestreamWriteClientBuilder.defaultClient();
+        timestreamWriteClient = TimestreamClientBuilder.buildWriteClient("timestream");
     }
 
     /**


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-athena-query-federation/issues/733

*Description of changes:*
Introducing a user-agent field to the client configuration we attach to the Timestream SDK clients (write and query).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
