### PR TITLE
athena-dynamodb: Fix issue with the Condition in FunctionRole

### DIFF
--- a/athena-dynamodb/athena-dynamodb.yaml
+++ b/athena-dynamodb/athena-dynamodb.yaml
@@ -46,8 +46,8 @@ Parameters:
     Default: ""
 
 Conditions:
- HasKMSKeyId: !Not [!Equals [!Ref KMSKeyId, ""]]
- HasLambdaRole: !Not [!Equals [!Ref LambdaRole, ""]]
+  HasKMSKeyId: !Not [!Equals [!Ref KMSKeyId, ""]]
+  NotHasLambdaRole: !Equals [!Ref LambdaRole, ""]
 
 Resources:
   ConnectorConfig:
@@ -66,10 +66,10 @@ Resources:
       Runtime: java11
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
-      Role: !If [HasLambdaRole, !Ref LambdaRole, !GetAtt FunctionRole.Arn]
+      Role: !If [NotHasLambdaRole, !GetAtt FunctionRole.Arn, !Ref LambdaRole]
 
   FunctionRole:
-    Condition: !Not HasLambdaRole
+    Condition: NotHasLambdaRole
     Type: AWS::IAM::Role
     Properties:
       ManagedPolicyArns:


### PR DESCRIPTION
The original Condition in FunctionRole will error out with:
  samcli.commands.validate.lib.exceptions.InvalidSamDocumentException: [InvalidTemplateException('Every Condition member must be a string.')] Every Condition member must be a string.

This patch changes it to not have to use !Not which fixes this.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
