### PR TITLE
Data Integrity: Add generative tests for FieldResolver, DynamoDBFieldResolver, ElasticsearchFieldResolver.

### DIFF
--- a/athena-dynamodb/pom.xml
+++ b/athena-dynamodb/pom.xml
@@ -88,6 +88,13 @@
             <version>${aws-cdk.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-athena-federation-sdk</artifactId>
+            <version>2022.39.1</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <repositories>
         <repository>

--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/resolver/DynamoDBFieldResolver.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/resolver/DynamoDBFieldResolver.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -58,6 +58,7 @@ public class DynamoDBFieldResolver
         Types.MinorType fieldType = Types.getMinorTypeForArrowType(field.getType());
         String fieldName = field.getName();
         Object fieldValue = originalValue;
+
         if (originalValue instanceof Map) {
             if (((Map) originalValue).containsKey(fieldName)) {
                 fieldValue = ((Map) originalValue).get(fieldName);
@@ -78,17 +79,26 @@ public class DynamoDBFieldResolver
                 }
                 break;
             default:
-                if (fieldValue instanceof Map) {
-                    // List of a Struct: array<struct<...>>
-                    return DDBTypeUtils.coerceValueToExpectedType(((Map<?, ?>) fieldValue).get(fieldName),
-                            field, fieldType, metadata);
-                }
-                else {
-                    return DDBTypeUtils.coerceValueToExpectedType(fieldValue, field, fieldType, metadata);
-                }
+                return DDBTypeUtils.coerceValueToExpectedType(fieldValue, field, fieldType, metadata);
         }
 
         throw new RuntimeException("Invalid field value encountered in DB record for field: " + field +
                 ",value: " + fieldValue);
+    }
+
+    // Return the field value of a map key
+    // For DynamoDB, the key is always a string so we can return the originalValue
+    @Override
+    public Object getMapKey(Field field, Object originalValue)
+    {
+        return originalValue;
+    }
+
+    // Return the field value of a map value
+    @Override
+    public Object getMapValue(Field field, Object originalValue)
+    {
+        Types.MinorType fieldType = Types.getMinorTypeForArrowType(field.getType());
+        return DDBTypeUtils.coerceValueToExpectedType(originalValue, field, fieldType, metadata);
     }
 }

