### PR TITLE
athena-msk: rename auth_type options to be more descriptive

### DIFF
--- a/athena-msk/athena-msk.yaml
+++ b/athena-msk/athena-msk.yaml
@@ -15,16 +15,16 @@ Metadata:
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AuthType:
-    Description: 'auth details TLS/SCRAM/IAM/NOAUTH/SASL_PLAINTEXT/SASL_SSL'
+    Description: 'Authentication details'
     Type: String
-    Default: NOAUTH
+    Default: NO_AUTH
     AllowedValues:
-      - TLS
-      - SCRAM
-      - NOAUTH
-      - IAM
-      - SASL_PLAINTEXT
-      - SASL_SSL
+      - SASL_SSL_AWS_MSK_IAM
+      - SASL_SSL_SCRAM_SHA512
+      - SASL_SSL_PLAIN
+      - SASL_PLAINTEXT_PLAIN
+      - SSL
+      - NO_AUTH
   KafkaEndpoint:
     Description: 'Kafka/MSK cluster endpoint'
     Type: String
@@ -62,7 +62,7 @@ Parameters:
     Description: 'One or more Subnet IDs corresponding to the Subnet that the Lambda function can use to access you data source. (e.g. subnet1,subnet2)'
     Type: 'List<AWS::EC2::Subnet::Id>'
   CertificatesS3Reference:
-    Description: 'The S3 bucket reference where keystore and truststore certificates are uploaded,applicable for TLS/SSL auth '
+    Description: 'The S3 bucket reference where keystore and truststore certificates are uploaded. Applicable for SSL auth'
     Default: ""
     Type: String
   GlueRegistryArn:
@@ -117,6 +117,7 @@ Resources:
               - "sts:AssumeRole"
 
   FunctionExecutionPolicy:
+    Condition: NotHasLambdaRole
     Type: "AWS::IAM::Policy"
     Properties:
       PolicyName: FunctionExecutionPolicy

--- a/athena-msk/etc/test-config.json
+++ b/athena-msk/etc/test-config.json
@@ -10,7 +10,7 @@
     "spill_bucket" : "<spill bucket>", /* The S3 bucket used for spilling excess data */
     "spill_prefix" : "athena-spill",              /* The prefix within the S3 spill bucket (default: athena-spill) */
     "disable_spill_encryption" : "false",         /* If set to true encryption for spilled data is disabled (default: false) */
-    "auth_type" : "<auth type>",                        /* Authentication type to kafka node eg:NOAUTH,TLS,SERVERLESS,SCRAM */
+    "auth_type" : "<auth type>",                        /* Authentication type to kafka node eg:NO_AUTH, SSL, SASL_SSL_PLAIN, etc */
     "certificates_s3_reference" : "<bucket_path to retrieve certificates>", /* The S3 bucket path used to retrieve certificate */
     "glue_registry_arn" : "<glue registry arn>", /* Glue Registry ARN to retrieve schema details from AWS Glue */
     "kafka_endpoint" : "<kafka node>", /* Kafka Node */

--- a/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/AmazonMskConstants.java
+++ b/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/AmazonMskConstants.java
@@ -32,7 +32,7 @@ public class AmazonMskConstants
      */
     public static final String GLUE_REGISTRY_ARN = "glue_registry_arn";
     /**
-     * For TLS authentication, user need to give S3 bucket reference where the client truststore and keystore
+     * For SSL authentication, user need to give S3 bucket reference where the client truststore and keystore
      * files are uploaded.
      */
     public static final String CERTIFICATES_S3_REFERENCE = "certificates_s3_reference";

