### PR TITLE
Allow the user to choose the CompositeHandler

### DIFF
--- a/athena-cloudera-hive/athena-cloudera-hive.yaml
+++ b/athena-cloudera-hive/athena-cloudera-hive.yaml
@@ -48,6 +48,11 @@ Parameters:
   SubnetIds:
     Description: 'One or more Subnet IDs corresponding to the Subnet that the Lambda function can use to access you data source. (e.g. subnet1,subnet2)'
     Type: 'List<AWS::EC2::Subnet::Id>'
+  CompositeHandler:
+    Description: 'Use "HiveMuxCompositeHandler" to access multiple instances and "HiveCompositeHandler" to access single instance using DefaultConnectionString'
+    Type: String
+    Default: "HiveMuxCompositeHandler"
+    AllowedValues : ["HiveMuxCompositeHandler", "HiveCompositeHandler"]
 Resources:
   JdbcConnectorConfig:
     Type: 'AWS::Serverless::Function'
@@ -59,7 +64,7 @@ Resources:
           spill_prefix: !Ref SpillPrefix
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
-      Handler: "com.amazonaws.athena.connectors.cloudera.HiveMuxCompositeHandler"
+      Handler: !Sub "com.amazonaws.athena.connectors.cloudera.${CompositeHandler}
       CodeUri: "./target/athena-cloudera-hive-2022.47.1.jar"
       Description: "Enables Amazon Athena to communicate with Coludera Hive using JDBC"
       Runtime: java11

--- a/athena-cloudera-impala/athena-cloudera-impala.yaml
+++ b/athena-cloudera-impala/athena-cloudera-impala.yaml
@@ -48,6 +48,11 @@ Parameters:
   SubnetIds:
     Description: 'One or more Subnet IDs corresponding to the Subnet that the Lambda function can use to access you data source. (e.g. subnet1,subnet2)'
     Type: 'List<AWS::EC2::Subnet::Id>'
+  CompositeHandler:
+    Description: 'Use "ImpalaMuxCompositeHandler" to access multiple instances and "ImpalaCompositeHandler" to access single instance using DefaultConnectionString'
+    Type: String
+    Default: "ImpalaMuxCompositeHandler"
+    AllowedValues : ["ImpalaMuxCompositeHandler", "ImpalaCompositeHandler"]
 Resources:
   JdbcConnectorConfig:
     Type: 'AWS::Serverless::Function'
@@ -59,7 +64,7 @@ Resources:
           spill_prefix: !Ref SpillPrefix
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
-      Handler: "com.amazonaws.athena.connectors.cloudera.ImpalaMuxCompositeHandler"
+      Handler: !Sub "com.amazonaws.athena.connectors.cloudera.${CompositeHandler}
       CodeUri: "./target/athena-cloudera-impala-2022.47.1.jar"
       Description: "Enables Amazon Athena to communicate with Cloudera Impala using JDBC"
       Runtime: java11

--- a/athena-datalakegen2/athena-datalakegen2.yaml
+++ b/athena-datalakegen2/athena-datalakegen2.yaml
@@ -50,6 +50,11 @@ Parameters:
   SubnetIds:
     Description: 'One or more Subnet IDs corresponding to the Subnet that the Lambda function can use to access you data source. (e.g. subnet1,subnet2)'
     Type: 'List<AWS::EC2::Subnet::Id>'
+  CompositeHandler:
+    Description: 'Use "DataLakeGen2MuxCompositeHandler" to access multiple instances and "DataLakeGen2CompositeHandler" to access single instance using DefaultConnectionString'
+    Type: String
+    Default: "DataLakeGen2MuxCompositeHandler"
+    AllowedValues : ["DataLakeGen2MuxCompositeHandler", "DataLakeGen2CompositeHandler"]
 Resources:
   JdbcConnectorConfig:
     Type: 'AWS::Serverless::Function'
