### PR TITLE
DDB: Add BETWEEN support

### DIFF
--- a/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBRecordHandlerTest.java
+++ b/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBRecordHandlerTest.java
@@ -520,7 +520,7 @@ public class DynamoDBRecordHandlerTest
         List<Column> columns = new ArrayList<>();
         columns.add(new Column().withName("col0").withType("string"));
         columns.add(new Column().withName("outermap").withType("struct<list:array<string>>"));
-        columns.add(new Column().withName("structcol").withType("struct<structKey:STRING,struct<key1:STRING,key2:STRING>>"));
+        columns.add(new Column().withName("structcol").withType("struct<structKey:struct<key1:STRING,key2:STRING>>"));
 
         Map<String, String> param = ImmutableMap.of(
                 SOURCE_TABLE_PROPERTY, TEST_TABLE6,


### PR DESCRIPTION
This patch converts inclusive ranges for DDB key conditions to use BETWEEN.

Also tests have been added to ensure that we do not convert the mixed inclusion ranges to BETWEEN.

Also fixes a long standing buggy test that has been masked over by
automatic type inference failover in: DynamoDBRecordHandlerTest.java


This patch is a safer version of this prior work.: https://github.com/awslabs/aws-athena-query-federation/pull/375


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
