### PR TITLE
Avoid errors on null values for dynamodb

### DIFF
--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/resolver/DynamoDBFieldResolver.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/resolver/DynamoDBFieldResolver.java
@@ -82,6 +82,10 @@ public class DynamoDBFieldResolver
                 return DDBTypeUtils.coerceValueToExpectedType(fieldValue, field, fieldType, metadata);
         }
 
+	if (fieldValue == null) {
+            return null;
+	}
+
         throw new RuntimeException("Invalid field value encountered in DB record for field: " + field +
                 ",value: " + fieldValue);
     }

--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/resolver/DynamoDBFieldResolver.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/resolver/DynamoDBFieldResolver.java
@@ -82,9 +82,9 @@ public class DynamoDBFieldResolver
                 return DDBTypeUtils.coerceValueToExpectedType(fieldValue, field, fieldType, metadata);
         }
 
-	if (fieldValue == null) {
+        if (fieldValue == null) {
             return null;
-	}
+        }
 
         throw new RuntimeException("Invalid field value encountered in DB record for field: " + field +
                 ",value: " + fieldValue);

--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/resolver/DynamoDBFieldResolver.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/resolver/DynamoDBFieldResolver.java
@@ -69,6 +69,10 @@ public class DynamoDBFieldResolver
             }
         }
 
+        if (fieldValue == null) {
+            return null;
+        }
+
         switch (fieldType) {
             case LIST:
                 return DDBTypeUtils.coerceListToExpectedType(fieldValue, field, metadata);
@@ -80,10 +84,6 @@ public class DynamoDBFieldResolver
                 break;
             default:
                 return DDBTypeUtils.coerceValueToExpectedType(fieldValue, field, fieldType, metadata);
-        }
-
-        if (fieldValue == null) {
-            return null;
         }
 
         throw new RuntimeException("Invalid field value encountered in DB record for field: " + field +


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/aws-athena-query-federation/issues/399

*Description of changes:*
As described in the issue, dynamodb connector breaks when there is `null` values in complex structures. There is a comment in the original issue mentioning that [this PR](https://github.com/awslabs/aws-athena-query-federation/pull/780) fixed the issue, but I'm still facing the same described error when my data structure contains `null`.

I've tested manually the connector with the following change, and it works fine.

I would like some feedback to know if this is an acceptable change, and if anything else would be needed for this PR to be accepted.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
