### PR TITLE
athena-jdbc: Don't trim string values

### DIFF
--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcRecordHandler.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcRecordHandler.java
@@ -277,8 +277,8 @@ public abstract class JdbcRecordHandler
             case VARCHAR:
                 return (VarCharExtractor) (Object context, NullableVarCharHolder dst) ->
                 {
-                    if (null != resultSet.getString(fieldName)) { // fixed char issue
-                        dst.value = resultSet.getString(fieldName).trim();
+                    if (null != resultSet.getString(fieldName)) {
+                        dst.value = resultSet.getString(fieldName);
                     }
                     dst.isSet = resultSet.wasNull() ? 0 : 1;
                 };


### PR DESCRIPTION
Previously the code was trimming the white space around String values.
This is not right since it is valid to have Strings with white spaces around them as values.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
