### PR TITLE
Add CompositeHandler parameter to CF template

### DIFF
--- a/athena-postgresql/athena-postgresql.yaml
+++ b/athena-postgresql/athena-postgresql.yaml
@@ -48,6 +48,10 @@ Parameters:
   SubnetIds:
     Description: 'One or more Subnet IDs corresponding to the Subnet that the Lambda function can use to access you data source. (e.g. subnet1,subnet2)'
     Type: 'List<AWS::EC2::Subnet::Id>'
+  CompositeHandler:
+    Description: 'Use "PostGreSqlMuxCompositeHandler" to access multiple postgres instances and "PostGreSqlCompositeHandler" to access single instance using DefaultConnectionString'
+    Type: String
+    AllowedValues : ["PostGreSqlMuxCompositeHandler", "PostGreSqlCompositeHandler"]
 Resources:
   JdbcConnectorConfig:
     Type: 'AWS::Serverless::Function'
@@ -59,7 +63,7 @@ Resources:
           spill_prefix: !Ref SpillPrefix
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
-      Handler: "com.amazonaws.athena.connectors.postgresql.PostGreSqlMuxCompositeHandler"
+      Handler: !Sub "com.amazonaws.athena.connectors.postgresql.${CompositeHandler}"
       CodeUri: "./target/athena-postgresql-2022.42.2.jar"
       Description: "Enables Amazon Athena to communicate with PostgreSQL using JDBC"
       Runtime: java11


### PR DESCRIPTION
*Description of changes:*
We need to add an extra env variable for connection string manually to the lambda function for Athena to access any database. By allowing to use different handler we can use the Default connection string when we only have one postgres instance.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
