### PR TITLE
Implemented SSL based connection logic in the oracle connector

### DIFF
--- a/athena-oracle/README.md
+++ b/athena-oracle/README.md
@@ -32,11 +32,11 @@ A JDBC Connection string is used to connect to a database instance. Following fo
 
 Multiplexer provides a way to connect to multiple database instances using a single Lambda function. Requests are routed depending on catalog name. Use following classes in Lambda for using multiplexer.
 
-|Handler|Class|
-|---	|---	|
-|Composite Handler|OracleMuxCompositeHandler|
-|Metadata Handler|OracleMuxMetadataHandler|
-|Record Handler|OracleMuxRecordHandler|
+| Handler           | Class                      |
+|-------------------|----------------------------|
+| Composite Handler | OracleMuxCompositeHandler  |
+| Metadata Handler  | OracleMuxMetadataHandler   |
+| Record Handler    | OracleMuxRecordHandler     |
 
 
 **Parameters:**
@@ -50,13 +50,11 @@ default                         Default connection string. Required. This will b
 
 Example properties for a Oracle Mux Lambda function that supports two database instances, oracle1(default) and oracle2:
 
-|Property|Value|
-|---|---|
-|default|oracle://jdbc:oracle:thin:${Test/RDS/Oracle1}@//oracle1.hostname:port/servicename|
-|	|	|
-|oracle_catalog1_connection_string|oracle://jdbc:oracle:thin:${Test/RDS/Oracle2}@//oracle1.hostname:port/servicename|
-|	|	|
-|oracle_catalog2_connection_string|oracle://jdbc:oracle:thin:${Test/RDS/Oracle2}@//oracle2.hostname:port/servicename|
+| Property                          | Value                                                                             |
+|-----------------------------------|-----------------------------------------------------------------------------------|
+| default                           | oracle://jdbc:oracle:thin:${Test/RDS/Oracle1}@//oracle1.hostname:port/servicename |
+| oracle_catalog1_connection_string | oracle://jdbc:oracle:thin:${Test/RDS/Oracle2}@//oracle1.hostname:port/servicename |
+| oracle_catalog2_connection_string | oracle://jdbc:oracle:thin:${Test/RDS/Oracle2}@//oracle2.hostname:port/servicename |
 
 Oracle Connector supports substitution of any string enclosed like *${Test/RDS/Oracle}* with *username* and *password* retrieved from AWS Secrets Manager. Example:
 
@@ -87,15 +85,23 @@ Record Handler       OracleRecordHandler
 
 ```
 default         Default connection string. Required. This will be used when a catalog is not recognized.
+ssl             SSL. Required. Based on this flag connection will be encrypted over ssl.
 ```
 
 These handlers support one database instance and must provide `default` connection string parameter. All other connection strings are ignored.
+The current version of oracle connector supports ssl based connection for Amazon RDS instances only.
 
 **Example property for a single oracle instance supported by a Lambda function:**
 
-|Property|Value|
-|---|---|
-|default|oracle://jdbc:oracle:thin:${Test/RDS/Oracle}@//hostname:port/servicename|
+| Property | Value                                                                    |
+|----------|--------------------------------------------------------------------------|
+| default  | oracle://jdbc:oracle:thin:${Test/RDS/Oracle}@//hostname:port/servicename |
+| ssl      | no                                                                       |
+
+| Property | Value                                                                                                                                                                                |
+|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| default  | oracle://jdbc:oracle:thin:@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCPS)(HOST=<HOSTNAME>)(PORT=<PORT>))(CONNECT_DATA=(SID=<SID>))(SECURITY=(SSL_SERVER_CERT_DN=<SSL_SERVER_CERT_DN_VALUE>))) |
+| ssl      | yes                                                                                                                                                                                  |
 
 ### Spill parameters:
 
@@ -109,21 +115,21 @@ spill_put_request_headers    JSON encoded map of request headers and values for 
 
 # Data types support
 
