### PR TITLE
Data Integrity: Add generative testing and fixes

### DIFF
--- a/athena-federation-sdk/pom.xml
+++ b/athena-federation-sdk/pom.xml
@@ -141,9 +141,24 @@
             <version>1.67</version>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -156,6 +171,18 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>3.9</version>
+        </dependency>
+        <dependency>
+            <groupId>net.jqwik</groupId>
+            <artifactId>jqwik</artifactId>
+            <version>${jqwik.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <build>
@@ -180,6 +207,31 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven.compiler.plugin.version}</version>
+                <configuration>
+                    <!-- required if you want to report source code names of property method parameters -->
+                    <compilerArgs>
+                        <arg>-parameters</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire.failsafe.version}</version>
+                <configuration>
+                <!--<groups>fast</groups>-->
+                <excludedGroups>slow</excludedGroups>
+                <properties>
+                    <!--
+                    <configurationParameters>
+                        junit.jupiter.conditions.deactivate = *
+                    </configurationParameters>
+                    -->
+                </properties>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/data/BlockUtilsPropertiesTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/data/BlockUtilsPropertiesTest.java
@@ -60,13 +60,19 @@ class BlockUtilsPropertiesTest {
         return fieldsGenerator.field();
     }
 
+    // Using the default number of tries here (1000)
+    // With a higher recursion level, we will not be able to cover all possible combinations
+    // This will do a random sampling of scenarios
+    // The purpose of this test is to cover depth
     @Property
