### PR TITLE
Don't catch just to rethrow

### DIFF
--- a/athena-cloudera-hive/src/main/java/com/amazonaws/athena/connectors/cloudera/HiveJdbcConnectionFactory.java
+++ b/athena-cloudera-hive/src/main/java/com/amazonaws/athena/connectors/cloudera/HiveJdbcConnectionFactory.java
@@ -28,7 +28,6 @@ import org.apache.commons.lang3.Validate;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
-import java.sql.SQLException;
 import java.util.Map;
 import java.util.Properties;
 import java.util.regex.Matcher;
@@ -57,26 +56,19 @@ public class HiveJdbcConnectionFactory extends GenericJdbcConnectionFactory
 
     @Override
     public Connection getConnection(final JdbcCredentialProvider jdbcCredentialProvider)
+            throws Exception
     {
-        try {
-            final String derivedJdbcString;
-            if (null != jdbcCredentialProvider) {
-                Matcher secretMatcher = SECRET_NAME_PATTERN.matcher(databaseConnectionConfig.getJdbcConnectionString());
-                final String secretReplacement = String.format("UID=%s;PWD=%s",
-                        jdbcCredentialProvider.getCredential().getUser(), jdbcCredentialProvider.getCredential().getPassword());
-                derivedJdbcString = secretMatcher.replaceAll(Matcher.quoteReplacement(secretReplacement));
-            }
-            else {
-                derivedJdbcString = databaseConnectionConfig.getJdbcConnectionString();
-            }
-            Class.forName(databaseConnectionInfo.getDriverClassName()).newInstance();
-            return DriverManager.getConnection(derivedJdbcString, this.jdbcProperties);
+        final String derivedJdbcString;
+        if (null != jdbcCredentialProvider) {
+            Matcher secretMatcher = SECRET_NAME_PATTERN.matcher(databaseConnectionConfig.getJdbcConnectionString());
+            final String secretReplacement = String.format("UID=%s;PWD=%s",
+                    jdbcCredentialProvider.getCredential().getUser(), jdbcCredentialProvider.getCredential().getPassword());
+            derivedJdbcString = secretMatcher.replaceAll(Matcher.quoteReplacement(secretReplacement));
         }
-        catch (SQLException sqlException) {
-            throw new RuntimeException(sqlException.getErrorCode() + ": " + sqlException);
+        else {
+            derivedJdbcString = databaseConnectionConfig.getJdbcConnectionString();
         }
-        catch (ClassNotFoundException | IllegalAccessException | InstantiationException ex) {
-            throw new RuntimeException(ex);
-        }
+        Class.forName(databaseConnectionInfo.getDriverClassName()).newInstance();
+        return DriverManager.getConnection(derivedJdbcString, this.jdbcProperties);
     }
 }

--- a/athena-cloudera-hive/src/main/java/com/amazonaws/athena/connectors/cloudera/HiveMetadataHandler.java
+++ b/athena-cloudera-hive/src/main/java/com/amazonaws/athena/connectors/cloudera/HiveMetadataHandler.java
@@ -102,11 +102,11 @@ public class HiveMetadataHandler extends JdbcMetadataHandler
      * @param blockWriter Used to write rows (hive partitions) into the Apache Arrow response.
      * @param getTableLayoutRequest Provides details of the catalog, database, and table being queried as well as any filter predicate.
      * @param queryStatusChecker A QueryStatusChecker that you can use to stop doing work for a query that has already terminated
-     * @throws SQLException A SQLException should be thrown for database connection failures , query syntax errors and so on.
+     * @throws Exception An Exception should be thrown for database connection failures , query syntax errors and so on.
      **/
     @Override
     public void getPartitions(BlockWriter blockWriter, GetTableLayoutRequest getTableLayoutRequest,
-                              QueryStatusChecker queryStatusChecker) throws SQLException
+                              QueryStatusChecker queryStatusChecker) throws Exception
     {
         LOGGER.info("{}: Schema {}, table {}", getTableLayoutRequest.getQueryId(), getTableLayoutRequest.getTableName().getSchemaName(),
                 getTableLayoutRequest.getTableName().getTableName());
@@ -244,17 +244,13 @@ public class HiveMetadataHandler extends JdbcMetadataHandler
      */
     @Override
     public GetTableResponse doGetTable(final BlockAllocator blockAllocator, final GetTableRequest getTableRequest)
+            throws Exception
     {
         try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider())) {
             Schema partitionSchema = getPartitionSchema(getTableRequest.getCatalogName());
             return new GetTableResponse(getTableRequest.getCatalogName(), getTableRequest.getTableName(),
                     getSchema(connection, getTableRequest.getTableName(), partitionSchema),
                     partitionSchema.getFields().stream().map(Field::getName).collect(Collectors.toSet()));
-        }
-        catch (SQLException sqlException) {
-            LOGGER.error(sqlException.getMessage());
-            throw new RuntimeException(sqlException.getErrorCode() + ": "
-                    + sqlException.getMessage());
         }
     }
     /**
@@ -263,9 +259,9 @@ public class HiveMetadataHandler extends JdbcMetadataHandler
      * @param tableName   Holds table name and schema name. see {@link TableName}
      * @param partitionSchema A partition schema for a given table .See {@link Schema}
      * @return Schema  Holds Table schema along with partition schema. See {@link Schema}
-     * @throws SQLException A SQLException should be thrown for database connection failures , query syntax errors and so on.
+     * @throws Exception An Exception should be thrown for database connection failures , query syntax errors and so on.
      */
