### PR TITLE
Bugfix/snowflake partitionlimit issue

### DIFF
--- a/athena-snowflake/athena-snowflake.yaml
+++ b/athena-snowflake/athena-snowflake.yaml
@@ -48,14 +48,6 @@ Parameters:
   SubnetIds:
     Description: 'One or more Subnet IDs corresponding to the Subnet that the Lambda function can use to access you data source. (e.g. subnet1,subnet2)'
     Type: 'List<AWS::EC2::Subnet::Id>'
-  PageCount:
-    Description: 'Limits the number of records per partition'
-    Type: Number
-    Default: 500000
-  PartitionLimit:
-    Description: 'Limits the number of partitions. A large number may cause a time-out issue. Please reset to a lower value if you encounter a time-out error'
-    Type: Number
-    Default: 10
 Resources:
   JdbcConnectorConfig:
     Type: 'AWS::Serverless::Function'
@@ -66,8 +58,6 @@ Resources:
           spill_bucket: !Ref SpillBucket
           spill_prefix: !Ref SpillPrefix
           default: !Ref DefaultConnectionString
-          pagecount: !Ref PageCount
-          partitionlimit: !Ref PartitionLimit
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.snowflake.SnowflakeMuxCompositeHandler"
       CodeUri: "./target/athena-snowflake-2022.39.1.jar"

--- a/athena-snowflake/etc/test-config.json
+++ b/athena-snowflake/etc/test-config.json
@@ -14,8 +14,6 @@
     "disable_spill_encryption" : "false", /* If set to true encryption for spilled data is disabled (default: false) */
     "spill_put_request_headers": "",  /* JSON encoded map of request headers and values for the s3 putObject request used for spilling. This is a String not an object. Optional.*/
     "region": "<region>", /* aws region name */
-    "pagecount": "100000", /* page count */
-    "partitionlimit": "100", /* partition limit */
     "default": "snowflake://jdbc:snowflake://<hostname>/?warehouse=<warehouse name>&db=<db name>&schema=<schena name>&${<secret name>}" /* snowflake jdbc connection string */
   },
   "vpc_configuration" : {

--- a/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeConstants.java
+++ b/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeConstants.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,6 +25,8 @@ public final class SnowflakeConstants
     public static final String SNOWFLAKE_NAME = "snowflake";
     public static final String SNOWFLAKE_DRIVER_CLASS = "com.snowflake.client.jdbc.SnowflakeDriver";
     public static final int SNOWFLAKE_DEFAULT_PORT = 1025;
+    public static final int PARTITION_RECORD_COUNT = 500000;
+    public static final int MAX_PARTITION_COUNT = 50;
 
     private SnowflakeConstants() {}
 }

--- a/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeConstants.java
+++ b/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeConstants.java
@@ -25,7 +25,15 @@ public final class SnowflakeConstants
     public static final String SNOWFLAKE_NAME = "snowflake";
     public static final String SNOWFLAKE_DRIVER_CLASS = "com.snowflake.client.jdbc.SnowflakeDriver";
     public static final int SNOWFLAKE_DEFAULT_PORT = 1025;
+    /**
+     * This constant limits the number of records for each partition. The default set to 500000
+     * We arrived at this number after performance testing with datasets of different size
+     */
     public static final int PARTITION_RECORD_COUNT = 500000;
+    /**
+     * This constant limits the number of partitions. The default set to 50. A large number may cause a timeout issue.
+     * We arrived at this number after performance testing with datasets of different size
+     */
     public static final int MAX_PARTITION_COUNT = 50;
 
     private SnowflakeConstants() {}

--- a/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMetadataHandler.java
+++ b/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMetadataHandler.java
@@ -72,6 +72,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.amazonaws.athena.connectors.snowflake.SnowflakeConstants.MAX_PARTITION_COUNT;
+import static com.amazonaws.athena.connectors.snowflake.SnowflakeConstants.PARTITION_RECORD_COUNT;
 import static java.util.Map.entry;
 
 /**
@@ -158,11 +160,8 @@ public class SnowflakeMetadataHandler extends JdbcMetadataHandler
          * "MAX_PARTITION_COUNT" is currently set to 50 to limit the number of partitions.
          * this is to handle timeout issues because of huge partitions
          */
