### PR TITLE
Fix a typo in README.md of athena-federation-sdk

### DIFF
--- a/athena-federation-sdk/README.md
+++ b/athena-federation-sdk/README.md
@@ -60,7 +60,7 @@ UDFs have access to the same type system. When extending UserDefinedFunctionHand
  | DOUBLE      | java.lang.Double                               |Yes|
  | DECIMAL     | java.math.BigDecimal                           |Yes|
  | BIGINT      | java.lang.Long                                 |Yes|
- | INTEGER     | java.lang.Int                                  |Yes, Int(32)|
+ | INTEGER     | java.lang.Integer                              |Yes, Int(32)|
  | VARCHAR     | java.lang.String                               |Yes|
  | VARBINARY   | byte[]                                         |No|
  | BOOLEAN     | java.lang.Boolean                              |Yes|


### PR DESCRIPTION
*Issue #, if available:* none

*Description of changes:* `java.lang.Int` -> `java.lang.Integer`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