@@ -61,7 +66,7 @@ Resources:
           spill_prefix: !Ref SpillPrefix
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
-      Handler: "com.amazonaws.athena.connectors.datalakegen2.DataLakeGen2MuxCompositeHandler"
+      Handler: !Sub "com.amazonaws.athena.connectors.datalakegen2.${CompositeHandler}
       CodeUri: "./target/athena-datalakegen2-2022.47.1.jar"
       Description: "Enables Amazon Athena to communicate with DataLake Gen2 using JDBC"
       Runtime: java11

--- a/athena-db2/athena-db2.yaml
+++ b/athena-db2/athena-db2.yaml
@@ -51,6 +51,11 @@ Parameters:
   SubnetIds:
     Description: 'One or more Subnet IDs corresponding to the Subnet that the Lambda function can use to access you data source. (e.g. subnet1,subnet2)'
     Type: 'List<AWS::EC2::Subnet::Id>'
+  CompositeHandler:
+    Description: 'Use "Db2MuxCompositeHandler" to access multiple instances and "Db2CompositeHandler" to access single instance using DefaultConnectionString'
+    Type: String
+    Default: "Db2MuxCompositeHandler"
+    AllowedValues : ["Db2MuxCompositeHandler", "Db2CompositeHandler"]
 Resources:
   JdbcConnectorConfig:
     Type: 'AWS::Serverless::Function'
@@ -62,7 +67,7 @@ Resources:
           spill_prefix: !Ref SpillPrefix
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
-      Handler: "com.amazonaws.athena.connectors.db2.Db2MuxCompositeHandler"
+      Handler: !Sub "com.amazonaws.athena.connectors.db2.${CompositeHandler}
       CodeUri: "./target/athena-db2-2022.47.1.jar"
       Description: "Enables Amazon Athena to communicate with DB2 using JDBC"
       Runtime: java11

--- a/athena-hortonworks-hive/athena-hortonworks-hive.yaml
+++ b/athena-hortonworks-hive/athena-hortonworks-hive.yaml
@@ -48,6 +48,11 @@ Parameters:
   SubnetIds:
     Description: 'One or more Subnet IDs corresponding to the Subnet that the Lambda function can use to access you data source. (e.g. subnet1,subnet2)'
     Type: 'List<AWS::EC2::Subnet::Id>'
+  CompositeHandler:
+    Description: 'Use "HiveMuxCompositeHandler" to access multiple instances and "HiveCompositeHandler" to access single instance using DefaultConnectionString'
+    Type: String
+    Default: "HiveMuxCompositeHandler"
+    AllowedValues : ["HiveMuxCompositeHandler", "HiveCompositeHandler"]
 Resources:
   JdbcConnectorConfig:
     Type: 'AWS::Serverless::Function'
@@ -59,7 +64,7 @@ Resources:
           spill_prefix: !Ref SpillPrefix
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
-      Handler: "com.amazonaws.athena.connectors.hortonworks.HiveMuxCompositeHandler"
+      Handler: !Sub "com.amazonaws.athena.connectors.hortonworks.${CompositeHandler}
       CodeUri: "./target/athena-hortonworks-hive-2022.47.1.jar"
       Description: "Enables Amazon Athena to communicate with Hortonworks Hive using JDBC"
       Runtime: java11

--- a/athena-mysql/athena-mysql.yaml
+++ b/athena-mysql/athena-mysql.yaml
@@ -48,6 +48,11 @@ Parameters:
   SubnetIds:
     Description: 'One or more Subnet IDs corresponding to the Subnet that the Lambda function can use to access you data source. (e.g. subnet1,subnet2)'
     Type: 'List<AWS::EC2::Subnet::Id>'
+  CompositeHandler:
+    Description: 'Use "MySqlMuxCompositeHandler" to access multiple instances and "MySqlCompositeHandler" to access single instance using DefaultConnectionString'
+    Type: String
+    Default: "MySqlMuxCompositeHandler"
+    AllowedValues : ["MySqlMuxCompositeHandler", "MySqlCompositeHandler"]
 Resources:
   JdbcConnectorConfig:
     Type: 'AWS::Serverless::Function'
