### PR TITLE
Added support for Azure AD ServicePrincipal authentication for Synaps…

### DIFF
--- a/athena-synapse/pom.xml
+++ b/athena-synapse/pom.xml
@@ -35,6 +35,11 @@
             <artifactId>mssql-jdbc</artifactId>
             <version>9.2.1.jre11</version>
         </dependency>
+        <dependency>
+            <groupId>com.microsoft.azure</groupId>
+            <artifactId>msal4j</artifactId>
+            <version>1.13.0</version>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-rds -->
         <dependency>
             <groupId>com.amazonaws</groupId>

--- a/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseJdbcConnectionFactory.java
+++ b/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseJdbcConnectionFactory.java
@@ -61,8 +61,23 @@ public class SynapseJdbcConnectionFactory extends GenericJdbcConnectionFactory
             final String derivedJdbcString;
             if (null != jdbcCredentialProvider) {
                 Matcher secretMatcher = SECRET_NAME_PATTERN.matcher(databaseConnectionConfig.getJdbcConnectionString());
-                // replace aws secret value with credentials and change username as user
-                final String secretReplacement = String.format("%s;%s", "user=" + jdbcCredentialProvider.getCredential().getUser(), "password=" + jdbcCredentialProvider.getCredential().getPassword());
+                final String secretReplacement;
+                if (databaseConnectionConfig.getJdbcConnectionString().contains("authentication=ActiveDirectoryServicePrincipal")) {
+                    // Set AADSecurePrincipal credentials
+                    secretReplacement = String.format(
+                        "%s;%s",
+                        "AADSecurePrincipalId=" + jdbcCredentialProvider.getCredential().getUser(),
+                        "AADSecurePrincipalSecret=" + jdbcCredentialProvider.getCredential().getPassword()
+                    );
+                }
+                else {
+                    // replace aws secret value with credentials and change username as user
+                    secretReplacement = String.format(
+                        "%s;%s",
+                        "user=" + jdbcCredentialProvider.getCredential().getUser(),
+                        "password=" + jdbcCredentialProvider.getCredential().getPassword()
+                    );
+                }
                 derivedJdbcString = secretMatcher.replaceAll(Matcher.quoteReplacement(secretReplacement));
             }
             else {

--- a/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseRecordHandler.java
+++ b/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseRecordHandler.java
@@ -29,7 +29,6 @@ import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
 import com.amazonaws.athena.connector.lambda.records.ReadRecordsRequest;
 import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionConfig;
 import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionInfo;
-import com.amazonaws.athena.connectors.jdbc.connection.GenericJdbcConnectionFactory;
 import com.amazonaws.athena.connectors.jdbc.connection.JdbcConnectionFactory;
 import com.amazonaws.athena.connectors.jdbc.manager.JDBCUtil;
 import com.amazonaws.athena.connectors.jdbc.manager.JdbcRecordHandler;
@@ -67,7 +66,7 @@ public class SynapseRecordHandler extends JdbcRecordHandler
     public SynapseRecordHandler(final DatabaseConnectionConfig databaseConnectionConfig)
     {
         this(databaseConnectionConfig, AmazonS3ClientBuilder.defaultClient(), AWSSecretsManagerClientBuilder.defaultClient(),
-                AmazonAthenaClientBuilder.defaultClient(), new GenericJdbcConnectionFactory(databaseConnectionConfig,
+                AmazonAthenaClientBuilder.defaultClient(), new SynapseJdbcConnectionFactory(databaseConnectionConfig,
                         SynapseMetadataHandler.JDBC_PROPERTIES, new DatabaseConnectionInfo(SynapseConstants.DRIVER_CLASS, SynapseConstants.DEFAULT_PORT)),
                 new SynapseQueryStringBuilder(QUOTE_CHARACTER));
     }


### PR DESCRIPTION
*AWS Support Case Id : 10496336321*

*Description of changes:*

- Updated `SynapseJdbcConnectionFactory` to support `authentication` scheme `ActiveDirectoryServicePrincipal`
- Updated `SynapseRecordHandler` to use the `SynapseJdbcConnectionFactory` instead of the `GenericJdbcConnectionFactory`
- Added `com.microsoft.azure/msal4j` dependency

It looks for the jdbc driver property `authentication=ActiveDirectoryServicePrincipal` in the jdbc connection String. If that is set, it will set `AADSecurePrincipalId` and `AADSecurePrincipalSecret` credentials instead of `user` and `password`.
This `authentication` setting should be set in the connection string in the environment variable for the lambda function.
