### PR TITLE
Add `disable_projection_and_casing` to deal with casing issues. Also undoes the revert of the Glue Lexer revert.

### DIFF
--- a/athena-dynamodb/README.md
+++ b/athena-dynamodb/README.md
@@ -20,6 +20,8 @@ generation for a stronger source of encryption keys. (e.g. a7e63k4b-8loc-40db-a2
 Setting this to false will disable spill encryption. You may wish to disable this for improved performance, especially if your spill location in S3 uses S3 Server Side Encryption. (e.g. True or False)
 6. **disable_glue** - (Optional) If present, with any value except false, the connector will no longer attempt to retrieve supplemental metadata from Glue.
 7. **glue_catalog** - (Optional) Can be used to target a cross-account Glue catalog. By default the connector will attempt to get metadata from its own Glue account.
+8. **disable_projection_and_casing** - (Optional) Defaults to: auto. Can be used to disable projection and casing in order to be able to query DynamoDB tables with casing in their column names without having to specify a "columnMapping" property on their Glue table. Go here for more info [disable_projection_and_casing](#disable_projection_and_casing).
+
 
 ### Setting Up Databases & Tables in Glue
 
@@ -90,3 +92,26 @@ The costs for use of this solution depends on the underlying AWS resources being
 ## Notes
 
 If glue is disabled, we perform schema inference. Under schema inference, we evaluate all [int, float, double..etc] to Decimal. If you wish to have correct type, please use glue to declare schema.
+
+## disable_projection_and_casing
+- auto
+    - This disables projection and casing when we see a previously unsupported type
+      and we see that the user does not have column name mapping on their table.
+    - This is the default setting.
+- true
+    - This disables projection and casing unconditionally.
+      This is useful when users have casing in their ddb column names but do not want to
+      specify a column name mapping at all.
+- false
+    - This enables projection and casing unconditionally.
+      This is useful when the users want projection enabled (mainly for bandwidth and latency)
+      and are not worried about their columns with casing or already have a column name mapping
+      for those columns.
+
+Caveats with setting this to true or auto:
+
+- May incur higher bandwidth usage depending on your query.
+This not a problem if your lambda is in the same region as your ddb table.
+
+- Overall latency may increase because there is a larger number of bytes being transferred and also
+higher deserialization time given the larger amount of bytes.

--- a/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DDBTypeUtilsTest.java
+++ b/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DDBTypeUtilsTest.java
@@ -172,7 +172,7 @@ public class DDBTypeUtilsTest
     {
         Map<String, Object> results = new HashMap<>();
         for (Field field : mapping.getFields()) {
-            Optional<Extractor> optionalExtractor = DDBTypeUtils.makeExtractor(field, ddbRecordMetadata);
+            Optional<Extractor> optionalExtractor = DDBTypeUtils.makeExtractor(field, ddbRecordMetadata, false);
 
             if (optionalExtractor.isPresent()) {
                 Extractor extractor = optionalExtractor.get();

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/metadata/glue/DefaultGlueType.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/metadata/glue/DefaultGlueType.java
@@ -24,43 +24,46 @@ import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 
 import java.time.ZoneId;
-import java.util.HashMap;
-import java.util.HashSet;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.util.Map.entry;
 
 /**
  * Defines the default mapping of AWS Glue Data Catalog types to Apache Arrow types. You can override these by
  * overriding convertField(...) on GlueMetadataHandler.
  */
-public enum DefaultGlueType
+public class DefaultGlueType
 {
-    INT("int", Types.MinorType.INT.getType()),
-    VARCHAR("varchar", Types.MinorType.VARCHAR.getType()),
-    STRING("string", Types.MinorType.VARCHAR.getType()),
-    BIGINT("bigint", Types.MinorType.BIGINT.getType()),
-    DOUBLE("double", Types.MinorType.FLOAT8.getType()),
-    FLOAT("float", Types.MinorType.FLOAT4.getType()),
-    SMALLINT("smallint", Types.MinorType.SMALLINT.getType()),
-    TINYINT("tinyint", Types.MinorType.TINYINT.getType()),
-    BIT("boolean", Types.MinorType.BIT.getType()),
-    VARBINARY("binary", Types.MinorType.VARBINARY.getType()),
-    TIMESTAMP("timestamp", Types.MinorType.DATEMILLI.getType()),
-    // ZoneId.systemDefault().getId() is just a place holder, each row will have a TZ value
-    // otherwise fall back to the table configured default TZ
-    TIMESTAMPMILLITZ("timestamptz", new ArrowType.Timestamp(org.apache.arrow.vector.types.TimeUnit.MILLISECOND, ZoneId.systemDefault().getId())),
-    DATE("date", Types.MinorType.DATEDAY.getType());
+    private static final String TIMESTAMPMILLITZ = "timestamptz";
+    private static final Set<String> NON_COMPARABALE_SET = Set.of("TIMESTAMPMILLITZ");
 
-    private static final Map<String, DefaultGlueType> TYPE_MAP = new HashMap<>();
-    private static final Set<String> NON_COMPARABALE_SET = new HashSet<>();
+    private static final Map<String, ArrowType> TYPE_MAP = Map.ofEntries(
+        entry("int", Types.MinorType.INT.getType()),
+        entry("varchar", Types.MinorType.VARCHAR.getType()),
+        entry("string", Types.MinorType.VARCHAR.getType()),
+        entry("bigint", Types.MinorType.BIGINT.getType()),
+        entry("double", Types.MinorType.FLOAT8.getType()),
+        entry("float", Types.MinorType.FLOAT4.getType()),
+        entry("smallint", Types.MinorType.SMALLINT.getType()),
+        entry("tinyint", Types.MinorType.TINYINT.getType()),
+        entry("boolean", Types.MinorType.BIT.getType()),
+        entry("binary", Types.MinorType.VARBINARY.getType()),
+        entry("timestamp", Types.MinorType.DATEMILLI.getType()),
+        entry("date", Types.MinorType.DATEDAY.getType()),
+        // ZoneId.systemDefault().getId() is just a place holder, each row will have a TZ value
+        // otherwise fall back to the table configured default TZ
+        entry(TIMESTAMPMILLITZ, new ArrowType.Timestamp(
+                org.apache.arrow.vector.types.TimeUnit.MILLISECOND, ZoneId.systemDefault().getId())));
 
-    static {
-        for (DefaultGlueType next : DefaultGlueType.values()) {
-            TYPE_MAP.put(next.id, next);
-        }
-
-        NON_COMPARABALE_SET.add(DefaultGlueType.TIMESTAMPMILLITZ.name());
-    }
+    // decimal match examples:
+    // decimal
+    // decimal(1,2)
+    // decimal(3,2,1)
+    private static final Pattern decimalPattern = Pattern.compile("decimal([(](([0-9]+,?){2,3})[)])?");
 
     private String id;
     private ArrowType arrowType;
@@ -71,24 +74,49 @@ public enum DefaultGlueType
         this.arrowType = arrowType;
     }
 
-    public static DefaultGlueType fromId(String id)
+    private static ArrowType getDecimalArrowType(String in)
     {
-        DefaultGlueType result = TYPE_MAP.get(id.toLowerCase());
+        Matcher decimalMatcher = decimalPattern.matcher(in);
+        if (!decimalMatcher.matches()) {
+            return null;
+        }
+        try {
+            int[] params = Arrays.stream(decimalMatcher.group(2).split(","))
+                    .mapToInt(Integer::parseInt).toArray();
+            if (params.length == 2) {
+                return new ArrowType.Decimal(params[0], params[1]);
+            }
+            // else this must be 3 because of the regex
+            return new ArrowType.Decimal(params[0], params[1], params[2]);
+        }
+        catch (java.lang.NullPointerException e) {
+            // This is the case where it is only "decimal" with no parameters
+            // Using the default precision and scale that spark sql defaults
+            // to when no parameters are specified.
+            // NOTE: I would prefer to check the decimalMatcher.groupCount() above
+            // rather than a try catch but decimalMatcher.groupCount() always returns
+            // 3 for some reason...
+            return new ArrowType.Decimal(38, 18);
+        }
+    }
+
+    public static ArrowType fromId(String id)
+    {
+        ArrowType result = toArrowType(id);
         if (result == null) {
             throw new IllegalArgumentException("Unknown DefaultGlueType for id: " + id);
         }
-
         return result;
     }
 
     public static ArrowType toArrowType(String id)
     {
-        DefaultGlueType result = TYPE_MAP.get(id.toLowerCase());
+        ArrowType result = TYPE_MAP.get(id.toLowerCase());
         if (result == null) {
-            return null;
+            return getDecimalArrowType(id);
         }
 
-        return result.getArrowType();
+        return result;
     }
 
     public ArrowType getArrowType()

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/metadata/glue/GlueFieldLexer.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/metadata/glue/GlueFieldLexer.java
@@ -27,6 +27,8 @@ import org.apache.arrow.vector.types.pojo.Field;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Set;
+
 /**
  * Extracts field definitions, including complex types like List and STRUCT, from AWS Glue Data Catalog's
  * definition of a field. This class makes use of GlueTypeParser to tokenize the definition of the field.
@@ -34,11 +36,15 @@ import org.slf4j.LoggerFactory;
  */
 public class GlueFieldLexer
 {
+    // NOTE:
+    // This entire class and file should really be called a parser instead...
+    // The GlueFieldParser should actually be called a GlueFieldLexer and vice versa.
+
     private static final Logger logger = LoggerFactory.getLogger(GlueFieldLexer.class);
 
     private static final String STRUCT = "struct";
-    private static final String ARRAY = "array";
-    private static final String SET = "set";
+
+    private static final Set<String> LIST_EQUIVALENTS = Set.of("array", "set");
 
     private static final BaseTypeMapper DEFAULT_TYPE_MAPPER = (String type) -> DefaultGlueType.toArrowType(type);
 
@@ -60,102 +66,85 @@ public class GlueFieldLexer
 
     public static Field lex(String name, String input)
     {
-        ArrowType typeResult = DEFAULT_TYPE_MAPPER.getType(input);
-        if (typeResult != null) {
-            return FieldBuilder.newBuilder(name, typeResult).build();
-        }
-
-        GlueTypeParser parser = new GlueTypeParser(input);
-        return lexComplex(name, parser.next(), parser, DEFAULT_TYPE_MAPPER);
+        return lex(name, input, DEFAULT_TYPE_MAPPER);
     }
 
     public static Field lex(String name, String input, BaseTypeMapper mapper)
     {
-        Field result = mapper.getField(name, input);
-        if (result != null) {
-            return result;
-        }
-
         GlueTypeParser parser = new GlueTypeParser(input);
-        return lexComplex(name, parser.next(), parser, mapper);
+        return lexInternal(name, parser, mapper);
     }
 
-    private static Field lexComplex(String name, GlueTypeParser.Token startToken, GlueTypeParser parser, BaseTypeMapper mapper)
+    private static Field lexInternal(String name, GlueTypeParser parser, BaseTypeMapper mapper)
     {
-        FieldBuilder fieldBuilder;
-
-        logger.debug("lexComplex: enter - {}", name);
-        if (startToken.getMarker() != GlueTypeParser.FIELD_START) {
-            throw new RuntimeException("Parse error, expected " + GlueTypeParser.FIELD_START
-                    + " but found " + startToken.getMarker());
-        }
-
-        final String startTokenValueLower = startToken.getValue().toLowerCase();
-
-        if (startTokenValueLower.equals(STRUCT)) {
-            fieldBuilder = FieldBuilder.newBuilder(name, Types.MinorType.STRUCT.getType());
-        }
-        else if (startTokenValueLower.equals(ARRAY) || startTokenValueLower.equals(SET)) {
-            GlueTypeParser.Token arrayType = parser.next();
-            Field child;
-            String type = arrayType.getValue().toLowerCase();
-            if (type.equals(STRUCT) || type.equals(ARRAY) || type.equals(SET)) {
-                child = lexComplex(name, arrayType, parser, mapper);
+        logger.debug("lexInternal: enter - {}", name);
+        try {
+            GlueTypeParser.Token typeToken = parser.next();
+            final String typeTokenValueLower = typeToken.getValue().toLowerCase();
+            if (typeTokenValueLower.equals(STRUCT)) {
+                return parseStruct(name, typeToken, parser, mapper);
             }
-            else {
-                child = mapper.getField(name, arrayType.getValue());
+            else if (LIST_EQUIVALENTS.contains(typeTokenValueLower)) {
+                return parseList(name, typeToken, parser, mapper);
             }
-            // Both Glue "array" and "set" get converted to Arrow LIST
-            return FieldBuilder.newBuilder(name, Types.MinorType.LIST.getType()).addField(child).build();
+            // Primitive case
+            expectTokenMarkerIsFieldEnd(typeToken);
+            return mapper.getField(name, typeTokenValueLower);
         }
-        else {
-            throw new RuntimeException("Unexpected start type " + startToken.getValue());
+        finally {
+            logger.debug("lexInternal: exit - {}", name);
         }
+    }
 
-        while (parser.hasNext() && parser.currentToken().getMarker() != GlueTypeParser.FIELD_END) {
-            Field child = lex(parser.next(), parser, mapper);
+    private static Field parseStruct(String name, GlueTypeParser.Token typeToken, GlueTypeParser parser, BaseTypeMapper mapper)
+    {
+        expectTokenMarkerIsFieldStart(typeToken);
+        FieldBuilder fieldBuilder = FieldBuilder.newBuilder(name, Types.MinorType.STRUCT.getType());
+        // Iterate through the child element types of the STRUCT
+        while (parser.hasNext()) {
+            GlueTypeParser.Token childNameToken = parser.next();
+            if (!childNameToken.getMarker().equals(GlueTypeParser.FIELD_DIV)) {
+                // Current token is not a child if it doesn't have a ":" (FIELD_DIV).
+                // Which means we are done with the struct. Just break out and build.
+                break;
+            }
+            // Recursive call to resolve child type
+            Field child = lexInternal(childNameToken.getValue(), parser, mapper);
             fieldBuilder.addField(child);
-            if (Types.getMinorTypeForArrowType(child.getType()) == Types.MinorType.LIST) {
-                // An ARRAY Glue type (LIST in Arrow) within a STRUCT has the same ending token as a STRUCT (">" or
-                // GlueTypeParser.FIELD_END). If allowed to proceed, the Glue parser will misinterpret the end of the
-                // ARRAY to be the end of the STRUCT (which is currently being processed) ending the loop prematurely
-                // and causing all subsequent fields in the STRUCT to be dropped.
-                // Example: movies: STRUCT<actors:ARRAY<STRING>,genre:ARRAY<STRING>>
-                // will result in Field definition: movies: Struct<actors: List<actors: Utf8>>.
-                // In order to prevent that from happening, we must consume an additional token to get past the LIST's
-                // ending token ">".
-                parser.next();
-            }
         }
-        parser.next();
-
-        logger.debug("lexComplex: exit - {}", name);
+        // Expect that we're ending on the closing token
+        expectTokenMarkerIsFieldEnd(parser.currentToken());
         return fieldBuilder.build();
     }
 
-    private static Field lex(GlueTypeParser.Token startToken, GlueTypeParser parser, BaseTypeMapper mapper)
+    private static Field parseList(String name, GlueTypeParser.Token typeToken, GlueTypeParser parser, BaseTypeMapper mapper)
     {
-        GlueTypeParser.Token nameToken = startToken;
-        logger.debug("lex: enter - {}", nameToken.getValue());
-        if (!nameToken.getMarker().equals(GlueTypeParser.FIELD_DIV)) {
-            throw new RuntimeException("Expected Field DIV but found " + nameToken.getMarker() +
-                    " while processing " + nameToken.getValue());
-        }
+        expectTokenMarkerIsFieldStart(typeToken);
+        // Recursive call to resolve child element type
+        Field child = lexInternal(name, parser, mapper);
+        // The next field must always be a closing token since we are building the field here
+        // So consume the closing token for this field
+        GlueTypeParser.Token closingToken = parser.next();
+        // Note that the closing token is , if the enclosing type is a struct
+        // and > if the enclosing type is a list
+        expectTokenMarkerIsFieldEnd(closingToken);
+        return FieldBuilder.newBuilder(name, Types.MinorType.LIST.getType()).addField(child).build();
+    }
 
-        String name = nameToken.getValue();
+    private static void expectTokenMarkerIsFieldStart(GlueTypeParser.Token token)
+    {
+        if (token.getMarker() != GlueTypeParser.FIELD_START) {
+            throw new RuntimeException("Expected field start: but found " + token.toString());
+        }
+    }
 
-        GlueTypeParser.Token typeToken = parser.next();
-        if (typeToken.getMarker().equals(GlueTypeParser.FIELD_START)) {
-            logger.debug("lex: exit - {}", nameToken.getValue());
-            return lexComplex(name, typeToken, parser, mapper);
+    private static void expectTokenMarkerIsFieldEnd(GlueTypeParser.Token token)
+    {
+        boolean isFieldEnd = (token.getMarker() == null ||
+              token.getMarker().equals(GlueTypeParser.FIELD_SEP) ||
+              token.getMarker().equals(GlueTypeParser.FIELD_END));
+        if (!isFieldEnd) {
+            throw new RuntimeException("Expected field ending but found: " + token.toString());
         }
-        else if (typeToken.getMarker().equals(GlueTypeParser.FIELD_SEP) ||
-                typeToken.getMarker().equals(GlueTypeParser.FIELD_END)
-        ) {
-            logger.debug("lex: exit - {}", nameToken.getValue());
-            return mapper.getField(name, typeToken.getValue());
-        }
-        throw new RuntimeException("Unexpected Token " + typeToken.getValue() + "[" + typeToken.getMarker() + "]"
-                + " @ " + typeToken.getPos() + " while processing " + name);
     }
 }

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/metadata/glue/GlueFieldLexerTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/metadata/glue/GlueFieldLexerTest.java
@@ -21,6 +21,7 @@ package com.amazonaws.athena.connector.lambda.metadata.glue;
  */
 
 import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -278,5 +279,47 @@ public class GlueFieldLexerTest
             assertEquals(Types.MinorType.BIGINT, Types.getMinorTypeForArrowType(mapinnerField.getChildren().get(0).getChildren().get(0).getType()));
         }
 
+    }
+
+    @Test
+    public void basicLexDecimalTest()
+    {
+        logger.info("basicLexDecimalTest: enter");
+        String input1 = "DECIMAL(13,7)";
+        Field field1 = GlueFieldLexer.lex("testField1", input1);
+        // 128 bits is the default for Arrow Decimal if not specified
+        assertEquals("testField1: Decimal(13, 7, 128)", field1.toString());
+
+        String input2 = "DECIMAL(13,7,8)";
+        Field field2 = GlueFieldLexer.lex("testField2", input2);
+        assertEquals("testField2: Decimal(13, 7, 8)", field2.toString());
+
+        String input3 = "DECIMAL";
+        Field field3 = GlueFieldLexer.lex("testField3", input3);
+        // This is what the default params are
+        assertEquals("testField3: Decimal(38, 18, 128)", field3.toString());
+    }
+
+    @Test
+    public void lexExtraInnerClosingFieldsDecimalsTest()
+    {
+        // Unfortunately we are on Java 11 so we don't have block quotes
+        String input = "struct<" +
+            "somearrfield0:array<set<struct<somefield:decimal(38,9),someset:set<decimal(11,7)>>>>," +
+            "mapinner0:struct<numberset_deep:set<decimal(23,3,8)>>," +
+            "somearrfield1:array<set<struct<somefield:decimal(38,9),someset:set<decimal(11,7)>>>>," +
+            "mapinner1:struct<numberset_deep:set<decimal(23,3,16)>>," +
+            "somearrfield2:array<set<struct<somefield:decimal(38,9),someset:set<decimal(11,7)>>>>," +
+            "mapinner2:struct<numberset_deep:set<decimal(23,3,32)>>>";
+
+        Field field = GlueFieldLexer.lex("testAsdf2", input);
+
+        String expectedFieldToString = "testAsdf2: " +
+            "Struct<somearrfield0: List<somearrfield0: List<somearrfield0: Struct<somefield: Decimal(38, 9, 128), someset: List<someset: Decimal(11, 7, 128)>>>>, mapinner0: Struct<numberset_deep: List<numberset_deep: Decimal(23, 3, 8)>>, " +
+            "somearrfield1: List<somearrfield1: List<somearrfield1: Struct<somefield: Decimal(38, 9, 128), someset: List<someset: Decimal(11, 7, 128)>>>>, mapinner1: Struct<numberset_deep: List<numberset_deep: Decimal(23, 3, 16)>>, " +
+            "somearrfield2: List<somearrfield2: List<somearrfield2: Struct<somefield: Decimal(38, 9, 128), someset: List<someset: Decimal(11, 7, 128)>>>>, mapinner2: Struct<numberset_deep: List<numberset_deep: Decimal(23, 3, 32)>>>";
+
+        // Just directly compare against the string, its pointless to write code to compare the fields individually
+        assertEquals(expectedFieldToString, field.toString());
     }
 }

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/metadata/glue/GlueFieldLexerTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/metadata/glue/GlueFieldLexerTest.java
@@ -212,4 +212,71 @@ public class GlueFieldLexerTest
 
         logger.info("lexListOfStructTest: exit");
     }
+
+    @Test
+    public void lexStructListChildAndStructChildTest()
+    {
+        String input = "struct<somearrfield:array<set<string>>,mapinner:struct<numberset_deep:set<bigint>>>";
+        Field field = GlueFieldLexer.lex("testAsdf", input);
+        logger.info("lexStructListChildAndStructChildTest: {}", field);
+
+        assertEquals("testAsdf", field.getName());
+        assertEquals(Types.MinorType.STRUCT, Types.getMinorTypeForArrowType(field.getType()));
+        assertEquals(2, field.getChildren().size());
+
+        List<Field> level1 = field.getChildren();
+        assertEquals("somearrfield", level1.get(0).getName());
+        assertEquals(Types.MinorType.LIST, Types.getMinorTypeForArrowType(level1.get(0).getType()));
+        assertEquals(Types.MinorType.LIST, Types.getMinorTypeForArrowType(level1.get(0).getChildren().get(0).getType()));
+        assertEquals(Types.MinorType.VARCHAR, Types.getMinorTypeForArrowType(level1.get(0).getChildren().get(0).getChildren().get(0).getType()));
+
+        assertEquals("mapinner", level1.get(1).getName());
+        assertEquals(Types.MinorType.STRUCT, Types.getMinorTypeForArrowType(level1.get(1).getType()));
+        assertEquals(Types.MinorType.LIST, Types.getMinorTypeForArrowType(level1.get(1).getChildren().get(0).getType()));
+        assertEquals(Types.MinorType.BIGINT, Types.getMinorTypeForArrowType(level1.get(1).getChildren().get(0).getChildren().get(0).getType()));
+    }
+
+    @Test
+    public void lexExtraInnerClosingFieldsTest()
+    {
+        // Unfortunately we are on Java 11 so we don't have block quotes
+        String input = "struct<" +
+            "somearrfield0:array<set<struct<somefield:string,someset:set<string>>>>," +
+            "mapinner0:struct<numberset_deep:set<bigint>>," +
+            "somearrfield1:array<set<struct<somefield:string,someset:set<string>>>>," +
+            "mapinner1:struct<numberset_deep:set<bigint>>," +
+            "somearrfield2:array<set<struct<somefield:string,someset:set<string>>>>," +
+            "mapinner2:struct<numberset_deep:set<bigint>> >";
+
+        Field field = GlueFieldLexer.lex("testAsdf2", input);
+        logger.info("lexExtraInnerClosingFieldsTest: {}", field);
+
+        assertEquals("testAsdf2", field.getName());
+        assertEquals(Types.MinorType.STRUCT, Types.getMinorTypeForArrowType(field.getType()));
+        assertEquals(6, field.getChildren().size());
+
+        List<Field> level1 = field.getChildren();
+
+        for (int i = 0; i < 3; ++i) {
+            int somearrFieldIdx = i * 2;
+            Field somearrField = level1.get(somearrFieldIdx);
+            assertEquals("somearrfield" + i, somearrField.getName());
+            assertEquals(Types.MinorType.LIST, Types.getMinorTypeForArrowType(somearrField.getType()));
+            assertEquals(Types.MinorType.LIST, Types.getMinorTypeForArrowType(somearrField.getChildren().get(0).getType()));
+            assertEquals(Types.MinorType.STRUCT, Types.getMinorTypeForArrowType(somearrField.getChildren().get(0).getChildren().get(0).getType()));
+
+            Field innerAsdfStruct = somearrField.getChildren().get(0).getChildren().get(0);
+            assertEquals(Types.MinorType.VARCHAR, Types.getMinorTypeForArrowType(innerAsdfStruct.getChildren().get(0).getType()));
+            assertEquals(Types.MinorType.LIST, Types.getMinorTypeForArrowType(innerAsdfStruct.getChildren().get(1).getType()));
+            assertEquals(Types.MinorType.VARCHAR, Types.getMinorTypeForArrowType(innerAsdfStruct.getChildren().get(1).getChildren().get(0).getType()));
+
+            int mapinnerIdx = (i*2) + 1;
+            Field mapinnerField = level1.get(mapinnerIdx);
+            assertEquals("mapinner" + i, mapinnerField.getName());
+            assertEquals(Types.MinorType.STRUCT, Types.getMinorTypeForArrowType(mapinnerField.getType()));
+            assertEquals(Types.MinorType.LIST, Types.getMinorTypeForArrowType(mapinnerField.getChildren().get(0).getType()));
+            assertEquals(Types.MinorType.BIGINT, Types.getMinorTypeForArrowType(mapinnerField.getChildren().get(0).getChildren().get(0).getType()));
+        }
+
+    }
 }

--- a/athena-redis/src/main/java/com/amazonaws/athena/connectors/redis/RedisMetadataHandler.java
+++ b/athena-redis/src/main/java/com/amazonaws/athena/connectors/redis/RedisMetadataHandler.java
@@ -399,7 +399,7 @@ public class RedisMetadataHandler
     @Override
     protected Field convertField(String name, String type)
     {
-        return FieldBuilder.newBuilder(name, DefaultGlueType.fromId(type).getArrowType()).build();
+        return FieldBuilder.newBuilder(name, DefaultGlueType.fromId(type)).build();
     }
 
     private String getValue(Block block, int row, String fieldName)


### PR DESCRIPTION
This `disable_projection_and_casing` variable supports 3 modes:
- auto
    - This disables projection and casing when we see a previously unsupported type
      and we see that the user does not have column name mapping on their table.
- true
    - This disables projection and casing unconditionally.
      This is useful when users have casing in their ddb column names but do not want to
      specify a column name mapping at all.
- false
    - This enables projection and casing unconditionally.
      This is useful when the users want projection enabled (mainly for bandwidth and latency)
      and are not worried about their columns with casing or already have a column name mapping
      for those columns.

Caveats with setting this to true or auto:

- May incur higher bandwidth usage depending on your query.
This not a problem if your lambda is in the same region as your ddb table.

- Overall latency may increase because there is a larger number of bytes being transferred and also
higher deserialization time given the larger amount of bytes.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
