### PR TITLE
Fix cloudwatch yaml

### DIFF
--- a/athena-cloudwatch/athena-cloudwatch.yaml
+++ b/athena-cloudwatch/athena-cloudwatch.yaml
@@ -46,8 +46,8 @@ Parameters:
     Default: ""
 
 Conditions:
- HasKMSKeyId: !Not [!Equals [!Ref KMSKeyId, ""]]
- HasLambdaRole: !Not [!Equals [!Ref LambdaRole, ""]]
+  HasKMSKeyId: !Not [!Equals [!Ref KMSKeyId, ""]]
+  NotHasLambdaRole: !Equals [!Ref LambdaRole, ""]
 
 Resources:
   ConnectorConfig:
@@ -66,10 +66,10 @@ Resources:
       Runtime: java11
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
-      Role: !If [HasLambdaRole, !Ref LambdaRole, !GetAtt FunctionRole.Arn]
+      Role: !If [NotHasLambdaRole, !GetAtt FunctionRole.Arn, !Ref LambdaRole]
 
   FunctionRole:
-    Condition: !Not HasLambdaRole
+    Condition: NotHasLambdaRole
     Type: AWS::IAM::Role
     Properties:
       ManagedPolicyArns:


### PR DESCRIPTION
athena-cloudwatch.yaml was broken just like the athena-dynamodb.yaml from the recent change to add the LambdaRole.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
