### PR TITLE
Fix the wrong jar name in tools/validate_connector.sh

### DIFF
--- a/tools/validate_connector.sh
+++ b/tools/validate_connector.sh
@@ -47,4 +47,4 @@ else
     mvn clean install
 fi
 
-java -cp target/athena-federation-sdk-tools-1.0-withdep.jar com.amazonaws.athena.connector.validation.ConnectorValidator $@
+java -cp target/athena-federation-sdk-tools-2022.39.1-withdep.jar com.amazonaws.athena.connector.validation.ConnectorValidator $@

--- a/tools/validate_connector.sh
+++ b/tools/validate_connector.sh
@@ -37,14 +37,16 @@ while true; do
     esac
 done
 
+VERSION=2022.39.1
+
 dir=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 
 cd "$dir/../athena-federation-sdk-tools"
 
-if test -f "target/athena-federation-sdk-tools-2022.39.1.jar"; then
+if test -f "target/athena-federation-sdk-tools-${VERSION}.jar"; then
     echo "athena-federation-sdk-tools is already built, skipping compilation."
 else
     mvn clean install
 fi
 
-java -cp target/athena-federation-sdk-tools-2022.39.1-withdep.jar com.amazonaws.athena.connector.validation.ConnectorValidator $@
+java -cp target/athena-federation-sdk-tools-${VERSION}-withdep.jar com.amazonaws.athena.connector.validation.ConnectorValidator $@


### PR DESCRIPTION
*Issue #, if available:https://github.com/awslabs/aws-athena-query-federation/issues/798

*Description of changes:*
the wrong jar name in tools/validate_connector.sh

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
