### PR TITLE
Add logic to check and handle bounds of Decimal type

### DIFF
--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcArrowTypeConverter.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcArrowTypeConverter.java
@@ -32,6 +32,8 @@ import org.slf4j.LoggerFactory;
 public final class JdbcArrowTypeConverter
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(JdbcMetadataHandler.class);
+    private static final int PRECISION_MAX = 38;
+    private static final int PRECISION_MIN = 1;
 
     private JdbcArrowTypeConverter() {}
 
@@ -45,8 +47,12 @@ public final class JdbcArrowTypeConverter
      */
     public static ArrowType toArrowType(final int jdbcType, final int precision, final int scale)
     {
+        // Check that Precision and Scale are within bounds
+        int defaultPrecision = ((precision > PRECISION_MAX) || (precision < PRECISION_MIN)) ? PRECISION_MAX : precision;
+        int defaultScale = (scale > defaultPrecision) ? defaultPrecision : scale;
+
         ArrowType arrowType = JdbcToArrowUtils.getArrowTypeFromJdbcType(
-                new JdbcFieldInfo(jdbcType, precision, scale),
+                new JdbcFieldInfo(jdbcType, defaultPrecision, defaultScale),
                 null);
 
         if (arrowType instanceof ArrowType.Date) {


### PR DESCRIPTION
*Issue #, if available:*
[BUG] Incompatible mapping for postgres numeric columns with connector Athena.JDBC https://github.com/awslabs/aws-athena-query-federation/issues/360

*Description of changes:*
Numeric data type that is initialized with no parameters in Postgres, gets converted into JDBC type Decimal with *precision* 0 and *scale 0*, which are invalid.

In *Athena* the Decimal type has 2 parameters: Precision and Scale.
- Precision has the bounds of **[1, 38]**
- Scale *(optional, default value is 0)* can't be greater than precision.

Added logic that checks the bounds of decimal data type, when converting JDBC type to Arrow type. If out of bounds, sets parameters to default values.

Query will no longer fail if. Only Decimal data value require precision and scale parameters so other data types would not be affected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