-|Jdbc|*Oracle[]|Arrow|
-| ---|---|---|
-|Boolean|boolean[]|Bit
-|Integer|**N/A**|Tiny
-|Short|smallint[]|Smallint
-|Integer|integer[]|Int
-|Long|bigint[]|Bigint
-|float|float4[]|Float4
-|Double|float8[]|Float8
-|Date|date[]|DateDay
-|Timestamp|timestamp[]|DateMilli
-|String|text[]|Varchar
-|Bytes|bytea[]|Varbinary
-|BigDecimal|numeric(p,s)[]|Decimal
-|**\*ARRAY**|**N/A**|List|
+| Jdbc        | *Oracle[]      | Arrow     |
+|-------------|----------------|-----------|
+| Boolean     | boolean[]      | Bit       |   
+| Integer     | **N/A**        | Tiny      | 
+| Short       | smallint[]     | Smallint  | 
+| Integer     | integer[]      | Int       | 
+| Long        | bigint[]       | Bigint    |  
+| float       | float4[]       | Float4    | 
+| Double      | float8[]       | Float8    |
+| Date        | date[]         | DateDay   |
+| Timestamp   | timestamp[]    | DateMilli |
+| String      | text[]         | Varchar   |
+| Bytes       | bytea[]        | Varbinary |
+| BigDecimal  | numeric(p,s)[] | Decimal   | 
+| **\*ARRAY** | **N/A**        | List      |
 
 See Oracle documentation for conversion between JDBC and database types.
 
@@ -137,9 +143,9 @@ We support two ways to input database username and password:
 # Partitions and Splits
 A partition is represented by a single partition column of type varchar. We leverage partitions defined on a Oracle table, and this column contains partition names. For a table that does not have partition names, * is returned which is equivalent to a single partition. A partition is equivalent to a split.
 
-|Name|Type|Description
-|---|---|---|
-|PARTITION_NAME|Varchar|Named partition in MySql. E.g. P_2006_DEC,P_2006_AUG ..|
+| Name           | Type    | Description                                             |
+|----------------|---------|---------------------------------------------------------|
+| PARTITION_NAME | Varchar | Named partition in MySql. E.g. P_2006_DEC,P_2006_AUG .. |
 
 # Running Integration Tests
 

--- a/athena-oracle/README.md
+++ b/athena-oracle/README.md
@@ -143,9 +143,9 @@ We support two ways to input database username and password:
 # Partitions and Splits
 A partition is represented by a single partition column of type varchar. We leverage partitions defined on a Oracle table, and this column contains partition names. For a table that does not have partition names, * is returned which is equivalent to a single partition. A partition is equivalent to a split.
 
-| Name           | Type    | Description                                             |
-|----------------|---------|---------------------------------------------------------|
-| PARTITION_NAME | Varchar | Named partition in MySql. E.g. P_2006_DEC,P_2006_AUG .. |
+| Name           | Type    | Description                                              |
+|----------------|---------|----------------------------------------------------------|
+| PARTITION_NAME | Varchar | Named partition in Oracle. E.g. P_2006_DEC,P_2006_AUG .. |
 
 # Running Integration Tests
 

--- a/athena-oracle/README.md
+++ b/athena-oracle/README.md
@@ -98,10 +98,10 @@ The current version of oracle connector supports ssl based connection for Amazon
 | default  | oracle://jdbc:oracle:thin:${Test/RDS/Oracle}@//hostname:port/servicename |
 | ssl      | no                                                                       |
 
-| Property | Value                                                                                                                                                                                |
-|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| default  | oracle://jdbc:oracle:thin:@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCPS)(HOST=<HOSTNAME>)(PORT=<PORT>))(CONNECT_DATA=(SID=<SID>))(SECURITY=(SSL_SERVER_CERT_DN=<SSL_SERVER_CERT_DN_VALUE>))) |
-| ssl      | yes                                                                                                                                                                                  |
+| Property | Value                                                                                                                                                                                                  |
+|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| default  | oracle://jdbc:oracle:thin:${Test/RDS/Oracle}@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCPS)(HOST=<HOSTNAME>)(PORT=<PORT>))(CONNECT_DATA=(SID=<SID>))(SECURITY=(SSL_SERVER_CERT_DN=<SSL_SERVER_CERT_DN_VALUE>))) |
+| ssl      | yes                                                                                                                                                                                                    |
 
 ### Spill parameters:
 

--- a/athena-oracle/README.md
+++ b/athena-oracle/README.md
@@ -85,7 +85,6 @@ Record Handler       OracleRecordHandler
 
 ```
 default         Default connection string. Required. This will be used when a catalog is not recognized.
-ssl             SSL. Required. Based on this flag connection will be encrypted over ssl.
 ```
 
 These handlers support one database instance and must provide `default` connection string parameter. All other connection strings are ignored.
