### PR TITLE
Reduce Privileges of Lambda Role for Timestream

### DIFF
--- a/athena-timestream/athena-timestream.yaml
+++ b/athena-timestream/athena-timestream.yaml
@@ -65,8 +65,9 @@ Resources:
                 - glue:GetDatabase
                 - athena:GetQueryExecution
                 - s3:ListAllMyBuckets
-                #TODO: make this more specific later
-                - timestream:*
+                - timestream:Describe*
+                - timestream:List*
+                - timestream:Select*
               Effect: Allow
               Resource: '*'
           Version: '2012-10-17'


### PR DESCRIPTION
- Previously, timestream:* actions were applied to the lambda's policy
- Now, we reduce to specific read operations for least privilege

*Issue #, if available:*

*Description of changes:*

Testing Done:

Deployed the connector to an aws account and ran the following queries against an existing timestream table:

Query 1 - describe the table
```
describe `lambda:timestream-least-privilege`.`timestream-db`.`timestream-store-sales-mini`
```
I see all the results.

Query 2 - select * (no projection)
```
select * from "lambda:timestream-least-privilege"."timestream-db"."timestream-store-sales-mini" limit 500;
```
This works too.

Query 3 - select with projection
```
select ss_cdemo_sk, ss_promo_sk from "lambda:timestream-least-privilege"."timestream-db"."timestream-store-sales-mini" limit 500;
```
This works too.

Query 4 - select with predicate
```
select * from "lambda:timestream-least-privilege"."timestream-db"."timestream-store-sales-mini"
where "ss_promo_sk"='65'
```
This works too.

Query 5 - cancel a query while it's running -> Athena successfully cancels the query without issue.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
