### PR TITLE
Implemented pagination logic in AthenaGoogleBigQueryConnector

### DIFF
--- a/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryConstants.java
+++ b/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryConstants.java
@@ -30,7 +30,7 @@ public class BigQueryConstants
     /**
      * The maximum number of datasets and tables that can be returned from Google BigQuery API calls for metadata.
      */
-    public static final long MAX_RESULTS = 10_000;
+    public static final long MAX_RESULTS = 100_000;
 
     /**
      * The Project ID within the Google Cloud Platform where the datasets and tables exist to query.


### PR DESCRIPTION
*Issue # INC00001088, Implemented Pagination in  AthenaGoogleBigQueryConnector.

Description of changes:
The connector was throwing an exception when BigQueryConstants.MAX_RESULTS was exceeded instead of correctly returning all of the results.
With the new pagination logic its handled by returning paginated results.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
