### PR TITLE
Add support for optional LambdaRole parameter for AthenaSynapseConnector

### DIFF
--- a/athena-synapse/athena-synapse.yaml
+++ b/athena-synapse/athena-synapse.yaml
@@ -40,11 +40,11 @@ Parameters:
     Description: 'Lambda memory in MB (min 128 - 3008 max).'
     Default: 3008
     Type: Number
-  LambdaRole:
+  LambdaRoleARN:
     Description: "(Optional) A custom role to be used by the Connector lambda"
     Default: ""
     Type: String
-  PermissionBoundary:
+  PermissionsBoundaryARN:
     Description: "(Optional) A custom Permission Boundary to be used by the Connector lambda"
     Default: ""
     Type: String
@@ -60,8 +60,8 @@ Parameters:
     Type: 'List<AWS::EC2::Subnet::Id>'
 
 Conditions:
-  NotHasLambdaRole: !Equals [!Ref LambdaRole, ""]
-  HasPermissionsBoundary: !Not [!Equals [!Ref PermissionBoundary, ""]]
+  NotHasLambdaRole: !Equals [!Ref LambdaRoleARN, ""]
+  HasPermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundaryARN, ""]]
 
 Resources:
   JdbcConnectorConfig:
@@ -80,7 +80,7 @@ Resources:
       Runtime: java11
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
-      Role: !If [NotHasLambdaRole, !GetAtt FunctionRole.Arn, !Ref LambdaRole]
+      Role: !If [NotHasLambdaRole, !GetAtt FunctionRole.Arn, !Ref LambdaRoleARN]
       VpcConfig:
         SecurityGroupIds: !Ref SecurityGroupIds
         SubnetIds: !Ref SubnetIds
@@ -90,7 +90,7 @@ Resources:
       PermissionsBoundary:
         Fn::If:
           - HasPermissionsBoundary
-          - Ref: PermissionBoundary
+          - Ref: PermissionsBoundaryARN
           - Ref: AWS::NoValue
       ManagedPolicyArns:
         - "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"

--- a/athena-synapse/athena-synapse.yaml
+++ b/athena-synapse/athena-synapse.yaml
@@ -40,6 +40,10 @@ Parameters:
     Description: 'Lambda memory in MB (min 128 - 3008 max).'
     Default: 3008
     Type: Number
+  LambdaRole:
+    Description: "(Optional) A custom role to be used by the Connector lambda"
+    Default: ""
+    Type: String
   DisableSpillEncryption:
     Description: 'If set to ''false'' data spilled to S3 is encrypted with AES GCM'
     Default: 'false'
@@ -50,6 +54,10 @@ Parameters:
   SubnetIds:
     Description: 'One or more Subnet IDs corresponding to the Subnet that the Lambda function can use to access you data source. (e.g. subnet1,subnet2)'
     Type: 'List<AWS::EC2::Subnet::Id>'
+
+Conditions:
+  NotHasLambdaRole: !Equals [!Ref LambdaRole, ""]
+
 Resources:
   JdbcConnectorConfig:
     Type: 'AWS::Serverless::Function'
@@ -67,39 +75,57 @@ Resources:
       Runtime: java11
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
-      Policies:
-        - Statement:
-            - Action:
-                - secretsmanager:GetSecretValue
-              Effect: Allow
-              Resource: !Sub 'arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:${SecretNamePrefix}*'
-          Version: '2012-10-17'
-        - Statement:
-            - Action:
-                - logs:CreateLogGroup
-              Effect: Allow
-              Resource: !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*'
-          Version: '2012-10-17'
-        - Statement:
-            - Action:
-                - logs:CreateLogStream
-                - logs:PutLogEvents
-              Effect: Allow
-              Resource: !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${LambdaFunctionName}:*'
-          Version: '2012-10-17'
-        - Statement:
-            - Action:
-                - athena:GetQueryExecution
-                - s3:ListAllMyBuckets
-              Effect: Allow
-              Resource: '*'
-          Version: '2012-10-17'
-        #S3CrudPolicy allows our connector to spill large responses to S3. You can optionally replace this pre-made policy
-        #with one that is more restrictive and can only 'put' but not read,delete, or overwrite files.
-        - S3CrudPolicy:
-            BucketName: !Ref SpillBucket
-        #VPCAccessPolicy allows our connector to run in a VPC so that it can access your data source.
-        - VPCAccessPolicy: {}
+      Role: !If [NotHasLambdaRole, !GetAtt FunctionRole.Arn, !Ref LambdaRole]
       VpcConfig:
         SecurityGroupIds: !Ref SecurityGroupIds
         SubnetIds: !Ref SubnetIds