@@ -93,15 +92,10 @@ The current version of oracle connector supports ssl based connection for Amazon
 
 **Example property for a single oracle instance supported by a Lambda function:**
 
-| Property | Value                                                                    |
-|----------|--------------------------------------------------------------------------|
-| default  | oracle://jdbc:oracle:thin:${Test/RDS/Oracle}@//hostname:port/servicename |
-| ssl      | no                                                                       |
-
-| Property | Value                                                                                                                                                                                                  |
-|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| default  | oracle://jdbc:oracle:thin:${Test/RDS/Oracle}@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCPS)(HOST=<HOSTNAME>)(PORT=<PORT>))(CONNECT_DATA=(SID=<SID>))(SECURITY=(SSL_SERVER_CERT_DN=<SSL_SERVER_CERT_DN_VALUE>))) |
-| ssl      | yes                                                                                                                                                                                                    |
+| Property | Value                                                                                                                                                                                     |
+|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| default  | oracle://jdbc:oracle:thin:${Test/RDS/Oracle}@//hostname:port/servicename (or)                                                                                                             |
+|          | oracle://jdbc:oracle:thin:${Test/RDS/Oracle}@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCPS)(HOST=<HOST_NAME>)(PORT=<PORT>))(CONNECT_DATA=(SID=<SID>))(SECURITY=(SSL_SERVER_CERT_DN=<PARAMETERS>))) | 
 
 ### Spill parameters:
 

--- a/athena-oracle/athena-oracle.yaml
+++ b/athena-oracle/athena-oracle.yaml
@@ -20,9 +20,12 @@ Parameters:
   DefaultConnectionString:
     Description: 'The default connection string is used when catalog is "lambda:${LambdaFunctionName}". Catalog specific Connection Strings can be added later. Format: ${DatabaseType}://${NativeJdbcConnectionString}.'
     Type: String
+  Ssl:
+    Description: 'connection can be encrypted through SSL based on this flag. Format: yes/no.'
+    Type: String
   SecretNamePrefix:
-      Description: 'Used to create resource-based authorization policy for "secretsmanager:GetSecretValue" action. E.g. All Athena JDBC Federation secret names can be prefixed with "AthenaJdbcFederation" and authorization policy will allow "arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:AthenaJdbcFederation*". Parameter value in this case should be "AthenaJdbcFederation". If you do not have a prefix, you can manually update the IAM policy to add allow any secret names.'
-      Type: String
+    Description: 'Used to create resource-based authorization policy for "secretsmanager:GetSecretValue" action. E.g. All Athena JDBC Federation secret names can be prefixed with "AthenaJdbcFederation" and authorization policy will allow "arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:AthenaJdbcFederation*". Parameter value in this case should be "AthenaJdbcFederation". If you do not have a prefix, you can manually update the IAM policy to add allow any secret names.'
+    Type: String
   SpillBucket:
     Description: 'The name of the bucket where this function can spill data.'
     Type: String
@@ -58,6 +61,8 @@ Resources:
           spill_bucket: !Ref SpillBucket
           spill_prefix: !Ref SpillPrefix
           default: !Ref DefaultConnectionString
+          ssl: !Ref Ssl
+          secret_name: !Ref SecretNamePrefix
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.oracle.OracleMuxCompositeHandler"
       CodeUri: "./target/athena-oracle-2022.24.1.jar"

--- a/athena-oracle/athena-oracle.yaml
+++ b/athena-oracle/athena-oracle.yaml
@@ -20,9 +20,6 @@ Parameters:
   DefaultConnectionString:
     Description: 'The default connection string is used when catalog is "lambda:${LambdaFunctionName}". Catalog specific Connection Strings can be added later. Format: ${DatabaseType}://${NativeJdbcConnectionString}.'
     Type: String
-  Ssl:
-    Description: 'connection can be encrypted through SSL based on this flag. Format: yes/no.'
-    Type: String
   SecretNamePrefix:
     Description: 'Used to create resource-based authorization policy for "secretsmanager:GetSecretValue" action. E.g. All Athena JDBC Federation secret names can be prefixed with "AthenaJdbcFederation" and authorization policy will allow "arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:AthenaJdbcFederation*". Parameter value in this case should be "AthenaJdbcFederation". If you do not have a prefix, you can manually update the IAM policy to add allow any secret names.'
     Type: String
