### PR TITLE
Timestream Connector Boolean Type Support

### DIFF
--- a/athena-timestream/src/main/java/com/amazonaws/athena/connectors/timestream/TimestreamType.java
+++ b/athena-timestream/src/main/java/com/amazonaws/athena/connectors/timestream/TimestreamType.java
@@ -28,6 +28,7 @@ public enum TimestreamType
 {
     VARCHAR("varchar", Types.MinorType.VARCHAR),
     DOUBLE("double", Types.MinorType.FLOAT8),
+    BOOLEAN("boolean", Types.MinorType.BIT),
     TIMESTAMP("timestamp", Types.MinorType.DATEMILLI);
 
     private static final Map<String, TimestreamType> TIMESTREAM_TYPEMAP = new HashMap<>();


### PR DESCRIPTION
- Issue https://github.com/awslabs/aws-athena-query-federation/issues/752
- Boolean types would cause Athena queries to fail. This adds support for Timestream's boolean type

*Issue #, if available:*
752


Testing was done in a dev aws account. Timestream is difficult to work with, ran this script to get some test data:

```
import boto3
import time

class Timestream:
    def __init__(self):
        self.write_client = boto3.client('timestream-write')
        self.query_client = boto3.client('timestream-query')
        self.db_name = 'sample-db'
        self.table_name = 'table_with_booleans'

    def create_table(self):
        self.write_client.create_table(
            DatabaseName=self.db_name,
            TableName=self.table_name,
            RetentionProperties={
                'MemoryStoreRetentionPeriodInHours': 1,  # 0 is not valid
                'MagneticStoreRetentionPeriodInDays': 365
            },
            MagneticStoreWriteProperties={
                'EnableMagneticStoreWrites': True
            }
        )
        print('Table creation started. Takes a few seconds but there is no status object, so we just sleep five seconds.')
        time.sleep(5)

    def make_dimension(self, string_col):
        return [
            {
                'Name': 'str_col',
                'Value': string_col,
                'DimensionValueType': 'VARCHAR'
            }
        ]

    def make_bool_record(self, value, dimension_val):
        dimensions = self.make_dimension(dimension_val)
        return {
            'Time': str(int(round(time.time() * 1000))),
            'Dimensions': dimensions,
            'MeasureName': 'bool_col',
            'MeasureValue': str(value),
            'MeasureValueType': 'BOOLEAN'
        }


    def write_content(self):
        records = [self.make_bool_record(True, 'abc'), self.make_bool_record(False, 'def')]
        self.write_client.write_records(
            DatabaseName=self.db_name,
            TableName=self.table_name,
            Records=records)


timestream_obj = Timestream()
timestream_obj.create_table()
timestream_obj.write_content()

```

Then published the timestream connector with `sam package --template-file athena-timestream.yaml --output-template-file packaged.yaml --s3-bucket <REDACTED> --region us-east-1 --force-upload`

Then ran select * Athena query and got results:
```
#	str_col	measure_name	time	measure_value::boolean
1	abc	bool_col	2022-08-17 15:08:00.000	true
2	abc	bool_col	2022-08-13 19:46:29.000	true
3	def	bool_col	2022-08-17 15:08:00.000	false
4	def	bool_col	2022-08-13 19:46:29.000	false

```

Describe table results in Timestream:
```
Column | Type | Timestream attribute type
-- | -- | --
str_col | varchar | DIMENSION
measure_name | varchar | MEASURE_NAME
time | timestamp | TIMESTAMP
measure_value::boolean | boolean | MEASURE_VALUE
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