-        LOGGER.info(" Total Partition Limit" + SnowflakeConstants.MAX_PARTITION_COUNT);
-        LOGGER.info(" Total Page  Count" +  SnowflakeConstants.PARTITION_RECORD_COUNT);
-        long offset = 0;
-        double limit = 0;
-        double totalRecordCount = 0;
+        LOGGER.info(" Total Partition Limit" + MAX_PARTITION_COUNT);
+        LOGGER.info(" Total Page  Count" +  PARTITION_RECORD_COUNT);
         boolean viewFlag = checkForView(getTableLayoutRequest);
         //if the input table is a view , there will be single split
         if (viewFlag) {
@@ -172,6 +171,7 @@ public class SnowflakeMetadataHandler extends JdbcMetadataHandler
             });
         }
         else {
+            double totalRecordCount = 0;
             LOGGER.info(COUNT_RECORDS_QUERY);
             List<String> parameters = Arrays.asList(getTableLayoutRequest.getTableName().getTableName());
 
@@ -182,21 +182,19 @@ public class SnowflakeMetadataHandler extends JdbcMetadataHandler
                 while (rs.next()) {
                     totalRecordCount = rs.getInt(1);
                 }
-                double limitValue = totalRecordCount / SnowflakeConstants.PARTITION_RECORD_COUNT;
-                limit = (int) Math.ceil(limitValue);
                 if (totalRecordCount > 0) {
                     // if number of partitions are more than defined limit "MAX_PARTITION_COUNT"
                     // it will do maximum 50 partitions,49 partitions will have 500000 records each and last partition will have the remaining number of records.
-                    if (limit > SnowflakeConstants.MAX_PARTITION_COUNT) {
-                        for (int i = 1; i <= SnowflakeConstants.MAX_PARTITION_COUNT; i++) {
-                            int partitionRecord = SnowflakeConstants.PARTITION_RECORD_COUNT;
-                            if (i > 1) {
-                                offset = offset + SnowflakeConstants.PARTITION_RECORD_COUNT;
-                            }
-                            if (i == SnowflakeConstants.MAX_PARTITION_COUNT) {
+                    double limitValue = totalRecordCount / PARTITION_RECORD_COUNT;
+                    double limit = (int) Math.ceil(limitValue);
+                    long offset = 0;
+                    if (limit > MAX_PARTITION_COUNT) {
+                        for (int i = 1; i <= MAX_PARTITION_COUNT; i++) {
+                            int partitionRecord = PARTITION_RECORD_COUNT;
+                            if (i == MAX_PARTITION_COUNT) {
                                 //Updating partitionRecord variable to display the remaining records in the last partition.
                                 //we get the value by subtracting the records displayed till 49th partition from the total number of records.
-                                partitionRecord = (int) totalRecordCount - (SnowflakeConstants.PARTITION_RECORD_COUNT * (SnowflakeConstants.MAX_PARTITION_COUNT - 1));
+                                partitionRecord = (int) totalRecordCount - (PARTITION_RECORD_COUNT * (MAX_PARTITION_COUNT - 1));
                             }
                             final String partitionVal = BLOCK_PARTITION_COLUMN_NAME + "-limit-" + partitionRecord + "-offset-" + offset;
                             LOGGER.info("partitionVal {} ", partitionVal);
@@ -205,6 +203,7 @@ public class SnowflakeMetadataHandler extends JdbcMetadataHandler
                                 block.setValue(BLOCK_PARTITION_COLUMN_NAME, rowNum, partitionVal);
                                 return 1;
                             });
+                            offset = offset + PARTITION_RECORD_COUNT;
                         }
                     }
                     else {
@@ -213,16 +212,14 @@ public class SnowflakeMetadataHandler extends JdbcMetadataHandler
                          * the partition values we are setting the limit and offset values like p-limit-3000-offset-0
                          */
                         for (int i = 1; i <= limit; i++) {
-                            if (i > 1) {
-                                offset = offset + SnowflakeConstants.PARTITION_RECORD_COUNT;
-                            }
-                            final String partitionVal = BLOCK_PARTITION_COLUMN_NAME + "-limit-" + SnowflakeConstants.PARTITION_RECORD_COUNT + "-offset-" + offset;
+                            final String partitionVal = BLOCK_PARTITION_COLUMN_NAME + "-limit-" + PARTITION_RECORD_COUNT + "-offset-" + offset;
                             LOGGER.info("partitionVal {} ", partitionVal);
                             blockWriter.writeRows((Block block, int rowNum) ->
                             {
                                 block.setValue(BLOCK_PARTITION_COLUMN_NAME, rowNum, partitionVal);
                                 return 1;
                             });
+                            offset = offset + PARTITION_RECORD_COUNT;
                         }
                     }
                 }

--- a/athena-snowflake/src/test/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMetadataHandlerTest.java
+++ b/athena-snowflake/src/test/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMetadataHandlerTest.java
@@ -70,9 +70,6 @@ public class SnowflakeMetadataHandlerTest
     @Before
     public void setup() {
 
-        environmentVariables.set("pagecount", "300000");
-        environmentVariables.set("partitionlimit", "300000");
-
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class , Mockito.RETURNS_DEEP_STUBS);
         this.connection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);
         Mockito.when(this.jdbcConnectionFactory.getConnection(Mockito.any(JdbcCredentialProvider.class))).thenReturn(this.connection);
@@ -95,8 +92,6 @@ public class SnowflakeMetadataHandlerTest
     @Test
     public void doGetTableLayout()
             throws Exception {
-        environmentVariables.set("pagecount", "100000");
-        environmentVariables.set("partitionlimit", "15");
         BlockAllocator blockAllocator = new BlockAllocatorImpl();
         Constraints constraints = Mockito.mock(Constraints.class);
         TableName tableName = new TableName("testSchema", "testTable");
@@ -109,50 +104,7 @@ public class SnowflakeMetadataHandlerTest
 
         String[] columns = {"partition"};
         int[] types = {Types.VARCHAR};
-        Object[][] values = {{"partition-limit-300000-offset-0"}, {"partition-limit-300000-offset-300000"}};
-        ResultSet resultSet = mockResultSet(columns, types, values, new AtomicInteger(-1));
-        Mockito.when(preparedStatement.executeQuery()).thenReturn(resultSet);
-
-        Mockito.when(this.connection.getMetaData().getSearchStringEscape()).thenReturn(null);
-        Mockito.when(resultSet.getInt(1)).thenReturn(200000);
-        GetTableLayoutResponse getTableLayoutResponse = this.snowflakeMetadataHandler.doGetTableLayout(blockAllocator, getTableLayoutRequest);
-
-        Assert.assertEquals(values.length, getTableLayoutResponse.getPartitions().getRowCount());
-
-        List<String> expectedValues = new ArrayList<>();
-        for (int i = 0; i < getTableLayoutResponse.getPartitions().getRowCount(); i++) {
-            expectedValues.add(BlockUtils.rowToString(getTableLayoutResponse.getPartitions(), i));
-        }
-        Assert.assertEquals(expectedValues, Arrays.asList("[partition : partition-limit-100000-offset-0]",
-                "[partition : partition-limit-100000-offset-100000]"));
-
-        SchemaBuilder expectedSchemaBuilder = SchemaBuilder.newBuilder();
-        expectedSchemaBuilder.addField(FieldBuilder.newBuilder("partition", org.apache.arrow.vector.types.Types.MinorType.VARCHAR.getType()).build());
-        Schema expectedSchema = expectedSchemaBuilder.build();
-        Assert.assertEquals(expectedSchema, getTableLayoutResponse.getPartitions().getSchema());
-        Assert.assertEquals(tableName, getTableLayoutResponse.getTableName());
-
-        Mockito.verify(preparedStatement, Mockito.times(1)).setString(1, tableName.getTableName());
-        Mockito.verify(resultSet, Mockito.times(2)).getInt(1);
-    }
-    @Test
-    public void doGetTableLayoutSinglePartition()
-            throws Exception {
-        environmentVariables.set("pagecount", "100000");
-        environmentVariables.set("partitionlimit", "5");
-        BlockAllocator blockAllocator = new BlockAllocatorImpl();
-        Constraints constraints = Mockito.mock(Constraints.class);
-        TableName tableName = new TableName("testSchema", "testTable");
-        Schema partitionSchema = this.snowflakeMetadataHandler.getPartitionSchema("testCatalogName");
-        Set<String> partitionCols = new HashSet<>(Arrays.asList("partition"));
-        GetTableLayoutRequest getTableLayoutRequest = new GetTableLayoutRequest(this.federatedIdentity, "testQueryId", "testCatalogName", tableName, constraints, partitionSchema, partitionCols);
-        PreparedStatement preparedStatement = Mockito.mock(PreparedStatement.class);
-
-        Mockito.when(this.connection.prepareStatement(SnowflakeMetadataHandler.COUNT_RECORDS_QUERY)).thenReturn(preparedStatement);
-
-        String[] columns = {"partition"};
-        int[] types = {Types.VARCHAR};
-        Object[][] values = {{"partition-limit-1000000.0-offset-0"}};
+        Object[][] values = {{"partition : partition-limit-500000-offset-0"},{"partition : partition-limit-500000-offset-500000"}};
         ResultSet resultSet = mockResultSet(columns, types, values, new AtomicInteger(-1));
         Mockito.when(preparedStatement.executeQuery()).thenReturn(resultSet);
 
@@ -166,7 +118,47 @@ public class SnowflakeMetadataHandlerTest
         for (int i = 0; i < getTableLayoutResponse.getPartitions().getRowCount(); i++) {
             expectedValues.add(BlockUtils.rowToString(getTableLayoutResponse.getPartitions(), i));
         }
-        Assert.assertEquals(expectedValues, Arrays.asList("[partition : partition-limit-1000000.0-offset-0]"));
+        Assert.assertEquals(expectedValues, Arrays.asList("[partition : partition-limit-500000-offset-0]", "[partition : partition-limit-500000-offset-500000]"));
+        SchemaBuilder expectedSchemaBuilder = SchemaBuilder.newBuilder();
+        expectedSchemaBuilder.addField(FieldBuilder.newBuilder("partition", org.apache.arrow.vector.types.Types.MinorType.VARCHAR.getType()).build());
+        Schema expectedSchema = expectedSchemaBuilder.build();
+        Assert.assertEquals(expectedSchema, getTableLayoutResponse.getPartitions().getSchema());
+        Assert.assertEquals(tableName, getTableLayoutResponse.getTableName());
+
+        Mockito.verify(preparedStatement, Mockito.times(1)).setString(1, tableName.getTableName());
+        Mockito.verify(resultSet, Mockito.times(2)).getInt(1);
+    }
+
+    @Test
+    public void doGetTableLayoutSinglePartition()
+            throws Exception {
+        BlockAllocator blockAllocator = new BlockAllocatorImpl();
+        Constraints constraints = Mockito.mock(Constraints.class);
+        TableName tableName = new TableName("testSchema", "testTable");
+        Schema partitionSchema = this.snowflakeMetadataHandler.getPartitionSchema("testCatalogName");
+        Set<String> partitionCols = new HashSet<>(Arrays.asList("partition"));
+        GetTableLayoutRequest getTableLayoutRequest = new GetTableLayoutRequest(this.federatedIdentity, "testQueryId", "testCatalogName", tableName, constraints, partitionSchema, partitionCols);
+        PreparedStatement preparedStatement = Mockito.mock(PreparedStatement.class);
+
+        Mockito.when(this.connection.prepareStatement(SnowflakeMetadataHandler.COUNT_RECORDS_QUERY)).thenReturn(preparedStatement);
+
+        String[] columns = {"partition"};
+        int[] types = {Types.VARCHAR};
+        Object[][] values = {{"partition : partition-limit-500000-offset-0"}};
+        ResultSet resultSet = mockResultSet(columns, types, values, new AtomicInteger(-1));
+        Mockito.when(preparedStatement.executeQuery()).thenReturn(resultSet);
+
+        Mockito.when(this.connection.getMetaData().getSearchStringEscape()).thenReturn(null);
+        Mockito.when(resultSet.getInt(1)).thenReturn(30000);
+        GetTableLayoutResponse getTableLayoutResponse = this.snowflakeMetadataHandler.doGetTableLayout(blockAllocator, getTableLayoutRequest);
+
+        Assert.assertEquals(values.length, getTableLayoutResponse.getPartitions().getRowCount());
+
+        List<String> expectedValues = new ArrayList<>();
+        for (int i = 0; i < getTableLayoutResponse.getPartitions().getRowCount(); i++) {
+            expectedValues.add(BlockUtils.rowToString(getTableLayoutResponse.getPartitions(), i));
+        }
+        Assert.assertEquals(expectedValues, Arrays.asList("[partition : partition-limit-500000-offset-0]"));
 
         SchemaBuilder expectedSchemaBuilder = SchemaBuilder.newBuilder();
         expectedSchemaBuilder.addField(FieldBuilder.newBuilder("partition", org.apache.arrow.vector.types.Types.MinorType.VARCHAR.getType()).build());
@@ -174,6 +166,65 @@ public class SnowflakeMetadataHandlerTest
         Assert.assertEquals(expectedSchema, getTableLayoutResponse.getPartitions().getSchema());
         Assert.assertEquals(tableName, getTableLayoutResponse.getTableName());
 
+        Mockito.verify(preparedStatement, Mockito.times(1)).setString(1, tableName.getTableName());
+        Mockito.verify(resultSet, Mockito.times(1)).getInt(1);
+    }
+
+    @Test
+    public void doGetTableLayoutMaxPartition()
+            throws Exception {
+        BlockAllocator blockAllocator = new BlockAllocatorImpl();
+        Constraints constraints = Mockito.mock(Constraints.class);
+        TableName tableName = new TableName("testSchema", "testTable");
+        Schema partitionSchema = this.snowflakeMetadataHandler.getPartitionSchema("testCatalogName");
+        Set<String> partitionCols = new HashSet<>(Arrays.asList("partition"));
+        GetTableLayoutRequest getTableLayoutRequest = new GetTableLayoutRequest(this.federatedIdentity, "testQueryId", "testCatalogName", tableName, constraints, partitionSchema, partitionCols);
+        PreparedStatement preparedStatement = Mockito.mock(PreparedStatement.class);
+        Mockito.when(this.connection.prepareStatement(SnowflakeMetadataHandler.COUNT_RECORDS_QUERY)).thenReturn(preparedStatement);
+        //By changing the value of variable totalRecordCount we can check the maximum number of partitions supported by the table dynamically
+        double totalActualRecordCount = 2500;
+        String[] columns = {"partition"};
+        int[] types = {Types.VARCHAR};
+        Object[][] values = {{"partition : partition-limit-500000-offset-0"}};
+        ResultSet resultSet = mockResultSet(columns, types, values, new AtomicInteger(-1));
+        Mockito.when(preparedStatement.executeQuery()).thenReturn(resultSet);
+        Mockito.when(this.connection.getMetaData().getSearchStringEscape()).thenReturn(null);
+        Mockito.when(resultSet.getInt(1)).thenReturn((int)totalActualRecordCount);
+        GetTableLayoutResponse getTableLayoutResponse = this.snowflakeMetadataHandler.doGetTableLayout(blockAllocator, getTableLayoutRequest);
+        List<String> actualValues = new ArrayList<>();
+        List<String> expectedValues = new ArrayList<>();
+        long offset = 0;
+        for (int i = 0; i < getTableLayoutResponse.getPartitions().getRowCount(); i++) {
+            expectedValues.add(BlockUtils.rowToString(getTableLayoutResponse.getPartitions(), i));
+        }
+        double limitValue = totalActualRecordCount / SnowflakeConstants.PARTITION_RECORD_COUNT;
+        double limit = (int) Math.ceil(limitValue);
+        double partitionActualRecordCount = SnowflakeConstants.PARTITION_RECORD_COUNT;
+        if(limit > SnowflakeConstants.MAX_PARTITION_COUNT) {
+            for (int i = 1; i <= SnowflakeConstants.MAX_PARTITION_COUNT; i++) {
+                if (i > 1) {
+                    offset = offset + SnowflakeConstants.PARTITION_RECORD_COUNT;
+                }
+                if (i == SnowflakeConstants.MAX_PARTITION_COUNT) {
+                    partitionActualRecordCount = totalActualRecordCount - (SnowflakeConstants.PARTITION_RECORD_COUNT * (SnowflakeConstants.MAX_PARTITION_COUNT - 1));
+                }
+                actualValues.add("[partition : partition-limit-" + (int)partitionActualRecordCount + "-offset-" + offset + "]");
+            }
+        }
+        else {
+            for (int i = 1; i <= limit; i++) {
+                if (i > 1) {
+                    offset = offset + SnowflakeConstants.PARTITION_RECORD_COUNT;
+                }
+                actualValues.add("[partition : partition-limit-" +(int)partitionActualRecordCount + "-offset-" + offset + "]");
+            }
+        }
+        Assert.assertEquals(expectedValues,actualValues);
+        SchemaBuilder expectedSchemaBuilder = SchemaBuilder.newBuilder();
+        expectedSchemaBuilder.addField(FieldBuilder.newBuilder("partition", org.apache.arrow.vector.types.Types.MinorType.VARCHAR.getType()).build());
+        Schema expectedSchema = expectedSchemaBuilder.build();
+        Assert.assertEquals(expectedSchema, getTableLayoutResponse.getPartitions().getSchema());
+        Assert.assertEquals(tableName, getTableLayoutResponse.getTableName());
         Mockito.verify(preparedStatement, Mockito.times(1)).setString(1, tableName.getTableName());
         Mockito.verify(resultSet, Mockito.times(1)).getInt(1);
     }
@@ -234,7 +285,6 @@ public class SnowflakeMetadataHandlerTest
         Set<Map<String, String>> actualSplits = getSplitsResponse.getSplits().stream().map(Split::getProperties).collect(Collectors.toSet());
         Assert.assertNotEquals(expectedSplits, actualSplits);
     }