@@ -59,7 +64,7 @@ Resources:
           spill_prefix: !Ref SpillPrefix
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
-      Handler: "com.amazonaws.athena.connectors.mysql.MySqlMuxCompositeHandler"
+      Handler: !Sub "com.amazonaws.athena.connectors.mysql.${CompositeHandler}"
       CodeUri: "./target/athena-mysql-2022.47.1.jar"
       Description: "Enables Amazon Athena to communicate with MySQL using JDBC"
       Runtime: java11

--- a/athena-oracle/athena-oracle.yaml
+++ b/athena-oracle/athena-oracle.yaml
@@ -48,6 +48,11 @@ Parameters:
   SubnetIds:
     Description: 'One or more Subnet IDs corresponding to the Subnet that the Lambda function can use to access you data source. (e.g. subnet1,subnet2)'
     Type: 'List<AWS::EC2::Subnet::Id>'
+  CompositeHandler:
+    Description: 'Use "OracleMuxCompositeHandler" to access multiple instances and "OracleCompositeHandler" to access single instance using DefaultConnectionString'
+    Type: String
+    Default: "OracleMuxCompositeHandler"
+    AllowedValues : ["OracleMuxCompositeHandler", "OracleCompositeHandler"]
 Resources:
   JdbcConnectorConfig:
     Type: 'AWS::Serverless::Function'
@@ -59,7 +64,7 @@ Resources:
           spill_prefix: !Ref SpillPrefix
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
-      Handler: "com.amazonaws.athena.connectors.oracle.OracleMuxCompositeHandler"
+      Handler: !Sub "com.amazonaws.athena.connectors.oracle.${CompositeHandler}
       CodeUri: "./target/athena-oracle-2022.47.1.jar"
       Description: "Enables Amazon Athena to communicate with ORACLE using JDBC"
       Runtime: java11

--- a/athena-redshift/athena-redshift.yaml
+++ b/athena-redshift/athena-redshift.yaml
@@ -48,6 +48,11 @@ Parameters:
   SubnetIds:
     Description: 'One or more Subnet IDs corresponding to the Subnet that the Lambda function can use to access you data source. (e.g. subnet1,subnet2)'
     Type: 'List<AWS::EC2::Subnet::Id>'
+  CompositeHandler:
+    Description: 'Use "RedshiftMuxCompositeHandler" to access multiple instances and "RedshiftCompositeHandler" to access single instance using DefaultConnectionString'
+    Type: String
+    Default: "RedshiftMuxCompositeHandler"
+    AllowedValues : ["RedshiftMuxCompositeHandler", "RedshiftCompositeHandler"]
 Resources:
   JdbcConnectorConfig:
     Type: 'AWS::Serverless::Function'
@@ -59,7 +64,7 @@ Resources:
           spill_prefix: !Ref SpillPrefix
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
-      Handler: "com.amazonaws.athena.connectors.redshift.RedshiftMuxCompositeHandler"
+      Handler: !Sub "com.amazonaws.athena.connectors.redshift.${CompositeHandler}"
       CodeUri: "./target/athena-redshift-2022.47.1.jar"
       Description: "Enables Amazon Athena to communicate with Redshift using JDBC"
       Runtime: java11

