### PR TITLE
Update maven_push.yml to build with 8 cpus

### DIFF
--- a/.github/workflows/maven_push.yml
+++ b/.github/workflows/maven_push.yml
@@ -14,4 +14,4 @@ jobs:
       with:
         java-version: 11
     - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      run: mvn -B package -T8 --file pom.xml


### PR DESCRIPTION
We're using self hosted runners, so try with -T8



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
