### PR TITLE
AWS Signer set empty content

### DIFF
--- a/athena-elasticsearch/src/main/java/com/amazonaws/athena/connectors/elasticsearch/AWSRequestSigningApacheInterceptor.java
+++ b/athena-elasticsearch/src/main/java/com/amazonaws/athena/connectors/elasticsearch/AWSRequestSigningApacheInterceptor.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -35,6 +35,7 @@ import org.apache.http.entity.BasicHttpEntity;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.protocol.HttpContext;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -119,6 +120,9 @@ public class AWSRequestSigningApacheInterceptor implements HttpRequestIntercepto
                     (HttpEntityEnclosingRequest) request;
             if (httpEntityEnclosingRequest.getEntity() != null) {
                 signableRequest.setContent(httpEntityEnclosingRequest.getEntity().getContent());
+            }
+            else {
+                signableRequest.setContent(new ByteArrayInputStream(new byte[0]));
             }
         }
         signableRequest.setParameters(nvpToMapParams(uriBuilder.getQueryParams()));

--- a/athena-elasticsearch/src/main/java/com/amazonaws/athena/connectors/elasticsearch/AWSRequestSigningApacheInterceptor.java
+++ b/athena-elasticsearch/src/main/java/com/amazonaws/athena/connectors/elasticsearch/AWSRequestSigningApacheInterceptor.java
@@ -122,6 +122,7 @@ public class AWSRequestSigningApacheInterceptor implements HttpRequestIntercepto
                 signableRequest.setContent(httpEntityEnclosingRequest.getEntity().getContent());
             }
             else {
+                // This is a workaround from here: https://github.com/aws/aws-sdk-java/issues/2078
                 signableRequest.setContent(new ByteArrayInputStream(new byte[0]));
             }
         }


### PR DESCRIPTION
[Issue 510](https://github.com/awslabs/aws-athena-query-federation/issues/510)
[Issue 340](https://github.com/awslabs/aws-athena-query-federation/issues/340)

AWS Signer: workaround for null content failure by setting an empty body. [See here for the discussion and suggested fix](https://github.com/aws/aws-sdk-java/issues/2078).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