@@ -61,7 +58,6 @@ Resources:
           spill_bucket: !Ref SpillBucket
           spill_prefix: !Ref SpillPrefix
           default: !Ref DefaultConnectionString
-          ssl: !Ref Ssl
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.oracle.OracleMuxCompositeHandler"
       CodeUri: "./target/athena-oracle-2022.30.2.jar"

--- a/athena-oracle/athena-oracle.yaml
+++ b/athena-oracle/athena-oracle.yaml
@@ -62,7 +62,6 @@ Resources:
           spill_prefix: !Ref SpillPrefix
           default: !Ref DefaultConnectionString
           ssl: !Ref Ssl
-          secret_name: !Ref SecretNamePrefix
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.oracle.OracleMuxCompositeHandler"
       CodeUri: "./target/athena-oracle-2022.24.1.jar"

--- a/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleConstants.java
+++ b/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleConstants.java
@@ -23,8 +23,7 @@ public final class OracleConstants
 {
     public static final String ORACLE_NAME = "oracle";
     public static final String ORACLE_DRIVER_CLASS = "oracle.jdbc.OracleDriver";
-    public static final int ORACLE_DEFAULT_PORT = 1025;
-    public static final String YES = "yes";
+    public static final int ORACLE_DEFAULT_PORT = 1521;
 
     private OracleConstants() {}
 }

--- a/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleConstants.java
+++ b/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleConstants.java
@@ -24,6 +24,7 @@ public final class OracleConstants
     public static final String ORACLE_NAME = "oracle";
     public static final String ORACLE_DRIVER_CLASS = "oracle.jdbc.OracleDriver";
     public static final int ORACLE_DEFAULT_PORT = 1025;
+    public static final String YES = "yes";
 
     private OracleConstants() {}
 }

--- a/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleJdbcConnectionFactory.java
+++ b/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleJdbcConnectionFactory.java
@@ -23,13 +23,7 @@ package com.amazonaws.athena.connectors.oracle;
 import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionConfig;
 import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionInfo;
 import com.amazonaws.athena.connectors.jdbc.connection.GenericJdbcConnectionFactory;
-import com.amazonaws.athena.connectors.jdbc.connection.JdbcCredential;
 import com.amazonaws.athena.connectors.jdbc.connection.JdbcCredentialProvider;
