### PR TITLE
Added table_schema condition in COUNT_RECORDS_QUERY to get the correct row count.

### DIFF
--- a/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMetadataHandler.java
+++ b/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMetadataHandler.java
@@ -93,6 +93,7 @@ public class SnowflakeMetadataHandler extends JdbcMetadataHandler
     static final String COUNT_RECORDS_QUERY = "SELECT row_count\n" +
             "FROM   information_schema.tables\n" +
             "WHERE  table_type = 'BASE TABLE'\n" +
+            "AND table_schema= ?\n" +
             "AND TABLE_NAME = ? ";
     private static final String CASE_UPPER = "upper";
     private static final String CASE_LOWER = "lower";
@@ -173,7 +174,7 @@ public class SnowflakeMetadataHandler extends JdbcMetadataHandler
         else {
             double totalRecordCount = 0;
             LOGGER.info(COUNT_RECORDS_QUERY);
-            List<String> parameters = Arrays.asList(getTableLayoutRequest.getTableName().getTableName());
+            List<String> parameters = Arrays.asList(getTableLayoutRequest.getTableName().getSchemaName(), getTableLayoutRequest.getTableName().getTableName());
 
             try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider());
                  PreparedStatement preparedStatement = new PreparedStatementBuilder().withConnection(connection)

--- a/athena-snowflake/src/test/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMetadataHandlerTest.java
+++ b/athena-snowflake/src/test/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMetadataHandlerTest.java
@@ -127,7 +127,7 @@ public class SnowflakeMetadataHandlerTest
         Assert.assertEquals(expectedSchema, getTableLayoutResponse.getPartitions().getSchema());
         Assert.assertEquals(tableName, getTableLayoutResponse.getTableName());
 
-        Mockito.verify(preparedStatement, Mockito.times(1)).setString(1, tableName.getTableName());
+        Mockito.verify(preparedStatement, Mockito.times(1)).setString(1, tableName.getSchemaName());
         Mockito.verify(resultSet, Mockito.times(2)).getInt(1);
     }
 
@@ -168,7 +168,8 @@ public class SnowflakeMetadataHandlerTest
         Assert.assertEquals(expectedSchema, getTableLayoutResponse.getPartitions().getSchema());
         Assert.assertEquals(tableName, getTableLayoutResponse.getTableName());
 
-        Mockito.verify(preparedStatement, Mockito.times(1)).setString(1, tableName.getTableName());
+        Mockito.verify(preparedStatement, Mockito.times(1)).setString(1, tableName.getSchemaName());
+        Mockito.verify(preparedStatement, Mockito.times(1)).setString(2, tableName.getTableName());
         Mockito.verify(resultSet, Mockito.times(1)).getInt(1);
     }
 
@@ -227,7 +228,8 @@ public class SnowflakeMetadataHandlerTest
         Schema expectedSchema = expectedSchemaBuilder.build();
         Assert.assertEquals(expectedSchema, getTableLayoutResponse.getPartitions().getSchema());
         Assert.assertEquals(tableName, getTableLayoutResponse.getTableName());
-        Mockito.verify(preparedStatement, Mockito.times(1)).setString(1, tableName.getTableName());
+        Mockito.verify(preparedStatement, Mockito.times(1)).setString(1, tableName.getSchemaName());
+        Mockito.verify(preparedStatement, Mockito.times(1)).setString(2, tableName.getTableName());
         Mockito.verify(resultSet, Mockito.times(1)).getInt(1);
     }
 


### PR DESCRIPTION
*Issue # INC00001086, Check only last row count with connector snowflake.

*Description of changes:*
Added table_schema condition in COUNT_RECORDS_QUERY,to check for the table in that particular schema and give the correct row count.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