-
 
     @Test
     public void doGetSplitsContinuation()
@@ -355,5 +405,20 @@ public class SnowflakeMetadataHandlerTest
         TableName tableName3 = snowflakeMetadataHandler.findTableNameFromQueryHint(inputTableName3);
         Assert.assertEquals(new TableName("testschema", "TESTTABLE"), tableName3);
 
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void doListSchemaNames() throws SQLException {
+        BlockAllocator blockAllocator = new BlockAllocatorImpl();
+        ListSchemasRequest listSchemasRequest = new ListSchemasRequest(federatedIdentity, "queryId", "testCatalog");
+
+        Statement statement = Mockito.mock(Statement.class);
+        Mockito.when(this.connection.createStatement()).thenReturn(statement);
+        String[][] SchemaandCatalogNames = {{"TESTSCHEMA"},{"TESTCATALOG"}};
+        ResultSet schemaResultSet = mockResultSet(new String[]{"TABLE_SCHEM","TABLE_CATALOG"}, new int[]{Types.VARCHAR,Types.VARCHAR}, SchemaandCatalogNames, new AtomicInteger(-1));
+        Mockito.when(this.connection.getMetaData().getSchemas()).thenReturn(schemaResultSet);
+        ListSchemasResponse listSchemasResponse = this.snowflakeMetadataHandler.doListSchemaNames(blockAllocator, listSchemasRequest);
+        String[] expectedResult = {"TESTSCHEMA","TESTCATALOG"};
+        Assert.assertEquals(Arrays.toString(expectedResult), listSchemasResponse.getSchemas().toString());
     }
 }

