### PR TITLE
Demonstrate second entry to a Map

### DIFF
--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/examples/ExampleRecordHandler.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/examples/ExampleRecordHandler.java
@@ -410,6 +410,7 @@ public class ExampleRecordHandler
                             UnionMapWriter writer  = ((MapVector) vector).getWriter();
                             writer.setPosition(rowNum);
                             writer.startMap();
+
                             writer.startEntry();
                             byte[] bytes = "chars".getBytes(Charsets.UTF_8);
                             try (ArrowBuf buf = vector.getAllocator().buffer(bytes.length)) {
@@ -419,6 +420,18 @@ public class ExampleRecordHandler
 
                             writer.value().integer("value").writeInt(1001);
                             writer.endEntry();
+
+                            writer.startEntry();
+                            byte[] bytesTwo = "chars2".getBytes(Charsets.UTF_8);
+                            try (ArrowBuf buf = vector.getAllocator().buffer(bytesTwo.length)) {
+                                buf.writeBytes(bytesTwo);
+                                writer.key().varChar("key").writeVarChar(0, (int) (buf.readableBytes()), buf);
+                            }
+
+                            writer.value().integer("value").writeInt(1002);
+                            writer.endEntry();
+
+
                             writer.endMap();
                             ((MapVector) vector).setNotNull(rowNum);
                             return true;


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/aws-athena-query-federation/issues/361

*Description of changes:*
Athena Works fine with federated query when having one entry in a map - {chars=1001}
When a second entry is added, the second entry is lost and Athena still returns {chars=1001}

Also 
Athena throws following error when loading table metadata from Glue
`Failed to get metadata for table (<table_name>) from lambda function due to java.lang.IllegalArgumentException: Unsupported Arrow Type [Map(false)] in Lambda Data Source
`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