--- a/athena-redshift/src/main/java/com/amazonaws/athena/connectors/redshift/RedshiftCompositeHandler.java
+++ b/athena-redshift/src/main/java/com/amazonaws/athena/connectors/redshift/RedshiftCompositeHandler.java
@@ -1,0 +1,37 @@
+/*-
+ * #%L
+ * athena-redshift
+ * %%
+ * Copyright (C) 2019 - 2022 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.redshift;
+
+import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
+
+/**
+ * Boilerplate composite handler that allows us to use a single Lambda function for both
+ * Metadata and Data. In this case we just compose {@link RedshiftMetadataHandler} and {@link RedshiftRecordHandler}.
+ *
+ * Recommend using {@link RedshiftMuxCompositeHandler} instead.
+ */
+public class RedshiftCompositeHandler
+        extends CompositeHandler
+{
+    public RedshiftCompositeHandler()
+    {
+        super(new RedshiftMetadataHandler(), new RedshiftRecordHandler());
+    }
+}

--- a/athena-saphana/athena-saphana.yaml
+++ b/athena-saphana/athena-saphana.yaml
@@ -48,6 +48,11 @@ Parameters:
   SubnetIds:
     Description: 'One or more Subnet IDs corresponding to the Subnet that the Lambda function can use to access you data source. (e.g. subnet1,subnet2)'
     Type: 'List<AWS::EC2::Subnet::Id>'
+  CompositeHandler:
+    Description: 'Use "SaphanaMuxCompositeHandler" to access multiple instances and "SaphanaCompositeHandler" to access single instance using DefaultConnectionString'
+    Type: String
+    Default: "SaphanaMuxCompositeHandler"
+    AllowedValues : ["SaphanaMuxCompositeHandler", "SaphanaCompositeHandler"]
 Resources:
   JdbcConnectorConfig:
     Type: 'AWS::Serverless::Function'
@@ -59,7 +64,7 @@ Resources:
           spill_prefix: !Ref SpillPrefix
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
-      Handler: "com.amazonaws.athena.connectors.saphana.SaphanaMuxCompositeHandler"
+      Handler: !Sub "com.amazonaws.athena.connectors.saphana.${CompositeHandler}
       CodeUri: "./target/athena-saphana-2022.47.1.jar"
       Description: "Enables Amazon Athena to communicate with Teradata using JDBC"
       Runtime: java11

--- a/athena-snowflake/athena-snowflake.yaml
+++ b/athena-snowflake/athena-snowflake.yaml
@@ -48,6 +48,11 @@ Parameters:
   SubnetIds:
     Description: 'One or more Subnet IDs corresponding to the Subnet that the Lambda function can use to access you data source. (e.g. subnet1,subnet2)'
     Type: 'List<AWS::EC2::Subnet::Id>'
+  CompositeHandler:
+    Description: 'Use "SnowflakeMuxCompositeHandler" to access multiple instances and "SnowflakeCompositeHandler" to access single instance using DefaultConnectionString'
+    Type: String
+    Default: "SnowflakeMuxCompositeHandler"
+    AllowedValues : ["SnowflakeMuxCompositeHandler", "SnowflakeCompositeHandler"]
 Resources:
   JdbcConnectorConfig:
     Type: 'AWS::Serverless::Function'
@@ -59,7 +64,7 @@ Resources:
           spill_prefix: !Ref SpillPrefix
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
-      Handler: "com.amazonaws.athena.connectors.snowflake.SnowflakeMuxCompositeHandler"
+      Handler: !Sub "com.amazonaws.athena.connectors.snowflake.${CompositeHandler}
       CodeUri: "./target/athena-snowflake-2022.47.1.jar"
       Description: "Enables Amazon Athena to communicate with Snowflake using JDBC"
       Runtime: java11

--- a/athena-sqlserver/athena-sqlserver.yaml
+++ b/athena-sqlserver/athena-sqlserver.yaml
@@ -50,6 +50,11 @@ Parameters:
   SubnetIds:
     Description: 'One or more Subnet IDs corresponding to the Subnet that the Lambda function can use to access you data source. (e.g. subnet1,subnet2)'
     Type: 'List<AWS::EC2::Subnet::Id>'