--- a/athena-snowflake/src/test/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMetadataHandlerTest.java
+++ b/athena-snowflake/src/test/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMetadataHandlerTest.java
@@ -181,7 +181,7 @@ public class SnowflakeMetadataHandlerTest
         GetTableLayoutRequest getTableLayoutRequest = new GetTableLayoutRequest(this.federatedIdentity, "testQueryId", "testCatalogName", tableName, constraints, partitionSchema, partitionCols);
         PreparedStatement preparedStatement = Mockito.mock(PreparedStatement.class);
         Mockito.when(this.connection.prepareStatement(SnowflakeMetadataHandler.COUNT_RECORDS_QUERY)).thenReturn(preparedStatement);
-        //By changing the value of variable totalRecordCount we can check the maximum number of partitions supported by the table dynamically
+        //By changing the value of variable totalActualRecordCount,we can check the maximum number of partitions supported by the table dynamically
         double totalActualRecordCount = 2500;
         String[] columns = {"partition"};
         int[] types = {Types.VARCHAR};


### PR DESCRIPTION
*Issue # INC00001080,Snowflake Connector Partitioning Logic Is Resulting In A Single Large Partition, Slowing Down Queries.

### Description of changes:
We have removed pagecount and partitionlimit variables from yaml file(environment variables).It is handled internally to make it user friendly and for better performance.
Maximum partition limit we have limited to 50 to handle timeout or slow performance issues because of huge partitions.
If the limit of partitions will increase beyond 50 partitions,it will handle internally to make maximum 50 partitions now(which was single partition before).

### Content needs to be removed from Readme:
PageCount parameter
Limits the number of records for each partition. The default value is 500000

PartitionLimit parameter
Limits the number of partitions. The default value is 10. A large number may cause a timeout issue. If you encounter a timeout error, set this parameter to a lower value.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