-    boolean setComplexValuesSetsAllFieldsCorrectlyGivenAnyInputShort(@ForAll("fieldHighRecursion") Field field) {
+    boolean setComplexValuesSetsAllFieldsCorrectlyGivenAnyInputHighRecursion(@ForAll("fieldHighRecursion") Field field) {
         return setComplexValuesSetsAllFieldsCorrectlyGivenAnyInput(field);
     }
 
+    // By setting a lower recursion level, we are able to cover all edge cases with 2000 tries
+    // The purpose of this test is to cover all the different combinations of fields (but with less depth)
     @Property(tries=2000, edgeCases=EdgeCasesMode.FIRST)
-    boolean setComplexValuesSetsAllFieldsCorrectlyGivenAnyInputComprehensive(@ForAll("fieldLowRecursion") Field field) {
+    boolean setComplexValuesSetsAllFieldsCorrectlyGivenAnyInputAllCombinations(@ForAll("fieldLowRecursion") Field field) {
         return setComplexValuesSetsAllFieldsCorrectlyGivenAnyInput(field);
     }
 

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/data/BlockUtilsPropertiesTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/data/BlockUtilsPropertiesTest.java
@@ -1,0 +1,188 @@
+package com.amazonaws.athena.connector.lambda.data;
+
+/*-
+ * #%L
+ * Amazon Athena Query Federation SDK
+ * %%
+ * Copyright (C) 2022 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.amazonaws.athena.connector.lambda.data.helpers.ValuesGenerator;
+import com.amazonaws.athena.connector.lambda.data.helpers.FieldsGenerator;
+
+import org.apache.arrow.vector.complex.MapVector;
+import org.apache.arrow.vector.types.Types.MinorType;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.arrow.vector.util.JsonStringArrayList;
+import org.apache.arrow.vector.util.JsonStringHashMap;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import net.jqwik.api.*;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+
+class BlockUtilsPropertiesTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(BlockUtilsTest.class);
+
+    static final RootAllocator allocator = new RootAllocator();
+
+    @Provide
+    private Arbitrary<Field> fieldLowRecursion() {
+        FieldsGenerator fieldsGenerator = new FieldsGenerator(2);
+        return fieldsGenerator.field();
+    }
+
+    @Provide
+    private Arbitrary<Field> fieldHighRecursion() {
+        FieldsGenerator fieldsGenerator = new FieldsGenerator(5);
+        return fieldsGenerator.field();
+    }
+
+    @Property
+    boolean setComplexValuesSetsAllFieldsCorrectlyGivenAnyInputShort(@ForAll("fieldHighRecursion") Field field) {
+        return setComplexValuesSetsAllFieldsCorrectlyGivenAnyInput(field);
+    }
+
+    @Property(tries=2000, edgeCases=EdgeCasesMode.FIRST)
+    boolean setComplexValuesSetsAllFieldsCorrectlyGivenAnyInputComprehensive(@ForAll("fieldLowRecursion") Field field) {
+        return setComplexValuesSetsAllFieldsCorrectlyGivenAnyInput(field);
+    }
+
+    private boolean setComplexValuesSetsAllFieldsCorrectlyGivenAnyInput(Field field) {
+        ValuesGenerator generator = new ValuesGenerator();
+        FieldVector vector = generator.generateValues(field, allocator);
+
+        VectorSchemaRoot inputSchemaRoot = new VectorSchemaRoot(
+            new Schema(java.util.List.of(field)),
+            java.util.List.of(vector), 1
+        );
+
+        int valueCount = inputSchemaRoot.getVector(0).getValueCount();
+        VectorSchemaRoot outputSchemaRoot = VectorSchemaRoot.create(inputSchemaRoot.getSchema(), allocator);
+        outputSchemaRoot.setRowCount(1);
+        ArrowToArrowResolver resolver = new ArrowToArrowResolver();
+
+        for (int i = 0; i < valueCount; i++) {
+            if (field.getType().isComplex()) {
+                BlockUtils.setComplexValue(
+                    outputSchemaRoot.getVector(0), i, resolver, getValue(vector, i, resolver)
+                );
+            }
+            else {
+                BlockUtils.setValue(outputSchemaRoot.getVector(0), i, getValue(vector, i, resolver));
+            }
+        }
+
+        outputSchemaRoot.getVector(0).setValueCount(valueCount);
+
+        if (inputSchemaRoot.equals(outputSchemaRoot)) {
+            logger.debug(
+                "Matched for Schema:\n\t"
+                + inputSchemaRoot.getSchema().toString() + "\n"
+                + "with FieldVectors:\n\t"
+                + inputSchemaRoot.getFieldVectors().toString() + "\n"
+            );
+        }
+        else {
+            logger.error(
+                "DID NOT MATCH\n"
+                + "Input Schema:\n\t"
+                + inputSchemaRoot.getSchema().toString() + "\n"
+                + "Output Schema:\n\t"
+                + outputSchemaRoot.getSchema().toString() + "\n"
+                + "Input FieldVectors:\n\t"
+                + inputSchemaRoot.getFieldVectors().toString() + "\n"
+                + "Output FieldVectors:\n\t"
+                + outputSchemaRoot.getFieldVectors().toString() + "\n"
+            );
+            return false;
+        }
+
+        return true;
+    }
+
+    private Object getValue(FieldVector vector, int pos, FieldResolver resolver) {
+        if (vector.getMinorType().equals(MinorType.MAP)) {
+            return resolver.getFieldValue(vector.getField(), vector.getObject(pos));
+        }
+        else {
+            return vector.getObject(pos);
+        }
+    }
+}
+
+class ArrowToArrowResolver implements FieldResolver {
+
+    // Needed for maps since IdentityHashMap does not maintain order and LinkedHashMap does not use reference equality
+    class KeyWithEquality {
+        public Object key;
+
+        KeyWithEquality(Object key) {
+            this.key = key;
+        }
+
+        public boolean equals(Object o) {
+            return this.key == o;
+        }
+    }
+
+    @Override
+    public Object getFieldValue(Field field, Object originalValue) {
+        if (originalValue.getClass().equals(KeyWithEquality.class)) {
+            originalValue = ((KeyWithEquality) originalValue).key;
+        }
+
+        if (field.getType().getTypeID() == ArrowType.Map.TYPE_TYPE) {
+            JsonStringArrayList input;
+            if (originalValue.getClass().equals(JsonStringHashMap.class)) {
+                input = (JsonStringArrayList) ((Map) originalValue).get(field.getName());
+            }
+            else {
+                input = (JsonStringArrayList) originalValue;
+            }
+
+            if (input == null) {
+                return null;
+            }
+
+            Map<Object, Object> outputMap = new LinkedHashMap<Object, Object>();
+            for (int i = 0; i <  input.size(); i++) {
+                JsonStringHashMap inputMap = (JsonStringHashMap) input.get(i);
+                outputMap.put(new KeyWithEquality(inputMap.get(MapVector.KEY_NAME)), inputMap.get(MapVector.VALUE_NAME));
+            }
+            return outputMap;
+        }
+
+        if (originalValue.getClass().equals(JsonStringHashMap.class) || originalValue.getClass().equals(Map.class)) {
+            Object fieldValue = ((Map) originalValue).get(field.getName());
+            return fieldValue;
+        }
+        return originalValue;
+    }
+
+
+}
+
+

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/data/helpers/FieldsGenerator.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/data/helpers/FieldsGenerator.java
@@ -1,0 +1,161 @@
+/*-
+ * #%L
+ * Amazon Athena Query Federation SDK
+ * %%
+ * Copyright (C) 2019 - 2022 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connector.lambda.data.helpers;
+
+import org.apache.arrow.vector.complex.MapVector;
+import org.apache.arrow.vector.types.DateUnit;
+import org.apache.arrow.vector.types.FloatingPointPrecision;
+import org.apache.arrow.vector.types.TimeUnit;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+
+import net.jqwik.api.*;
+
+import java.util.List;
+import java.util.TimeZone;
+
+public class FieldsGenerator {
+
+    private int counter = 0; // use to guarentee field names are unique for structs
+    private boolean DEFAULT_NULLABLE = true;
+    private int max_recursion_depth;
+
+    public FieldsGenerator(int max_recursion_depth) {
+        this.max_recursion_depth = max_recursion_depth;
+    }
+
+    @Provide
+    public Arbitrary<Field> field() {
+        return field(0, null, DEFAULT_NULLABLE);
+    }
+
+    private Arbitrary<Field> field(int depth, String name, boolean nullable) {
+        return
+            fieldType(depth+1, nullable).flatMap(fieldType ->
+                fieldChildren(fieldType, depth+1).flatMap(children -> {
+                    String fieldName = name;
+                    if (name == null) {
+                        counter++;
+                        fieldName = Arbitraries.strings().sample() + counter;
+                    }
+                    return Arbitraries.just(new Field(fieldName, fieldType, children));
+                })
+            );
+    }
+
+    private Arbitrary<FieldType> intField(boolean nullable) {
+        return Arbitraries.of(true, false).flatMap(signed ->
+            Arbitraries.of(8, 16, 32, 64).map(bits ->
+                new FieldType(nullable, new ArrowType.Int(bits, signed), null)
+            )
+        );
+    }
+
+    private Arbitrary<FieldType> dateField(boolean nullable) {
+        return Arbitraries.of(DateUnit.DAY, DateUnit.MILLISECOND).map(unit ->
+            new FieldType(nullable, new ArrowType.Date(unit), null)
+        );
+    }
+
+    private Arbitrary<FieldType> floatingPointField(boolean nullable) {
+        // FloatingPointPrecision.HALF not supported yet in BlockUtils yet
+        return Arbitraries.of(FloatingPointPrecision.SINGLE, FloatingPointPrecision.DOUBLE).map(precision ->
+            new FieldType(nullable, new ArrowType.FloatingPoint(precision), null)
+        );
+    }
+
+    private Arbitrary<FieldType> timestampField(boolean nullable) {
+        return Arbitraries.of(TimeZone.getAvailableIDs()).fixGenSize(5).flatMap(timezone ->
+            Arbitraries.of(TimeUnit.SECOND, TimeUnit.MILLISECOND, TimeUnit.MICROSECOND, TimeUnit.NANOSECOND).map(unit ->
+                new FieldType(nullable, new ArrowType.Timestamp(unit, timezone), null)
+            )
+        );
+    }
+
+    private Arbitrary<FieldType> decimalField(boolean nullable) {
+        return Arbitraries.integers().between(1,20).flatMap(precision ->
+            Arbitraries.integers().greaterOrEqual(0).lessOrEqual(precision-1).flatMap(scale ->
+                Arbitraries.of(32, 64, 128).map(bitWidth ->
+                    new FieldType(nullable, new ArrowType.Decimal(precision, scale, bitWidth), null)
+                )
+            )
+        );
+    }
+
+    private Arbitrary<FieldType> primitiveFieldType(boolean nullable) {
+        return Arbitraries.oneOf(
+            Arbitraries.just(new FieldType(nullable, new ArrowType.Binary(), null))
+            , Arbitraries.just(new FieldType(nullable, new ArrowType.Bool(), null))
+            , dateField(nullable)
+            , decimalField(nullable)
+            , intField(nullable)
+            , floatingPointField(nullable)
+            // TODO: Known failure, Arrow has a bug with writing some types to Lists like ArrowType.Timestamp
+            // Uncomment once Arrow has resolve
+            //, timestampField(nullable)
+            , Arbitraries.just(new FieldType(nullable, new ArrowType.Utf8(), null))
+        );
+    }
+
+    private Arbitrary<FieldType> complexFieldType(boolean nullable) {
+        return Arbitraries.of(
+            new FieldType(nullable, new ArrowType.List(), null)
+            , new FieldType(nullable, new ArrowType.Struct(), null)
+            , new FieldType(nullable, new ArrowType.Map(true), null)
+        );
+    }
+
+    private Arbitrary<FieldType> fieldType(int depth, boolean nullable) {
+        if (depth >= max_recursion_depth) {
+            return primitiveFieldType(nullable);
+        }
+
+        return Arbitraries.oneOf(
+            primitiveFieldType(nullable)
+            , complexFieldType(nullable)
+        );
+    }
+
+    private Arbitrary<java.util.List<Field>> fieldChildren(FieldType parentType, int depth) {
+        if (parentType.getType().equals(ArrowType.List.INSTANCE)) {
+            return field(depth, null, DEFAULT_NULLABLE).list().ofSize(1);
+        }
+
+        if (parentType.getType().equals(ArrowType.Struct.INSTANCE)) {
+            return field(depth, null, DEFAULT_NULLABLE).list().uniqueElements().ofMinSize(1).ofMaxSize(3);
+        }
+
+        if (parentType.getType().getTypeID().equals(ArrowType.Map.TYPE_TYPE)) {
+            Arbitrary<Field> keyField = field(depth, MapVector.KEY_NAME, false);
+            Arbitrary<Field> valueField = field(depth, MapVector.VALUE_NAME, DEFAULT_NULLABLE);
+
+            FieldType structType = new FieldType(false, ArrowType.Struct.INSTANCE, null);
+            Arbitrary<List<Field>> structField = Combinators.combine(keyField, valueField).as((key, value) ->
+                new Field(MapVector.DATA_VECTOR_NAME,
+                    structType,
+                    List.of(key, value)
+            )).list().ofSize(1);
+            return structField;
+        }
+
+        return Arbitraries.just((java.util.List<Field>) null);
+    }
+}

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/data/helpers/ValuesGenerator.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/data/helpers/ValuesGenerator.java
@@ -154,12 +154,7 @@ public class ValuesGenerator {
         }
 
         // randomly determine if the value should be null or not
-        boolean isNull = Arbitraries.integers().between(0, 5).sample() == 0 ? true : false;
-        if (!isNull) {
-            return false;
-        }
-
-        return true;
+        return Arbitraries.integers().between(0, 5).sample() == 0 ? true : false;
     }
 
     /*

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/data/helpers/ValuesGenerator.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/data/helpers/ValuesGenerator.java
@@ -1,0 +1,653 @@
+/*-
+ * #%L
+ * Amazon Athena Query Federation SDK
+ * %%
+ * Copyright (C) 2019 - 2022 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connector.lambda.data.helpers;
+
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.complex.ListVector;
+import org.apache.arrow.vector.complex.MapVector;
+import org.apache.arrow.vector.complex.StructVector;
+import org.apache.arrow.vector.holders.NullableBigIntHolder;
+import org.apache.arrow.vector.holders.NullableBitHolder;
+import org.apache.arrow.vector.holders.NullableDateDayHolder;
+import org.apache.arrow.vector.holders.NullableDateMilliHolder;
+import org.apache.arrow.vector.holders.NullableDecimalHolder;
+import org.apache.arrow.vector.holders.NullableFloat4Holder;
+import org.apache.arrow.vector.holders.NullableFloat8Holder;
+import org.apache.arrow.vector.holders.NullableIntHolder;
+import org.apache.arrow.vector.holders.NullableSmallIntHolder;
+import org.apache.arrow.vector.holders.NullableTinyIntHolder;
+import org.apache.arrow.vector.holders.NullableTimeStampMicroTZHolder;
+import org.apache.arrow.vector.holders.NullableTimeStampMilliTZHolder;
+import org.apache.arrow.vector.holders.NullableTimeStampNanoTZHolder;
+import org.apache.arrow.vector.holders.NullableTimeStampSecTZHolder;
+import org.apache.arrow.vector.holders.NullableUInt1Holder;
+import org.apache.arrow.vector.holders.NullableUInt2Holder;
+import org.apache.arrow.vector.holders.NullableUInt4Holder;
+import org.apache.arrow.vector.holders.NullableUInt8Holder;
+import org.apache.arrow.vector.holders.NullableVarBinaryHolder;
+import org.apache.arrow.vector.holders.NullableVarCharHolder;
+import org.apache.arrow.vector.types.Types.MinorType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.BitVector;
+import org.apache.arrow.vector.DateDayVector;
+import org.apache.arrow.vector.DateMilliVector;
+import org.apache.arrow.vector.DecimalVector;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.Float4Vector;
+import org.apache.arrow.vector.Float8Vector;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.SmallIntVector;
+import org.apache.arrow.vector.TinyIntVector;
+import org.apache.arrow.vector.TimeStampMicroTZVector;
+import org.apache.arrow.vector.TimeStampMilliTZVector;
+import org.apache.arrow.vector.TimeStampNanoTZVector;
+import org.apache.arrow.vector.TimeStampSecTZVector;
+import org.apache.arrow.vector.UInt1Vector;
+import org.apache.arrow.vector.UInt2Vector;
+import org.apache.arrow.vector.UInt4Vector;
+import org.apache.arrow.vector.UInt8Vector;
+import org.apache.arrow.vector.VarBinaryVector;
+import org.apache.arrow.vector.VarCharVector;
+
+import net.jqwik.api.*;
+import net.jqwik.time.api.*;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+public class ValuesGenerator {
+
+    private static final Long MIN_TIME = Instant.ofEpochMilli(Long.MIN_VALUE).toEpochMilli();
+    private static final Long MAX_TIME = Instant.ofEpochMilli(Long.MAX_VALUE).toEpochMilli();
+
+    public FieldVector generateValues(Field field, RootAllocator allocator) {
+        FieldVector vector = field.createVector(allocator);
+        generateValues(field, vector, 0, false);
+        return vector;
+    }
+
+    public int generateValues(Field field, FieldVector vector, int length, boolean unique) {
+        switch (vector.getMinorType()) {
+            case BIGINT:
+                return setBigInt(field, vector, length, unique);
+            case BIT:
+                return setBit(field, vector, length, unique);
+            case DATEDAY:
+                return setDateDay(field, vector, length, unique);
+            case DATEMILLI:
+                return setDateMilli(field, vector, length, unique);
+            case DECIMAL:
+                return setDecimal(field, vector, length, unique);
+            case FLOAT4:
+                return setFloat4(field, vector, length, unique);
+            case FLOAT8:
+                return setFloat8(field, vector, length, unique);
+            case INT:
+                return setInt(field, vector, length, unique);
+            case LIST:
+                return setList(field, vector, length, unique);
+            case MAP:
+                return setMap(field, vector, length, unique);
+            case SMALLINT:
+                return setSmallInt(field, vector, length, unique);
+            case STRUCT:
+                return setStruct(field, vector, length, unique);
+            case TIMESTAMPMICROTZ:
+                return setTimestampMicroTz(field, vector, length, unique);
+            case TIMESTAMPMILLITZ:
+                return setTimestampMilliTz(field, vector, length, unique);
+            case TIMESTAMPNANOTZ:
+                return setTimestampNanoTz(field, vector, length, unique);
+            case TIMESTAMPSECTZ:
+                return setTimestampSecTz(field, vector, length, unique);
+            case TINYINT:
+                return setTinyInt(field, vector, length, unique);
+            case UINT1:
+                return setUint1(field, vector, length, unique);
+            case UINT2:
+                return setUint2(field, vector, length, unique);
+            case UINT4:
+                return setUint4(field, vector, length, unique);
+            case UINT8:
+                return setUint8(field, vector, length, unique);
+            case VARBINARY:
+                return setVarBinary(field, vector, length, unique);
+            case VARCHAR:
+                return setVarChar(field, vector, length, unique);
+            default:
+                throw new RuntimeException("Not yet implemented for typeId " + vector.getMinorType());
+        }
+    }
+
+    private int getLength(int length) {
+        if (length == 0) {
+            length = Arbitraries.integers().between(1, 5).sample();
+        }
+        return length;
+    }
+
+    private boolean isNull(Field field) {
+        if (!field.isNullable()) {
+            return false;
+        }
+
+        // randomly determine if the value should be null or not
+        boolean isNull = Arbitraries.integers().between(0, 5).sample() == 0 ? true : false;
+        if (!isNull) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /*
+     * Complex Types
+     */
+
+    private int setStruct(Field field, FieldVector vector, int length, boolean unique) {
+        int position = vector.getValueCount();
+        int maxChildSize = 0;
+
+        for (int i = 0; i < vector.getChildrenFromFields().size(); i++) {
+            Field childField = field.getChildren().get(i);
+            FieldVector childVector = vector.getChildrenFromFields().get(i);
+            maxChildSize = Math.max(generateValues(childField, childVector, length, false), maxChildSize);
+        }
+
+        for (int i = position; i < maxChildSize; i++) {
+            ((StructVector) vector).setIndexDefined(i);
+        }
+        vector.setValueCount(maxChildSize);
+        return vector.getValueCount();
+    }
+
+    private int setList(Field field, FieldVector vector, int length, boolean unique) {
+        assertThat(vector.getChildrenFromFields().size()).isEqualTo(1);
+
+        int position = vector.getValueCount();
+        Field childField = field.getChildren().get(0);
+        FieldVector childVector = vector.getChildrenFromFields().get(0);
+        length = getLength(length);
+
+        int prevChildSize = childVector.getValueCount();
+        for (int i = 0; i < length; i++) {
+            if (!isNull(field)) {
+                ((ListVector) vector).startNewValue(position + i);
+                int newChildSize = generateValues(childField, childVector, 0, false);
+                ((ListVector) vector).endValue(position + i, newChildSize - prevChildSize);
+                prevChildSize = newChildSize;
+            }
+        }
+        vector.setValueCount(position + length);
+        return vector.getValueCount();
+    }
+
+    private int setMap(Field field, FieldVector vector, int length, boolean unique) {
+        assertThat(vector.getChildrenFromFields().size()).isEqualTo(1);
+
+        int position = vector.getValueCount();
+
+        Field entriesField = field.getChildren().get(0);
+        FieldVector entries = vector.getChildrenFromFields().get(0);
+
+        assertThat(entries.getChildrenFromFields().size()).isEqualTo(2);
+        Field keysField = entriesField.getChildren().get(0);
+        FieldVector keys = entries.getChildrenFromFields().get(0);
+        Field valuesField = entriesField.getChildren().get(1);
+        FieldVector values = entries.getChildrenFromFields().get(1);
+
+        length = getLength(length);
+
+        for (int i = 0; i < length; i++) {
+            ((MapVector) vector).startNewValue(position+i);
+            int keysValuesLength = getLength(0);
+            if (keys.getMinorType().equals(MinorType.VARBINARY) || keys.getMinorType().equals(MinorType.BIT)) {
+                keysValuesLength = 2; // special case if key is of binary/bit type
+            }
+
+            generateValues(keysField, keys, keysValuesLength, true);
+            generateValues(valuesField, values, keysValuesLength, false);
+            ((MapVector) vector).endValue(position+i, keysValuesLength);
+        }
+        vector.setValueCount(position+length);
+
+        for (int i = 0; i < keys.getValueCount(); i++) {
+            ((StructVector) entries).setIndexDefined(i);
+        }
+        entries.setValueCount(keys.getValueCount());
+        return vector.getValueCount();
+    }
+
+    /*
+     * Primitive Types
+     */
+
+    private int setBigInt(Field field, FieldVector vector, int length, boolean unique) {
+        int position = vector.getValueCount();
+
+        length = getLength(length);
+        List<Long> items = unique ?
+            Arbitraries.longs().list().ofSize(length).uniqueElements().sample() :
+            Arbitraries.longs().list().ofSize(length).sample();
+
+        for (int i = 0; i < length; i++) {
+            if (isNull(field)) {
+                ((BigIntVector) vector).setSafe(i+position, new NullableBigIntHolder());
+            } else {
+                ((BigIntVector) vector).setSafe(i+position, items.get(i));
+            }
+        }
+        vector.setValueCount(position + length);
+        return vector.getValueCount();
+    }
+
+    private int setBit(Field field, FieldVector vector, int length, boolean unique) {
+        int position = vector.getValueCount();
+
+        length = getLength(length);
+        List<Integer> items = unique ?
+            Arbitraries.integers().between(0, 1).list().ofSize(length).uniqueElements().sample() :
+            Arbitraries.integers().between(0, 1).list().ofSize(length).sample();
+
+        for (int i = 0; i < length; i++) {
+            if (isNull(field)) {
+                ((BitVector) vector).setSafe(i+position, new NullableBitHolder());
+            }
+            else {
+                ((BitVector) vector).setSafe(i+position, items.get(i));
+            }
+        }
+
+        vector.setValueCount(position + length);
+        return vector.getValueCount();
+    }
+
+    private int setDateDay(Field field, FieldVector vector, int length, boolean unique) {
+        int position = vector.getValueCount();
+
+        length = getLength(length);
+        List<LocalDate> items = unique ?
+            Dates.dates().list().ofSize(length).uniqueElements().sample() :
+            Dates.dates().list().ofSize(length).sample();
+
+
+        for (int i = 0; i < length; i++) {
+            if (isNull(field)) {
+                ((DateDayVector) vector).setSafe(i+position, new NullableDateDayHolder());
+            }
+            else {
+                ((DateDayVector) vector).setSafe(i+position, (int) items.get(i).toEpochDay());
+            }
+        }
+
+        vector.setValueCount(position + length);
+        return vector.getValueCount();
+    }
+
+    private int setDateMilli(Field field, FieldVector vector, int length, boolean unique) {
+        int position = vector.getValueCount();
+
+        length = getLength(length);
+
+        List<Long> items = unique ?
+            Arbitraries.longs().greaterOrEqual(MIN_TIME).lessOrEqual(MAX_TIME).list().ofSize(length).uniqueElements().sample() :
+            Arbitraries.longs().greaterOrEqual(MIN_TIME).lessOrEqual(MAX_TIME).list().ofSize(length).sample();
+
+        for (int i = 0; i < length; i++) {
+            if (isNull(field)){
+                ((DateMilliVector) vector).setSafe(i+position, new NullableDateMilliHolder());
+            }
+            else {
+                ((DateMilliVector) vector).setSafe(i+position, items.get(i));
+            }
+        }
+
+        vector.setValueCount(position + length);
+        return vector.getValueCount();
+    }
+
+    private int setDecimal(Field field, FieldVector vector, int length, boolean unique) {
+        int position = vector.getValueCount();
+        length = getLength(length);
+        int scale = ((DecimalVector) vector).getScale();
+        int precision = ((DecimalVector) vector).getPrecision();
+        double range = Math.pow(10, (precision-scale));
+
+        List<BigDecimal> items = unique ?
+            Arbitraries.bigDecimals().greaterThan(new BigDecimal(range*-1)).lessThan(new BigDecimal(range)).ofScale(scale)
+                .list().ofSize(length).uniqueElements().sample() :
+            Arbitraries.bigDecimals().greaterThan(new BigDecimal(range*-1)).lessThan(new BigDecimal(range)).ofScale(scale)
+                .list().ofSize(length).sample();
+
+        for (int i = 0; i < length; i++) {
+            if (isNull(field)) {
+                ((DecimalVector) vector).setSafe(i+position, new NullableDecimalHolder());
+            } else {
+                ((DecimalVector) vector).setSafe(i+position, items.get(i));
+            }
+        }
+
+        vector.setValueCount(position + length);
+        return vector.getValueCount();
+    }
+
+    private int setFloat4(Field field, FieldVector vector, int length, boolean unique) {
+        int position = vector.getValueCount();
+
+        length = getLength(length);
+        List<Float> items = unique ?
+            Arbitraries.floats().list().ofSize(length).uniqueElements().sample() :
+            Arbitraries.floats().list().ofSize(length).sample();
+
+        for (int i = 0; i < length; i++) {
+            if (isNull(field)) {
+                ((Float4Vector) vector).setSafe(i+position, new NullableFloat4Holder());
+            } else {
+                ((Float4Vector) vector).setSafe(i+position, items.get(i));
+            }
+        }
+
+        vector.setValueCount(position + length);
+        return vector.getValueCount();
+    }
+
+    private int setFloat8(Field field, FieldVector vector, int length, boolean unique) {
+        int position = vector.getValueCount();
+
+        length = getLength(length);
+        List<Float> items = unique ?
+            Arbitraries.floats().list().ofSize(length).uniqueElements().sample() :
+            Arbitraries.floats().list().ofSize(length).sample();
+
+        for (int i = 0; i < length; i++) {
+            if (isNull(field)) {
+                ((Float8Vector) vector).setSafe(i+position, new NullableFloat8Holder());
+            } else {
+                ((Float8Vector) vector).setSafe(i+position, items.get(i));
+            }
+        }
+
+        vector.setValueCount(position + length);
+        return vector.getValueCount();
+    }
+
+    private int setInt(Field field, FieldVector vector, int length, boolean unique) {
+        int position = vector.getValueCount();
+
+        length = getLength(length);
+        List<Integer> items = unique ?
+            Arbitraries.integers().list().ofSize(length).uniqueElements().sample() :
+            Arbitraries.integers().list().ofSize(length).sample();
+
+        for (int i = 0; i < length; i++) {
+            if (isNull(field)) {
+                ((IntVector) vector).setSafe(i+position, new NullableIntHolder());
+            }
+            else {
+                ((IntVector) vector).setSafe(i+position, items.get(i));
+            }
+        }
+        vector.setValueCount(position + length);
+        return vector.getValueCount();
+    }
+
+    private int setSmallInt(Field field, FieldVector vector, int length, boolean unique) {
+        int position = vector.getValueCount();
+
+        length = getLength(length);
+        List<Short> items = unique ?
+            Arbitraries.shorts().list().ofSize(length).uniqueElements().sample() :
+            Arbitraries.shorts().list().ofSize(length).sample();
+
+        for (int i = 0; i < length; i++) {
+            if (isNull(field)) {
+                ((SmallIntVector) vector).setSafe(i+position, new NullableSmallIntHolder());
+            }
+            else {
+                ((SmallIntVector) vector).setSafe(i+position, items.get(i));
+            }
+        }
+        vector.setValueCount(position + length);
+        return vector.getValueCount();
+    }
+
+    private int setTimestampMicroTz(Field field, FieldVector vector, int length, boolean unique) {
+        int position = vector.getValueCount();
+
+        length = getLength(length);
+        List<Long> items = unique ?
+            Arbitraries.longs().greaterOrEqual(MIN_TIME).lessOrEqual(MAX_TIME).list().ofSize(length).uniqueElements().sample() :
+            Arbitraries.longs().greaterOrEqual(MIN_TIME).lessOrEqual(MAX_TIME).list().ofSize(length).sample();
+
+        for (int i = 0; i < length; i++) {
+            if (isNull(field)) {
+                ((TimeStampMicroTZVector) vector).setSafe(i+position, new NullableTimeStampMicroTZHolder());
+            } else {
+                ((TimeStampMicroTZVector) vector).setSafe(i+position, items.get(i));
+            }
+        }
+
+        vector.setValueCount(position + length);
+        return vector.getValueCount();
+    }
+
+    private int setTimestampMilliTz(Field field, FieldVector vector, int length, boolean unique) {
+        int position = vector.getValueCount();
+
+        length = getLength(length);
+        List<Long> items = unique ?
+            Arbitraries.longs().greaterOrEqual(MIN_TIME).lessOrEqual(MAX_TIME).list().ofSize(length).uniqueElements().sample() :
+            Arbitraries.longs().greaterOrEqual(MIN_TIME).lessOrEqual(MAX_TIME).list().ofSize(length).sample();
+
+        for (int i = 0; i < length; i++) {
+            if (isNull(field)) {
+                ((TimeStampMilliTZVector) vector).setSafe(i+position, new NullableTimeStampMilliTZHolder());
+            } else {
+                ((TimeStampMilliTZVector) vector).setSafe(i+position, items.get(i));
+            }
+        }
+
+        vector.setValueCount(position + length);
+        return vector.getValueCount();
+    }
+
+    private int setTimestampNanoTz(Field field, FieldVector vector, int length, boolean unique) {
+        int position = vector.getValueCount();
+
+        length = getLength(length);
+        List<Long> items = unique ?
+            Arbitraries.longs().greaterOrEqual(MIN_TIME).lessOrEqual(MAX_TIME).list().ofSize(length).uniqueElements().sample() :
+            Arbitraries.longs().greaterOrEqual(MIN_TIME).lessOrEqual(MAX_TIME).list().ofSize(length).sample();
+
+        for (int i = 0; i < length; i++) {
+            if (isNull(field)) {
+                ((TimeStampNanoTZVector) vector).setSafe(i+position, new NullableTimeStampNanoTZHolder());
+            } else {
+                ((TimeStampNanoTZVector) vector).setSafe(i+position, items.get(i));
+            }
+        }
+
+        vector.setValueCount(position + length);
+        return vector.getValueCount();
+    }
+
+    private int setTimestampSecTz(Field field, FieldVector vector, int length, boolean unique) {
+        int position = vector.getValueCount();
+
+        length = getLength(length);
+        List<Long> items = unique ?
+            Arbitraries.longs().greaterOrEqual(MIN_TIME).lessOrEqual(MAX_TIME).list().ofSize(length).uniqueElements().sample() :
+            Arbitraries.longs().greaterOrEqual(MIN_TIME).lessOrEqual(MAX_TIME).list().ofSize(length).sample();
+
+        for (int i = 0; i < length; i++) {
+            if (isNull(field)) {
+                ((TimeStampSecTZVector) vector).setSafe(i+position, new NullableTimeStampSecTZHolder());
+            } else {
+                ((TimeStampSecTZVector) vector).setSafe(i+position, items.get(i));
+            }
+        }
+
+        vector.setValueCount(position + length);
+        return vector.getValueCount();
+    }
+
+    private int setTinyInt(Field field, FieldVector vector, int length, boolean unique) {
+        int position = vector.getValueCount();
+
+        length = getLength(length);
+        List<Byte> items = unique ?
+            Arbitraries.bytes().list().ofSize(length).uniqueElements().sample() :
+            Arbitraries.bytes().list().ofSize(length).sample();
+
+        for (int i = 0; i < length; i++) {
+            if (isNull(field)) {
+                ((TinyIntVector) vector).setSafe(i+position, new NullableTinyIntHolder());
+            }
+            else {
+                ((TinyIntVector) vector).setSafe(i+position, items.get(i));
+            }
+        }
+        vector.setValueCount(position + length);
+        return vector.getValueCount();
+    }
+
+    private int setVarChar(Field field, FieldVector vector, int length, boolean unique) {
+        int position = vector.getValueCount();
+
+        length = getLength(length);
+        List<String> items = unique ?
+            Arbitraries.strings().list().ofSize(length).uniqueElements().sample() :
+            Arbitraries.strings().list().ofSize(length).sample();
+
+        for (int i = 0; i < length; i++) {
+            if (isNull(field)) {
+                ((VarCharVector) vector).setSafe(i+position, new NullableVarCharHolder());
+            }
+            else {
+                ((VarCharVector) vector).setSafe(i+position, items.get(i).getBytes());
+            }
+        }
+
+        vector.setValueCount(position + length);
+        return vector.getValueCount();
+    }
+
+    private int setUint1(Field field, FieldVector vector, int length, boolean unique) {
+        int position = vector.getValueCount();
+
+        length = getLength(length);
+        List<Byte> items = unique ?
+            Arbitraries.bytes().greaterOrEqual((byte) 0).list().ofSize(length).uniqueElements().sample() :
+            Arbitraries.bytes().greaterOrEqual((byte) 0).list().ofSize(length).sample();
+
+        for (int i = 0; i < length; i++) {
+            if (isNull(field)) {
+                ((UInt1Vector) vector).setSafe(i+position, new NullableUInt1Holder());
+            } else {
+                ((UInt1Vector) vector).setSafe(i+position, items.get(i));
+            }
+        }
+        vector.setValueCount(position + length);
+        return vector.getValueCount();
+    }
+
+    private int setUint2(Field field, FieldVector vector, int length, boolean unique) {
+        int position = vector.getValueCount();
+
+        length = getLength(length);
+        List<Short> items = unique ?
+            Arbitraries.shorts().greaterOrEqual((short) 0).list().ofSize(length).uniqueElements().sample() :
+            Arbitraries.shorts().greaterOrEqual((short) 0).list().ofSize(length).sample();
+
+        for (int i = 0; i < length; i++) {
+            if (isNull(field)) {
+                ((UInt2Vector) vector).setSafe(i+position, new NullableUInt2Holder());
+            } else {
+                ((UInt2Vector) vector).setSafe(i+position, items.get(i));
+            }
+        }
+        vector.setValueCount(position + length);
+        return vector.getValueCount();
+    }
+
+    private int setUint4(Field field, FieldVector vector, int length, boolean unique) {
+        int position = vector.getValueCount();
+
+        length = getLength(length);
+        List<Integer> items = unique ?
+            Arbitraries.integers().greaterOrEqual(0).list().ofSize(length).uniqueElements().sample() :
+            Arbitraries.integers().greaterOrEqual(0).list().ofSize(length).sample();
+
+        for (int i = 0; i < length; i++) {
+            if (isNull(field)) {
+                ((UInt4Vector) vector).setSafe(i+position, new NullableUInt4Holder());
+            } else {
+                ((UInt4Vector) vector).setSafe(i+position, items.get(i));
+            }
+        }
+        vector.setValueCount(position + length);
+        return vector.getValueCount();
+    }
+
+    private int setUint8(Field field, FieldVector vector, int length, boolean unique) {
+        int position = vector.getValueCount();
+
+        length = getLength(length);
+        List<Long> items = unique ?
+            Arbitraries.longs().greaterOrEqual(0).list().ofSize(length).uniqueElements().sample() :
+            Arbitraries.longs().greaterOrEqual(0).list().ofSize(length).sample();
+
+        for (int i = 0; i < length; i++) {
+            if (isNull(field)) {
+                ((UInt8Vector) vector).setSafe(i+position, new NullableUInt8Holder());
+            } else {
+                ((UInt8Vector) vector).setSafe(i+position, items.get(i));
+            }
+        }
+        vector.setValueCount(position + length);
+        return vector.getValueCount();
+    }
+
+    private int setVarBinary(Field field, FieldVector vector, int length, boolean unique) {
+        int position = vector.getValueCount();
+
+        length = getLength(length);
+        List<String> items = unique ?
+            Arbitraries.strings().list().ofSize(length).uniqueElements().sample() :
+            Arbitraries.strings().list().ofSize(length).sample();
+
+        for (int i = 0; i < length; i++) {
+            if (isNull(field)) {
+                ((VarBinaryVector) vector).setSafe(i+position, new NullableVarBinaryHolder());
+            }
+            else {
+                ((VarBinaryVector) vector).setSafe(i+position, items.get(i).getBytes());
+            }
+        }
+
+        vector.setValueCount(position + length);
+        return vector.getValueCount();
+    }
+}

--- a/athena-hbase/pom.xml
+++ b/athena-hbase/pom.xml
@@ -159,6 +159,17 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire.failsafe.version}</version>
+                <configuration>
+                    <argLine>-Xmx4g</argLine>
+                    <excludes>
+                        <exclude>*IntegTest</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -11,20 +11,34 @@
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
         <aws-sdk.version>1.11.800</aws-sdk.version>
         <aws.lambda-java-core.version>1.2.0</aws.lambda-java-core.version>
         <aws.lambda-java-log4j2.version>1.5.1</aws.lambda-java-log4j2.version>
         <slf4j-log4j.version>1.7.28</slf4j-log4j.version>
         <mockito.version>1.10.19</mockito.version>
         <junit.version>4.13.1</junit.version>