+  CompositeHandler:
+    Description: 'Use "SqlServerMuxCompositeHandler" to access multiple instances and "SqlServerCompositeHandler" to access single instance using DefaultConnectionString'
+    Type: String
+    Default: "SqlServerMuxCompositeHandler"
+    AllowedValues : ["SqlServerMuxCompositeHandler", "SqlServerCompositeHandler"]
 Resources:
   JdbcConnectorConfig:
     Type: 'AWS::Serverless::Function'
@@ -61,7 +66,7 @@ Resources:
           spill_prefix: !Ref SpillPrefix
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
-      Handler: "com.amazonaws.athena.connectors.sqlserver.SqlServerMuxCompositeHandler"
+      Handler: !Sub "com.amazonaws.athena.connectors.sqlserver.${CompositeHandler}
       CodeUri: "./target/athena-sqlserver-2022.47.1.jar"
       Description: "Enables Amazon Athena to communicate with SQLSERVER using JDBC"
       Runtime: java11

--- a/athena-synapse/athena-synapse.yaml
+++ b/athena-synapse/athena-synapse.yaml
@@ -58,6 +58,11 @@ Parameters:
   SubnetIds:
     Description: 'One or more Subnet IDs corresponding to the Subnet that the Lambda function can use to access you data source. (e.g. subnet1,subnet2)'
     Type: 'List<AWS::EC2::Subnet::Id>'
+  CompositeHandler:
+    Description: 'Use "SynapseMuxCompositeHandler" to access multiple instances and "SynapseCompositeHandler" to access single instance using DefaultConnectionString'
+    Type: String
+    Default: "SynapseMuxCompositeHandler"
+    AllowedValues : ["SynapseMuxCompositeHandler", "SynapseCompositeHandler"]
 
 Conditions:
   NotHasLambdaRole: !Equals [!Ref LambdaRoleARN, ""]
@@ -74,7 +79,7 @@ Resources:
           spill_prefix: !Ref SpillPrefix
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
-      Handler: "com.amazonaws.athena.connectors.synapse.SynapseMuxCompositeHandler"
+      Handler: !Sub "com.amazonaws.athena.connectors.synapse.${CompositeHandler}
       CodeUri: "./target/athena-synapse-2022.47.1.jar"
       Description: "Enables Amazon Athena to communicate with SYNPASE using JDBC"
       Runtime: java11

--- a/athena-teradata/athena-teradata.yaml
+++ b/athena-teradata/athena-teradata.yaml
@@ -55,6 +55,11 @@ Parameters:
     Description: 'Partition Count Limit'
     Type: Number
     Default: 500
+  CompositeHandler:
+    Description: 'Use "TeradataMuxCompositeHandler" to access multiple instances and "TeradataCompositeHandler" to access single instance using DefaultConnectionString'
+    Type: String
+    Default: "TeradataMuxCompositeHandler"
+    AllowedValues : ["TeradataMuxCompositeHandler", "TeradataCompositeHandler"]
 Resources:
   JdbcConnectorConfig:
     Type: 'AWS::Serverless::Function'
@@ -67,7 +72,7 @@ Resources:
           default: !Ref DefaultConnectionString
           partitioncount: !Ref PartitionCount
       FunctionName: !Ref LambdaFunctionName
-      Handler: "com.amazonaws.athena.connectors.teradata.TeradataMuxCompositeHandler"
+      Handler: !Sub "com.amazonaws.athena.connectors.teradata.${CompositeHandler}
       Layers:
         - !Ref LambdaJDBCLayername
       CodeUri: "./target/athena-teradata-2022.47.1.jar"


### PR DESCRIPTION
Allow the user to choose the CompositeHandler

This is useful when the user has only a single connection that and they do
not want to modify the environment variables on their lambda after deployment.

In this situation, with this patch, a user during deployment can:

  - Set the DefaultConnectionString to their only connection string.

  - Set the CompositeHandler to *CompositeHandler (instead of
    *MuxCompositeHandler)

Original idea and implementation comes from this pull request for the postgres connector: #821

This patch addresses issues: #827, #683

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