-import com.amazonaws.athena.connectors.jdbc.connection.RdsSecretsCredentialProvider;
-import com.amazonaws.services.secretsmanager.AWSSecretsManager;
-import com.amazonaws.services.secretsmanager.AWSSecretsManagerClient;
-import com.amazonaws.services.secretsmanager.model.GetSecretValueRequest;
-import com.amazonaws.services.secretsmanager.model.GetSecretValueResult;
 import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,23 +40,22 @@ public class OracleJdbcConnectionFactory extends GenericJdbcConnectionFactory
 {
     private final DatabaseConnectionInfo databaseConnectionInfo;
     private final DatabaseConnectionConfig databaseConnectionConfig;
-    private final Properties jdbcProperties;
     private static final Logger LOGGER = LoggerFactory.getLogger(OracleJdbcConnectionFactory.class);
+    private static final String SSL_CONNECTION_STRING_REGEX = "jdbc:oracle:thin:\\$\\{([a-zA-Z0-9:_/+=.@-]+)\\}@" +
+            "\\((?i)description=\\(address=\\(protocol=tcps\\)\\(host=[a-zA-Z0-9-.]+\\)" +
+            "\\(port=([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])\\)\\)" +
+            "\\(connect_data=\\(sid=[a-zA-Z_]+\\)\\)\\(security=\\(ssl_server_cert_dn=\"[=a-zA-Z,0-9-.,]+\"\\)\\)\\)";
+    private static final Pattern SSL_CONNECTION_STRING_PATTERN = Pattern.compile(SSL_CONNECTION_STRING_REGEX);
 
     /**
      * @param databaseConnectionConfig database connection configuration {@link DatabaseConnectionConfig}
-     * @param properties               JDBC connection properties.
      * @param databaseConnectionInfo
      */
-    public OracleJdbcConnectionFactory(DatabaseConnectionConfig databaseConnectionConfig, Map<String, String> properties, DatabaseConnectionInfo databaseConnectionInfo)
+    public OracleJdbcConnectionFactory(DatabaseConnectionConfig databaseConnectionConfig, DatabaseConnectionInfo databaseConnectionInfo)
     {
-        super(databaseConnectionConfig, properties, databaseConnectionInfo);
+        super(databaseConnectionConfig, null, databaseConnectionInfo);
         this.databaseConnectionInfo = Validate.notNull(databaseConnectionInfo, "databaseConnectionInfo must not be null");
         this.databaseConnectionConfig = Validate.notNull(databaseConnectionConfig, "databaseEngine must not be null");
-        this.jdbcProperties = new Properties();
-        if (properties != null) {
-            this.jdbcProperties.putAll(properties);
-        }
     }
 
     @Override
@@ -71,51 +64,39 @@ public class OracleJdbcConnectionFactory extends GenericJdbcConnectionFactory
         try {
             final String derivedJdbcString;
             final Map<String, String> envVariables = System.getenv();
+            Properties properties = new Properties();
 
-            if (OracleConstants.YES.equalsIgnoreCase(envVariables.get("ssl"))) {
-                derivedJdbcString = databaseConnectionConfig.getJdbcConnectionString();
-                Pattern connStringPattern = Pattern.compile("jdbc:oracle:thin:@\\((?i)description=\\(address=\\(protocol=tcps\\)\\(host=[a-zA-Z0-9-.]+\\)" +
-                        "\\(port=([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])\\)\\)" +
-                        "\\(connect_data=\\(sid=[a-zA-Z_]+\\)\\)\\(security=\\(ssl_server_cert_dn=\\\"[=a-zA-Z,0-9-.,]+\\\"\\)\\)\\)");
-                Matcher connStringMatcher = connStringPattern.matcher(derivedJdbcString);
-                if (!connStringMatcher.matches()) {
-                    throw new RuntimeException("Invalid connection string to establish connection over SSL, Please check.");
-                }
+            if (null != jdbcCredentialProvider) {
+                Matcher connStringMatcher = SSL_CONNECTION_STRING_PATTERN.matcher(databaseConnectionConfig.getJdbcConnectionString());
+                if (OracleConstants.YES.equalsIgnoreCase(envVariables.get("ssl"))) {
+                    if (!connStringMatcher.matches()) {
+                        throw new RuntimeException("Invalid connection string to establish connection over SSL, Please check.");
+                    }
+                    properties.put("javax.net.ssl.trustStoreType", "JKS");
+                    properties.put("javax.net.ssl.trustStorePassword", "changeit");
+                    properties.put("oracle.net.ssl_server_dn_match", "true");
 
-                JdbcCredential credential = getCredentialsFromSecretsManager(envVariables.get("secret_name"));
-                this.jdbcProperties.put("user", credential.getUser());
-                this.jdbcProperties.put("password", credential.getPassword());
-                this.jdbcProperties.put("javax.net.ssl.trustStoreType", "JKS");
-                this.jdbcProperties.put("javax.net.ssl.trustStorePassword", "changeit");
-                this.jdbcProperties.put("oracle.net.ssl_server_dn_match", "true");
-
-                LOGGER.info("Establishing connection over SSL..");
-            }
-            else {
-                if (null != jdbcCredentialProvider) {
-                    Matcher secretMatcher = SECRET_NAME_PATTERN.matcher(databaseConnectionConfig.getJdbcConnectionString());
-                    final String secretReplacement = String.format("%s/%s", jdbcCredentialProvider.getCredential().getUser(),
-                            jdbcCredentialProvider.getCredential().getPassword());
-                    derivedJdbcString = secretMatcher.replaceAll(Matcher.quoteReplacement(secretReplacement));
-                    LOGGER.info("Establishing normal connection..");
+                    LOGGER.info("Establishing connection over SSL..");
                 }
                 else {
-                    throw new RuntimeException("Invalid connection string, Secret name is required.");
+                    if (connStringMatcher.matches()) {
+                        throw new RuntimeException("Invalid connection string, Please check.");
+                    }
+                    LOGGER.info("Establishing normal connection..");
                 }
+                Matcher secretMatcher = SECRET_NAME_PATTERN.matcher(databaseConnectionConfig.getJdbcConnectionString());
+                final String secretReplacement = String.format("%s/%s", jdbcCredentialProvider.getCredential().getUser(),
+                        jdbcCredentialProvider.getCredential().getPassword());
+                derivedJdbcString = secretMatcher.replaceAll(Matcher.quoteReplacement(secretReplacement));
+            }
+            else {
+                throw new RuntimeException("Invalid connection string, Secret name is required.");
             }
             LOGGER.info("derivedJdbcString: " + derivedJdbcString);
-            return DriverManager.getConnection(derivedJdbcString, this.jdbcProperties);
+            return DriverManager.getConnection(derivedJdbcString, properties);
         }
         catch (SQLException sqlException) {
             throw new RuntimeException(sqlException.getErrorCode() + ": " + sqlException);
         }
-    }
-
-    public JdbcCredential getCredentialsFromSecretsManager(String secretName)
-    {
-        AWSSecretsManager secretsManager = AWSSecretsManagerClient.builder().build();
-        GetSecretValueResult secretValueResult = secretsManager.getSecretValue(new GetSecretValueRequest()
-                .withSecretId(secretName));
-        return new RdsSecretsCredentialProvider(secretValueResult.getSecretString()).getCredential();
     }
 }

--- a/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleMetadataHandler.java
+++ b/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleMetadataHandler.java
@@ -46,7 +46,6 @@ import com.amazonaws.services.athena.AmazonAthena;
 import com.amazonaws.services.secretsmanager.AWSSecretsManager;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableMap;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.ArrowType;
@@ -64,7 +63,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 /**
@@ -74,7 +72,6 @@ import java.util.stream.Collectors;
 public class OracleMetadataHandler
         extends JdbcMetadataHandler
 {
-    static final Map<String, String> JDBC_PROPERTIES = ImmutableMap.of("databaseTerm", "SCHEMA");
     static final String GET_PARTITIONS_QUERY = "Select DISTINCT PARTITION_NAME FROM USER_TAB_PARTITIONS where table_name= ?";
     static final String BLOCK_PARTITION_COLUMN_NAME = "PARTITION_NAME";
     static final String ALL_PARTITIONS = "0";
@@ -98,7 +95,7 @@ public class OracleMetadataHandler
      */
     public OracleMetadataHandler(final DatabaseConnectionConfig databaseConnectionConfig)
     {
-        this(databaseConnectionConfig, new OracleJdbcConnectionFactory(databaseConnectionConfig, JDBC_PROPERTIES, new DatabaseConnectionInfo(OracleConstants.ORACLE_DRIVER_CLASS, OracleConstants.ORACLE_DEFAULT_PORT)));
+        this(databaseConnectionConfig, new OracleJdbcConnectionFactory(databaseConnectionConfig, null, new DatabaseConnectionInfo(OracleConstants.ORACLE_DRIVER_CLASS, OracleConstants.ORACLE_DEFAULT_PORT)));
     }
 
     public OracleMetadataHandler(final DatabaseConnectionConfig databaseConnectionConfig, final JdbcConnectionFactory jdbcConnectionFactory)

--- a/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleMetadataHandler.java
+++ b/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleMetadataHandler.java
@@ -95,7 +95,7 @@ public class OracleMetadataHandler
      */
     public OracleMetadataHandler(final DatabaseConnectionConfig databaseConnectionConfig)
     {
-        this(databaseConnectionConfig, new OracleJdbcConnectionFactory(databaseConnectionConfig, null, new DatabaseConnectionInfo(OracleConstants.ORACLE_DRIVER_CLASS, OracleConstants.ORACLE_DEFAULT_PORT)));
+        this(databaseConnectionConfig, new OracleJdbcConnectionFactory(databaseConnectionConfig, new DatabaseConnectionInfo(OracleConstants.ORACLE_DRIVER_CLASS, OracleConstants.ORACLE_DEFAULT_PORT)));
     }
 
     public OracleMetadataHandler(final DatabaseConnectionConfig databaseConnectionConfig, final JdbcConnectionFactory jdbcConnectionFactory)

--- a/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleRecordHandler.java
+++ b/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleRecordHandler.java
@@ -72,7 +72,7 @@ public class OracleRecordHandler
 
     public OracleRecordHandler(final DatabaseConnectionConfig databaseConnectionConfig)
     {
-        this(databaseConnectionConfig, new OracleJdbcConnectionFactory(databaseConnectionConfig, null, new DatabaseConnectionInfo(ORACLE_DRIVER_CLASS, ORACLE_DEFAULT_PORT)));
+        this(databaseConnectionConfig, new OracleJdbcConnectionFactory(databaseConnectionConfig, new DatabaseConnectionInfo(ORACLE_DRIVER_CLASS, ORACLE_DEFAULT_PORT)));
     }
 
     public OracleRecordHandler(final DatabaseConnectionConfig databaseConnectionConfig, final JdbcConnectionFactory jdbcConnectionFactory)

--- a/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleRecordHandler.java
+++ b/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleRecordHandler.java
@@ -72,7 +72,7 @@ public class OracleRecordHandler
 
     public OracleRecordHandler(final DatabaseConnectionConfig databaseConnectionConfig)
     {
-        this(databaseConnectionConfig, new OracleJdbcConnectionFactory(databaseConnectionConfig, OracleMetadataHandler.JDBC_PROPERTIES, new DatabaseConnectionInfo(ORACLE_DRIVER_CLASS, ORACLE_DEFAULT_PORT)));
+        this(databaseConnectionConfig, new OracleJdbcConnectionFactory(databaseConnectionConfig, null, new DatabaseConnectionInfo(ORACLE_DRIVER_CLASS, ORACLE_DEFAULT_PORT)));
     }
 
     public OracleRecordHandler(final DatabaseConnectionConfig databaseConnectionConfig, final JdbcConnectionFactory jdbcConnectionFactory)

--- a/athena-oracle/src/test/java/com/amazonaws/athena/connectors/oracle/OracleJdbcConnectionFactoryTest.java
+++ b/athena-oracle/src/test/java/com/amazonaws/athena/connectors/oracle/OracleJdbcConnectionFactoryTest.java
@@ -19,8 +19,11 @@
  */
 package com.amazonaws.athena.connectors.oracle;
 
-import com.amazonaws.athena.connectors.jdbc.connection.*;
-import com.google.common.collect.ImmutableMap;
+import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionConfig;
+import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionInfo;
+import com.amazonaws.athena.connectors.jdbc.connection.JdbcCredential;
+import com.amazonaws.athena.connectors.jdbc.connection.JdbcCredentialProvider;
+import com.amazonaws.athena.connectors.jdbc.connection.StaticJdbcCredentialProvider;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -28,7 +31,6 @@ import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.DriverManager;
 import java.sql.SQLException;
-import java.util.Map;
 
 public class OracleJdbcConnectionFactoryTest {
 
@@ -38,9 +40,8 @@ public class OracleJdbcConnectionFactoryTest {
         JdbcCredentialProvider jdbcCredentialProvider = new StaticJdbcCredentialProvider(expectedCredential);
         DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", OracleConstants.ORACLE_NAME,
                 "oracle://jdbc:oracle:thin:username/password@//127.0.0.1:1521/orcl", "test");
-        Map<String, String> JDBC_PROPERTIES = ImmutableMap.of("databaseTerm", "SCHEMA");
         DatabaseConnectionInfo DatabaseConnectionInfo = new DatabaseConnectionInfo(OracleConstants.ORACLE_DRIVER_CLASS,OracleConstants.ORACLE_DEFAULT_PORT);
-        Connection connection =  new OracleJdbcConnectionFactory(databaseConnectionConfig, JDBC_PROPERTIES,DatabaseConnectionInfo).getConnection(jdbcCredentialProvider);
+        Connection connection =  new OracleJdbcConnectionFactory(databaseConnectionConfig, DatabaseConnectionInfo).getConnection(jdbcCredentialProvider);
         String originalURL = connection.getMetaData().getURL();
         Driver drv = DriverManager.getDriver(originalURL);
         String driverClass = drv.getClass().getName();


### PR DESCRIPTION
*Issue INC00001066 #,Improve Oracle Connector To Support SSL Connections To The Oracle Db*

Implemented SSL based connection logic in the connector.  
The current version of oracle connector supports ssl based connection for Amazon RDS instances only.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