+        <jqwik.version>1.6.3</jqwik.version>
+        <assertj.version>3.22.0</assertj.version>
         <testng.version>7.0.0</testng.version>
         <fasterxml.jackson.version>2.13.4</fasterxml.jackson.version>
         <aws-cdk.version>1.89.0</aws-cdk.version>
-        <surefire.failsafe.version>3.0.0-M5</surefire.failsafe.version>
+        <surefire.failsafe.version>3.0.0-M7</surefire.failsafe.version>
         <log4j2Version>2.17.1</log4j2Version>
         <apache.arrow.version>9.0.0</apache.arrow.version>
         <netty.version>4.1.81.Final</netty.version>
     </properties>
+    <dependencyManagement>
+      <dependencies>
+              <dependency>
+                  <groupId>org.junit</groupId>
+                  <artifactId>junit-bom</artifactId>
+                  <version>5.9.0</version>
+                  <type>pom</type>
+                  <scope>import</scope>
+              </dependency>
+      </dependencies>
+    </dependencyManagement>
     <organization>
         <name>Amazon Web Services</name>
         <url>https://https://aws.amazon.com//</url>
@@ -93,9 +107,36 @@
             <version>${aws.lambda-java-core.version}</version>
         </dependency>
         <dependency>
+            <groupId>net.jqwik</groupId>
+            <artifactId>jqwik</artifactId>
+            <version>${jqwik.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -207,16 +248,19 @@
                 </executions>
             </plugin>
             <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven.compiler.plugin.version}</version>
+                <configuration>
+                    <!-- required if you want to report source code names of property method parameters -->
+                    <compilerArgs>
+                        <arg>-parameters</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${surefire.failsafe.version}</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.apache.maven.surefire</groupId>
-                        <artifactId>surefire-junit4</artifactId>
-                        <version>${surefire.failsafe.version}</version>
-                    </dependency>
-                </dependencies>
                 <configuration>
                     <excludes>
                         <exclude>*IntegTest</exclude>


### PR DESCRIPTION
Dependency changes:
  - Upgraded JUnit to Jupiter
  - Added JQwik

Added BlockUtilsPropertiesTest

Found and fixed the following issues with BlockUtils (via the added test above):
  - Null values not being preserved in any container types (Lists, Maps, Structs)
  - List of maps was not supported (threw an exception)
  - Struct of maps was not supported (thew an exception)
  - Incorrect casting of primitive types (thew an exception)
  - Struct of DateMilli fields was not working (threw an exception)

Remaining issues:
  - List and Map of TimeStamp*TZ fields are not working right now because of a bug in Arrow. - This is an existing problem. - Test is not generating and testing these fields right now (commented out).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
