### PR TITLE
ValuesGenerator: fix String:getBytes() issue

### DIFF
--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/data/helpers/ValuesGenerator.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/data/helpers/ValuesGenerator.java
@@ -70,6 +70,7 @@ import net.jqwik.api.*;
 import net.jqwik.time.api.*;
 
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
@@ -561,7 +562,7 @@ public class ValuesGenerator {
                 ((VarCharVector) vector).setSafe(i+position, new NullableVarCharHolder());
             }
             else {
-                ((VarCharVector) vector).setSafe(i+position, items.get(i).getBytes());
+                ((VarCharVector) vector).setSafe(i+position, items.get(i).getBytes(StandardCharsets.UTF_8));
             }
             customVector.add(vector.getObject(i+position));
         }


### PR DESCRIPTION
Different JDKs have different internal representations of Strings.

When the JDK has a non UTF8 representation (like UTF16), these tests were setting invalid byte values for Arrow string fields/values which are expecting UTF8 encoded bytes.

This was causing test failures because it caused keys that were expected to be unique to not be unique since invalid UTF8 strings can be considered equal (UTF16 can't just be casted to UTF8).

The fix here is to make sure that we use getBytes(StandardCharsets.UTF_8) to ensure that we get the byte encoding that we want.