+  FunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      ManagedPolicyArns:
+        - "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - "sts:AssumeRole"
+
+  FunctionExecutionPolicy:
+    Type: "AWS::IAM::Policy"
+    Properties:
+      PolicyName: FunctionExecutionPolicy
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Action:
+              - secretsmanager:GetSecretValue
+            Effect: Allow
+            Resource: !Sub 'arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:${SecretNamePrefix}*'
+          - Action:
+              - logs:CreateLogGroup
+            Effect: Allow
+            Resource: !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*'
+          - Action:
+              - logs:CreateLogStream
+              - logs:PutLogEvents
+            Effect: Allow
+            Resource: !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${LambdaFunctionName}:*'
+          - Action:
+              - athena:GetQueryExecution
+              - s3:ListAllMyBuckets
+            Effect: Allow
+            Resource: '*'
+          - Action:
+              - ec2:CreateNetworkInterface
+              - ec2:DeleteNetworkInterface
+              - ec2:DescribeNetworkInterfaces
+              - ec2:DetachNetworkInterface
+              - autoscaling:CompleteLifecycleAction
+            Effect: Allow
+            Resource: '*'
+      Roles:
+        - !Ref FunctionRole

--- a/athena-synapse/athena-synapse.yaml
+++ b/athena-synapse/athena-synapse.yaml
@@ -44,6 +44,10 @@ Parameters:
     Description: "(Optional) A custom role to be used by the Connector lambda"
     Default: ""
     Type: String
+  PermissionBoundary:
+    Description: "(Optional) A custom Permission Boundary to be used by the Connector lambda"
+    Default: ""
+    Type: String
   DisableSpillEncryption:
     Description: 'If set to ''false'' data spilled to S3 is encrypted with AES GCM'
     Default: 'false'
@@ -57,6 +61,7 @@ Parameters:
 
 Conditions:
   NotHasLambdaRole: !Equals [!Ref LambdaRole, ""]
+  HasPermissionsBoundary: !Not [!Equals [!Ref PermissionBoundary, ""]]
 
 Resources:
   JdbcConnectorConfig:
@@ -82,6 +87,11 @@ Resources:
   FunctionRole:
     Type: AWS::IAM::Role
     Properties:
+      PermissionsBoundary:
+        Fn::If:
+          - HasPermissionsBoundary
+          - Ref: PermissionBoundary
+          - Ref: AWS::NoValue
       ManagedPolicyArns:
         - "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
       AssumeRolePolicyDocument:

--- a/athena-synapse/etc/test-config.json
+++ b/athena-synapse/etc/test-config.json
@@ -4,12 +4,12 @@
   "secrets_manager_secret" : "<secret name>",  /* Secret name used to retrieve user credentials from SecretsManager. */
   "region": "<region>", /* aws region name */
   "schema_name": "<schema name>", /* synapse schema name*/
-  "table_name": "<table name>",/*synaapse table name*/
-  "table_name1": "<table name>",/*synaapse table name*/
-  "table_name2": "<table name>",/*synaapse table name*/
-  "table_name5":"<table name>",/*synaapse table name*/
+  "table_name": "<table name>",/*synapse table name*/
+  "table_name1": "<table name>",/*synapse table name*/
+  "table_name2": "<table name>",/*synapse table name*/
+  "table_name5":"<table name>",/*synapse table name*/
   "table_name6":"<table name>",/*synaapse table name*/
-  "table_name7":"<table name>",/*synaapse table name*/
+  "table_name7":"<table name>",/*synapse table name*/
   "environment_vars" : {
     "spill_bucket" : "<spill bucket>", /* The S3 bucket used for spilling excess data */
     "spill_prefix" : "athena-spill", /* The prefix within the S3 spill bucket (default: athena-spill) */


### PR DESCRIPTION
*Issue # INC00001084, Being able to set the Lambda Role in AthenaSynapseConnector.

*Description of changes:*
Added support for optional LambdaRole parameter for AthenaSynapseConnector. The Lambda function created will now allow users to select own role.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
