### PR TITLE
Fix athena-saphana.yaml after changing from maven-assembly to maven-shade

### DIFF
--- a/athena-saphana/athena-saphana.yaml
+++ b/athena-saphana/athena-saphana.yaml
@@ -60,7 +60,7 @@ Resources:
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.saphana.SaphanaMuxCompositeHandler"
-      CodeUri: "./target/athena-saphana.zip"
+      CodeUri: "./target/athena-saphana-2022.47.1.jar"
       Description: "Enables Amazon Athena to communicate with Teradata using JDBC"
       Runtime: java11
       Timeout: !Ref LambdaTimeout


### PR DESCRIPTION
Fix athena-saphana.yaml after changing from maven-assembly to maven-shade




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