--- a/athena-msk/src/test/java/com/amazonaws/athena/connectors/msk/AmazonMskMetadataHandlerTest.java
+++ b/athena-msk/src/test/java/com/amazonaws/athena/connectors/msk/AmazonMskMetadataHandlerTest.java
@@ -93,7 +93,7 @@ public class AmazonMskMetadataHandlerTest {
         constraints = Mockito.mock(Constraints.class);
         environmentVariables.set("aws.region", "us-west-2");
         environmentVariables.set("glue_registry_arn", "arn:aws:glue:us-west-2:123456789101:registry/Athena-NEW");
-        environmentVariables.set("auth_type", "TLS");
+        environmentVariables.set("auth_type", AmazonMskUtils.AuthType.SSL.toString());
         environmentVariables.set("secret_manager_msk_creds_name", "testSecret");
         environmentVariables.set("kafka_endpoint", "12.207.18.179:9092");
         environmentVariables.set("certificates_s3_reference", "s3://msk-connector-test-bucket/mskfiles/");

--- a/athena-msk/src/test/java/com/amazonaws/athena/connectors/msk/AmazonMskUtilsTest.java
+++ b/athena-msk/src/test/java/com/amazonaws/athena/connectors/msk/AmazonMskUtilsTest.java
@@ -164,7 +164,7 @@ public class AmazonMskUtilsTest {
 
     @Test
     public void testGetScramAuthKafkaProperties() throws Exception {
-        environmentVariables.set("auth_type", "SCRAM");
+        environmentVariables.set("auth_type", AmazonMskUtils.AuthType.SASL_SSL_SCRAM_SHA512.toString());
         String sasljaasconfig = "org.apache.kafka.common.security.scram.ScramLoginModule required username=\"admin\" password=\"test\";";
         Properties properties = getKafkaProperties();
         assertEquals("SASL_SSL", properties.get("security.protocol"));
@@ -174,7 +174,7 @@ public class AmazonMskUtilsTest {
 
     @Test
     public void testGetIAMAuthKafkaProperties() throws Exception {
-        environmentVariables.set("auth_type", "IAM");
+        environmentVariables.set("auth_type", AmazonMskUtils.AuthType.SASL_SSL_AWS_MSK_IAM.toString());
         Properties properties = getKafkaProperties();
         assertEquals("SASL_SSL", properties.get("security.protocol"));
         assertEquals("AWS_MSK_IAM", properties.get("sasl.mechanism"));
@@ -183,8 +183,8 @@ public class AmazonMskUtilsTest {
     }
 
     @Test
-    public void testGetTLSAuthKafkaProperties() throws Exception {
-        environmentVariables.set("auth_type", "TLS");
+    public void testGetSSLAuthKafkaProperties() throws Exception {
+        environmentVariables.set("auth_type", AmazonMskUtils.AuthType.SSL.toString());
         Properties properties = getKafkaProperties();
         assertEquals("SSL", properties.get("security.protocol"));
         assertEquals("keypass", properties.get("ssl.keystore.password"));
@@ -225,7 +225,7 @@ public class AmazonMskUtilsTest {
 
     @Test
     public void testGetKafkaConsumerWithSchema() throws Exception {
-        environmentVariables.set("auth_type", "NOAUTH");
+        environmentVariables.set("auth_type", AmazonMskUtils.AuthType.NO_AUTH.toString());
         Field field = new Field("name", FieldType.nullable(new ArrowType.Utf8()), null);
         Map<String, String> metadataSchema = new HashMap<>();
         metadataSchema.put("dataFormat", "json");
@@ -236,7 +236,7 @@ public class AmazonMskUtilsTest {
 
     @Test
     public void testGetKafkaConsumer() throws Exception {
-        environmentVariables.set("auth_type", "NOAUTH");
+        environmentVariables.set("auth_type", AmazonMskUtils.AuthType.NO_AUTH.toString());
         Consumer<String, String> consumer = AmazonMskUtils.getKafkaConsumer();
         assertNotNull(consumer);
     }


### PR DESCRIPTION
Rename auth_type options to be more descriptive.
  - The original naming does not make it apparent to the user that most of these options are just different kinds of SASL options.
  - Also uses enums to enhance safety.

Also fixes a bug with the FunctionExecutionPolicy when a LambdaRole is provided.
  - Thanks to @adithyapathipaka for initially finding and fixing this in the DDB yaml.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
