### PR TITLE
codeql-analysis.yml: try to fix permissions error

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,8 +10,10 @@ on:
 
 jobs:
   CodeQL-Build:
-
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
Error:
```
Workflows triggered by Dependabot on the "push" event run with read-only access. Uploading Code Scanning results requires write access. To use Code Scanning with Dependabot, please ensure you are using the "pull_request" event for this workflow and avoid triggering on the "push" event for Dependabot branches. See https://docs.github.com/en/code-security/secure-coding/configuring-code-scanning#scanning-on-push for more information on how to configure these events.
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