--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/util/DDBTypeUtils.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/util/DDBTypeUtils.java
@@ -342,6 +342,10 @@ public final class DDBTypeUtils
     public static List<Object> coerceListToExpectedType(Object value, Field field, DDBRecordMetadata recordMetadata)
             throws RuntimeException
     {
+        if (value == null) {
+            return null;
+        }
+
         Field childField = field.getChildren().get(0);
         Types.MinorType fieldType = Types.getMinorTypeForArrowType(childField.getType());
 

--- a/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DDBFieldResolverTest.java
+++ b/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DDBFieldResolverTest.java
@@ -1,0 +1,66 @@
+/*-
+ * #%L
+ * athena-dynamodb
+ * %%
+ * Copyright (C) 2019 - 2022 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.dynamodb;
+
+import com.amazonaws.athena.connectors.dynamodb.util.DDBRecordMetadata;
+import com.amazonaws.athena.connectors.dynamodb.resolver.DynamoDBFieldResolver;
+import com.amazonaws.athena.connector.lambda.data.BlockUtilsPropertiesTest;
+import com.amazonaws.athena.connector.lambda.data.FieldResolver;
+import com.amazonaws.athena.connector.lambda.data.helpers.CustomFieldVector;
+import com.amazonaws.athena.connector.lambda.data.helpers.FieldsGenerator;
+
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.arrow.vector.FieldVector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+import net.jqwik.api.*;
+
+class DDBFieldResolverTest extends BlockUtilsPropertiesTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(DDBFieldResolverTest.class);
+
+    @Override @Provide
+    protected Arbitrary<Field> fieldLowRecursion() {
+        FieldsGenerator fieldsGenerator = new FieldsGenerator(2, false);
+        return fieldsGenerator.field();
+    }
+
+    @Override @Provide
+    protected Arbitrary<Field> fieldHighRecursion() {
+        FieldsGenerator fieldsGenerator = new FieldsGenerator(5, false);
+        return fieldsGenerator.field();
+    }
+
+    @Override
+    protected FieldResolver getFieldResolver(Schema schema) {
+        DDBRecordMetadata recordMetadata = new DDBRecordMetadata(schema);
+        DynamoDBFieldResolver resolver = new DynamoDBFieldResolver(recordMetadata);
+        return (FieldResolver) resolver;
+    }
+
+    @Override
+    protected Object getValue(FieldVector vector, CustomFieldVector customFieldVector, int pos, FieldResolver resolver) {
+        return ((List<Object>) (customFieldVector.objList)).get(pos);
+    }
+}

--- a/athena-elasticsearch/pom.xml
+++ b/athena-elasticsearch/pom.xml
@@ -109,6 +109,13 @@
             <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-athena-federation-sdk</artifactId>
+            <version>2022.39.1</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/athena-elasticsearch/src/main/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchFieldResolver.java
+++ b/athena-elasticsearch/src/main/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchFieldResolver.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -90,14 +90,26 @@ public class ElasticsearchFieldResolver
                 }
                 break;
             default:
-                if (!(fieldValue instanceof Map)) {
-                    return coerceField(field, fieldValue);
-                }
-                break;
+                return coerceField(field, fieldValue);
         }
 
         throw new RuntimeException("Invalid field value encountered in Document for field: " + field +
                 ",value: " + fieldValue);
+    }
+
+    // Return the field value of a map key
+    // For Elasticsearch, the key is always a string so we can return the originalValue
+    @Override
+    public Object getMapKey(Field field, Object originalValue)
+    {
+        return originalValue;
+    }
+
+    // Return the field value of a map value
+    @Override
+    public Object getMapValue(Field field, Object originalValue)
+    {
+        return coerceField(field, originalValue);
     }
 
     /**
@@ -111,6 +123,10 @@ public class ElasticsearchFieldResolver
     protected Object coerceListField(Field field, Object fieldValue)
             throws RuntimeException
     {
+        if (fieldValue == null) {
+            return null;
+        }
+
         Types.MinorType fieldType = Types.getMinorTypeForArrowType(field.getType());
 
         switch (fieldType) {

--- a/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchFieldResolverGenerativeTest.java
+++ b/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchFieldResolverGenerativeTest.java
@@ -1,0 +1,62 @@
+/*-
+ * #%L
+ * athena-dynamodb
+ * %%
+ * Copyright (C) 2019 - 2022 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.elasticsearch;
+
+import com.amazonaws.athena.connector.lambda.data.BlockUtilsPropertiesTest;
+import com.amazonaws.athena.connector.lambda.data.FieldResolver;
+import com.amazonaws.athena.connector.lambda.data.helpers.CustomFieldVector;
+import com.amazonaws.athena.connector.lambda.data.helpers.FieldsGenerator;
+
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.arrow.vector.FieldVector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+import net.jqwik.api.*;
+
+class ElasticsearchFieldResolverGenerativeTest extends BlockUtilsPropertiesTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(ElasticsearchFieldResolverGenerativeTest.class);
+
+    @Override @Provide
+    protected Arbitrary<Field> fieldLowRecursion() {
+        FieldsGenerator fieldsGenerator = new FieldsGenerator(2, false);
+        return fieldsGenerator.field();
+    }
+
+    @Override @Provide
+    protected Arbitrary<Field> fieldHighRecursion() {
+        FieldsGenerator fieldsGenerator = new FieldsGenerator(5, false);
+        return fieldsGenerator.field();
+    }
+
+    @Override
+    protected FieldResolver getFieldResolver(Schema schema) {
+        return (FieldResolver) (new ElasticsearchFieldResolver());
+    }
+
+    @Override
+    protected Object getValue(FieldVector vector, CustomFieldVector customFieldVector, int pos, FieldResolver resolver) {
+        return ((List<Object>) (customFieldVector.objList)).get(pos);
+    }
+}

--- a/athena-federation-sdk/pom.xml
+++ b/athena-federation-sdk/pom.xml
@@ -189,6 +189,18 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.2</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>3.1.0</version>
                 <configuration>

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/BlockUtils.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/BlockUtils.java
@@ -719,14 +719,14 @@ public class BlockUtils
             //  eventually we will want to unify this behavior across the SDK and the rest of the connectors.
             //  We just want to limit the blast radius from this change for now
             if (Types.getMinorTypeForArrowType(keyField.getType()) != Types.MinorType.STRUCT) {
-                entryKeyValue = resolver.getFieldValue(keyField, entry.getKey());
+                entryKeyValue = resolver.getMapKey(keyField, entry.getKey());
             }
             writeAllValue((FieldWriter) writer.key(), keyField, allocator, pos, resolver, entryKeyValue, true);
 
             Object entryValValue = entry.getValue();
             if (entryValValue != null) {
                 if (Types.getMinorTypeForArrowType(valueField.getType()) != Types.MinorType.STRUCT) {
-                    entryValValue = resolver.getFieldValue(valueField, entryValValue);
+                    entryValValue = resolver.getMapValue(valueField, entryValValue);
                 }
                 writeAllValue((FieldWriter) writer.value(), valueField, allocator, pos, resolver, entryValValue, true);
             }

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/FieldResolver.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/FieldResolver.java
@@ -66,4 +66,32 @@ public interface FieldResolver
      * @return The value to use for the given field.
      */
     Object getFieldValue(Field field, Object value);
+
+    /**
+     * Allow for additional logic to be apply for the retrieval of map keys
+     * If not overwritten, the default behavior is to assume no special logic
+     * and call getFieldValue as usual.
+     *
+     * @param field The field that we would like to extract from the provided value.
+     * @param value The complex value we'd like to extract the provided field from.
+     * @return The value to use for the given field.
+     */
+    default Object getMapKey(Field field, Object value)
+    {
+        return getFieldValue(field, value);
+    }
+
+    /**
+     * Allow for additional logic to be apply for the retrieval of map values
+     * If not overwritten, the default behavior is to assume no special logic
+     * and call getFieldValue as usual.
+     *
+     * @param field The field that we would like to extract from the provided value.
+     * @param value The complex value we'd like to extract the provided field from.
+     * @return The value to use for the given field.
+     */
+    default Object getMapValue(Field field, Object value)
+    {
+        return getFieldValue(field, value);
+    }
 }

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/FieldResolver.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/FieldResolver.java
@@ -69,8 +69,8 @@ public interface FieldResolver
 
     /**
      * Allow for additional logic to be apply for the retrieval of map keys
-     * If not overwritten, the default behavior is to assume no special logic
-     * and call getFieldValue as usual.
+     * If not overwritten, the default behavior is to assume a standard map with
+     * no special logic where the key is NOT a complex value
      *
      * @param field The field that we would like to extract from the provided value.
      * @param value The complex value we'd like to extract the provided field from.
@@ -78,13 +78,13 @@ public interface FieldResolver
      */
     default Object getMapKey(Field field, Object value)
     {
-        return getFieldValue(field, value);
+        return value;
     }
 
     /**
      * Allow for additional logic to be apply for the retrieval of map values
-     * If not overwritten, the default behavior is to assume no special logic
-     * and call getFieldValue as usual.
+     * If not overwritten, the default behavior is to assume a standard map with
+     * no special logic and return the value directly
      *
      * @param field The field that we would like to extract from the provided value.
      * @param value The complex value we'd like to extract the provided field from.
@@ -92,6 +92,6 @@ public interface FieldResolver
      */
     default Object getMapValue(Field field, Object value)
     {
-        return getFieldValue(field, value);
+        return value;
     }
 }

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/data/BlockUtilsPropertiesTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/data/BlockUtilsPropertiesTest.java
@@ -189,6 +189,16 @@ class ArrowToArrowResolver implements FieldResolver {
         }
         return originalValue;
     }