-    private Schema getSchema(Connection jdbcConnection, TableName tableName, Schema partitionSchema) throws SQLException
+    private Schema getSchema(Connection jdbcConnection, TableName tableName, Schema partitionSchema) throws Exception
     {
         SchemaBuilder schemaBuilder = SchemaBuilder.newBuilder();
         try (ResultSet resultSet = getColumns(jdbcConnection.getCatalog(), tableName, jdbcConnection.getMetaData());

--- a/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveJdbcConnectionFactoryTest.java
+++ b/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveJdbcConnectionFactoryTest.java
@@ -30,8 +30,8 @@ import java.sql.SQLException;
 import java.util.Map;
 
 public class HiveJdbcConnectionFactoryTest {
-    @Test(expected = RuntimeException.class)
-    public void getConnectionTest() throws ClassNotFoundException, SQLException {
+    @Test(expected = SQLException.class)
+    public void getConnectionTest() throws Exception {
         JdbcCredential expectedCredential = new JdbcCredential("hive", "hive");
         JdbcCredentialProvider jdbcCredentialProvider = new StaticJdbcCredentialProvider(expectedCredential);
         DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", HiveConstants.HIVE_NAME,

--- a/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveMetadataHandlerTest.java
+++ b/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveMetadataHandlerTest.java
@@ -67,7 +67,9 @@ public class HiveMetadataHandlerTest
     }
 
     @Before
-    public void setup() {
+    public void setup()
+            throws Exception
+    {
         this.blockAllocator = Mockito.mock(BlockAllocator.class);
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class, Mockito.RETURNS_DEEP_STUBS);
         this.connection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);

--- a/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveMuxMetadataHandlerTest.java
+++ b/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveMuxMetadataHandlerTest.java
@@ -78,6 +78,7 @@ public class HiveMuxMetadataHandlerTest
 
     @Test
     public void doListSchemaNames()
+            throws Exception
     {
         ListSchemasRequest listSchemasRequest = Mockito.mock(ListSchemasRequest.class);
         Mockito.when(listSchemasRequest.getCatalogName()).thenReturn("metaHive");
@@ -87,6 +88,7 @@ public class HiveMuxMetadataHandlerTest
 
     @Test
     public void doListTables()
+            throws Exception
     {
         ListTablesRequest listTablesRequest = Mockito.mock(ListTablesRequest.class);
         Mockito.when(listTablesRequest.getCatalogName()).thenReturn("metaHive");

--- a/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveMuxRecordHandlerTest.java
+++ b/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveMuxRecordHandlerTest.java
@@ -75,7 +75,7 @@ public class HiveMuxRecordHandlerTest
     }
 
     @Test
-    public void readWithConstraint() throws SQLException
+    public void readWithConstraint() throws Exception
     {
         BlockSpiller blockSpiller = Mockito.mock(BlockSpiller.class);
         ReadRecordsRequest readRecordsRequest = Mockito.mock(ReadRecordsRequest.class);
@@ -103,7 +103,7 @@ public class HiveMuxRecordHandlerTest
     }
 
     @Test(expected = RuntimeException.class)
-    public void readWithConstraintWithUnsupportedCatalog() throws SQLException
+    public void readWithConstraintWithUnsupportedCatalog() throws Exception
     {
         BlockSpiller blockSpiller = Mockito.mock(BlockSpiller.class);
         ReadRecordsRequest readRecordsRequest = Mockito.mock(ReadRecordsRequest.class);

--- a/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveRecordHandlerTest.java
+++ b/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveRecordHandlerTest.java
@@ -67,6 +67,7 @@ public class HiveRecordHandlerTest
 
     @Before
     public void setup()
+            throws Exception
     {
         this.amazonS3 = Mockito.mock(AmazonS3.class);
         this.secretsManager = Mockito.mock(AWSSecretsManager.class);

--- a/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/integ/HiveIntegTest.java
+++ b/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/integ/HiveIntegTest.java
@@ -99,14 +99,9 @@ public class HiveIntegTest extends IntegrationTestBase {
     @BeforeClass
     @Override
     protected void setUp()
+            throws Exception
     {
-        try {
-            super.setUp();
-        }
-        catch (Exception e) {
-
-            throw e;
-        }
+        super.setUp();
     }
 
 

--- a/athena-cloudera-impala/src/main/java/com/amazonaws/athena/connectors/cloudera/ImpalaMetadataHandler.java
+++ b/athena-cloudera-impala/src/main/java/com/amazonaws/athena/connectors/cloudera/ImpalaMetadataHandler.java
@@ -102,11 +102,12 @@ public class ImpalaMetadataHandler extends JdbcMetadataHandler
      * @param blockWriter Used to write rows (Impala partitions) into the Apache Arrow response.
      * @param getTableLayoutRequest Provides details of the catalog, database, and table being queried as well as any filter predicate.
      * @param queryStatusChecker A QueryStatusChecker that you can use to stop doing work for a query that has already terminated
-     * @throws SQLException A SQLException should be thrown for database connection failures , query syntax errors and so on.
+     * @throws Exception An Exception should be thrown for database connection failures , query syntax errors and so on.
      **/
     @Override
     public void getPartitions(BlockWriter blockWriter, GetTableLayoutRequest getTableLayoutRequest,
-                              QueryStatusChecker queryStatusChecker) throws SQLException
+                              QueryStatusChecker queryStatusChecker)
+            throws Exception
     {
         LOGGER.info("{}: Schema {}, table {}", getTableLayoutRequest.getQueryId(), getTableLayoutRequest.getTableName().getSchemaName(),
                 getTableLayoutRequest.getTableName().getTableName());
@@ -244,17 +245,13 @@ public class ImpalaMetadataHandler extends JdbcMetadataHandler
      */
     @Override
     public GetTableResponse doGetTable(final BlockAllocator blockAllocator, final GetTableRequest getTableRequest)
+            throws Exception
     {
         try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider())) {
             Schema partitionSchema = getPartitionSchema(getTableRequest.getCatalogName());
             return new GetTableResponse(getTableRequest.getCatalogName(), getTableRequest.getTableName(),
                     getSchema(connection, getTableRequest.getTableName(), partitionSchema),
                     partitionSchema.getFields().stream().map(Field::getName).collect(Collectors.toSet()));
-        }
-        catch (SQLException sqlException) {
-            LOGGER.error(sqlException.getMessage());
-            throw new RuntimeException(sqlException.getErrorCode() + ": "
-                    + sqlException.getMessage());
         }
     }
     /**
@@ -263,9 +260,9 @@ public class ImpalaMetadataHandler extends JdbcMetadataHandler
      * @param tableName   Holds table name and schema name. see {@link TableName}
      * @param partitionSchema A partition schema for a given table .See {@link Schema}
      * @return Schema  Holds Table schema along with partition schema. See {@link Schema}
-     * @throws SQLException A SQLException should be thrown for database connection failures , query syntax errors and so on.
+     * @throws Exception An Exception should be thrown for database connection failures , query syntax errors and so on.
      */
-    private Schema getSchema(Connection jdbcConnection, TableName tableName, Schema partitionSchema) throws SQLException
+    private Schema getSchema(Connection jdbcConnection, TableName tableName, Schema partitionSchema) throws Exception
     {
         SchemaBuilder schemaBuilder = SchemaBuilder.newBuilder();
         try (ResultSet resultSet = getColumns(jdbcConnection.getCatalog(), tableName, jdbcConnection.getMetaData());

--- a/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaMetadataHandlerTest.java
+++ b/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaMetadataHandlerTest.java
@@ -63,7 +63,9 @@ public class ImpalaMetadataHandlerTest
         System.setProperty("aws.region", "us-west-2");
     }
     @Before
-    public void setup() {
+    public void setup()
+            throws Exception
+    {
         this.blockAllocator = Mockito.mock(BlockAllocator.class);
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class, Mockito.RETURNS_DEEP_STUBS);
         this.connection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);

--- a/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaMuxMetadataHandlerTest.java
+++ b/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaMuxMetadataHandlerTest.java
@@ -78,6 +78,7 @@ public class ImpalaMuxMetadataHandlerTest
 
     @Test
     public void doListSchemaNames()
+            throws Exception
     {
         ListSchemasRequest listSchemasRequest = Mockito.mock(ListSchemasRequest.class);
         Mockito.when(listSchemasRequest.getCatalogName()).thenReturn("metaImpala");
@@ -87,6 +88,7 @@ public class ImpalaMuxMetadataHandlerTest
 
     @Test
     public void doListTables()
+            throws Exception
     {
         ListTablesRequest listTablesRequest = Mockito.mock(ListTablesRequest.class);
         Mockito.when(listTablesRequest.getCatalogName()).thenReturn("metaImpala");
@@ -96,6 +98,7 @@ public class ImpalaMuxMetadataHandlerTest
 
     @Test
     public void doGetTable()
+            throws Exception
     {
         GetTableRequest getTableRequest = Mockito.mock(GetTableRequest.class);
         Mockito.when(getTableRequest.getCatalogName()).thenReturn("metaImpala");

--- a/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaMuxRecordHandlerTest.java
+++ b/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaMuxRecordHandlerTest.java
@@ -75,7 +75,7 @@ public class ImpalaMuxRecordHandlerTest
     }
 
     @Test
-    public void readWithConstraint() throws SQLException
+    public void readWithConstraint() throws Exception
     {
         BlockSpiller blockSpiller = Mockito.mock(BlockSpiller.class);
         ReadRecordsRequest readRecordsRequest = Mockito.mock(ReadRecordsRequest.class);
@@ -103,7 +103,7 @@ public class ImpalaMuxRecordHandlerTest
     }
 
     @Test(expected = RuntimeException.class)
-    public void readWithConstraintWithUnsupportedCatalog() throws SQLException
+    public void readWithConstraintWithUnsupportedCatalog() throws Exception
     {
         BlockSpiller blockSpiller = Mockito.mock(BlockSpiller.class);
         ReadRecordsRequest readRecordsRequest = Mockito.mock(ReadRecordsRequest.class);

--- a/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaRecordHandlerTest.java
+++ b/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaRecordHandlerTest.java
@@ -67,6 +67,7 @@ public class ImpalaRecordHandlerTest
 
     @Before
     public void setup()
+            throws Exception
     {
         this.amazonS3 = Mockito.mock(AmazonS3.class);
         this.secretsManager = Mockito.mock(AWSSecretsManager.class);

--- a/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/integ/ImpalaIntegTest.java
+++ b/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/integ/ImpalaIntegTest.java
@@ -99,13 +99,10 @@ public class ImpalaIntegTest extends IntegrationTestBase {
 
     @BeforeClass
     @Override
-    protected void setUp() {
-        try {
-            super.setUp();
-        } catch (Exception e) {
-
-            throw e;
-        }
+    protected void setUp()
+            throws Exception
+    {
+        super.setUp();
     }
 
 

--- a/athena-datalakegen2/src/main/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2MetadataHandler.java
+++ b/athena-datalakegen2/src/main/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2MetadataHandler.java
@@ -144,15 +144,13 @@ public class DataLakeGen2MetadataHandler extends JdbcMetadataHandler
 
     @Override
     public GetTableResponse doGetTable(final BlockAllocator blockAllocator, final GetTableRequest getTableRequest)
+            throws Exception
     {
         try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider())) {
             Schema partitionSchema = getPartitionSchema(getTableRequest.getCatalogName());
             TableName tableName = new TableName(getTableRequest.getTableName().getSchemaName().toUpperCase(), getTableRequest.getTableName().getTableName().toUpperCase());
             return new GetTableResponse(getTableRequest.getCatalogName(), tableName, getSchema(connection, tableName, partitionSchema),
                     partitionSchema.getFields().stream().map(Field::getName).collect(Collectors.toSet()));
-        }
-        catch (SQLException sqlException) {
-            throw new RuntimeException(sqlException.getErrorCode() + ": " + sqlException.getMessage());
         }
     }
 
@@ -162,10 +160,10 @@ public class DataLakeGen2MetadataHandler extends JdbcMetadataHandler
      * @param tableName
      * @param partitionSchema
      * @return
-     * @throws SQLException
+     * @throws Exception
      */
     private Schema getSchema(Connection jdbcConnection, TableName tableName, Schema partitionSchema)
-            throws SQLException
+            throws Exception
     {
         LOGGER.info("Inside getSchema");
 

--- a/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2MetadataHandlerTest.java
+++ b/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2MetadataHandlerTest.java
@@ -80,6 +80,7 @@ public class DataLakeGen2MetadataHandlerTest
 
     @Before
     public void setup()
+            throws Exception
     {
         System.setProperty("aws.region", "us-east-1");
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class, Mockito.RETURNS_DEEP_STUBS);

--- a/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2MuxMetadataHandlerTest.java
+++ b/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2MuxMetadataHandlerTest.java
@@ -69,6 +69,7 @@ public class DataLakeGen2MuxMetadataHandlerTest
 
     @Test
     public void doListSchemaNames()
+            throws Exception
     {
         ListSchemasRequest listSchemasRequest = Mockito.mock(ListSchemasRequest.class);
         Mockito.when(listSchemasRequest.getCatalogName()).thenReturn("fakedatabase");
@@ -78,6 +79,7 @@ public class DataLakeGen2MuxMetadataHandlerTest
 
     @Test
     public void doListTables()
+            throws Exception
     {
         ListTablesRequest listTablesRequest = Mockito.mock(ListTablesRequest.class);
         Mockito.when(listTablesRequest.getCatalogName()).thenReturn("fakedatabase");
@@ -87,6 +89,7 @@ public class DataLakeGen2MuxMetadataHandlerTest
 
     @Test
     public void doGetTable()
+            throws Exception
     {
         GetTableRequest getTableRequest = Mockito.mock(GetTableRequest.class);
         Mockito.when(getTableRequest.getCatalogName()).thenReturn("fakedatabase");

--- a/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2MuxRecordHandlerTest.java
+++ b/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2MuxRecordHandlerTest.java
@@ -69,6 +69,7 @@ public class DataLakeGen2MuxRecordHandlerTest
 
     @Test
     public void readWithConstraint()
+            throws Exception
     {
         BlockSpiller blockSpiller = Mockito.mock(BlockSpiller.class);
         ReadRecordsRequest readRecordsRequest = Mockito.mock(ReadRecordsRequest.class);
@@ -79,6 +80,7 @@ public class DataLakeGen2MuxRecordHandlerTest
 
     @Test(expected = RuntimeException.class)
     public void readWithConstraintWithUnsupportedCatalog()
+            throws Exception
     {
         BlockSpiller blockSpiller = Mockito.mock(BlockSpiller.class);
         ReadRecordsRequest readRecordsRequest = Mockito.mock(ReadRecordsRequest.class);

--- a/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeRecordHandlerTest.java
+++ b/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeRecordHandlerTest.java
@@ -59,6 +59,7 @@ public class DataLakeRecordHandlerTest
 
     @Before
     public void setup()
+            throws Exception
     {
         System.setProperty("aws.region", "us-east-1");
         this.amazonS3 = Mockito.mock(AmazonS3.class);

--- a/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/integ/DataLakeGen2IntegTest.java
+++ b/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/integ/DataLakeGen2IntegTest.java
@@ -95,14 +95,9 @@ public class DataLakeGen2IntegTest extends IntegrationTestBase {
     @BeforeClass
     @Override
     protected void setUp()
+            throws Exception
     {
-        try {
-            super.setUp();
-        }
-        catch (Exception e) {
-
-            throw e;
-        }
+        super.setUp();
     }
 
     public DataLakeGen2IntegTest()

--- a/athena-docdb/src/test/java/com/amazonaws/athena/connectors/docdb/integ/DocDbIntegTest.java
+++ b/athena-docdb/src/test/java/com/amazonaws/athena/connectors/docdb/integ/DocDbIntegTest.java
@@ -108,7 +108,9 @@ public class DocDbIntegTest extends IntegrationTestBase {
      */
     @BeforeClass
     @Override
-    protected void setUp() {
+    protected void setUp()
+            throws Exception
+    {
         cloudFormationClient = new CloudFormationClient(theApp, getDocDbStack());
         try {
             // Create the CloudFormation stack for the DocumentDb cluster.

--- a/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/integ/ElasticsearchIntegTest.java
+++ b/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/integ/ElasticsearchIntegTest.java
@@ -80,6 +80,7 @@ public class ElasticsearchIntegTest extends IntegrationTestBase
     @BeforeClass
     @Override
     protected void setUp()
+            throws Exception
     {
         cloudFormationClient = new CloudFormationClient(theApp, getElasticsearchStack());
         try {

--- a/athena-federation-integ-test/src/main/java/com/amazonaws/athena/connector/integ/IntegrationTestBase.java
+++ b/athena-federation-integ-test/src/main/java/com/amazonaws/athena/connector/integ/IntegrationTestBase.java
@@ -202,7 +202,7 @@ public abstract class IntegrationTestBase
     /**
      * Must be overridden in the extending class to setup the DB table (i.e. insert rows into table, etc...)
      */
-    protected abstract void setUpTableData();
+    protected abstract void setUpTableData() throws Exception;
 
     /**
      * Must be overridden in the extending class (can be a no-op) to create a connector-specific CloudFormation stack
@@ -232,7 +232,7 @@ public abstract class IntegrationTestBase
      * with Athena.
      */
     @BeforeClass
-    protected void setUp()
+    protected void setUp() throws Exception
     {
         cloudFormationClient = new CloudFormationClient(connectorStackProvider.getStack());
         try {

--- a/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/integ/BigQueryIntegTest.java
+++ b/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/integ/BigQueryIntegTest.java
@@ -110,15 +110,9 @@ public class BigQueryIntegTest  extends IntegrationTestBase
 
     @BeforeClass
     @Override
-    protected void setUp()
+    protected void setUp() throws Exception
     {
-        try {
-            super.setUp();
-        }
-        catch (Exception e) {
-
-            throw e;
-        }
+        super.setUp();
     }
 
     public BigQueryIntegTest()

--- a/athena-hbase/src/test/java/com/amazonaws/athena/connectors/hbase/integ/HbaseIntegTest.java
+++ b/athena-hbase/src/test/java/com/amazonaws/athena/connectors/hbase/integ/HbaseIntegTest.java
@@ -99,6 +99,7 @@ public class HbaseIntegTest extends IntegrationTestBase
     @BeforeClass
     @Override
     protected void setUp()
+            throws Exception
     {
         cloudFormationClient = new CloudFormationClient(getHbaseStack());
         try {

--- a/athena-hortonworks-hive/src/main/java/com/amazonaws/athena/connectors/hortonworks/HiveMetadataHandler.java
+++ b/athena-hortonworks-hive/src/main/java/com/amazonaws/athena/connectors/hortonworks/HiveMetadataHandler.java
@@ -101,11 +101,12 @@ public class HiveMetadataHandler extends JdbcMetadataHandler
      * @param blockWriter Used to write rows (hive partitions) into the Apache Arrow response.
      * @param getTableLayoutRequest Provides details of the catalog, database, and table being queried as well as any filter predicate.
      * @param queryStatusChecker A QueryStatusChecker that you can use to stop doing work for a query that has already terminated
-     * @throws SQLException A SQLException should be thrown for database connection failures , query syntax errors and so on.
+     * @throws Exception An Exception should be thrown for database connection failures , query syntax errors and so on.
      **/
     @Override
     public void getPartitions(BlockWriter blockWriter, GetTableLayoutRequest getTableLayoutRequest,
-                              QueryStatusChecker queryStatusChecker) throws SQLException
+                              QueryStatusChecker queryStatusChecker)
+            throws Exception
     {
         LOGGER.info("{}: Schema {}, table {}", getTableLayoutRequest.getQueryId(), getTableLayoutRequest.getTableName().getSchemaName(),
                 getTableLayoutRequest.getTableName().getTableName());
@@ -244,17 +245,13 @@ public class HiveMetadataHandler extends JdbcMetadataHandler
      */
     @Override
     public GetTableResponse doGetTable(final BlockAllocator blockAllocator, final GetTableRequest getTableRequest)
+            throws Exception
     {
         try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider())) {
             Schema partitionSchema = getPartitionSchema(getTableRequest.getCatalogName());
             return new GetTableResponse(getTableRequest.getCatalogName(), getTableRequest.getTableName(),
                     getSchema(connection, getTableRequest.getTableName(), partitionSchema),
                     partitionSchema.getFields().stream().map(Field::getName).collect(Collectors.toSet()));
-        }
-        catch (SQLException sqlException) {
-            LOGGER.error(sqlException.getMessage());
-            throw new RuntimeException(sqlException.getErrorCode() + ": "
-                    + sqlException.getMessage());
         }
     }
 
@@ -264,9 +261,9 @@ public class HiveMetadataHandler extends JdbcMetadataHandler
      * @param tableName   Holds table name and schema name. see {@link TableName}
      * @param partitionSchema A partition schema for a given table .See {@link Schema}
      * @return Schema  Holds Table schema along with partition schema. See {@link Schema}
-     * @throws SQLException A SQLException should be thrown for database connection failures , query syntax errors and so on.
+     * @throws Exception An Exception should be thrown for database connection failures , query syntax errors and so on.
      */
-    private Schema getSchema(Connection jdbcConnection, TableName tableName, Schema partitionSchema) throws SQLException
+    private Schema getSchema(Connection jdbcConnection, TableName tableName, Schema partitionSchema) throws Exception
     {
         SchemaBuilder schemaBuilder = SchemaBuilder.newBuilder();
         try (ResultSet resultSet = getColumns(jdbcConnection.getCatalog(), tableName, jdbcConnection.getMetaData());

--- a/athena-hortonworks-hive/src/test/java/com/amazonaws/athena/connectors/hortonworks/HiveMetadataHandlerTest.java
+++ b/athena-hortonworks-hive/src/test/java/com/amazonaws/athena/connectors/hortonworks/HiveMetadataHandlerTest.java
@@ -65,7 +65,9 @@ public class HiveMetadataHandlerTest
     }
 
     @Before
-    public void setup() {
+    public void setup()
+            throws Exception
+    {
         this.blockAllocator = Mockito.mock(BlockAllocator.class);
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class, Mockito.RETURNS_DEEP_STUBS);
         this.connection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);

--- a/athena-hortonworks-hive/src/test/java/com/amazonaws/athena/connectors/hortonworks/HiveMuxMetadataHandlerTest.java
+++ b/athena-hortonworks-hive/src/test/java/com/amazonaws/athena/connectors/hortonworks/HiveMuxMetadataHandlerTest.java
@@ -78,6 +78,7 @@ public class HiveMuxMetadataHandlerTest
 
     @Test
     public void doListSchemaNames()
+            throws Exception
     {
         ListSchemasRequest listSchemasRequest = Mockito.mock(ListSchemasRequest.class);
         Mockito.when(listSchemasRequest.getCatalogName()).thenReturn("metaHive");
@@ -87,6 +88,7 @@ public class HiveMuxMetadataHandlerTest
 
     @Test
     public void doListTables()
+            throws Exception
     {
         ListTablesRequest listTablesRequest = Mockito.mock(ListTablesRequest.class);
         Mockito.when(listTablesRequest.getCatalogName()).thenReturn("metaHive");

--- a/athena-hortonworks-hive/src/test/java/com/amazonaws/athena/connectors/hortonworks/HiveMuxRecordHandlerTest.java
+++ b/athena-hortonworks-hive/src/test/java/com/amazonaws/athena/connectors/hortonworks/HiveMuxRecordHandlerTest.java
@@ -75,7 +75,7 @@ public class HiveMuxRecordHandlerTest
     }
 
     @Test
-    public void readWithConstraint() throws SQLException
+    public void readWithConstraint() throws Exception
     {
         BlockSpiller blockSpiller = Mockito.mock(BlockSpiller.class);
         ReadRecordsRequest readRecordsRequest = Mockito.mock(ReadRecordsRequest.class);
@@ -103,7 +103,7 @@ public class HiveMuxRecordHandlerTest
     }
 
     @Test(expected = RuntimeException.class)
-    public void readWithConstraintWithUnsupportedCatalog() throws SQLException
+    public void readWithConstraintWithUnsupportedCatalog() throws Exception
     {
         BlockSpiller blockSpiller = Mockito.mock(BlockSpiller.class);
         ReadRecordsRequest readRecordsRequest = Mockito.mock(ReadRecordsRequest.class);

--- a/athena-hortonworks-hive/src/test/java/com/amazonaws/athena/connectors/hortonworks/HiveRecordHandlerTest.java
+++ b/athena-hortonworks-hive/src/test/java/com/amazonaws/athena/connectors/hortonworks/HiveRecordHandlerTest.java
@@ -67,6 +67,7 @@ public class HiveRecordHandlerTest
 
     @Before
     public void setup()
+            throws Exception
     {
         this.amazonS3 = Mockito.mock(AmazonS3.class);
         this.secretsManager = Mockito.mock(AWSSecretsManager.class);

--- a/athena-hortonworks-hive/src/test/java/com/amazonaws/athena/connectors/hortonworks/integ/HiveIntegTest.java
+++ b/athena-hortonworks-hive/src/test/java/com/amazonaws/athena/connectors/hortonworks/integ/HiveIntegTest.java
@@ -99,14 +99,9 @@ public class HiveIntegTest extends IntegrationTestBase {
     @BeforeClass
     @Override
     protected void setUp()
+            throws Exception
     {
-        try {
-            super.setUp();
-        }
-        catch (Exception e) {
-
-            throw e;
-        }
+        super.setUp();
     }
 
 

--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/MultiplexingJdbcMetadataHandler.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/MultiplexingJdbcMetadataHandler.java
@@ -97,6 +97,7 @@ public class MultiplexingJdbcMetadataHandler
 
     @Override
     public ListSchemasResponse doListSchemaNames(BlockAllocator blockAllocator, ListSchemasRequest listSchemasRequest)
+            throws Exception
     {
         validateMultiplexer(listSchemasRequest.getCatalogName());
         return this.metadataHandlerMap.get(listSchemasRequest.getCatalogName()).doListSchemaNames(blockAllocator, listSchemasRequest);
@@ -104,6 +105,7 @@ public class MultiplexingJdbcMetadataHandler
 
     @Override
     public ListTablesResponse doListTables(BlockAllocator blockAllocator, ListTablesRequest listTablesRequest)
+            throws Exception
     {
         validateMultiplexer(listTablesRequest.getCatalogName());
         return this.metadataHandlerMap.get(listTablesRequest.getCatalogName()).doListTables(blockAllocator, listTablesRequest);
@@ -111,6 +113,7 @@ public class MultiplexingJdbcMetadataHandler
 
     @Override
     public GetTableResponse doGetTable(BlockAllocator blockAllocator, GetTableRequest getTableRequest)
+            throws Exception
     {
         validateMultiplexer(getTableRequest.getCatalogName());
         return this.metadataHandlerMap.get(getTableRequest.getCatalogName()).doGetTable(blockAllocator, getTableRequest);

--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/MultiplexingJdbcRecordHandler.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/MultiplexingJdbcRecordHandler.java
@@ -82,6 +82,7 @@ public class MultiplexingJdbcRecordHandler
     public void readWithConstraint(
             final BlockSpiller blockSpiller,
             final ReadRecordsRequest readRecordsRequest, QueryStatusChecker queryStatusChecker)
+            throws Exception
     {
         validateMultiplexer(readRecordsRequest.getCatalogName());
         this.recordHandlerMap.get(readRecordsRequest.getCatalogName()).readWithConstraint(blockSpiller, readRecordsRequest, queryStatusChecker);

--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/connection/GenericJdbcConnectionFactory.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/connection/GenericJdbcConnectionFactory.java
@@ -28,7 +28,6 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.DriverManager;
-import java.sql.SQLException;
 import java.util.Map;
 import java.util.Properties;
 import java.util.regex.Matcher;
@@ -70,32 +69,25 @@ public class GenericJdbcConnectionFactory
 
     @Override
     public Connection getConnection(final JdbcCredentialProvider jdbcCredentialProvider)
+            throws Exception
     {
-        try {
-            final String derivedJdbcString;
-            if (jdbcCredentialProvider != null) {
-                Matcher secretMatcher = SECRET_NAME_PATTERN.matcher(databaseConnectionConfig.getJdbcConnectionString());
-                derivedJdbcString = secretMatcher.replaceAll(Matcher.quoteReplacement(""));
+        final String derivedJdbcString;
+        if (jdbcCredentialProvider != null) {
+            Matcher secretMatcher = SECRET_NAME_PATTERN.matcher(databaseConnectionConfig.getJdbcConnectionString());
+            derivedJdbcString = secretMatcher.replaceAll(Matcher.quoteReplacement(""));
 
-                jdbcProperties.put("user", jdbcCredentialProvider.getCredential().getUser());
-                jdbcProperties.put("password", jdbcCredentialProvider.getCredential().getPassword());
-            }
-            else {
-                derivedJdbcString = databaseConnectionConfig.getJdbcConnectionString();
-            }
+            jdbcProperties.put("user", jdbcCredentialProvider.getCredential().getUser());
+            jdbcProperties.put("password", jdbcCredentialProvider.getCredential().getPassword());
+        }
+        else {
+            derivedJdbcString = databaseConnectionConfig.getJdbcConnectionString();
+        }
 
-            // register driver
-            Class.forName(databaseConnectionInfo.getDriverClassName()).newInstance();
+        // register driver
+        Class.forName(databaseConnectionInfo.getDriverClassName()).newInstance();
 
-            // create connection
-            return DriverManager.getConnection(derivedJdbcString, this.jdbcProperties);
-        }
-        catch (SQLException sqlException) {
-            throw new RuntimeException(sqlException.getErrorCode() + ": " + sqlException);
-        }
-        catch (ClassNotFoundException | IllegalAccessException | InstantiationException ex) {
-            throw new RuntimeException(ex);
-        }
+        // create connection
+        return DriverManager.getConnection(derivedJdbcString, this.jdbcProperties);
     }
 
     private String encodeValue(String value)

--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/connection/JdbcConnectionFactory.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/connection/JdbcConnectionFactory.java
@@ -32,5 +32,5 @@ public interface JdbcConnectionFactory
      * @param jdbcCredentialProvider jdbc user and password provider.
      * @return JDBC connection. See {@link Connection}.
      */
-    Connection getConnection(JdbcCredentialProvider jdbcCredentialProvider);
+    Connection getConnection(JdbcCredentialProvider jdbcCredentialProvider) throws Exception;
 }

--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandler.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandler.java
@@ -125,13 +125,11 @@ public abstract class JdbcMetadataHandler
 
     @Override
     public ListSchemasResponse doListSchemaNames(final BlockAllocator blockAllocator, final ListSchemasRequest listSchemasRequest)
+            throws Exception
     {
         try (Connection connection = jdbcConnectionFactory.getConnection(getCredentialProvider())) {
             LOGGER.info("{}: List schema names for Catalog {}", listSchemasRequest.getQueryId(), listSchemasRequest.getCatalogName());
             return new ListSchemasResponse(listSchemasRequest.getCatalogName(), listDatabaseNames(connection));
-        }
-        catch (SQLException sqlException) {
-            throw new RuntimeException(sqlException.getErrorCode() + ": " + sqlException.getMessage());
         }
     }
 
@@ -153,14 +151,12 @@ public abstract class JdbcMetadataHandler
 
     @Override
     public ListTablesResponse doListTables(final BlockAllocator blockAllocator, final ListTablesRequest listTablesRequest)
+            throws Exception
     {
         try (Connection connection = jdbcConnectionFactory.getConnection(getCredentialProvider())) {
             LOGGER.info("{}: List table names for Catalog {}, Table {}", listTablesRequest.getQueryId(), listTablesRequest.getCatalogName(), listTablesRequest.getSchemaName());
             return new ListTablesResponse(listTablesRequest.getCatalogName(),
                     listTables(connection, listTablesRequest.getSchemaName()), null);
-        }
-        catch (SQLException sqlException) {
-            throw new RuntimeException(sqlException.getErrorCode() + ": " + sqlException.getMessage());
         }
     }
 
@@ -211,14 +207,12 @@ public abstract class JdbcMetadataHandler
 
     @Override
     public GetTableResponse doGetTable(final BlockAllocator blockAllocator, final GetTableRequest getTableRequest)
+            throws Exception
     {
         try (Connection connection = jdbcConnectionFactory.getConnection(getCredentialProvider())) {
             Schema partitionSchema = getPartitionSchema(getTableRequest.getCatalogName());
             return new GetTableResponse(getTableRequest.getCatalogName(), getTableRequest.getTableName(), getSchema(connection, getTableRequest.getTableName(), partitionSchema),
                     partitionSchema.getFields().stream().map(Field::getName).collect(Collectors.toSet()));
-        }
-        catch (SQLException sqlException) {
-            throw new RuntimeException(sqlException.getErrorCode() + ": " + sqlException.getMessage());
         }
     }
 

--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcRecordHandler.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcRecordHandler.java
@@ -132,6 +132,7 @@ public abstract class JdbcRecordHandler
 
     @Override
     public void readWithConstraint(BlockSpiller blockSpiller, ReadRecordsRequest readRecordsRequest, QueryStatusChecker queryStatusChecker)
+            throws Exception
     {
         LOGGER.info("{}: Catalog: {}, table {}, splits {}", readRecordsRequest.getQueryId(), readRecordsRequest.getCatalogName(), readRecordsRequest.getTableName(),
                 readRecordsRequest.getSplit().getProperties());
@@ -165,9 +166,6 @@ public abstract class JdbcRecordHandler
 
                 connection.commit();
             }
-        }
-        catch (SQLException sqlException) {
-            throw new RuntimeException(sqlException.getErrorCode() + ": " + sqlException.getMessage(), sqlException);
         }
     }
 

--- a/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/MultiplexingJdbcMetadataHandlerTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/MultiplexingJdbcMetadataHandlerTest.java
@@ -71,6 +71,7 @@ public class MultiplexingJdbcMetadataHandlerTest
 
     @Test
     public void doListSchemaNames()
+            throws Exception
     {
         ListSchemasRequest listSchemasRequest = Mockito.mock(ListSchemasRequest.class);
         Mockito.when(listSchemasRequest.getCatalogName()).thenReturn("fakedatabase");
@@ -80,6 +81,7 @@ public class MultiplexingJdbcMetadataHandlerTest
 
     @Test
     public void doListTables()
+            throws Exception
     {
         ListTablesRequest listTablesRequest = Mockito.mock(ListTablesRequest.class);
         Mockito.when(listTablesRequest.getCatalogName()).thenReturn("fakedatabase");
@@ -89,6 +91,7 @@ public class MultiplexingJdbcMetadataHandlerTest
 
     @Test
     public void doGetTable()
+            throws Exception
     {
         GetTableRequest getTableRequest = Mockito.mock(GetTableRequest.class);
         Mockito.when(getTableRequest.getCatalogName()).thenReturn("fakedatabase");

--- a/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/MultiplexingJdbcRecordHandlerTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/MultiplexingJdbcRecordHandlerTest.java
@@ -69,6 +69,7 @@ public class MultiplexingJdbcRecordHandlerTest
 
     @Test
     public void readWithConstraint()
+            throws Exception
     {
         BlockSpiller blockSpiller = Mockito.mock(BlockSpiller.class);
         ReadRecordsRequest readRecordsRequest = Mockito.mock(ReadRecordsRequest.class);
@@ -79,6 +80,7 @@ public class MultiplexingJdbcRecordHandlerTest
 
     @Test(expected = RuntimeException.class)
     public void readWithConstraintWithUnsupportedCatalog()
+            throws Exception
     {
         BlockSpiller blockSpiller = Mockito.mock(BlockSpiller.class);
         ReadRecordsRequest readRecordsRequest = Mockito.mock(ReadRecordsRequest.class);

--- a/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/integ/JdbcTableUtils.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/integ/JdbcTableUtils.java
@@ -65,11 +65,11 @@ public class JdbcTableUtils
 
     /**
      * Creates a DB schema.
-     * @throws RuntimeException The SQL statement failed.
+     * @throws Exception The SQL statement failed.
      * @param databaseConnectionInfo
      */
     public void createDbSchema(DatabaseConnectionInfo databaseConnectionInfo)
-            throws RuntimeException
+            throws Exception
     {
         try (Connection connection = getDbConnection(databaseConnectionInfo)) {
             // Prepare create schema statement
@@ -80,20 +80,16 @@ public class JdbcTableUtils
             createSchema.execute();
             logger.info("Created the DB schema: {}", schemaName);
         }
-        catch(SQLException e) {
-            throw new RuntimeException(String.format("Unable to create DB schema (%s): %s",
-                    schemaName, e.getMessage()), e);
-        }
     }
 
     /**
      * Creates a DB table.
      * @param tableSchema String representing the table's schema (e.g. "year int, first_name varchar").
      * @param databaseConnectionInfo
-     * @throws RuntimeException The SQL statement failed.
+     * @throws Exception The SQL statement failed.
      */
     public void createTable(String tableSchema, DatabaseConnectionInfo databaseConnectionInfo)
-            throws RuntimeException
+            throws Exception
     {
         try (Connection connection = getDbConnection(databaseConnectionInfo)) {
             // Prepare create table statement
@@ -104,20 +100,16 @@ public class JdbcTableUtils
             createTable.execute();
             logger.info("Created the '{}' table.", tableName);
         }
-        catch(SQLException e) {
-            throw new RuntimeException(String.format("Unable to create table '%s' in DB '%s': %s",
-                    tableName, schemaName, e.getMessage()), e);
-        }
     }
 
     /**
      * Inserts a row into a DB table.
      * @param tableValues String representing the row's values (e.g. "1992, 'James'").
      * @param databaseConnectionInfo
-     * @throws RuntimeException The SQL statement failed.
+     * @throws Exception The SQL statement failed.
      */
     public void insertRow(String tableValues, DatabaseConnectionInfo databaseConnectionInfo)
-            throws RuntimeException
+            throws Exception
     {
         try (Connection connection = getDbConnection(databaseConnectionInfo)) {
 
@@ -129,10 +121,6 @@ public class JdbcTableUtils
             insertValues.execute();
             logger.info("Inserted row into the '{}' table.", tableName);
         }
-        catch(SQLException e) {
-            throw new RuntimeException(String.format("Unable to insert row into table '%s': %s",
-                    tableName, e.getMessage()), e);
-        }
     }
 
     /**
@@ -141,6 +129,7 @@ public class JdbcTableUtils
      * @param databaseConnectionInfo
      */
     protected Connection getDbConnection(DatabaseConnectionInfo databaseConnectionInfo)
+            throws Exception
     {
         DatabaseConnectionConfig connectionConfig = getDbConfig();
         JdbcConnectionFactory connectionFactory = new GenericJdbcConnectionFactory(connectionConfig, properties, databaseConnectionInfo);
@@ -154,7 +143,6 @@ public class JdbcTableUtils
      * environmentVars map.
      */
     protected DatabaseConnectionConfig getDbConfig()
-            throws RuntimeException
     {
         DatabaseConnectionConfigBuilder configBuilder = new DatabaseConnectionConfigBuilder();
         for (DatabaseConnectionConfig config : configBuilder.properties(environmentVars).engine(this.engine).build()) {

--- a/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandlerTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandlerTest.java
@@ -72,6 +72,7 @@ public class JdbcMetadataHandlerTest
 
     @Before
     public void setup()
+            throws Exception
     {
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         this.connection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);
@@ -112,7 +113,7 @@ public class JdbcMetadataHandlerTest
 
     @Test
     public void doListSchemaNames()
-            throws SQLException
+            throws Exception
     {
         String[] schema = {"TABLE_SCHEM"};
         Object[][] values = {{"testDB"}, {"testdb2"}, {"information_schema"}};
@@ -126,7 +127,7 @@ public class JdbcMetadataHandlerTest
 
     @Test
     public void doListTables()
-            throws SQLException
+            throws Exception
     {
         String[] schema = {"TABLE_SCHEM", "TABLE_NAME"};
         Object[][] values = {{"testSchema", "testTable"}, {"testSchema", "testtable2"}};
@@ -144,7 +145,7 @@ public class JdbcMetadataHandlerTest
 
     @Test
     public void doListTablesEscaped()
-            throws SQLException
+            throws Exception
     {
         String[] schema = {"TABLE_SCHEM", "TABLE_NAME"};
         Object[][] values = {{"test_Schema", "testTable"}, {"test_Schema", "testtable2"}};
@@ -162,7 +163,7 @@ public class JdbcMetadataHandlerTest
 
     @Test(expected = IllegalArgumentException.class)
     public void doListTablesEscapedException()
-            throws SQLException
+            throws Exception
     {
         Mockito.when(connection.getMetaData().getSearchStringEscape()).thenReturn("_");
         this.jdbcMetadataHandler.doListTables(this.blockAllocator, new ListTablesRequest(this.federatedIdentity,
@@ -171,7 +172,7 @@ public class JdbcMetadataHandlerTest
 
     @Test
     public void doGetTable()
-            throws SQLException
+            throws Exception
     {
         String[] schema = {"DATA_TYPE", "COLUMN_SIZE", "COLUMN_NAME", "DECIMAL_DIGITS", "NUM_PREC_RADIX"};
         Object[][] values = {{Types.INTEGER, 12, "testCol1", 0, 0}, {Types.VARCHAR, 25, "testCol2", 0, 0},
@@ -201,15 +202,16 @@ public class JdbcMetadataHandlerTest
 
     @Test(expected = RuntimeException.class)
     public void doGetTableNoColumns()
+            throws Exception
     {
         TableName inputTableName = new TableName("testSchema", "testTable");
 
         this.jdbcMetadataHandler.doGetTable(this.blockAllocator, new GetTableRequest(this.federatedIdentity, "testQueryId", "testCatalog", inputTableName));
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test(expected = SQLException.class)
     public void doGetTableSQLException()
-            throws SQLException
+            throws Exception
     {
         TableName inputTableName = new TableName("testSchema", "testTable");
         Mockito.when(this.connection.getMetaData().getColumns(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString()))
@@ -217,17 +219,17 @@ public class JdbcMetadataHandlerTest
         this.jdbcMetadataHandler.doGetTable(this.blockAllocator, new GetTableRequest(this.federatedIdentity, "testQueryId", "testCatalog", inputTableName));
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test(expected = SQLException.class)
     public void doListSchemaNamesSQLException()
-            throws SQLException
+            throws Exception
     {
         Mockito.when(this.connection.getMetaData().getSchemas()).thenThrow(new SQLException());
         this.jdbcMetadataHandler.doListSchemaNames(this.blockAllocator, new ListSchemasRequest(this.federatedIdentity, "testQueryId", "testCatalog"));
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test(expected = SQLException.class)
     public void doListTablesSQLException()
-            throws SQLException
+            throws Exception
     {
         Mockito.when(this.connection.getMetaData().getTables(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.any())).thenThrow(new SQLException());
         this.jdbcMetadataHandler.doListTables(this.blockAllocator, new ListTablesRequest(this.federatedIdentity,

--- a/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcRecordHandlerTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcRecordHandlerTest.java
@@ -80,7 +80,7 @@ public class JdbcRecordHandlerTest
 
     @Before
     public void setup()
-            throws SQLException
+            throws Exception
     {
         this.connection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
@@ -108,7 +108,7 @@ public class JdbcRecordHandlerTest
 
     @Test
     public void readWithConstraint()
-            throws SQLException
+            throws Exception
     {
         ConstraintEvaluator constraintEvaluator = Mockito.mock(ConstraintEvaluator.class);
         Mockito.when(constraintEvaluator.apply(Mockito.anyString(), Mockito.any())).thenReturn(true);

--- a/athena-mysql/src/main/java/com/amazonaws/athena/connectors/mysql/MySqlMetadataHandler.java
+++ b/athena-mysql/src/main/java/com/amazonaws/athena/connectors/mysql/MySqlMetadataHandler.java
@@ -49,7 +49,6 @@ import org.slf4j.LoggerFactory;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -116,6 +115,7 @@ public class MySqlMetadataHandler
 
     @Override
     public void getPartitions(final BlockWriter blockWriter, final GetTableLayoutRequest getTableLayoutRequest, QueryStatusChecker queryStatusChecker)
+            throws Exception
     {
         LOGGER.info("{}: Schema {}, table {}", getTableLayoutRequest.getQueryId(), getTableLayoutRequest.getTableName().getSchemaName(),
                 getTableLayoutRequest.getTableName().getTableName());
@@ -150,9 +150,6 @@ public class MySqlMetadataHandler
                     while (resultSet.next() && queryStatusChecker.isQueryRunning());
                 }
             }
-        }
-        catch (SQLException sqlException) {
-            throw new RuntimeException(sqlException.getErrorCode() + ": " + sqlException.getMessage(), sqlException);
         }
     }
 

--- a/athena-mysql/src/test/java/com/amazonaws/athena/connectors/mysql/MySqlMetadataHandlerTest.java
+++ b/athena-mysql/src/test/java/com/amazonaws/athena/connectors/mysql/MySqlMetadataHandlerTest.java
@@ -78,6 +78,7 @@ public class MySqlMetadataHandlerTest
 
     @Before
     public void setup()
+            throws Exception
     {
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         this.connection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);

--- a/athena-mysql/src/test/java/com/amazonaws/athena/connectors/mysql/MySqlMuxJdbcMetadataHandlerTest.java
+++ b/athena-mysql/src/test/java/com/amazonaws/athena/connectors/mysql/MySqlMuxJdbcMetadataHandlerTest.java
@@ -71,6 +71,7 @@ public class MySqlMuxJdbcMetadataHandlerTest
 
     @Test
     public void doListSchemaNames()
+            throws Exception
     {
         ListSchemasRequest listSchemasRequest = Mockito.mock(ListSchemasRequest.class);
         Mockito.when(listSchemasRequest.getCatalogName()).thenReturn("fakedatabase");
@@ -80,6 +81,7 @@ public class MySqlMuxJdbcMetadataHandlerTest
 
     @Test
     public void doListTables()
+            throws Exception
     {
         ListTablesRequest listTablesRequest = Mockito.mock(ListTablesRequest.class);
         Mockito.when(listTablesRequest.getCatalogName()).thenReturn("fakedatabase");
@@ -89,6 +91,7 @@ public class MySqlMuxJdbcMetadataHandlerTest
 
     @Test
     public void doGetTable()
+            throws Exception
     {
         GetTableRequest getTableRequest = Mockito.mock(GetTableRequest.class);
         Mockito.when(getTableRequest.getCatalogName()).thenReturn("fakedatabase");

--- a/athena-mysql/src/test/java/com/amazonaws/athena/connectors/mysql/MySqlMuxJdbcRecordHandlerTest.java
+++ b/athena-mysql/src/test/java/com/amazonaws/athena/connectors/mysql/MySqlMuxJdbcRecordHandlerTest.java
@@ -69,6 +69,7 @@ public class MySqlMuxJdbcRecordHandlerTest
 
     @Test
     public void readWithConstraint()
+            throws Exception
     {
         BlockSpiller blockSpiller = Mockito.mock(BlockSpiller.class);
         ReadRecordsRequest readRecordsRequest = Mockito.mock(ReadRecordsRequest.class);
@@ -79,6 +80,7 @@ public class MySqlMuxJdbcRecordHandlerTest
 
     @Test(expected = RuntimeException.class)
     public void readWithConstraintWithUnsupportedCatalog()
+            throws Exception
     {
         BlockSpiller blockSpiller = Mockito.mock(BlockSpiller.class);
         ReadRecordsRequest readRecordsRequest = Mockito.mock(ReadRecordsRequest.class);

--- a/athena-mysql/src/test/java/com/amazonaws/athena/connectors/mysql/MySqlRecordHandlerTest.java
+++ b/athena-mysql/src/test/java/com/amazonaws/athena/connectors/mysql/MySqlRecordHandlerTest.java
@@ -63,6 +63,7 @@ public class MySqlRecordHandlerTest
 
     @Before
     public void setup()
+            throws Exception
     {
         this.amazonS3 = Mockito.mock(AmazonS3.class);
         this.secretsManager = Mockito.mock(AWSSecretsManager.class);

--- a/athena-mysql/src/test/java/com/amazonaws/athena/connectors/mysql/integ/MySqlIntegTest.java
+++ b/athena-mysql/src/test/java/com/amazonaws/athena/connectors/mysql/integ/MySqlIntegTest.java
@@ -116,7 +116,7 @@ public class MySqlIntegTest extends IntegrationTestBase
      */
     @BeforeClass
     @Override
-    protected void setUp()
+    protected void setUp() throws Exception
     {
         cloudFormationClient = new CloudFormationClient(theApp, getMySqlStack());
         try {
@@ -223,6 +223,7 @@ public class MySqlIntegTest extends IntegrationTestBase
      * Creates the DB schema used for the integration tests.
      */
     private void createDbSchema()
+            throws Exception
     {
         logger.info("----------------------------------------------------");
         logger.info("Setting up DB Schema: {}", mysqlDbName);
@@ -270,7 +271,7 @@ public class MySqlIntegTest extends IntegrationTestBase
      * Sets up the DB tables used by the tests.
      */
     @Override
-    protected void setUpTableData()
+    protected void setUpTableData() throws Exception
     {
         setUpMoviesTable();
         setUpBdayTable();
@@ -283,6 +284,7 @@ public class MySqlIntegTest extends IntegrationTestBase
      * Creates the 'movies' table and inserts rows.
      */
     private void setUpMoviesTable()
+            throws Exception
     {
         logger.info("----------------------------------------------------");
         logger.info("Setting up DB table: {}", mysqlTableMovies);
@@ -298,6 +300,7 @@ public class MySqlIntegTest extends IntegrationTestBase
      * Creates the 'bday' table and inserts rows.
      */
     private void setUpBdayTable()
+            throws Exception
     {
         logger.info("----------------------------------------------------");
         logger.info("Setting up DB table: {}", mysqlTableBday);
@@ -314,6 +317,7 @@ public class MySqlIntegTest extends IntegrationTestBase
      * Creates the 'datatypes' table and inserts rows.
      */
     protected void setUpDatatypesTable()
+            throws Exception
     {
         logger.info("----------------------------------------------------");
         logger.info("Setting up DB table: {}", TEST_DATATYPES_TABLE_NAME);
@@ -339,6 +343,7 @@ public class MySqlIntegTest extends IntegrationTestBase
      * Creates the 'null_table' table and inserts rows.
      */
     protected void setUpNullTable()
+            throws Exception
     {
         logger.info("----------------------------------------------------");
         logger.info("Setting up DB table: {}", TEST_NULL_TABLE_NAME);
@@ -353,6 +358,7 @@ public class MySqlIntegTest extends IntegrationTestBase
      * Creates the 'empty_table' table and inserts rows.
      */
     protected void setUpEmptyTable()
+            throws Exception
     {
         logger.info("----------------------------------------------------");
         logger.info("Setting up DB table: {}", TEST_EMPTY_TABLE_NAME);
@@ -369,6 +375,7 @@ public class MySqlIntegTest extends IntegrationTestBase
 
     @Test
     public void listDatabasesIntegTest()
+            throws Exception
     {
         logger.info("--------------------------------------");
         logger.info("Executing listDatabasesIntegTest");
@@ -381,6 +388,7 @@ public class MySqlIntegTest extends IntegrationTestBase
 
     @Test
     public void listTablesIntegTest()
+            throws Exception
     {
         logger.info("-----------------------------------");
         logger.info("Executing listTablesIntegTest");
@@ -397,6 +405,7 @@ public class MySqlIntegTest extends IntegrationTestBase
 
     @Test
     public void listTableSchemaIntegTest()
+            throws Exception
     {
         logger.info("--------------------------------------");
         logger.info("Executing listTableSchemaIntegTest");
@@ -419,6 +428,7 @@ public class MySqlIntegTest extends IntegrationTestBase
 
     @Test
     public void selectColumnWithPredicateIntegTest()
+            throws Exception
     {
         logger.info("--------------------------------------------------");
         logger.info("Executing selectColumnWithPredicateIntegTest");
@@ -439,7 +449,9 @@ public class MySqlIntegTest extends IntegrationTestBase
     }
 
     @Test
-    public void selectColumnBetweenDatesIntegTest() {
+    public void selectColumnBetweenDatesIntegTest()
+            throws Exception
+    {
         logger.info("--------------------------------------------------");
         logger.info("Executing selectColumnBetweenDatesIntegTest");
         logger.info("--------------------------------------------------");

--- a/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleMetadataHandler.java
+++ b/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleMetadataHandler.java
@@ -129,6 +129,7 @@ public class OracleMetadataHandler
      */
     @Override
     public void getPartitions(final BlockWriter blockWriter, final GetTableLayoutRequest getTableLayoutRequest, QueryStatusChecker queryStatusChecker)
+            throws Exception
     {
         LOGGER.debug("{}: Schema {}, table {}", getTableLayoutRequest.getQueryId(), getTableLayoutRequest.getTableName().getSchemaName(),
                 getTableLayoutRequest.getTableName().getTableName());
@@ -161,9 +162,6 @@ public class OracleMetadataHandler
                     while (resultSet.next() && queryStatusChecker.isQueryRunning());
                 }
             }
-        }
-        catch (SQLException sqlException) {
-            throw new RuntimeException(sqlException.getErrorCode() + ": " + sqlException.getMessage(), sqlException);
         }
     }
 
@@ -221,15 +219,13 @@ public class OracleMetadataHandler
     }
     @Override
     public GetTableResponse doGetTable(final BlockAllocator blockAllocator, final GetTableRequest getTableRequest)
+          throws Exception
     {
         try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider())) {
             Schema partitionSchema = getPartitionSchema(getTableRequest.getCatalogName());
             TableName tableName = new TableName(getTableRequest.getTableName().getSchemaName().toUpperCase(), getTableRequest.getTableName().getTableName().toUpperCase());
             return new GetTableResponse(getTableRequest.getCatalogName(), tableName, getSchema(connection, tableName, partitionSchema),
                     partitionSchema.getFields().stream().map(Field::getName).collect(Collectors.toSet()));
-        }
-        catch (SQLException sqlException) {
-            throw new RuntimeException(sqlException.getErrorCode() + ": " + sqlException.getMessage());
         }
     }
 
@@ -263,10 +259,10 @@ public class OracleMetadataHandler
      * @param tableName
      * @param partitionSchema
      * @return
-     * @throws SQLException
+     * @throws Exception
      */
     private Schema getSchema(Connection jdbcConnection, TableName tableName, Schema partitionSchema)
-            throws SQLException
+            throws Exception
     {
         SchemaBuilder schemaBuilder = SchemaBuilder.newBuilder();
 

--- a/athena-oracle/src/test/java/com/amazonaws/athena/connectors/oracle/OracleMetadataHandlerTest.java
+++ b/athena-oracle/src/test/java/com/amazonaws/athena/connectors/oracle/OracleMetadataHandlerTest.java
@@ -77,6 +77,7 @@ public class OracleMetadataHandlerTest
 
     @Before
     public void setup()
+            throws Exception
     {
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class, Mockito.RETURNS_DEEP_STUBS);
         this.connection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);
@@ -272,7 +273,7 @@ public class OracleMetadataHandlerTest
 
     @Test
     public void doGetTable()
-            throws SQLException
+            throws Exception
     {
         BlockAllocator blockAllocator = new BlockAllocatorImpl();
         String[] schema = {"DATA_TYPE", "COLUMN_SIZE", "COLUMN_NAME", "DECIMAL_DIGITS", "NUM_PREC_RADIX"};

--- a/athena-oracle/src/test/java/com/amazonaws/athena/connectors/oracle/OracleMuxJdbcMetadataHandlerTest.java
+++ b/athena-oracle/src/test/java/com/amazonaws/athena/connectors/oracle/OracleMuxJdbcMetadataHandlerTest.java
@@ -73,6 +73,7 @@ public class OracleMuxJdbcMetadataHandlerTest
 
     @Test
     public void doListSchemaNames()
+            throws Exception
     {
         ListSchemasRequest listSchemasRequest = Mockito.mock(ListSchemasRequest.class);
         Mockito.when(listSchemasRequest.getCatalogName()).thenReturn("fakedatabase");
@@ -82,6 +83,7 @@ public class OracleMuxJdbcMetadataHandlerTest
 
     @Test
     public void doListTables()
+            throws Exception
     {
         ListTablesRequest listTablesRequest = Mockito.mock(ListTablesRequest.class);
         Mockito.when(listTablesRequest.getCatalogName()).thenReturn("fakedatabase");
@@ -91,6 +93,7 @@ public class OracleMuxJdbcMetadataHandlerTest
 
     @Test
     public void doGetTable()
+            throws Exception
     {
         GetTableRequest getTableRequest = Mockito.mock(GetTableRequest.class);
         Mockito.when(getTableRequest.getCatalogName()).thenReturn("fakedatabase");

--- a/athena-oracle/src/test/java/com/amazonaws/athena/connectors/oracle/OracleMuxJdbcRecordHandlerTest.java
+++ b/athena-oracle/src/test/java/com/amazonaws/athena/connectors/oracle/OracleMuxJdbcRecordHandlerTest.java
@@ -71,6 +71,7 @@ public class OracleMuxJdbcRecordHandlerTest
 
     @Test
     public void readWithConstraint()
+            throws Exception
     {
         BlockSpiller blockSpiller = Mockito.mock(BlockSpiller.class);
         ReadRecordsRequest readRecordsRequest = Mockito.mock(ReadRecordsRequest.class);
@@ -81,6 +82,7 @@ public class OracleMuxJdbcRecordHandlerTest
 
     @Test(expected = RuntimeException.class)
     public void readWithConstraintWithUnsupportedCatalog()
+            throws Exception
     {
         BlockSpiller blockSpiller = Mockito.mock(BlockSpiller.class);
         ReadRecordsRequest readRecordsRequest = Mockito.mock(ReadRecordsRequest.class);

--- a/athena-oracle/src/test/java/com/amazonaws/athena/connectors/oracle/OracleRecordHandlerTest.java
+++ b/athena-oracle/src/test/java/com/amazonaws/athena/connectors/oracle/OracleRecordHandlerTest.java
@@ -64,6 +64,7 @@ public class OracleRecordHandlerTest
     private static final String ORACLE_QUOTE_CHARACTER = "\"";
     @Before
     public void setup()
+            throws Exception
     {
         this.amazonS3 = Mockito.mock(AmazonS3.class);
         this.secretsManager = Mockito.mock(AWSSecretsManager.class);

--- a/athena-oracle/src/test/java/com/amazonaws/athena/connectors/oracle/integ/OracleIntegTest.java
+++ b/athena-oracle/src/test/java/com/amazonaws/athena/connectors/oracle/integ/OracleIntegTest.java
@@ -120,14 +120,9 @@ public class OracleIntegTest extends IntegrationTestBase
     @BeforeClass
     @Override
     protected void setUp()
+            throws Exception
     {
-        try {
-            super.setUp();
-        }
-        catch (Exception e) {
-
-            throw e;
-        }
+        super.setUp();
     }
 
     public OracleIntegTest()

--- a/athena-postgresql/src/main/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlMetadataHandler.java
+++ b/athena-postgresql/src/main/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlMetadataHandler.java
@@ -50,7 +50,6 @@ import org.slf4j.LoggerFactory;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -120,6 +119,7 @@ public class PostGreSqlMetadataHandler
 
     @Override
     public void getPartitions(final BlockWriter blockWriter, final GetTableLayoutRequest getTableLayoutRequest, QueryStatusChecker queryStatusChecker)
+            throws Exception
     {
         LOGGER.info("{}: Catalog {}, table {}", getTableLayoutRequest.getQueryId(), getTableLayoutRequest.getTableName().getSchemaName(),
                 getTableLayoutRequest.getTableName().getTableName());
@@ -154,9 +154,6 @@ public class PostGreSqlMetadataHandler
                     while (resultSet.next());
                 }
             }
-        }
-        catch (SQLException sqlException) {
-            throw new RuntimeException(sqlException.getErrorCode() + ": " + sqlException.getMessage(), sqlException);
         }
     }
 

--- a/athena-postgresql/src/test/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlMetadataHandlerTest.java
+++ b/athena-postgresql/src/test/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlMetadataHandlerTest.java
@@ -86,6 +86,7 @@ public class PostGreSqlMetadataHandlerTest
 
     @Before
     public void setup()
+            throws Exception
     {
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         this.connection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);

--- a/athena-postgresql/src/test/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlMuxJdbcMetadataHandlerTest.java
+++ b/athena-postgresql/src/test/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlMuxJdbcMetadataHandlerTest.java
@@ -71,6 +71,7 @@ public class PostGreSqlMuxJdbcMetadataHandlerTest
 
     @Test
     public void doListSchemaNames()
+            throws Exception
     {
         ListSchemasRequest listSchemasRequest = Mockito.mock(ListSchemasRequest.class);
         Mockito.when(listSchemasRequest.getCatalogName()).thenReturn("postgres");
@@ -80,6 +81,7 @@ public class PostGreSqlMuxJdbcMetadataHandlerTest
 
     @Test
     public void doListTables()
+            throws Exception
     {
         ListTablesRequest listTablesRequest = Mockito.mock(ListTablesRequest.class);
         Mockito.when(listTablesRequest.getCatalogName()).thenReturn("postgres");
@@ -89,6 +91,7 @@ public class PostGreSqlMuxJdbcMetadataHandlerTest
 
     @Test
     public void doGetTable()
+            throws Exception
     {
         GetTableRequest getTableRequest = Mockito.mock(GetTableRequest.class);
         Mockito.when(getTableRequest.getCatalogName()).thenReturn("postgres");

--- a/athena-postgresql/src/test/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlMuxJdbcRecordHandlerTest.java
+++ b/athena-postgresql/src/test/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlMuxJdbcRecordHandlerTest.java
@@ -69,6 +69,7 @@ public class PostGreSqlMuxJdbcRecordHandlerTest
 
     @Test
     public void readWithConstraint()
+            throws Exception
     {
         BlockSpiller blockSpiller = Mockito.mock(BlockSpiller.class);
         ReadRecordsRequest readRecordsRequest = Mockito.mock(ReadRecordsRequest.class);
@@ -79,6 +80,7 @@ public class PostGreSqlMuxJdbcRecordHandlerTest
 
     @Test(expected = RuntimeException.class)
     public void readWithConstraintWithUnsupportedCatalog()
+            throws Exception
     {
         BlockSpiller blockSpiller = Mockito.mock(BlockSpiller.class);
         ReadRecordsRequest readRecordsRequest = Mockito.mock(ReadRecordsRequest.class);

--- a/athena-postgresql/src/test/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlRecordHandlerTest.java
+++ b/athena-postgresql/src/test/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlRecordHandlerTest.java
@@ -72,6 +72,7 @@ public class PostGreSqlRecordHandlerTest extends TestBase
 
     @Before
     public void setup()
+            throws Exception
     {
         this.amazonS3 = Mockito.mock(AmazonS3.class);
         this.secretsManager = Mockito.mock(AWSSecretsManager.class);

--- a/athena-postgresql/src/test/java/com/amazonaws/athena/connectors/postgresql/integ/PostGreSqlIntegTest.java
+++ b/athena-postgresql/src/test/java/com/amazonaws/athena/connectors/postgresql/integ/PostGreSqlIntegTest.java
@@ -117,6 +117,7 @@ public class PostGreSqlIntegTest extends IntegrationTestBase
     @BeforeClass
     @Override
     protected void setUp()
+            throws Exception
     {
         cloudFormationClient = new CloudFormationClient(theApp, getPostGreSqlStack());
         try {
@@ -222,6 +223,7 @@ public class PostGreSqlIntegTest extends IntegrationTestBase
      * Creates the DB schema used for the integration tests.
      */
     private void createDbSchema()
+            throws Exception
     {
         logger.info("----------------------------------------------------");
         logger.info("Setting up DB Schema: {}", postgresDbName);
@@ -271,6 +273,7 @@ public class PostGreSqlIntegTest extends IntegrationTestBase
      */
     @Override
     protected void setUpTableData()
+          throws Exception
     {
         setUpMoviesTable();
         setUpBdayTable();
@@ -283,6 +286,7 @@ public class PostGreSqlIntegTest extends IntegrationTestBase
      * Creates the 'movies' table and inserts rows.
      */
     private void setUpMoviesTable()
+          throws Exception
     {
         logger.info("----------------------------------------------------");
         logger.info("Setting up DB table: {}", postgresTableMovies);
@@ -302,6 +306,7 @@ public class PostGreSqlIntegTest extends IntegrationTestBase
      * Creates the 'bday' table and inserts rows.
      */
     private void setUpBdayTable()
+          throws Exception
     {
         logger.info("----------------------------------------------------");
         logger.info("Setting up DB table: {}", postgresTableBday);
@@ -318,6 +323,7 @@ public class PostGreSqlIntegTest extends IntegrationTestBase
      * Creates the 'datatypes' table and inserts rows.
      */
     protected void setUpDatatypesTable()
+          throws Exception
     {
         logger.info("----------------------------------------------------");
         logger.info("Setting up DB table: {}", TEST_DATATYPES_TABLE_NAME);
@@ -344,6 +350,7 @@ public class PostGreSqlIntegTest extends IntegrationTestBase
      * Creates the 'null_table' table and inserts rows.
      */
     protected void setUpNullTable()
+          throws Exception
     {
         logger.info("----------------------------------------------------");
         logger.info("Setting up DB table: {}", TEST_NULL_TABLE_NAME);
@@ -358,6 +365,7 @@ public class PostGreSqlIntegTest extends IntegrationTestBase
      * Creates the 'empty_table' table and inserts rows.
      */
     protected void setUpEmptyTable()
+          throws Exception
     {
         logger.info("----------------------------------------------------");
         logger.info("Setting up DB table: {}", TEST_EMPTY_TABLE_NAME);
@@ -370,6 +378,7 @@ public class PostGreSqlIntegTest extends IntegrationTestBase
 
     @Test
     public void listDatabasesIntegTest()
+          throws Exception
     {
         logger.info("--------------------------------------");
         logger.info("Executing listDatabasesIntegTest");
@@ -382,6 +391,7 @@ public class PostGreSqlIntegTest extends IntegrationTestBase
 
     @Test
     public void listTablesIntegTest()
+          throws Exception
     {
         logger.info("-----------------------------------");
         logger.info("Executing listTablesIntegTest");
@@ -398,6 +408,7 @@ public class PostGreSqlIntegTest extends IntegrationTestBase
 
     @Test
     public void listTableSchemaIntegTest()
+          throws Exception
     {
         logger.info("--------------------------------------");
         logger.info("Executing listTableSchemaIntegTest");
@@ -420,6 +431,7 @@ public class PostGreSqlIntegTest extends IntegrationTestBase
 
     @Test
     public void selectColumnWithPredicateIntegTest()
+          throws Exception
     {
         logger.info("--------------------------------------------------");
         logger.info("Executing selectColumnWithPredicateIntegTest");
@@ -441,6 +453,7 @@ public class PostGreSqlIntegTest extends IntegrationTestBase
 
     @Test
     public void selectColumnBetweenDatesIntegTest()
+          throws Exception
     {
         logger.info("--------------------------------------------------");
         logger.info("Executing selectColumnBetweenDatesIntegTest");

--- a/athena-redis/src/test/java/com/amazonaws/athena/connectors/redis/integ/RedisIntegTest.java
+++ b/athena-redis/src/test/java/com/amazonaws/athena/connectors/redis/integ/RedisIntegTest.java
@@ -133,6 +133,7 @@ public class RedisIntegTest extends IntegrationTestBase
     @BeforeClass
     @Override
     protected void setUp()
+            throws Exception
     {
         cloudFormationClient = new CloudFormationClient(theApp, getRedisStack());
         try {

--- a/athena-redshift/src/test/java/com/amazonaws/athena/connectors/redshift/RedshiftMetadataHandlerTest.java
+++ b/athena-redshift/src/test/java/com/amazonaws/athena/connectors/redshift/RedshiftMetadataHandlerTest.java
@@ -87,6 +87,7 @@ public class RedshiftMetadataHandlerTest
 
     @Before
     public void setup()
+            throws Exception
     {
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         this.connection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);

--- a/athena-redshift/src/test/java/com/amazonaws/athena/connectors/redshift/RedshiftMuxJdbcMetadataHandlerTest.java
+++ b/athena-redshift/src/test/java/com/amazonaws/athena/connectors/redshift/RedshiftMuxJdbcMetadataHandlerTest.java
@@ -71,6 +71,7 @@ public class RedshiftMuxJdbcMetadataHandlerTest
 
     @Test
     public void doListSchemaNames()
+            throws Exception
     {
         ListSchemasRequest listSchemasRequest = Mockito.mock(ListSchemasRequest.class);
         Mockito.when(listSchemasRequest.getCatalogName()).thenReturn("redshift");
@@ -80,6 +81,7 @@ public class RedshiftMuxJdbcMetadataHandlerTest
 
     @Test
     public void doListTables()
+            throws Exception
     {
         ListTablesRequest listTablesRequest = Mockito.mock(ListTablesRequest.class);
         Mockito.when(listTablesRequest.getCatalogName()).thenReturn("redshift");
@@ -89,6 +91,7 @@ public class RedshiftMuxJdbcMetadataHandlerTest
 
     @Test
     public void doGetTable()
+            throws Exception
     {
         GetTableRequest getTableRequest = Mockito.mock(GetTableRequest.class);
         Mockito.when(getTableRequest.getCatalogName()).thenReturn("redshift");

--- a/athena-redshift/src/test/java/com/amazonaws/athena/connectors/redshift/RedshiftMuxJdbcRecordHandlerTest.java
+++ b/athena-redshift/src/test/java/com/amazonaws/athena/connectors/redshift/RedshiftMuxJdbcRecordHandlerTest.java
@@ -69,6 +69,7 @@ public class RedshiftMuxJdbcRecordHandlerTest
 
     @Test
     public void readWithConstraint()
+            throws Exception
     {
         BlockSpiller blockSpiller = Mockito.mock(BlockSpiller.class);
         ReadRecordsRequest readRecordsRequest = Mockito.mock(ReadRecordsRequest.class);
@@ -79,6 +80,7 @@ public class RedshiftMuxJdbcRecordHandlerTest
 
     @Test(expected = RuntimeException.class)
     public void readWithConstraintWithUnsupportedCatalog()
+            throws Exception
     {
         BlockSpiller blockSpiller = Mockito.mock(BlockSpiller.class);
         ReadRecordsRequest readRecordsRequest = Mockito.mock(ReadRecordsRequest.class);

--- a/athena-redshift/src/test/java/com/amazonaws/athena/connectors/redshift/RedshiftRecordHandlerTest.java
+++ b/athena-redshift/src/test/java/com/amazonaws/athena/connectors/redshift/RedshiftRecordHandlerTest.java
@@ -75,6 +75,7 @@ public class RedshiftRecordHandlerTest
 
     @Before
     public void setup()
+            throws Exception
     {
         this.amazonS3 = Mockito.mock(AmazonS3.class);
         this.secretsManager = Mockito.mock(AWSSecretsManager.class);

--- a/athena-redshift/src/test/java/com/amazonaws/athena/connectors/redshift/integ/RedshiftIntegTest.java
+++ b/athena-redshift/src/test/java/com/amazonaws/athena/connectors/redshift/integ/RedshiftIntegTest.java
@@ -114,6 +114,7 @@ public class RedshiftIntegTest extends IntegrationTestBase
     @BeforeClass
     @Override
     protected void setUp()
+            throws Exception
     {
         cloudFormationClient = new CloudFormationClient(theApp, getRedshiftStack());
         try {
@@ -217,6 +218,7 @@ public class RedshiftIntegTest extends IntegrationTestBase
      * Creates the DB schema used for the integration tests.
      */
     private void createDbSchema()
+            throws Exception
     {
         logger.info("----------------------------------------------------");
         logger.info("Setting up DB Schema: {}", redshiftDbName);
@@ -265,6 +267,7 @@ public class RedshiftIntegTest extends IntegrationTestBase
      */
     @Override
     protected void setUpTableData()
+            throws Exception
     {
         try {
             logger.info("Allowing Redshift cluster to fully warm up - Sleeping for 1 min...");
@@ -284,6 +287,7 @@ public class RedshiftIntegTest extends IntegrationTestBase
      * Creates the 'movies' table and inserts rows.
      */
     private void setUpMoviesTable()
+            throws Exception
     {
         logger.info("----------------------------------------------------");
         logger.info("Setting up DB table: {}", redshiftTableMovies);
@@ -300,6 +304,7 @@ public class RedshiftIntegTest extends IntegrationTestBase
      * Creates the 'bday' table and inserts rows.
      */
     private void setUpBdayTable()
+            throws Exception
     {
         logger.info("----------------------------------------------------");
         logger.info("Setting up DB table: {}", redshiftTableBday);
@@ -317,6 +322,7 @@ public class RedshiftIntegTest extends IntegrationTestBase
      * Creates the 'datatypes' table and inserts rows.
      */
     protected void setUpDatatypesTable()
+            throws Exception
     {
         logger.info("----------------------------------------------------");
         logger.info("Setting up DB table: {}", TEST_DATATYPES_TABLE_NAME);
@@ -348,6 +354,7 @@ public class RedshiftIntegTest extends IntegrationTestBase
      * Creates the 'null_table' table and inserts rows.
      */
     protected void setUpNullTable()
+            throws Exception
     {
         logger.info("----------------------------------------------------");
         logger.info("Setting up DB table: {}", TEST_NULL_TABLE_NAME);
@@ -362,6 +369,7 @@ public class RedshiftIntegTest extends IntegrationTestBase
      * Creates the 'empty_table' table and inserts rows.
      */
     protected void setUpEmptyTable()
+            throws Exception
     {
         logger.info("----------------------------------------------------");
         logger.info("Setting up DB table: {}", TEST_EMPTY_TABLE_NAME);
@@ -373,6 +381,7 @@ public class RedshiftIntegTest extends IntegrationTestBase
 
     @Test
     public void listDatabasesIntegTest()
+            throws Exception
     {
         logger.info("--------------------------------------");
         logger.info("Executing listDatabasesIntegTest");
@@ -385,6 +394,7 @@ public class RedshiftIntegTest extends IntegrationTestBase
 
     @Test
     public void listTablesIntegTest()
+            throws Exception
     {
         logger.info("-----------------------------------");
         logger.info("Executing listTablesIntegTest");
@@ -401,6 +411,7 @@ public class RedshiftIntegTest extends IntegrationTestBase
 
     @Test
     public void listTableSchemaIntegTest()
+            throws Exception
     {
         logger.info("--------------------------------------");
         logger.info("Executing listTableSchemaIntegTest");
@@ -423,6 +434,7 @@ public class RedshiftIntegTest extends IntegrationTestBase
 
     @Test
     public void selectColumnWithPredicateIntegTest()
+            throws Exception
     {
         logger.info("--------------------------------------------------");
         logger.info("Executing selectColumnWithPredicateIntegTest");
@@ -444,6 +456,7 @@ public class RedshiftIntegTest extends IntegrationTestBase
 
     @Test
     public void selectColumnBetweenDatesIntegTest()
+            throws Exception
     {
         logger.info("--------------------------------------------------");
         logger.info("Executing selectColumnBetweenDatesIntegTest");

--- a/athena-saphana/src/test/java/com/amazonaws/athena/connectors/saphana/SaphanaMetadataHandlerTest.java
+++ b/athena-saphana/src/test/java/com/amazonaws/athena/connectors/saphana/SaphanaMetadataHandlerTest.java
@@ -70,6 +70,7 @@ public class SaphanaMetadataHandlerTest
 
     @Before
     public void setup()
+            throws Exception
     {
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class, Mockito.RETURNS_DEEP_STUBS);
         this.connection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);

--- a/athena-saphana/src/test/java/com/amazonaws/athena/connectors/saphana/SaphanaMuxJdbcMetadataHandlerTest.java
+++ b/athena-saphana/src/test/java/com/amazonaws/athena/connectors/saphana/SaphanaMuxJdbcMetadataHandlerTest.java
@@ -67,6 +67,7 @@ public class SaphanaMuxJdbcMetadataHandlerTest {
     }
     @Test
     public void doListSchemaNames()
+            throws Exception
     {
         ListSchemasRequest listSchemasRequest = Mockito.mock(ListSchemasRequest.class);
         Mockito.when(listSchemasRequest.getCatalogName()).thenReturn("fakedatabase");
@@ -76,6 +77,7 @@ public class SaphanaMuxJdbcMetadataHandlerTest {
 
     @Test
     public void doListTables()
+            throws Exception
     {
         ListTablesRequest listTablesRequest = Mockito.mock(ListTablesRequest.class);
         Mockito.when(listTablesRequest.getCatalogName()).thenReturn("fakedatabase");
@@ -85,6 +87,7 @@ public class SaphanaMuxJdbcMetadataHandlerTest {
 
     @Test
     public void doGetTable()
+            throws Exception
     {
         GetTableRequest getTableRequest = Mockito.mock(GetTableRequest.class);
         Mockito.when(getTableRequest.getCatalogName()).thenReturn("fakedatabase");

--- a/athena-saphana/src/test/java/com/amazonaws/athena/connectors/saphana/SaphanaMuxJdbcRecordHandlerTest.java
+++ b/athena-saphana/src/test/java/com/amazonaws/athena/connectors/saphana/SaphanaMuxJdbcRecordHandlerTest.java
@@ -69,6 +69,7 @@ public class SaphanaMuxJdbcRecordHandlerTest
 
     @Test
     public void readWithConstraint()
+            throws Exception
     {
         BlockSpiller blockSpiller = Mockito.mock(BlockSpiller.class);
         ReadRecordsRequest readRecordsRequest = Mockito.mock(ReadRecordsRequest.class);
@@ -79,6 +80,7 @@ public class SaphanaMuxJdbcRecordHandlerTest
 
     @Test(expected = RuntimeException.class)
     public void readWithConstraintWithUnsupportedCatalog()
+            throws Exception
     {
         BlockSpiller blockSpiller = Mockito.mock(BlockSpiller.class);
         ReadRecordsRequest readRecordsRequest = Mockito.mock(ReadRecordsRequest.class);

--- a/athena-saphana/src/test/java/com/amazonaws/athena/connectors/saphana/SaphanaRecordHandlerTest.java
+++ b/athena-saphana/src/test/java/com/amazonaws/athena/connectors/saphana/SaphanaRecordHandlerTest.java
@@ -57,6 +57,7 @@ public class SaphanaRecordHandlerTest
 
     @Before
     public void setup()
+            throws Exception
     {
         this.amazonS3 = Mockito.mock(AmazonS3.class);
         this.secretsManager = Mockito.mock(AWSSecretsManager.class);

--- a/athena-saphana/src/test/java/com/amazonaws/athena/connectors/saphana/integ/SaphanaIntegTest.java
+++ b/athena-saphana/src/test/java/com/amazonaws/athena/connectors/saphana/integ/SaphanaIntegTest.java
@@ -118,14 +118,9 @@ public class SaphanaIntegTest extends IntegrationTestBase
     @BeforeClass
     @Override
     protected void setUp()
+            throws Exception
     {
-        try {
-            super.setUp();
-        }
-        catch (Exception e) {
-
-            throw e;
-        }
+        super.setUp();
     }
 
     public SaphanaIntegTest()

--- a/athena-snowflake/src/test/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMetadataHandlerTest.java
+++ b/athena-snowflake/src/test/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMetadataHandlerTest.java
@@ -68,7 +68,9 @@ public class SnowflakeMetadataHandlerTest
     private static final Schema PARTITION_SCHEMA = SchemaBuilder.newBuilder().addField("partition", org.apache.arrow.vector.types.Types.MinorType.VARCHAR.getType()).build();
 
     @Before
-    public void setup() {
+    public void setup()
+            throws Exception
+    {
 
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class , Mockito.RETURNS_DEEP_STUBS);
         this.connection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);
@@ -408,7 +410,7 @@ public class SnowflakeMetadataHandlerTest
     }
 
     @Test(expected = RuntimeException.class)
-    public void doListSchemaNames() throws SQLException {
+    public void doListSchemaNames() throws Exception {
         BlockAllocator blockAllocator = new BlockAllocatorImpl();
         ListSchemasRequest listSchemasRequest = new ListSchemasRequest(federatedIdentity, "queryId", "testCatalog");
 

--- a/athena-snowflake/src/test/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMuxJdbcMetadataHandlerTest.java
+++ b/athena-snowflake/src/test/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMuxJdbcMetadataHandlerTest.java
@@ -65,6 +65,7 @@ public class SnowflakeMuxJdbcMetadataHandlerTest
 
     @Test
     public void doListSchemaNames()
+            throws Exception
     {
         ListSchemasRequest listSchemasRequest = Mockito.mock(ListSchemasRequest.class);
         Mockito.when(listSchemasRequest.getCatalogName()).thenReturn("fakedatabase");
@@ -74,6 +75,7 @@ public class SnowflakeMuxJdbcMetadataHandlerTest
 
     @Test
     public void doListTables()
+            throws Exception
     {
         ListTablesRequest listTablesRequest = Mockito.mock(ListTablesRequest.class);
         Mockito.when(listTablesRequest.getCatalogName()).thenReturn("fakedatabase");
@@ -83,6 +85,7 @@ public class SnowflakeMuxJdbcMetadataHandlerTest
 
     @Test
     public void doGetTable()
+            throws Exception
     {
         GetTableRequest getTableRequest = Mockito.mock(GetTableRequest.class);
         Mockito.when(getTableRequest.getCatalogName()).thenReturn("fakedatabase");

--- a/athena-snowflake/src/test/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMuxJdbcRecordHandlerTest.java
+++ b/athena-snowflake/src/test/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMuxJdbcRecordHandlerTest.java
@@ -73,6 +73,7 @@ public class SnowflakeMuxJdbcRecordHandlerTest
 
     @Test
     public void readWithConstraint()
+            throws Exception
     {
         BlockSpiller blockSpiller = Mockito.mock(BlockSpiller.class);
         ReadRecordsRequest readRecordsRequest = Mockito.mock(ReadRecordsRequest.class);
@@ -83,6 +84,7 @@ public class SnowflakeMuxJdbcRecordHandlerTest
 
     @Test(expected = RuntimeException.class)
     public void readWithConstraintWithUnsupportedCatalog()
+            throws Exception
     {
         BlockSpiller blockSpiller = Mockito.mock(BlockSpiller.class);
         ReadRecordsRequest readRecordsRequest = Mockito.mock(ReadRecordsRequest.class);

--- a/athena-snowflake/src/test/java/com/amazonaws/athena/connectors/snowflake/SnowflakeRecordHandlerTest.java
+++ b/athena-snowflake/src/test/java/com/amazonaws/athena/connectors/snowflake/SnowflakeRecordHandlerTest.java
@@ -62,6 +62,7 @@ public class SnowflakeRecordHandlerTest
 
     @Before
     public void setup()
+            throws Exception
     {
         this.amazonS3 = Mockito.mock(AmazonS3.class);
         this.secretsManager = Mockito.mock(AWSSecretsManager.class);

--- a/athena-snowflake/src/test/java/com/amazonaws/athena/connectors/snowflake/integ/SnowflakeIntegTest.java
+++ b/athena-snowflake/src/test/java/com/amazonaws/athena/connectors/snowflake/integ/SnowflakeIntegTest.java
@@ -113,14 +113,9 @@ public class SnowflakeIntegTest extends IntegrationTestBase
     @BeforeClass
     @Override
     protected void setUp()
+            throws Exception
     {
-        try {
-            super.setUp();
-        }
-        catch (Exception e) {
-
-            throw e;
-        }
+        super.setUp();
     }
 
     public SnowflakeIntegTest()

--- a/athena-sqlserver/src/test/java/com/amazonaws/athena/connectors/sqlserver/SqlServerMetadataHandlerTest.java
+++ b/athena-sqlserver/src/test/java/com/amazonaws/athena/connectors/sqlserver/SqlServerMetadataHandlerTest.java
@@ -85,6 +85,7 @@ public class SqlServerMetadataHandlerTest
 
     @Before
     public void setup()
+            throws Exception
     {
         System.setProperty("aws.region", "us-east-1");
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class, Mockito.RETURNS_DEEP_STUBS);
@@ -407,6 +408,7 @@ public class SqlServerMetadataHandlerTest
 
     @Test
     public void doListSchemaNames()
+            throws Exception
     {
         ListSchemasRequest listSchemasRequest = Mockito.mock(ListSchemasRequest.class);
         Mockito.when(listSchemasRequest.getCatalogName()).thenReturn("fakedatabase");

--- a/athena-sqlserver/src/test/java/com/amazonaws/athena/connectors/sqlserver/SqlServerMuxMetadataHandlerTest.java
+++ b/athena-sqlserver/src/test/java/com/amazonaws/athena/connectors/sqlserver/SqlServerMuxMetadataHandlerTest.java
@@ -69,6 +69,7 @@ public class SqlServerMuxMetadataHandlerTest
 
     @Test
     public void doListSchemaNames()
+            throws Exception
     {
         ListSchemasRequest listSchemasRequest = Mockito.mock(ListSchemasRequest.class);
         Mockito.when(listSchemasRequest.getCatalogName()).thenReturn("fakedatabase");
@@ -78,6 +79,7 @@ public class SqlServerMuxMetadataHandlerTest
 
     @Test
     public void doListTables()
+            throws Exception
     {
         ListTablesRequest listTablesRequest = Mockito.mock(ListTablesRequest.class);
         Mockito.when(listTablesRequest.getCatalogName()).thenReturn("fakedatabase");
@@ -87,6 +89,7 @@ public class SqlServerMuxMetadataHandlerTest
 
     @Test
     public void doGetTable()
+            throws Exception
     {
         GetTableRequest getTableRequest = Mockito.mock(GetTableRequest.class);
         Mockito.when(getTableRequest.getCatalogName()).thenReturn("fakedatabase");

--- a/athena-sqlserver/src/test/java/com/amazonaws/athena/connectors/sqlserver/SqlServerMuxRecordHandlerTest.java
+++ b/athena-sqlserver/src/test/java/com/amazonaws/athena/connectors/sqlserver/SqlServerMuxRecordHandlerTest.java
@@ -69,6 +69,7 @@ public class SqlServerMuxRecordHandlerTest
 
     @Test
     public void readWithConstraint()
+            throws Exception
     {
         BlockSpiller blockSpiller = Mockito.mock(BlockSpiller.class);
         ReadRecordsRequest readRecordsRequest = Mockito.mock(ReadRecordsRequest.class);
@@ -79,6 +80,7 @@ public class SqlServerMuxRecordHandlerTest
 
     @Test(expected = RuntimeException.class)
     public void readWithConstraintWithUnsupportedCatalog()
+            throws Exception
     {
         BlockSpiller blockSpiller = Mockito.mock(BlockSpiller.class);
         ReadRecordsRequest readRecordsRequest = Mockito.mock(ReadRecordsRequest.class);

--- a/athena-sqlserver/src/test/java/com/amazonaws/athena/connectors/sqlserver/SqlServerRecordHandlerTest.java
+++ b/athena-sqlserver/src/test/java/com/amazonaws/athena/connectors/sqlserver/SqlServerRecordHandlerTest.java
@@ -60,6 +60,7 @@ public class SqlServerRecordHandlerTest
 
     @Before
     public void setup()
+            throws Exception
     {
         System.setProperty("aws.region", "us-east-1");
         this.amazonS3 = Mockito.mock(AmazonS3.class);

--- a/athena-sqlserver/src/test/java/com/amazonaws/athena/connectors/sqlserver/integ/SqlServerIntegTest.java
+++ b/athena-sqlserver/src/test/java/com/amazonaws/athena/connectors/sqlserver/integ/SqlServerIntegTest.java
@@ -106,14 +106,9 @@ public class SqlServerIntegTest extends IntegrationTestBase {
     @BeforeClass
     @Override
     protected void setUp()
+            throws Exception
     {
-        try {
-            super.setUp();
-        }
-        catch (Exception e) {
-
-            throw e;
-        }
+        super.setUp();
     }
 
     public SqlServerIntegTest()

--- a/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseMetadataHandler.java
+++ b/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseMetadataHandler.java
@@ -204,9 +204,6 @@ public class SynapseMetadataHandler extends JdbcMetadataHandler
                 }
             }
         }
-        catch (SQLException sqlException) {
-            throw new SQLException(sqlException.getErrorCode() + ": " + sqlException.getMessage(), sqlException);
-        }
     }
 
     /**
@@ -274,15 +271,13 @@ public class SynapseMetadataHandler extends JdbcMetadataHandler
      */
     @Override
     public GetTableResponse doGetTable(final BlockAllocator blockAllocator, final GetTableRequest getTableRequest)
+            throws Exception
     {
         try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider())) {
             Schema partitionSchema = getPartitionSchema(getTableRequest.getCatalogName());
             TableName tableName = new TableName(getTableRequest.getTableName().getSchemaName().toUpperCase(), getTableRequest.getTableName().getTableName().toUpperCase());
             return new GetTableResponse(getTableRequest.getCatalogName(), tableName, getSchema(connection, tableName, partitionSchema),
                     partitionSchema.getFields().stream().map(Field::getName).collect(Collectors.toSet()));
-        }
-        catch (SQLException sqlException) {
-            throw new RuntimeException(sqlException.getErrorCode() + ": " + sqlException.getMessage());
         }
     }
 
@@ -292,10 +287,10 @@ public class SynapseMetadataHandler extends JdbcMetadataHandler
      * @param tableName
      * @param partitionSchema
      * @return
-     * @throws SQLException
+     * @throws Exception
      */
     private Schema getSchema(Connection jdbcConnection, TableName tableName, Schema partitionSchema)
-            throws SQLException
+            throws Exception
     {
         LOGGER.info("Inside getSchema");
 

--- a/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseRecordHandler.java
+++ b/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseRecordHandler.java
@@ -90,6 +90,7 @@ public class SynapseRecordHandler extends JdbcRecordHandler
 
     @Override
     public void readWithConstraint(BlockSpiller blockSpiller, ReadRecordsRequest readRecordsRequest, QueryStatusChecker queryStatusChecker)
+            throws Exception
     {
         LOGGER.info("{}: Catalog: {}, table {}, splits {}", readRecordsRequest.getQueryId(), readRecordsRequest.getCatalogName(), readRecordsRequest.getTableName(),
                 readRecordsRequest.getSplit().getProperties());
@@ -131,9 +132,6 @@ public class SynapseRecordHandler extends JdbcRecordHandler
                     connection.commit();
                 }
             }
-        }
-        catch (SQLException sqlException) {
-            throw new RuntimeException(sqlException.getErrorCode() + ": " + sqlException.getMessage(), sqlException);
         }
     }
 }

--- a/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/SynapseMetadataHandlerTest.java
+++ b/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/SynapseMetadataHandlerTest.java
@@ -82,6 +82,7 @@ public class SynapseMetadataHandlerTest
 
     @Before
     public void setup()
+            throws Exception
     {
         System.setProperty("aws.region", "us-east-1");
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class, Mockito.RETURNS_DEEP_STUBS);

--- a/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/SynapseMuxMetadataHandlerTest.java
+++ b/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/SynapseMuxMetadataHandlerTest.java
@@ -69,6 +69,7 @@ public class SynapseMuxMetadataHandlerTest
 
     @Test
     public void doListSchemaNames()
+            throws Exception
     {
         ListSchemasRequest listSchemasRequest = Mockito.mock(ListSchemasRequest.class);
         Mockito.when(listSchemasRequest.getCatalogName()).thenReturn("fakedatabase");
@@ -78,6 +79,7 @@ public class SynapseMuxMetadataHandlerTest
 
     @Test
     public void doListTables()
+            throws Exception
     {
         ListTablesRequest listTablesRequest = Mockito.mock(ListTablesRequest.class);
         Mockito.when(listTablesRequest.getCatalogName()).thenReturn("fakedatabase");
@@ -87,6 +89,7 @@ public class SynapseMuxMetadataHandlerTest
 
     @Test
     public void doGetTable()
+            throws Exception
     {
         GetTableRequest getTableRequest = Mockito.mock(GetTableRequest.class);
         Mockito.when(getTableRequest.getCatalogName()).thenReturn("fakedatabase");

--- a/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/SynapseMuxRecordHandlerTest.java
+++ b/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/SynapseMuxRecordHandlerTest.java
@@ -69,6 +69,7 @@ public class SynapseMuxRecordHandlerTest
 
     @Test
     public void readWithConstraint()
+            throws Exception
     {
         BlockSpiller blockSpiller = Mockito.mock(BlockSpiller.class);
         ReadRecordsRequest readRecordsRequest = Mockito.mock(ReadRecordsRequest.class);
@@ -79,6 +80,7 @@ public class SynapseMuxRecordHandlerTest
 
     @Test(expected = RuntimeException.class)
     public void readWithConstraintWithUnsupportedCatalog()
+            throws Exception
     {
         BlockSpiller blockSpiller = Mockito.mock(BlockSpiller.class);
         ReadRecordsRequest readRecordsRequest = Mockito.mock(ReadRecordsRequest.class);

--- a/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/SynapseRecordHandlerTest.java
+++ b/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/SynapseRecordHandlerTest.java
@@ -60,6 +60,7 @@ public class SynapseRecordHandlerTest
 
     @Before
     public void setup()
+            throws Exception
     {
         this.amazonS3 = Mockito.mock(AmazonS3.class);
         this.secretsManager = Mockito.mock(AWSSecretsManager.class);

--- a/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/integ/AzureSynapseIntegTest.java
+++ b/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/integ/AzureSynapseIntegTest.java
@@ -112,13 +112,9 @@ public class AzureSynapseIntegTest extends IntegrationTestBase
     @BeforeClass
     @Override
     protected void setUp()
+            throws Exception
     {
-        try {
-            super.setUp();
-        }
-        catch (Exception e) {
-            throw e;
-        }
+        super.setUp();
     }
 
     public AzureSynapseIntegTest()

--- a/athena-teradata/src/test/java/com/amazonaws/athena/connectors/teradata/TeradataMetadataHandlerTest.java
+++ b/athena-teradata/src/test/java/com/amazonaws/athena/connectors/teradata/TeradataMetadataHandlerTest.java
@@ -290,7 +290,7 @@ public class TeradataMetadataHandlerTest
     }
     @Test
     public void doGetTable()
-            throws SQLException
+            throws Exception
     {
         String[] schema = {"DATA_TYPE", "COLUMN_SIZE", "COLUMN_NAME", "DECIMAL_DIGITS", "NUM_PREC_RADIX"};
         Object[][] values = {{Types.INTEGER, 12, "testCol1", 0, 0}, {Types.VARCHAR, 25, "testCol2", 0, 0},

--- a/athena-teradata/src/test/java/com/amazonaws/athena/connectors/teradata/TeradataMuxJdbcMetadataHandlerTest.java
+++ b/athena-teradata/src/test/java/com/amazonaws/athena/connectors/teradata/TeradataMuxJdbcMetadataHandlerTest.java
@@ -65,6 +65,7 @@ public class TeradataMuxJdbcMetadataHandlerTest {
     }
     @Test
     public void doListSchemaNames()
+            throws Exception
     {
         ListSchemasRequest listSchemasRequest = Mockito.mock(ListSchemasRequest.class);
         Mockito.when(listSchemasRequest.getCatalogName()).thenReturn("fakedatabase");
@@ -74,6 +75,7 @@ public class TeradataMuxJdbcMetadataHandlerTest {
 
     @Test
     public void doListTables()
+            throws Exception
     {
         ListTablesRequest listTablesRequest = Mockito.mock(ListTablesRequest.class);
         Mockito.when(listTablesRequest.getCatalogName()).thenReturn("fakedatabase");
@@ -83,6 +85,7 @@ public class TeradataMuxJdbcMetadataHandlerTest {
 
     @Test
     public void doGetTable()
+            throws Exception
     {
         GetTableRequest getTableRequest = Mockito.mock(GetTableRequest.class);
         Mockito.when(getTableRequest.getCatalogName()).thenReturn("fakedatabase");

--- a/athena-teradata/src/test/java/com/amazonaws/athena/connectors/teradata/TeradataMuxJdbcRecordHandlerTest.java
+++ b/athena-teradata/src/test/java/com/amazonaws/athena/connectors/teradata/TeradataMuxJdbcRecordHandlerTest.java
@@ -69,6 +69,7 @@ public class TeradataMuxJdbcRecordHandlerTest
 
     @Test
     public void readWithConstraint()
+            throws Exception
     {
         BlockSpiller blockSpiller = Mockito.mock(BlockSpiller.class);
         ReadRecordsRequest readRecordsRequest = Mockito.mock(ReadRecordsRequest.class);
@@ -79,6 +80,7 @@ public class TeradataMuxJdbcRecordHandlerTest
 
     @Test(expected = RuntimeException.class)
     public void readWithConstraintWithUnsupportedCatalog()
+            throws Exception
     {
         BlockSpiller blockSpiller = Mockito.mock(BlockSpiller.class);
         ReadRecordsRequest readRecordsRequest = Mockito.mock(ReadRecordsRequest.class);

--- a/athena-teradata/src/test/java/com/amazonaws/athena/connectors/teradata/TeradataRecordHandlerTest.java
+++ b/athena-teradata/src/test/java/com/amazonaws/athena/connectors/teradata/TeradataRecordHandlerTest.java
@@ -57,6 +57,7 @@ public class TeradataRecordHandlerTest
 
     @Before
     public void setup()
+            throws Exception
     {
         this.amazonS3 = Mockito.mock(AmazonS3.class);
         this.secretsManager = Mockito.mock(AWSSecretsManager.class);

--- a/athena-teradata/src/test/java/com/amazonaws/athena/connectors/teradata/integ/TeradataIntegTest.java
+++ b/athena-teradata/src/test/java/com/amazonaws/athena/connectors/teradata/integ/TeradataIntegTest.java
@@ -109,14 +109,9 @@ public class TeradataIntegTest extends IntegrationTestBase
     @BeforeClass
     @Override
     protected void setUp()
+            throws Exception
     {
-        try {
-            super.setUp();
-        }
-        catch (Exception e) {
-
-            throw e;
-        }
+        super.setUp();
     }
 
     public TeradataIntegTest()

--- a/athena-timestream/src/test/java/com/amazonaws/athena/connectors/timestream/integ/TimestreamIntegTest.java
+++ b/athena-timestream/src/test/java/com/amazonaws/athena/connectors/timestream/integ/TimestreamIntegTest.java
@@ -84,6 +84,7 @@ public class TimestreamIntegTest extends IntegrationTestBase
     @BeforeClass
     @Override
     protected void setUp()
+            throws Exception
     {
         try {
             // Invoke the framework's setUp() that also creates the Timestream database.

--- a/athena-vertica/src/test/java/com/amazonaws/athena/connectors/vertica/VerticaMetadataHandlerTest.java
+++ b/athena-vertica/src/test/java/com/amazonaws/athena/connectors/vertica/VerticaMetadataHandlerTest.java
@@ -309,7 +309,7 @@ public class VerticaMetadataHandlerTest extends TestBase
 
 
     @Test
-    public void doGetSplits() {
+    public void doGetSplits() throws SQLException {
 
         logger.info("doGetSplits: enter");
 


### PR DESCRIPTION
There are several instances in the code where we caught an exception just to rethrow it as a RuntimeException.

Sometimes this was due to the interfaces not declaring that they throw, so the implementations were forced to catch exceptions and then rethrow them as RuntimeExceptions.

This patch fixes the interfaces and implementations that inherit from those interfaces to not catch just to rethrow.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
