### PR TITLE
Removed Default values for GCPProjectId and SecretNamePrefix for Goog…

### DIFF
--- a/athena-google-bigquery/athena-google-bigquery.yaml
+++ b/athena-google-bigquery/athena-google-bigquery.yaml
@@ -22,11 +22,9 @@ Parameters:
     AllowedPattern: ^[a-z0-9-_]{1,64}$
   GCPProjectID:
     Description: "The project ID within Google Cloud Platform ."
-    Default: BigQueryCred
     Type: String
   SecretNamePrefix:
     Description: "The secret name within AWS Secrets Manager that contains your Google Cloud Platform Credentials."
-    Default: GoogleCloudPlatformCredentials
     Type: String
   SpillBucket:
     Description: 'The name of the bucket where this function can spill data.'


### PR DESCRIPTION
BigQuery

[FEATURE] Feature request: Removed Default Values for GCPProjectId and SecretNamePrefix for Google BigQuery while deploying connector from SAR.

Description of changes:
Removed Default Parameters for GCPProjectId and SecretNamePrefix in athena-google-bigquery.yaml file.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
