### PR TITLE
BlockUtils ClassCastException

### DIFF
--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/BlockUtils.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/BlockUtils.java
@@ -851,6 +851,9 @@ public class BlockUtils
                     if (value == null) {
                         float8Writer.writeNull();
                     }
+                    else if (value instanceof Integer) {
+                        float8Writer.writeFloat8((int) value);
+                    }
                     else {
                         float8Writer.writeFloat8((double) value);
                     }


### PR DESCRIPTION
[Issue #790](https://github.com/awslabs/aws-athena-query-federation/issues/790)

Resolve ClassCastException in BlockUtils where integer values are being incorrectly casted. Verified that the changes work with the DocDB example provided in issue #790.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