+
+    @Override
+    public Object getMapKey(Field field, Object originalValue) {
+        return getFieldValue(field, originalValue);
+    }
+
+    @Override
+    public Object getMapValue(Field field, Object originalValue) {
+        return getFieldValue(field, originalValue);
+    }
 }
 
 

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/data/BlockUtilsPropertiesTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/data/BlockUtilsPropertiesTest.java
@@ -21,6 +21,7 @@ package com.amazonaws.athena.connector.lambda.data;
  */
 
 import com.amazonaws.athena.connector.lambda.data.helpers.ValuesGenerator;
+import com.amazonaws.athena.connector.lambda.data.helpers.CustomFieldVector;
 import com.amazonaws.athena.connector.lambda.data.helpers.FieldsGenerator;
 
 import org.apache.arrow.vector.complex.MapVector;
@@ -42,22 +43,33 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 
-class BlockUtilsPropertiesTest {
+public class BlockUtilsPropertiesTest {
 
     private static final Logger logger = LoggerFactory.getLogger(BlockUtilsTest.class);
 
-    static final RootAllocator allocator = new RootAllocator();
-
     @Provide
-    private Arbitrary<Field> fieldLowRecursion() {
+    protected Arbitrary<Field> fieldLowRecursion() {
         FieldsGenerator fieldsGenerator = new FieldsGenerator(2);
         return fieldsGenerator.field();
     }
 
     @Provide
-    private Arbitrary<Field> fieldHighRecursion() {
+    protected Arbitrary<Field> fieldHighRecursion() {
         FieldsGenerator fieldsGenerator = new FieldsGenerator(5);
         return fieldsGenerator.field();
+    }
+
+    protected FieldResolver getFieldResolver(Schema schema) {
+        return new ArrowToArrowResolver();
+    }
+
+    protected Object getValue(FieldVector vector, CustomFieldVector customFieldVector, int pos, FieldResolver resolver) {
+        if (vector.getMinorType().equals(MinorType.MAP)) {
+            return resolver.getFieldValue(vector.getField(), vector.getObject(pos));
+        }
+        else {
+            return vector.getObject(pos);
+        }
     }
 
     // Using the default number of tries here (1000)
@@ -78,31 +90,30 @@ class BlockUtilsPropertiesTest {
 
     private boolean setComplexValuesSetsAllFieldsCorrectlyGivenAnyInput(Field field) {
         ValuesGenerator generator = new ValuesGenerator();
-        FieldVector vector = generator.generateValues(field, allocator);
+        RootAllocator allocator = new RootAllocator();
+        FieldVector vector = field.createVector(allocator);
+        CustomFieldVector customFieldVector = new CustomFieldVector(field);
+        generator.generateValues(field, vector, customFieldVector);
 
-        VectorSchemaRoot inputSchemaRoot = new VectorSchemaRoot(
-            new Schema(java.util.List.of(field)),
-            java.util.List.of(vector), 1
-        );
+        Schema schema = new Schema(java.util.List.of(field));
+        VectorSchemaRoot inputSchemaRoot = new VectorSchemaRoot(schema, java.util.List.of(vector), 1);
 
         int valueCount = inputSchemaRoot.getVector(0).getValueCount();
         VectorSchemaRoot outputSchemaRoot = VectorSchemaRoot.create(inputSchemaRoot.getSchema(), allocator);
         outputSchemaRoot.setRowCount(1);
-        ArrowToArrowResolver resolver = new ArrowToArrowResolver();
-
+        FieldResolver resolver = getFieldResolver(schema);
         for (int i = 0; i < valueCount; i++) {
             if (field.getType().isComplex()) {
                 BlockUtils.setComplexValue(
-                    outputSchemaRoot.getVector(0), i, resolver, getValue(vector, i, resolver)
+                    outputSchemaRoot.getVector(0), i, resolver, getValue(vector, customFieldVector, i, resolver)
                 );
             }
             else {
-                BlockUtils.setValue(outputSchemaRoot.getVector(0), i, getValue(vector, i, resolver));
+                BlockUtils.setValue(outputSchemaRoot.getVector(0), i, getValue(vector, customFieldVector, i, resolver));
             }
         }
 
         outputSchemaRoot.getVector(0).setValueCount(valueCount);
-
         if (inputSchemaRoot.equals(outputSchemaRoot)) {
             logger.debug(
                 "Matched for Schema:\n\t"
@@ -127,15 +138,6 @@ class BlockUtilsPropertiesTest {
         }
 
         return true;
-    }
-
-    private Object getValue(FieldVector vector, int pos, FieldResolver resolver) {
-        if (vector.getMinorType().equals(MinorType.MAP)) {
-            return resolver.getFieldValue(vector.getField(), vector.getObject(pos));
-        }
-        else {
-            return vector.getObject(pos);
-        }
     }
 }
 
@@ -187,8 +189,6 @@ class ArrowToArrowResolver implements FieldResolver {
         }
         return originalValue;
     }
-
-
 }
 
 

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/data/FieldResolverTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/data/FieldResolverTest.java
@@ -1,0 +1,61 @@
+package com.amazonaws.athena.connector.lambda.data;
+
+/*-
+ * #%L
+ * Amazon Athena Query Federation SDK
+ * %%
+ * Copyright (C) 2022 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.amazonaws.athena.connector.lambda.data.helpers.CustomFieldVector;
+import com.amazonaws.athena.connector.lambda.data.helpers.FieldsGenerator;
+
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.arrow.vector.FieldVector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import net.jqwik.api.*;
+
+import java.util.List;
+
+class FieldResolverTest extends BlockUtilsPropertiesTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(FieldResolverTest.class);
+
+    @Override @Provide
+    protected Arbitrary<Field> fieldLowRecursion() {
+        FieldsGenerator fieldsGenerator = new FieldsGenerator(2, false);
+        return fieldsGenerator.field();
+    }
+
+    @Override @Provide
+    protected Arbitrary<Field> fieldHighRecursion() {
+        FieldsGenerator fieldsGenerator = new FieldsGenerator(5, false);
+        return fieldsGenerator.field();
+    }
+
+    @Override
+    protected FieldResolver getFieldResolver(Schema schema) {
+        return FieldResolver.DEFAULT;
+    }
+
+    @Override
+    protected Object getValue(FieldVector vector, CustomFieldVector customFieldVector, int pos, FieldResolver resolver) {
+        return ((List<Object>) (customFieldVector.objList)).get(pos);
+    }
+}

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/data/helpers/CustomFieldVector.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/data/helpers/CustomFieldVector.java
@@ -1,0 +1,82 @@
+/*-
+ * #%L
+ * Amazon Athena Query Federation SDK
+ * %%
+ * Copyright (C) 2019 - 2022 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connector.lambda.data.helpers;
+
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.Types;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class CustomFieldVector
+{
+    public List<Object> objList;
+    public Field field;
+
+    public CustomFieldVector(Field field) {
+        this.objList = new ArrayList<Object>();
+        this.field = field;
+    }
+
+    public void add(Object childObj) {
+        if (childObj == null) {
+            this.objList.add(null);
+            return;
+        }
+
+        Types.MinorType fieldType = Types.getMinorTypeForArrowType(this.field.getType());
+
+        switch (fieldType) {
+            case LIST:
+                this.objList.add(((CustomFieldVector) childObj).objList);
+                break;
+            case STRUCT:
+                String childName = ((CustomFieldVector) childObj).field.getName();
+                List<Object> childObjList = ((CustomFieldVector) childObj).objList;
+
+                for (int i = 0; i < childObjList.size(); i++) {
+                    if (i >= this.objList.size()) {
+                        this.objList.add(new LinkedHashMap<String, Object>());
+                    }
+                    Map<String, Object> curr = (Map<String, Object>) this.objList.get(i);
+                    if (childObjList.get(i) != null) {
+                        curr.put(childName, childObjList.get(i));
+                    }
+                }
+                break;
+            default:
+                this.objList.add(childObj);
+        }
+    }
+
+    public void addMap(CustomFieldVector keysObject, CustomFieldVector valuesObject) {
+        if (keysObject.objList.size() != valuesObject.objList.size()) {
+            throw new RuntimeException("Mismatched key/value object sizes.");
+        }
+
+        Map<Object, Object> keyValueMap = new LinkedHashMap<Object, Object>();
+        for (int i = 0; i < keysObject.objList.size(); i++) {
+            keyValueMap.put(keysObject.objList.get(i), valuesObject.objList.get(i));
+        }
+        this.objList.add(keyValueMap);
+    }
+}


### PR DESCRIPTION
Added FiedResolverTest, DDBFieldResolverTest and ElasticsearchFieldResolverGenerativeTest

Found and fixed the following issues in FieldResolver:
1) Values not being set correctly for maps (throws exception)

Found and fixed the following issues in DynamoDBFieldResolver and ElasticsearchFieldResolver: 
1) Null values not being set correctly for nested lists (eg. Lists of lists) (incorrect behavior where a null list would be represented as a list with a null value) 
2) Values not being set correctly for maps (throws exceptiton)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
