### PR TITLE
Bump dependency versions

### DIFF
--- a/athena-aws-cmdb/pom.xml
+++ b/athena-aws-cmdb/pom.xml
@@ -13,6 +13,7 @@
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
             <version>2022.47.1</version>
+            <classifier>withdep</classifier>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
@@ -48,7 +49,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <version>${log4j2Version}</version>
             <scope>runtime</scope>
         </dependency>
@@ -76,7 +77,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>${mvn.shade.plugin.version}</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <filters>
@@ -91,7 +92,7 @@
                     </filters>
                     <transformers>
                         <!-- This transformer is here to concatenate log4j2 cache during shading -->
-                        <transformer implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer">
+                        <transformer implementation="com.github.edwgiz.maven_shade_plugin.log4j2_cache_transformer.PluginsCacheFileTransformer">
 </transformer>
                     </transformers>
                 </configuration>
@@ -99,7 +100,7 @@
                     <dependency>
                         <groupId>com.github.edwgiz</groupId>
                         <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
-                        <version>2.8.1</version>
+                        <version>${log4j2.cachefile.transformer.version}</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/AwsCmdbMetadataHandlerTest.java
+++ b/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/AwsCmdbMetadataHandlerTest.java
@@ -48,7 +48,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -58,8 +58,8 @@ import java.util.Map;
 
 import static com.amazonaws.athena.connector.lambda.metadata.ListTablesRequest.UNLIMITED_PAGE_SIZE_VALUE;
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/AwsCmdbRecordHandlerTest.java
+++ b/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/AwsCmdbRecordHandlerTest.java
@@ -39,13 +39,14 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Collections;
 import java.util.UUID;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -97,7 +98,7 @@ public class AwsCmdbRecordHandlerTest
         verify(mockTableProviderFactory, times(1)).getTableProviders();
         verifyNoMoreInteractions(mockTableProviderFactory);
 
-        when(queryStatusChecker.isQueryRunning()).thenReturn(true);
+        Mockito.lenient().when(queryStatusChecker.isQueryRunning()).thenReturn(true);
     }
 
     @Test
@@ -119,6 +120,6 @@ public class AwsCmdbRecordHandlerTest
 
         handler.readWithConstraint(mockBlockSpiller, request, queryStatusChecker);
 
-        verify(mockTableProvider, times(1)).readWithConstraint(any(BlockSpiller.class), eq(request), eq(queryStatusChecker));
+        verify(mockTableProvider, times(1)).readWithConstraint(nullable(BlockSpiller.class), eq(request), eq(queryStatusChecker));
     }
 }

--- a/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/TableProviderFactoryTest.java
+++ b/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/TableProviderFactoryTest.java
@@ -28,7 +28,7 @@ import com.amazonaws.services.s3.AmazonS3;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.List;
 import java.util.Map;

--- a/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/AbstractTableProviderTest.java
+++ b/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/AbstractTableProviderTest.java
@@ -56,8 +56,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,8 +72,8 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -127,7 +128,7 @@ public abstract class AbstractTableProviderTest
     {
         allocator = new BlockAllocatorImpl();
 
-        when(amazonS3.putObject(anyObject()))
+        when(amazonS3.putObject(any()))
                 .thenAnswer((InvocationOnMock invocationOnMock) -> {
                     InputStream inputStream = ((PutObjectRequest) invocationOnMock.getArguments()[0]).getInputStream();
                     ByteHolder byteHolder = new ByteHolder();
@@ -136,7 +137,7 @@ public abstract class AbstractTableProviderTest
                     return mock(PutObjectResult.class);
                 });
 
-        when(amazonS3.getObject(anyString(), anyString()))
+        when(amazonS3.getObject(nullable(String.class), nullable(String.class)))
                 .thenAnswer((InvocationOnMock invocationOnMock) -> {
                     S3Object mockObject = mock(S3Object.class);
                     ByteHolder byteHolder = mockS3Store.get(0);
@@ -151,7 +152,7 @@ public abstract class AbstractTableProviderTest
 
         provider = setUpSource();
 
-        when(queryStatusChecker.isQueryRunning()).thenReturn(true);
+        Mockito.lenient().when(queryStatusChecker.isQueryRunning()).thenReturn(true);
     }
 
     @After

--- a/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/EmrClusterTableProviderTest.java
+++ b/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/EmrClusterTableProviderTest.java
@@ -38,7 +38,7 @@ import org.apache.arrow.vector.types.pojo.Field;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,7 +48,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -94,7 +94,7 @@ public class EmrClusterTableProviderTest
     @Override
     protected void setUpRead()
     {
-        when(mockEmr.listClusters(any(ListClustersRequest.class)))
+        when(mockEmr.listClusters(nullable(ListClustersRequest.class)))
                 .thenAnswer((InvocationOnMock invocation) -> {
                     ListClustersResult mockResult = mock(ListClustersResult.class);
                     List<ClusterSummary> values = new ArrayList<>();
@@ -105,7 +105,7 @@ public class EmrClusterTableProviderTest
                     return mockResult;
                 });
 
-        when(mockEmr.describeCluster(any(DescribeClusterRequest.class)))
+        when(mockEmr.describeCluster(nullable(DescribeClusterRequest.class)))
                 .thenAnswer((InvocationOnMock invocation) -> {
                     DescribeClusterRequest request = (DescribeClusterRequest) invocation.getArguments()[0];
                     DescribeClusterResult mockResult = mock(DescribeClusterResult.class);

--- a/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/RdsTableProviderTest.java
+++ b/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/RdsTableProviderTest.java
@@ -50,7 +50,7 @@ import org.apache.arrow.vector.types.pojo.Field;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,7 +62,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -109,7 +109,7 @@ public class RdsTableProviderTest
     protected void setUpRead()
     {
         final AtomicLong requestCount = new AtomicLong(0);
-        when(mockRds.describeDBInstances(any(DescribeDBInstancesRequest.class)))
+        when(mockRds.describeDBInstances(nullable(DescribeDBInstancesRequest.class)))
                 .thenAnswer((InvocationOnMock invocation) -> {
                     DescribeDBInstancesResult mockResult = mock(DescribeDBInstancesResult.class);
                     List<DBInstance> values = new ArrayList<>();

--- a/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/ec2/EbsTableProviderTest.java
+++ b/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/ec2/EbsTableProviderTest.java
@@ -35,7 +35,7 @@ import org.apache.arrow.vector.types.pojo.Field;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,7 +46,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -92,7 +92,7 @@ public class EbsTableProviderTest
     @Override
     protected void setUpRead()
     {
-        when(mockEc2.describeVolumes(any(DescribeVolumesRequest.class))).thenAnswer((InvocationOnMock invocation) -> {
+        when(mockEc2.describeVolumes(nullable(DescribeVolumesRequest.class))).thenAnswer((InvocationOnMock invocation) -> {
             DescribeVolumesRequest request = (DescribeVolumesRequest) invocation.getArguments()[0];
 
             assertEquals(getIdValue(), request.getVolumeIds().get(0));

--- a/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/ec2/Ec2TableProviderTest.java
+++ b/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/ec2/Ec2TableProviderTest.java
@@ -40,7 +40,7 @@ import org.apache.arrow.vector.types.pojo.Field;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,7 +49,7 @@ import java.util.Date;
 import java.util.List;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -95,7 +95,7 @@ public class Ec2TableProviderTest
     @Override
     protected void setUpRead()
     {
-        when(mockEc2.describeInstances(any(DescribeInstancesRequest.class))).thenAnswer((InvocationOnMock invocation) -> {
+        when(mockEc2.describeInstances(nullable(DescribeInstancesRequest.class))).thenAnswer((InvocationOnMock invocation) -> {
             DescribeInstancesRequest request = (DescribeInstancesRequest) invocation.getArguments()[0];
 
             assertEquals(getIdValue(), request.getInstanceIds().get(0));

--- a/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/ec2/ImagesTableProviderTest.java
+++ b/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/ec2/ImagesTableProviderTest.java
@@ -36,7 +36,7 @@ import org.apache.arrow.vector.types.pojo.Field;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,7 +46,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -92,7 +92,7 @@ public class ImagesTableProviderTest
     @Override
     protected void setUpRead()
     {
-        when(mockEc2.describeImages(any(DescribeImagesRequest.class))).thenAnswer((InvocationOnMock invocation) -> {
+        when(mockEc2.describeImages(nullable(DescribeImagesRequest.class))).thenAnswer((InvocationOnMock invocation) -> {
             DescribeImagesRequest request = (DescribeImagesRequest) invocation.getArguments()[0];
 
             assertEquals(getIdValue(), request.getImageIds().get(0));

--- a/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/ec2/RouteTableProviderTest.java
+++ b/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/ec2/RouteTableProviderTest.java
@@ -37,7 +37,7 @@ import org.apache.arrow.vector.types.pojo.Field;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,7 +47,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -93,7 +93,7 @@ public class RouteTableProviderTest
     @Override
     protected void setUpRead()
     {
-        when(mockEc2.describeRouteTables(any(DescribeRouteTablesRequest.class))).thenAnswer((InvocationOnMock invocation) -> {
+        when(mockEc2.describeRouteTables(nullable(DescribeRouteTablesRequest.class))).thenAnswer((InvocationOnMock invocation) -> {
             DescribeRouteTablesRequest request = (DescribeRouteTablesRequest) invocation.getArguments()[0];
 
             assertEquals(getIdValue(), request.getRouteTableIds().get(0));

--- a/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/ec2/SecurityGroupsTableProviderTest.java
+++ b/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/ec2/SecurityGroupsTableProviderTest.java
@@ -38,7 +38,7 @@ import org.apache.arrow.vector.types.pojo.Field;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,7 +48,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -94,7 +94,7 @@ public class SecurityGroupsTableProviderTest
     @Override
     protected void setUpRead()
     {
-        when(mockEc2.describeSecurityGroups(any(DescribeSecurityGroupsRequest.class)))
+        when(mockEc2.describeSecurityGroups(nullable(DescribeSecurityGroupsRequest.class)))
                 .thenAnswer((InvocationOnMock invocation) -> {
                     DescribeSecurityGroupsRequest request = (DescribeSecurityGroupsRequest) invocation.getArguments()[0];
 

--- a/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/ec2/SubnetTableProviderTest.java
+++ b/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/ec2/SubnetTableProviderTest.java
@@ -34,7 +34,7 @@ import org.apache.arrow.vector.types.pojo.Field;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,7 +44,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -90,7 +90,7 @@ public class SubnetTableProviderTest
     @Override
     protected void setUpRead()
     {
-        when(mockEc2.describeSubnets(any(DescribeSubnetsRequest.class))).thenAnswer((InvocationOnMock invocation) -> {
+        when(mockEc2.describeSubnets(nullable(DescribeSubnetsRequest.class))).thenAnswer((InvocationOnMock invocation) -> {
             DescribeSubnetsRequest request = (DescribeSubnetsRequest) invocation.getArguments()[0];
 
             assertEquals(getIdValue(), request.getSubnetIds().get(0));

--- a/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/ec2/VpcTableProviderTest.java
+++ b/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/ec2/VpcTableProviderTest.java
@@ -34,7 +34,7 @@ import org.apache.arrow.vector.types.pojo.Field;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,7 +44,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -90,7 +90,7 @@ public class VpcTableProviderTest
     @Override
     protected void setUpRead()
     {
-        when(mockEc2.describeVpcs(any(DescribeVpcsRequest.class))).thenAnswer((InvocationOnMock invocation) -> {
+        when(mockEc2.describeVpcs(nullable(DescribeVpcsRequest.class))).thenAnswer((InvocationOnMock invocation) -> {
             DescribeVpcsRequest request = (DescribeVpcsRequest) invocation.getArguments()[0];
 
             assertEquals(getIdValue(), request.getVpcIds().get(0));

--- a/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/s3/S3ObjectsTableProviderTest.java
+++ b/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/s3/S3ObjectsTableProviderTest.java
@@ -44,7 +44,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -90,7 +90,7 @@ public class S3ObjectsTableProviderTest
     protected void setUpRead()
     {
         AtomicLong count = new AtomicLong(0);
-        when(mockS3.listObjectsV2(any(ListObjectsV2Request.class))).thenAnswer((InvocationOnMock invocation) -> {
+        when(mockS3.listObjectsV2(nullable(ListObjectsV2Request.class))).thenAnswer((InvocationOnMock invocation) -> {
             ListObjectsV2Request request = (ListObjectsV2Request) invocation.getArguments()[0];
             assertEquals(getIdValue(), request.getBucketName());
 

--- a/athena-cloudera-hive/pom.xml
+++ b/athena-cloudera-hive/pom.xml
@@ -35,24 +35,35 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
+        <!--
+          This is purposefully using a legacy version because these tests
+          rely on powermock and it will break on a later version.
+          Eventually we should fix the test code to not rely on powermock.
+        -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.legacy.version}</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
-            <version>2.0.9</version>
+            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.powermock/powermock-api-mockito2 -->
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-api-mockito2</artifactId>
-            <version>2.0.9</version>
+            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.powermock/powermock-core -->
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-core</artifactId>
-            <version>2.0.9</version>
+            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-rds -->
@@ -72,7 +83,7 @@
         <dependency>
             <groupId>com.github.stefanbirkner</groupId>
             <artifactId>system-rules</artifactId>
-            <version>1.19.0</version>
+            <version>${test.system.rules.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -81,7 +92,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>${mvn.shade.plugin.version}</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <filters>
@@ -96,7 +107,7 @@
                     </filters>
                     <transformers>
                         <!-- This transformer is here to concatenate log4j2 cache during shading -->
-                        <transformer implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer">
+                        <transformer implementation="com.github.edwgiz.maven_shade_plugin.log4j2_cache_transformer.PluginsCacheFileTransformer">
 </transformer>
                     </transformers>
                 </configuration>
@@ -104,7 +115,7 @@
                     <dependency>
                         <groupId>com.github.edwgiz</groupId>
                         <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
-                        <version>2.8.1</version>
+                        <version>${log4j2.cachefile.transformer.version}</version>
                     </dependency>
                 </dependencies>
                 <executions>
@@ -138,7 +149,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>${mvn.checkstyle.version}</version>
                 <configuration>
                     <configLocation>checkstyle.xml</configLocation>
                     <encoding>UTF-8</encoding>

--- a/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveMetadataHandlerTest.java
+++ b/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveMetadataHandlerTest.java
@@ -47,6 +47,8 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 
 public class HiveMetadataHandlerTest
         extends TestBase {
@@ -73,7 +75,7 @@ public class HiveMetadataHandlerTest
         this.blockAllocator = Mockito.mock(BlockAllocator.class);
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class, Mockito.RETURNS_DEEP_STUBS);
         this.connection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);
-        Mockito.when(this.jdbcConnectionFactory.getConnection(Mockito.any(JdbcCredentialProvider.class))).thenReturn(this.connection);
+        Mockito.when(this.jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(this.connection);
         this.secretsManager = Mockito.mock(AWSSecretsManager.class);
         this.athena = Mockito.mock(AmazonAthena.class);
         Mockito.when(this.secretsManager.getSecretValue(Mockito.eq(new GetSecretValueRequest().withSecretId("testSecret")))).thenReturn(new GetSecretValueResult().withSecretString("{\"username\": \"testUser\", \"password\": \"testPassword\"}"));
@@ -115,7 +117,7 @@ public class HiveMetadataHandlerTest
         int[] types3 = {Types.VARCHAR};
         Object[][] values4 = {{"PARTITIONED:true"}};
         ResultSet resultSet2 = mockResultSet(columns3, types3, values4, new AtomicInteger(-1));
-        Mockito.when(jdbcConnectionFactory.getConnection(Mockito.any(JdbcCredentialProvider.class))).thenReturn(connection);
+        Mockito.when(jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(connection);
         String tableName =getTableLayoutRequest.getTableName().getTableName().toUpperCase();
         PreparedStatement preparestatement1 = Mockito.mock(PreparedStatement.class);
         Mockito.when(this.connection.prepareStatement(HiveMetadataHandler.GET_METADATA_QUERY + tableName)).thenReturn(preparestatement1);
@@ -159,7 +161,7 @@ public class HiveMetadataHandlerTest
         String[] columns2 = {"Partition"};
         int[] types2 = {Types.VARCHAR};
         Object[][] values1 = {};
-        Mockito.when(jdbcConnectionFactory.getConnection(Mockito.any(JdbcCredentialProvider.class))).thenReturn(connection);
+        Mockito.when(jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(connection);
         PreparedStatement preparestatement1 = Mockito.mock(PreparedStatement.class);
         Mockito.when(this.connection.prepareStatement(HiveMetadataHandler.GET_METADATA_QUERY+tempTableName.getTableName())).thenReturn(preparestatement1);
         final String getPartitionDetailsSql = "show partitions "  + getTableLayoutRequest.getTableName().getTableName().toUpperCase();
@@ -191,7 +193,7 @@ public class HiveMetadataHandlerTest
         GetTableLayoutRequest getTableLayoutRequest = new GetTableLayoutRequest(this.federatedIdentity, "testQueryId", "testCatalogName", tableName, constraints, partitionSchema, partitionCols);
         Connection connection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);
         JdbcConnectionFactory jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
-        Mockito.when(jdbcConnectionFactory.getConnection(Mockito.any(JdbcCredentialProvider.class))).thenReturn(connection);
+        Mockito.when(jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(connection);
         Mockito.when(connection.getMetaData().getSearchStringEscape()).thenThrow(new SQLException());
         HiveMetadataHandler implalaMetadataHandler = new HiveMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, jdbcConnectionFactory);
         implalaMetadataHandler.doGetTableLayout(Mockito.mock(BlockAllocator.class), getTableLayoutRequest);
@@ -221,7 +223,7 @@ public class HiveMetadataHandlerTest
         String[] columns2 = {"Partition"};
         int[] types2 = {Types.VARCHAR};
         Object[][] values1 = {{value2},{value3}};
-        Mockito.when(jdbcConnectionFactory.getConnection(Mockito.any(JdbcCredentialProvider.class))).thenReturn(connection);
+        Mockito.when(jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(connection);
         String tableName =getTableLayoutRequest.getTableName().getTableName().toUpperCase();
         PreparedStatement preparestatement1 = Mockito.mock(PreparedStatement.class);
         Mockito.when(this.connection.prepareStatement(HiveMetadataHandler.GET_METADATA_QUERY+tableName)).thenReturn(preparestatement1);
@@ -296,18 +298,20 @@ public class HiveMetadataHandlerTest
         Assert.assertEquals(inputTableName, getTableResponse.getTableName());
         Assert.assertEquals("testCatalog", getTableResponse.getCatalogName());
     }
+
     @Test
     public void doGetTableNoColumns() throws Exception
     {
         TableName inputTableName = new TableName("testSchema", "testTable");
         this.hiveMetadataHandler.doGetTable(this.blockAllocator, new GetTableRequest(this.federatedIdentity, "testQueryId", "testCatalog", inputTableName));
     }
-    @Test
+
+    @Test(expected = SQLException.class)
     public void doGetTableSQLException()
             throws Exception
     {
         TableName inputTableName = new TableName("testSchema", "testTable");
-        Mockito.when(this.connection.getMetaData().getColumns(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString()))
+        Mockito.when(this.connection.getMetaData().getColumns(nullable(String.class), nullable(String.class), nullable(String.class), nullable(String.class)))
                 .thenThrow(new SQLException());
         this.hiveMetadataHandler.doGetTable(this.blockAllocator, new GetTableRequest(this.federatedIdentity, "testQueryId", "testCatalog", inputTableName));
     }

--- a/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveMuxMetadataHandlerTest.java
+++ b/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveMuxMetadataHandlerTest.java
@@ -46,6 +46,7 @@ import com.amazonaws.athena.connector.lambda.metadata.ListTablesRequest;
 import com.amazonaws.services.athena.AmazonAthena;
 import com.amazonaws.services.secretsmanager.AWSSecretsManager;
 
+import static org.mockito.ArgumentMatchers.nullable;
 
 public class HiveMuxMetadataHandlerTest
 {
@@ -154,7 +155,7 @@ public class HiveMuxMetadataHandlerTest
         GetTableLayoutRequest getTableLayoutRequest = Mockito.mock(GetTableLayoutRequest.class);
         Mockito.when(getTableLayoutRequest.getCatalogName()).thenReturn("metaHive");
         this.jdbcMetadataHandler.getPartitions(Mockito.mock(BlockWriter.class), getTableLayoutRequest, queryStatusChecker);
-        Mockito.verify(this.hiveMetadataHandler, Mockito.times(1)).getPartitions(Mockito.any(BlockWriter.class), Mockito.eq(getTableLayoutRequest), Mockito.eq(queryStatusChecker));
+        Mockito.verify(this.hiveMetadataHandler, Mockito.times(1)).getPartitions(nullable(BlockWriter.class), Mockito.eq(getTableLayoutRequest), Mockito.eq(queryStatusChecker));
     }
 
     @Test

--- a/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveQueryStringBuilderTest.java
+++ b/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveQueryStringBuilderTest.java
@@ -24,7 +24,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @SuppressWarnings("deprecation")
 @RunWith(MockitoJUnitRunner.class)

--- a/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveRecordHandlerTest.java
+++ b/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveRecordHandlerTest.java
@@ -54,6 +54,8 @@ import com.amazonaws.services.secretsmanager.model.GetSecretValueResult;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 
 public class HiveRecordHandlerTest
 {
@@ -75,7 +77,7 @@ public class HiveRecordHandlerTest
         Mockito.when(this.secretsManager.getSecretValue(Mockito.eq(new GetSecretValueRequest().withSecretId("testSecret")))).thenReturn(new GetSecretValueResult().withSecretString("{\"username\": \"testUser\", \"password\": \"testPassword\"}"));
         this.connection = Mockito.mock(Connection.class);
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
-        Mockito.when(this.jdbcConnectionFactory.getConnection(Mockito.mock(JdbcCredentialProvider.class))).thenReturn(this.connection);
+        Mockito.when(this.jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(this.connection);
         jdbcSplitQueryBuilder = new HiveQueryStringBuilder("`");
         final DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", HiveConstants.HIVE_NAME,
                 "hive2://jdbc:hive2://54.89.6.2:10000/authena;AuthMech=3;UID=hive;PWD=hive");
@@ -126,7 +128,7 @@ public class HiveRecordHandlerTest
                 .put("testCol2", valueSet2)
                 .build());
         PreparedStatement expectedPreparedStatement = Mockito.mock(PreparedStatement.class);
-        Mockito.when(this.connection.prepareStatement(Mockito.anyString())).thenReturn(expectedPreparedStatement);
+        Mockito.when(this.connection.prepareStatement(nullable(String.class))).thenReturn(expectedPreparedStatement);
         PreparedStatement preparedStatement = this.hiveRecordHandler.buildSplitSql(this.connection, "testCatalogName", tableName, schema, constraints, split);
         Assert.assertEquals(expectedPreparedStatement, preparedStatement);
     }

--- a/athena-cloudera-impala/pom.xml
+++ b/athena-cloudera-impala/pom.xml
@@ -35,24 +35,35 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
+        <!--
+          This is purposefully using a legacy version because these tests
+          rely on powermock and it will break on a later version.
+          Eventually we should fix the test code to not rely on powermock.
+        -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.legacy.version}</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
-            <version>2.0.9</version>
+            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.powermock/powermock-api-mockito2 -->
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-api-mockito2</artifactId>
-            <version>2.0.9</version>
+            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.powermock/powermock-core -->
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-core</artifactId>
-            <version>2.0.9</version>
+            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-rds -->
@@ -81,7 +92,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>${mvn.shade.plugin.version}</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <filters>
@@ -96,7 +107,7 @@
                     </filters>
                     <transformers>
                         <!-- This transformer is here to concatenate log4j2 cache during shading -->
-                        <transformer implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer">
+                        <transformer implementation="com.github.edwgiz.maven_shade_plugin.log4j2_cache_transformer.PluginsCacheFileTransformer">
 </transformer>
                     </transformers>
                 </configuration>
@@ -104,7 +115,7 @@
                     <dependency>
                         <groupId>com.github.edwgiz</groupId>
                         <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
-                        <version>2.8.1</version>
+                        <version>${log4j2.cachefile.transformer.version}</version>
                     </dependency>
                 </dependencies>
                 <executions>
@@ -138,7 +149,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>${mvn.checkstyle.version}</version>
                 <configuration>
                     <configLocation>checkstyle.xml</configLocation>
                     <encoding>UTF-8</encoding>

--- a/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaMetadataHandlerTest.java
+++ b/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaMetadataHandlerTest.java
@@ -45,6 +45,9 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
+
 public class ImpalaMetadataHandlerTest
         extends TestBase {
 
@@ -69,7 +72,7 @@ public class ImpalaMetadataHandlerTest
         this.blockAllocator = Mockito.mock(BlockAllocator.class);
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class, Mockito.RETURNS_DEEP_STUBS);
         this.connection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);
-        Mockito.when(this.jdbcConnectionFactory.getConnection(Mockito.any(JdbcCredentialProvider.class))).thenReturn(this.connection);
+        Mockito.when(this.jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(this.connection);
         this.secretsManager = Mockito.mock(AWSSecretsManager.class);
         this.athena = Mockito.mock(AmazonAthena.class);
         Mockito.when(this.secretsManager.getSecretValue(Mockito.eq(new GetSecretValueRequest().withSecretId("testSecret")))).thenReturn(new GetSecretValueResult().withSecretString("{\"username\": \"testUser\", \"password\": \"testPassword\"}"));
@@ -146,7 +149,7 @@ public class ImpalaMetadataHandlerTest
        String[] columns2 = {"Partition"};
        int[] types2 = {Types.VARCHAR};
        Object[][] values1 = {};
-       Mockito.when(jdbcConnectionFactory.getConnection(Mockito.any(JdbcCredentialProvider.class))).thenReturn(connection);
+       Mockito.when(jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(connection);
        String tableName =getTableLayoutRequest.getTableName().getTableName().toUpperCase();
        PreparedStatement preparestatement1 = Mockito.mock(PreparedStatement.class);
        Mockito.when(this.connection.prepareStatement(ImpalaMetadataHandler.GET_METADATA_QUERY+tableName)).thenReturn(preparestatement1);
@@ -179,7 +182,7 @@ public class ImpalaMetadataHandlerTest
         GetTableLayoutRequest getTableLayoutRequest = new GetTableLayoutRequest(this.federatedIdentity, "testQueryId", "testCatalogName", tableName, constraints, partitionSchema, partitionCols);
         Connection connection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);
         JdbcConnectionFactory jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
-        Mockito.when(jdbcConnectionFactory.getConnection(Mockito.any(JdbcCredentialProvider.class))).thenReturn(connection);
+        Mockito.when(jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(connection);
         Mockito.when(connection.getMetaData().getSearchStringEscape()).thenThrow(new SQLException());
         ImpalaMetadataHandler implalaMetadataHandler = new ImpalaMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, jdbcConnectionFactory);
         implalaMetadataHandler.doGetTableLayout(Mockito.mock(BlockAllocator.class), getTableLayoutRequest);
@@ -205,7 +208,7 @@ public class ImpalaMetadataHandlerTest
         String[] columns2 = {"Partition"};
         int[] types2 = {Types.VARCHAR};
         Object[][] values1 = {{value2},{value3}};
-        Mockito.when(jdbcConnectionFactory.getConnection(Mockito.any(JdbcCredentialProvider.class))).thenReturn(connection);
+        Mockito.when(jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(connection);
         String tableName =getTableLayoutRequest.getTableName().getTableName().toUpperCase();
         PreparedStatement preparestatement1 = Mockito.mock(PreparedStatement.class);
         Mockito.when(this.connection.prepareStatement(ImpalaMetadataHandler.GET_METADATA_QUERY+tableName)).thenReturn(preparestatement1);
@@ -283,12 +286,13 @@ public class ImpalaMetadataHandlerTest
         TableName inputTableName = new TableName("testSchema", "testTable");
         this.impalaMetadataHandler.doGetTable(this.blockAllocator, new GetTableRequest(this.federatedIdentity, "testQueryId", "testCatalog", inputTableName));
     }
-    @Test
+
+    @Test(expected = SQLException.class)
     public void doGetTableSQLException()
             throws Exception
     {
         TableName inputTableName = new TableName("testSchema", "testTable");
-        Mockito.when(this.connection.getMetaData().getColumns(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString()))
+        Mockito.when(this.connection.getMetaData().getColumns(nullable(String.class), nullable(String.class), nullable(String.class), nullable(String.class)))
                 .thenThrow(new SQLException());
         this.impalaMetadataHandler.doGetTable(this.blockAllocator, new GetTableRequest(this.federatedIdentity, "testQueryId", "testCatalog", inputTableName));
     }

--- a/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaMuxMetadataHandlerTest.java
+++ b/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaMuxMetadataHandlerTest.java
@@ -46,6 +46,7 @@ import com.amazonaws.athena.connector.lambda.metadata.ListTablesRequest;
 import com.amazonaws.services.athena.AmazonAthena;
 import com.amazonaws.services.secretsmanager.AWSSecretsManager;
 
+import static org.mockito.ArgumentMatchers.nullable;
 
 public class ImpalaMuxMetadataHandlerTest
 {
@@ -155,7 +156,7 @@ public class ImpalaMuxMetadataHandlerTest
         GetTableLayoutRequest getTableLayoutRequest = Mockito.mock(GetTableLayoutRequest.class);
         Mockito.when(getTableLayoutRequest.getCatalogName()).thenReturn("metaImpala");
         this.jdbcMetadataHandler.getPartitions(Mockito.mock(BlockWriter.class), getTableLayoutRequest, queryStatusChecker);
-        Mockito.verify(this.impalaMetadataHandler, Mockito.times(1)).getPartitions(Mockito.any(BlockWriter.class), Mockito.eq(getTableLayoutRequest), Mockito.eq(queryStatusChecker));
+        Mockito.verify(this.impalaMetadataHandler, Mockito.times(1)).getPartitions(nullable(BlockWriter.class), Mockito.eq(getTableLayoutRequest), Mockito.eq(queryStatusChecker));
     }
 
     @Test

--- a/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaQueryStringBuilderTest.java
+++ b/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaQueryStringBuilderTest.java
@@ -24,7 +24,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @SuppressWarnings("deprecation")
 @RunWith(MockitoJUnitRunner.class)

--- a/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaRecordHandlerTest.java
+++ b/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaRecordHandlerTest.java
@@ -54,6 +54,9 @@ import com.amazonaws.services.secretsmanager.model.GetSecretValueResult;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
+
 
 public class ImpalaRecordHandlerTest
 {
@@ -75,7 +78,7 @@ public class ImpalaRecordHandlerTest
         Mockito.when(this.secretsManager.getSecretValue(Mockito.eq(new GetSecretValueRequest().withSecretId("testSecret")))).thenReturn(new GetSecretValueResult().withSecretString("{\"username\": \"testUser\", \"password\": \"testPassword\"}"));
         this.connection = Mockito.mock(Connection.class);
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
-        Mockito.when(this.jdbcConnectionFactory.getConnection(Mockito.mock(JdbcCredentialProvider.class))).thenReturn(this.connection);
+        Mockito.when(this.jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(this.connection);
         jdbcSplitQueryBuilder = new ImpalaQueryStringBuilder("`");
 
         final DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", ImpalaConstants.IMPALA_NAME,
@@ -126,7 +129,7 @@ public class ImpalaRecordHandlerTest
                 .put("testCol2", valueSet2)
                 .build());
         PreparedStatement expectedPreparedStatement = Mockito.mock(PreparedStatement.class);
-        Mockito.when(this.connection.prepareStatement(Mockito.anyString())).thenReturn(expectedPreparedStatement);
+        Mockito.when(this.connection.prepareStatement(nullable(String.class))).thenReturn(expectedPreparedStatement);
         PreparedStatement preparedStatement = this.impalaRecordHandler.buildSplitSql(this.connection, "testCatalogName", tableName, schema, constraints, split);
         Assert.assertEquals(expectedPreparedStatement, preparedStatement);
     }

--- a/athena-cloudwatch-metrics/pom.xml
+++ b/athena-cloudwatch-metrics/pom.xml
@@ -13,6 +13,7 @@
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
             <version>2022.47.1</version>
+            <classifier>withdep</classifier>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
@@ -38,7 +39,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <version>${log4j2Version}</version>
             <scope>runtime</scope>
         </dependency>
@@ -66,7 +67,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>${mvn.shade.plugin.version}</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <filters>
@@ -81,7 +82,7 @@
                     </filters>
                     <transformers>
                         <!-- This transformer is here to concatenate log4j2 cache during shading -->
-                        <transformer implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer">
+                        <transformer implementation="com.github.edwgiz.maven_shade_plugin.log4j2_cache_transformer.PluginsCacheFileTransformer">
 </transformer>
                     </transformers>
                 </configuration>
@@ -89,7 +90,7 @@
                     <dependency>
                         <groupId>com.github.edwgiz</groupId>
                         <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
-                        <version>2.8.1</version>
+                        <version>${log4j2.cachefile.transformer.version}</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/athena-cloudwatch-metrics/src/test/java/com/amazonaws/athena/connectors/cloudwatch/metrics/MetricsMetadataHandlerTest.java
+++ b/athena-cloudwatch-metrics/src/test/java/com/amazonaws/athena/connectors/cloudwatch/metrics/MetricsMetadataHandlerTest.java
@@ -57,7 +57,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,7 +75,7 @@ import static com.amazonaws.athena.connectors.cloudwatch.metrics.tables.Table.ST
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -267,8 +267,8 @@ public class MetricsMetadataHandlerTest
         String statistic = "p90";
         int numMetrics = 10;
 
-        when(mockMetrics.listMetrics(any(ListMetricsRequest.class))).thenAnswer((InvocationOnMock invocation) -> {
-            ListMetricsRequest request = invocation.getArgumentAt(0, ListMetricsRequest.class);
+        when(mockMetrics.listMetrics(nullable(ListMetricsRequest.class))).thenAnswer((InvocationOnMock invocation) -> {
+            ListMetricsRequest request = invocation.getArgument(0, ListMetricsRequest.class);
 
             //assert that the namespace filter was indeed pushed down
             assertEquals(namespaceFilter, request.getNamespace());
@@ -345,7 +345,7 @@ public class MetricsMetadataHandlerTest
         String invalidNamespaceFilter = "InvalidNameSpace";
         int numMetrics = 10;
 
-        when(mockMetrics.listMetrics(any(ListMetricsRequest.class))).thenAnswer((InvocationOnMock invocation) -> {
+        when(mockMetrics.listMetrics(nullable(ListMetricsRequest.class))).thenAnswer((InvocationOnMock invocation) -> {
             List<Metric> metrics = new ArrayList<>();
             for (int i = 0; i < numMetrics; i++) {
                 metrics.add(new Metric().withNamespace(namespace).withMetricName("metric-" + i));

--- a/athena-cloudwatch-metrics/src/test/java/com/amazonaws/athena/connectors/cloudwatch/metrics/MetricsRecordHandlerTest.java
+++ b/athena-cloudwatch-metrics/src/test/java/com/amazonaws/athena/connectors/cloudwatch/metrics/MetricsRecordHandlerTest.java
@@ -60,8 +60,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -86,9 +87,8 @@ import static com.amazonaws.athena.connectors.cloudwatch.metrics.tables.Table.ST
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -131,7 +131,7 @@ public class MetricsRecordHandlerTest
         handler = new MetricsRecordHandler(mockS3, mockSecretsManager, mockAthena, mockMetrics);
         spillReader = new S3BlockSpillReader(mockS3, allocator);
 
-        when(mockS3.putObject(anyObject()))
+        Mockito.lenient().when(mockS3.putObject(any()))
                 .thenAnswer((InvocationOnMock invocationOnMock) -> {
                     InputStream inputStream = ((PutObjectRequest) invocationOnMock.getArguments()[0]).getInputStream();
                     ByteHolder byteHolder = new ByteHolder();
@@ -143,7 +143,7 @@ public class MetricsRecordHandlerTest
                     return mock(PutObjectResult.class);
                 });
 
-        when(mockS3.getObject(anyString(), anyString()))
+        Mockito.lenient().when(mockS3.getObject(nullable(String.class), nullable(String.class)))
                 .thenAnswer((InvocationOnMock invocationOnMock) -> {
                     S3Object mockObject = mock(S3Object.class);
                     ByteHolder byteHolder;
@@ -178,8 +178,8 @@ public class MetricsRecordHandlerTest
 
         int numMetrics = 100;
         AtomicLong numCalls = new AtomicLong(0);
-        when(mockMetrics.listMetrics(any(ListMetricsRequest.class))).thenAnswer((InvocationOnMock invocation) -> {
-            ListMetricsRequest request = invocation.getArgumentAt(0, ListMetricsRequest.class);
+        when(mockMetrics.listMetrics(nullable(ListMetricsRequest.class))).thenAnswer((InvocationOnMock invocation) -> {
+            ListMetricsRequest request = invocation.getArgument(0, ListMetricsRequest.class);
             numCalls.incrementAndGet();
             //assert that the namespace filter was indeed pushed down
             assertEquals(namespace, request.getNamespace());
@@ -250,7 +250,7 @@ public class MetricsRecordHandlerTest
         int numMetrics = 10;
         int numSamples = 10;
         AtomicLong numCalls = new AtomicLong(0);
-        when(mockMetrics.getMetricData(any(GetMetricDataRequest.class))).thenAnswer((InvocationOnMock invocation) -> {
+        when(mockMetrics.getMetricData(nullable(GetMetricDataRequest.class))).thenAnswer((InvocationOnMock invocation) -> {
             numCalls.incrementAndGet();
             return mockMetricData(invocation, numMetrics, numSamples);
         });
@@ -311,7 +311,7 @@ public class MetricsRecordHandlerTest
 
     private GetMetricDataResult mockMetricData(InvocationOnMock invocation, int numMetrics, int numSamples)
     {
-        GetMetricDataRequest request = invocation.getArgumentAt(0, GetMetricDataRequest.class);
+        GetMetricDataRequest request = invocation.getArgument(0, GetMetricDataRequest.class);
 
         /**
          * Confirm that all available criteria were pushed down into Cloudwatch Metrics

--- a/athena-cloudwatch/pom.xml
+++ b/athena-cloudwatch/pom.xml
@@ -13,6 +13,7 @@
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
             <version>2022.47.1</version>
+            <classifier>withdep</classifier>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
@@ -50,7 +51,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <version>${log4j2Version}</version>
             <scope>runtime</scope>
         </dependency>
@@ -78,7 +79,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>${mvn.shade.plugin.version}</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <filters>
@@ -93,7 +94,7 @@
                     </filters>
                     <transformers>
                         <!-- This transformer is here to concatenate log4j2 cache during shading -->
-                        <transformer implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer">
+                        <transformer implementation="com.github.edwgiz.maven_shade_plugin.log4j2_cache_transformer.PluginsCacheFileTransformer">
 </transformer>
                     </transformers>
                 </configuration>
@@ -101,7 +102,7 @@
                     <dependency>
                         <groupId>com.github.edwgiz</groupId>
                         <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
-                        <version>2.8.1</version>
+                        <version>${log4j2.cachefile.transformer.version}</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/athena-cloudwatch/src/test/java/com/amazonaws/athena/connectors/cloudwatch/CloudwatchMetadataHandlerTest.java
+++ b/athena-cloudwatch/src/test/java/com/amazonaws/athena/connectors/cloudwatch/CloudwatchMetadataHandlerTest.java
@@ -60,8 +60,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -74,7 +75,7 @@ import java.util.concurrent.TimeoutException;
 
 import static com.amazonaws.athena.connector.lambda.metadata.ListTablesRequest.UNLIMITED_PAGE_SIZE_VALUE;
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -102,12 +103,12 @@ public class CloudwatchMetadataHandlerTest
     public void setUp()
             throws Exception
     {
-        when(mockAwsLogs.describeLogStreams(any(DescribeLogStreamsRequest.class))).thenAnswer((InvocationOnMock invocationOnMock) -> {
+        Mockito.lenient().when(mockAwsLogs.describeLogStreams(nullable(DescribeLogStreamsRequest.class))).thenAnswer((InvocationOnMock invocationOnMock) -> {
             return new DescribeLogStreamsResult().withLogStreams(new LogStream().withLogStreamName("table-9"),
                     new LogStream().withLogStreamName("table-10"));
         });
 
-        when(mockAwsLogs.describeLogGroups(any(DescribeLogGroupsRequest.class))).thenAnswer((InvocationOnMock invocationOnMock) -> {
+        when(mockAwsLogs.describeLogGroups(nullable(DescribeLogGroupsRequest.class))).thenAnswer((InvocationOnMock invocationOnMock) -> {
             return new DescribeLogGroupsResult().withLogGroups(new LogGroup().withLogGroupName("schema-1"),
                     new LogGroup().withLogGroupName("schema-20"));
         });
@@ -128,7 +129,7 @@ public class CloudwatchMetadataHandlerTest
     {
         logger.info("doListSchemas - enter");
 
-        when(mockAwsLogs.describeLogGroups(any(DescribeLogGroupsRequest.class))).thenAnswer((InvocationOnMock invocationOnMock) -> {
+        when(mockAwsLogs.describeLogGroups(nullable(DescribeLogGroupsRequest.class))).thenAnswer((InvocationOnMock invocationOnMock) -> {
             DescribeLogGroupsRequest request = (DescribeLogGroupsRequest) invocationOnMock.getArguments()[0];
 
             DescribeLogGroupsResult result = new DescribeLogGroupsResult();
@@ -166,7 +167,7 @@ public class CloudwatchMetadataHandlerTest
         logger.info("doListSchemas - {}", res.getSchemas());
 
         assertTrue(res.getSchemas().size() == 30);
-        verify(mockAwsLogs, times(4)).describeLogGroups(any(DescribeLogGroupsRequest.class));
+        verify(mockAwsLogs, times(4)).describeLogGroups(nullable(DescribeLogGroupsRequest.class));
         verifyNoMoreInteractions(mockAwsLogs);
 
         logger.info("doListSchemas - exit");
@@ -178,7 +179,7 @@ public class CloudwatchMetadataHandlerTest
     {
         logger.info("doListTables - enter");
 
-        when(mockAwsLogs.describeLogStreams(any(DescribeLogStreamsRequest.class))).thenAnswer((InvocationOnMock invocationOnMock) -> {
+        when(mockAwsLogs.describeLogStreams(nullable(DescribeLogStreamsRequest.class))).thenAnswer((InvocationOnMock invocationOnMock) -> {
             DescribeLogStreamsRequest request = (DescribeLogStreamsRequest) invocationOnMock.getArguments()[0];
 
             DescribeLogStreamsResult result = new DescribeLogStreamsResult();
@@ -220,8 +221,8 @@ public class CloudwatchMetadataHandlerTest
 
         assertTrue(res.getTables().size() == 31);
 
-        verify(mockAwsLogs, times(4)).describeLogStreams(any(DescribeLogStreamsRequest.class));
-        verify(mockAwsLogs, times(1)).describeLogGroups(any(DescribeLogGroupsRequest.class));
+        verify(mockAwsLogs, times(4)).describeLogStreams(nullable(DescribeLogStreamsRequest.class));
+        verify(mockAwsLogs, times(1)).describeLogGroups(nullable(DescribeLogGroupsRequest.class));
         verifyNoMoreInteractions(mockAwsLogs);
 
         logger.info("doListTables - exit");
@@ -233,7 +234,7 @@ public class CloudwatchMetadataHandlerTest
         logger.info("doGetTable - enter");
         String expectedSchema = "schema-20";
 
-        when(mockAwsLogs.describeLogStreams(any(DescribeLogStreamsRequest.class))).thenAnswer((InvocationOnMock invocationOnMock) -> {
+        when(mockAwsLogs.describeLogStreams(nullable(DescribeLogStreamsRequest.class))).thenAnswer((InvocationOnMock invocationOnMock) -> {
             DescribeLogStreamsRequest request = (DescribeLogStreamsRequest) invocationOnMock.getArguments()[0];
 
             assertTrue(request.getLogGroupName().equals(expectedSchema));
@@ -274,7 +275,7 @@ public class CloudwatchMetadataHandlerTest
         assertEquals(new TableName(expectedSchema, "table-9"), res.getTableName());
         assertTrue(res.getSchema() != null);
 
-        verify(mockAwsLogs, times(1)).describeLogStreams(any(DescribeLogStreamsRequest.class));
+        verify(mockAwsLogs, times(1)).describeLogStreams(nullable(DescribeLogStreamsRequest.class));
 
         logger.info("doGetTable - exit");
     }
@@ -285,7 +286,7 @@ public class CloudwatchMetadataHandlerTest
     {
         logger.info("doGetTableLayout - enter");
 
-        when(mockAwsLogs.describeLogStreams(any(DescribeLogStreamsRequest.class))).thenAnswer((InvocationOnMock invocationOnMock) -> {
+        when(mockAwsLogs.describeLogStreams(nullable(DescribeLogStreamsRequest.class))).thenAnswer((InvocationOnMock invocationOnMock) -> {
             DescribeLogStreamsRequest request = (DescribeLogStreamsRequest) invocationOnMock.getArguments()[0];
 
             DescribeLogStreamsResult result = new DescribeLogStreamsResult();
@@ -344,7 +345,7 @@ public class CloudwatchMetadataHandlerTest
         assertTrue(res.getPartitions().getSchema().findField("log_stream") != null);
         assertTrue(res.getPartitions().getRowCount() == 1);
 
-        verify(mockAwsLogs, times(4)).describeLogStreams(any(DescribeLogStreamsRequest.class));
+        verify(mockAwsLogs, times(4)).describeLogStreams(nullable(DescribeLogStreamsRequest.class));
 
         logger.info("doGetTableLayout - exit");
     }

--- a/athena-cloudwatch/src/test/java/com/amazonaws/athena/connectors/cloudwatch/CloudwatchRecordHandlerTest.java
+++ b/athena-cloudwatch/src/test/java/com/amazonaws/athena/connectors/cloudwatch/CloudwatchRecordHandlerTest.java
@@ -60,7 +60,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -74,9 +74,8 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -116,7 +115,7 @@ public class CloudwatchRecordHandlerTest
         handler = new CloudwatchRecordHandler(mockS3, mockSecretsManager, mockAthena, mockAwsLogs);
         spillReader = new S3BlockSpillReader(mockS3, allocator);
 
-        when(mockS3.putObject(anyObject()))
+        when(mockS3.putObject(any()))
                 .thenAnswer((InvocationOnMock invocationOnMock) -> {
                     InputStream inputStream = ((PutObjectRequest) invocationOnMock.getArguments()[0]).getInputStream();
                     ByteHolder byteHolder = new ByteHolder();
@@ -128,7 +127,7 @@ public class CloudwatchRecordHandlerTest
                     return mock(PutObjectResult.class);
                 });
 
-        when(mockS3.getObject(anyString(), anyString()))
+        when(mockS3.getObject(nullable(String.class), nullable(String.class)))
                 .thenAnswer((InvocationOnMock invocationOnMock) -> {
                     S3Object mockObject = mock(S3Object.class);
                     ByteHolder byteHolder;
@@ -143,7 +142,7 @@ public class CloudwatchRecordHandlerTest
                     return mockObject;
                 });
 
-        when(mockAwsLogs.getLogEvents(any(GetLogEventsRequest.class))).thenAnswer((InvocationOnMock invocationOnMock) -> {
+        when(mockAwsLogs.getLogEvents(nullable(GetLogEventsRequest.class))).thenAnswer((InvocationOnMock invocationOnMock) -> {
             GetLogEventsRequest request = (GetLogEventsRequest) invocationOnMock.getArguments()[0];
 
             //Check that predicate pushdown was propagated to cloudwatch

--- a/athena-datalakegen2/pom.xml
+++ b/athena-datalakegen2/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>
-            <version>9.2.1.jre11</version>
+            <version>${mssql.jdbc.version}</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-rds -->
         <dependency>
@@ -46,22 +46,33 @@
             <version>${aws-cdk.version}</version>
             <scope>test</scope>
         </dependency>
+        <!--
+          This is purposefully using a legacy version because these tests
+          rely on powermock and it will break on a later version.
+          Eventually we should fix the test code to not rely on powermock.
+        -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.legacy.version}</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-api-mockito2</artifactId>
-            <version>2.0.9</version>
+            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-core</artifactId>
-            <version>2.0.9</version>
+            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
-            <version>2.0.9</version>
+            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -70,7 +81,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>${mvn.shade.plugin.version}</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <filters>
@@ -85,7 +96,7 @@
                     </filters>
                     <transformers>
                         <!-- This transformer is here to concatenate log4j2 cache during shading -->
-                        <transformer implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer">
+                        <transformer implementation="com.github.edwgiz.maven_shade_plugin.log4j2_cache_transformer.PluginsCacheFileTransformer">
 </transformer>
                     </transformers>
                 </configuration>
@@ -93,7 +104,7 @@
                     <dependency>
                         <groupId>com.github.edwgiz</groupId>
                         <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
-                        <version>2.8.1</version>
+                        <version>${log4j2.cachefile.transformer.version}</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2MetadataHandlerTest.java
+++ b/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2MetadataHandlerTest.java
@@ -64,6 +64,8 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import static org.mockito.ArgumentMatchers.nullable;
+
 public class DataLakeGen2MetadataHandlerTest
         extends TestBase
 {
@@ -86,7 +88,7 @@ public class DataLakeGen2MetadataHandlerTest
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class, Mockito.RETURNS_DEEP_STUBS);
         this.connection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);
         logger.info(" this.connection.."+ this.connection);
-        Mockito.when(this.jdbcConnectionFactory.getConnection(Mockito.any(JdbcCredentialProvider.class))).thenReturn(this.connection);
+        Mockito.when(this.jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(this.connection);
         this.secretsManager = Mockito.mock(AWSSecretsManager.class);
         this.athena = Mockito.mock(AmazonAthena.class);
         Mockito.when(this.secretsManager.getSecretValue(Mockito.eq(new GetSecretValueRequest().withSecretId("testSecret")))).thenReturn(new GetSecretValueResult().withSecretString("{\"user\": \"testUser\", \"password\": \"testPassword\"}"));
@@ -142,7 +144,7 @@ public class DataLakeGen2MetadataHandlerTest
 
         Connection connection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);
         JdbcConnectionFactory jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
-        Mockito.when(jdbcConnectionFactory.getConnection(Mockito.any(JdbcCredentialProvider.class))).thenReturn(connection);
+        Mockito.when(jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(connection);
         Mockito.when(connection.getMetaData().getSearchStringEscape()).thenThrow(new SQLException());
         DataLakeGen2MetadataHandler dataLakeGen2MetadataHandler = new DataLakeGen2MetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, jdbcConnectionFactory);
 

--- a/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2MuxMetadataHandlerTest.java
+++ b/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2MuxMetadataHandlerTest.java
@@ -41,6 +41,8 @@ import org.mockito.Mockito;
 import java.util.Collections;
 import java.util.Map;
 
+import static org.mockito.ArgumentMatchers.nullable;
+
 public class DataLakeGen2MuxMetadataHandlerTest
 {
     private Map<String, JdbcMetadataHandler> metadataHandlerMap;
@@ -128,7 +130,7 @@ public class DataLakeGen2MuxMetadataHandlerTest
         GetTableLayoutRequest getTableLayoutRequest = Mockito.mock(GetTableLayoutRequest.class);
         Mockito.when(getTableLayoutRequest.getCatalogName()).thenReturn("fakedatabase");
         this.jdbcMetadataHandler.getPartitions(Mockito.mock(BlockWriter.class), getTableLayoutRequest, queryStatusChecker);
-        Mockito.verify(this.dataLakeGen2MetadataHandler, Mockito.times(1)).getPartitions(Mockito.any(BlockWriter.class), Mockito.eq(getTableLayoutRequest), Mockito.eq(queryStatusChecker));
+        Mockito.verify(this.dataLakeGen2MetadataHandler, Mockito.times(1)).getPartitions(nullable(BlockWriter.class), Mockito.eq(getTableLayoutRequest), Mockito.eq(queryStatusChecker));
     }
 
     @Test

--- a/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeRecordHandlerTest.java
+++ b/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeRecordHandlerTest.java
@@ -47,6 +47,8 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.Collections;
 
+import static org.mockito.ArgumentMatchers.nullable;
+
 public class DataLakeRecordHandlerTest
 {
     private DataLakeGen2RecordHandler dataLakeGen2RecordHandler;
@@ -67,7 +69,7 @@ public class DataLakeRecordHandlerTest
         this.athena = Mockito.mock(AmazonAthena.class);
         this.connection = Mockito.mock(Connection.class);
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
-        Mockito.when(this.jdbcConnectionFactory.getConnection(Mockito.mock(JdbcCredentialProvider.class))).thenReturn(this.connection);
+        Mockito.when(this.jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(this.connection);
         jdbcSplitQueryBuilder = new DataLakeGen2QueryStringBuilder("`");
         final DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", DataLakeGen2Constants.NAME,
                 "datalakegentwo://jdbc:sqlserver://hostname;databaseName=fakedatabase");

--- a/athena-db2/pom.xml
+++ b/athena-db2/pom.xml
@@ -47,29 +47,40 @@
             <version>${aws-cdk.version}</version>
             <scope>test</scope>
         </dependency>
+        <!--
+          This is purposefully using a legacy version because these tests
+          rely on powermock and it will break on a later version.
+          Eventually we should fix the test code to not rely on powermock.
+        -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.legacy.version}</version>
+            <scope>test</scope>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/org.powermock/powermock-api-easymock -->
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-api-easymock</artifactId>
-            <version>2.0.9</version>
+            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-api-mockito2</artifactId>
-            <version>2.0.9</version>
+            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-core</artifactId>
-            <version>2.0.9</version>
+            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
-            <version>2.0.9</version>
+            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -78,7 +89,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>${mvn.shade.plugin.version}</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <filters>
@@ -93,7 +104,7 @@
                     </filters>
                     <transformers>
                         <!-- This transformer is here to concatenate log4j2 cache during shading -->
-                        <transformer implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer">
+                        <transformer implementation="com.github.edwgiz.maven_shade_plugin.log4j2_cache_transformer.PluginsCacheFileTransformer">
 </transformer>
                     </transformers>
                 </configuration>
@@ -101,7 +112,7 @@
                     <dependency>
                         <groupId>com.github.edwgiz</groupId>
                         <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
-                        <version>2.8.1</version>
+                        <version>${log4j2.cachefile.transformer.version}</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/athena-db2/src/test/java/com/amazonaws/athena/connectors/db2/Db2MetadataHandlerTest.java
+++ b/athena-db2/src/test/java/com/amazonaws/athena/connectors/db2/Db2MetadataHandlerTest.java
@@ -69,6 +69,9 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
+
 public class Db2MetadataHandlerTest extends TestBase {
     private static final Logger logger = LoggerFactory.getLogger(Db2MetadataHandlerTest.class);
     private static final Schema PARTITION_SCHEMA = SchemaBuilder.newBuilder().addField("PARTITION_NUMBER", org.apache.arrow.vector.types.Types.MinorType.VARCHAR.getType()).build();
@@ -88,7 +91,7 @@ public class Db2MetadataHandlerTest extends TestBase {
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class, Mockito.RETURNS_DEEP_STUBS);
         this.connection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);
         logger.info(" this.connection.."+ this.connection);
-        Mockito.when(this.jdbcConnectionFactory.getConnection(Mockito.any(JdbcCredentialProvider.class))).thenReturn(this.connection);
+        Mockito.when(this.jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(this.connection);
         this.secretsManager = Mockito.mock(AWSSecretsManager.class);
         this.athena = Mockito.mock(AmazonAthena.class);
         Mockito.when(this.secretsManager.getSecretValue(Mockito.eq(new GetSecretValueRequest().withSecretId("testSecret")))).thenReturn(new GetSecretValueResult().withSecretString("{\"user\": \"testUser\", \"password\": \"testPassword\"}"));
@@ -226,7 +229,7 @@ public class Db2MetadataHandlerTest extends TestBase {
         Assert.assertEquals("testCatalog", getTableResponse.getCatalogName());
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test(expected = SQLException.class)
     public void doGetTableCaseSensitivity()
             throws Exception
     {
@@ -244,12 +247,12 @@ public class Db2MetadataHandlerTest extends TestBase {
         Mockito.when(tableStmt.executeQuery()).thenReturn(tableResultSet);
 
         TableName inputTableName = new TableName(schemaName, tableName);
-        Mockito.when(this.connection.getMetaData().getColumns(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString()))
+        Mockito.when(this.connection.getMetaData().getColumns(nullable(String.class), nullable(String.class), nullable(String.class), nullable(String.class)))
                 .thenThrow(new SQLException());
         this.db2MetadataHandler.doGetTable(this.blockAllocator, new GetTableRequest(this.federatedIdentity, "testQueryId", "testCatalog", inputTableName));
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test(expected = SQLException.class)
     public void doGetTableCaseSensitivity2()
             throws Exception {
         String schemaName = "testschema";
@@ -266,12 +269,12 @@ public class Db2MetadataHandlerTest extends TestBase {
         Mockito.when(tablePstmt.executeQuery()).thenReturn(tableResultSet);
 
         TableName inputTableName = new TableName(schemaName, tableName);
-        Mockito.when(this.connection.getMetaData().getColumns(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString()))
+        Mockito.when(this.connection.getMetaData().getColumns(nullable(String.class), nullable(String.class), nullable(String.class), nullable(String.class)))
                 .thenThrow(new SQLException());
         this.db2MetadataHandler.doGetTable(this.blockAllocator, new GetTableRequest(this.federatedIdentity, "testQueryId", "testCatalog", inputTableName));
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test(expected = SQLException.class)
     public void doGetTableCaseSensitivity3()
             throws Exception {
         String schemaName = "TESTSCHEMA";
@@ -288,12 +291,12 @@ public class Db2MetadataHandlerTest extends TestBase {
         Mockito.when(tableStmt.executeQuery()).thenReturn(tableResultSet);
 
         TableName inputTableName = new TableName(schemaName, tableName);
-        Mockito.when(this.connection.getMetaData().getColumns(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString()))
+        Mockito.when(this.connection.getMetaData().getColumns(nullable(String.class), nullable(String.class), nullable(String.class), nullable(String.class)))
                 .thenThrow(new SQLException());
         this.db2MetadataHandler.doGetTable(this.blockAllocator, new GetTableRequest(this.federatedIdentity, "testQueryId", "testCatalog", inputTableName));
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test(expected = SQLException.class)
     public void doGetTableCaseSensitivity4()
             throws Exception {
         String schemaName = "TESTSCHEMA";
@@ -310,7 +313,7 @@ public class Db2MetadataHandlerTest extends TestBase {
         Mockito.when(tableStmt.executeQuery()).thenReturn(tableResultSet);
 
         TableName inputTableName = new TableName(schemaName, tableName);
-        Mockito.when(this.connection.getMetaData().getColumns(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString()))
+        Mockito.when(this.connection.getMetaData().getColumns(nullable(String.class), nullable(String.class), nullable(String.class), nullable(String.class)))
                 .thenThrow(new SQLException());
         this.db2MetadataHandler.doGetTable(this.blockAllocator, new GetTableRequest(this.federatedIdentity, "testQueryId", "testCatalog", inputTableName));
     }

--- a/athena-db2/src/test/java/com/amazonaws/athena/connectors/db2/Db2RecordHandlerTest.java
+++ b/athena-db2/src/test/java/com/amazonaws/athena/connectors/db2/Db2RecordHandlerTest.java
@@ -47,6 +47,8 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.Collections;
 
+import static org.mockito.ArgumentMatchers.nullable;
+
 public class Db2RecordHandlerTest {
     private Db2RecordHandler db2RecordHandler;
     private Connection connection;
@@ -64,7 +66,7 @@ public class Db2RecordHandlerTest {
         this.athena = Mockito.mock(AmazonAthena.class);
         this.connection = Mockito.mock(Connection.class);
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
-        Mockito.when(this.jdbcConnectionFactory.getConnection(Mockito.mock(JdbcCredentialProvider.class))).thenReturn(this.connection);
+        Mockito.when(this.jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(this.connection);
         jdbcSplitQueryBuilder = new Db2QueryStringBuilder("`");
         final DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", Db2Constants.NAME,
                 "dbtwo://jdbc:db2://hostname/fakedatabase:${testsecret}");

--- a/athena-docdb/pom.xml
+++ b/athena-docdb/pom.xml
@@ -13,6 +13,7 @@
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
             <version>2022.47.1</version>
+            <classifier>withdep</classifier>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
                 <exclusion>
@@ -58,9 +59,14 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <version>${log4j2Version}</version>
             <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j-log4j.version}</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
@@ -86,7 +92,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>${mvn.shade.plugin.version}</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <filters>
@@ -101,7 +107,7 @@
                     </filters>
                     <transformers>
                         <!-- This transformer is here to concatenate log4j2 cache during shading -->
-                        <transformer implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer">
+                        <transformer implementation="com.github.edwgiz.maven_shade_plugin.log4j2_cache_transformer.PluginsCacheFileTransformer">
 </transformer>
                     </transformers>
                 </configuration>
@@ -109,7 +115,7 @@
                     <dependency>
                         <groupId>com.github.edwgiz</groupId>
                         <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
-                        <version>2.8.1</version>
+                        <version>${log4j2.cachefile.transformer.version}</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/athena-docdb/src/test/java/com/amazonaws/athena/connectors/docdb/DocDBMetadataHandlerTest.java
+++ b/athena-docdb/src/test/java/com/amazonaws/athena/connectors/docdb/DocDBMetadataHandlerTest.java
@@ -57,7 +57,8 @@ import org.junit.Test;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,9 +69,10 @@ import java.util.List;
 
 import static com.amazonaws.athena.connector.lambda.metadata.ListTablesRequest.UNLIMITED_PAGE_SIZE_VALUE;
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -107,7 +109,7 @@ public class DocDBMetadataHandlerTest
     {
         logger.info("{}: enter", testName.getMethodName());
 
-        when(connectionFactory.getOrCreateConn(anyString())).thenReturn(mockClient);
+        when(connectionFactory.getOrCreateConn(nullable(String.class))).thenReturn(mockClient);
 
         handler = new DocDBMetadataHandler(awsGlue, connectionFactory, new LocalKeyFactory(), secretsManager, mockAthena, "spillBucket", "spillPrefix");
         allocator = new BlockAllocatorImpl();
@@ -200,7 +202,7 @@ public class DocDBMetadataHandlerTest
         when(mockDatabase.getCollection(eq(TEST_TABLE))).thenReturn(mockCollection);
         when(mockCollection.find()).thenReturn(mockIterable);
         when(mockIterable.limit(anyInt())).thenReturn(mockIterable);
-        when(mockIterable.maxScan(anyInt())).thenReturn(mockIterable);
+        Mockito.lenient().when(mockIterable.maxScan(anyInt())).thenReturn(mockIterable);
         when(mockIterable.batchSize(anyInt())).thenReturn(mockIterable);
         when(mockIterable.iterator()).thenReturn(new StubbingCursor(documents.iterator()));
 

--- a/athena-docdb/src/test/java/com/amazonaws/athena/connectors/docdb/DocDBRecordHandlerTest.java
+++ b/athena-docdb/src/test/java/com/amazonaws/athena/connectors/docdb/DocDBRecordHandlerTest.java
@@ -66,8 +66,9 @@ import org.junit.Test;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -83,11 +84,10 @@ import java.util.UUID;
 
 import static com.amazonaws.athena.connectors.docdb.DocDBMetadataHandler.DOCDB_CONN_STR;
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -167,7 +167,7 @@ public class DocDBRecordHandlerTest
                 .addListField("list", Types.MinorType.VARCHAR.getType())
                 .build();
 
-        when(connectionFactory.getOrCreateConn(anyString())).thenReturn(mockClient);
+        when(connectionFactory.getOrCreateConn(nullable(String.class))).thenReturn(mockClient);
 
         allocator = new BlockAllocatorImpl();
 
@@ -179,7 +179,7 @@ public class DocDBRecordHandlerTest
         when(mockClient.getDatabase(eq(DEFAULT_SCHEMA))).thenReturn(mockDatabase);
         when(mockDatabase.getCollection(eq(TEST_TABLE))).thenReturn(mockCollection);
 
-        when(amazonS3.putObject(anyObject()))
+        when(amazonS3.putObject(any()))
                 .thenAnswer((InvocationOnMock invocationOnMock) -> {
                     InputStream inputStream = ((PutObjectRequest) invocationOnMock.getArguments()[0]).getInputStream();
                     ByteHolder byteHolder = new ByteHolder();
@@ -191,7 +191,7 @@ public class DocDBRecordHandlerTest
                     return mock(PutObjectResult.class);
                 });
 
-        when(amazonS3.getObject(anyString(), anyString()))
+        when(amazonS3.getObject(nullable(String.class), nullable(String.class)))
                 .thenAnswer((InvocationOnMock invocationOnMock) -> {
                     S3Object mockObject = mock(S3Object.class);
                     ByteHolder byteHolder;
@@ -238,11 +238,11 @@ public class DocDBRecordHandlerTest
         doc3.put("col3", 21.0D);
         doc3.put("unsupported",new UnsupportedType());
 
-        when(mockCollection.find(any(Document.class))).thenAnswer((InvocationOnMock invocationOnMock) -> {
+        when(mockCollection.find(nullable(Document.class))).thenAnswer((InvocationOnMock invocationOnMock) -> {
             logger.info("doReadRecordsNoSpill: query[{}]", invocationOnMock.getArguments()[0]);
             return mockIterable;
         });
-        when(mockIterable.projection(any(Document.class))).thenAnswer((InvocationOnMock invocationOnMock) -> {
+        when(mockIterable.projection(nullable(Document.class))).thenAnswer((InvocationOnMock invocationOnMock) -> {
             logger.info("doReadRecordsNoSpill: projection[{}]", invocationOnMock.getArguments()[0]);
             return mockIterable;
         });
@@ -292,11 +292,11 @@ public class DocDBRecordHandlerTest
             documents.add(DocumentGenerator.makeRandomRow(schemaForRead.getFields(), docNum));
         }
 
-        when(mockCollection.find(any(Document.class))).thenAnswer((InvocationOnMock invocationOnMock) -> {
+        when(mockCollection.find(nullable(Document.class))).thenAnswer((InvocationOnMock invocationOnMock) -> {
             logger.info("doReadRecordsNoSpill: query[{}]", invocationOnMock.getArguments()[0]);
             return mockIterable;
         });
-        when(mockIterable.projection(any(Document.class))).thenAnswer((InvocationOnMock invocationOnMock) -> {
+        when(mockIterable.projection(nullable(Document.class))).thenAnswer((InvocationOnMock invocationOnMock) -> {
             logger.info("doReadRecordsNoSpill: projection[{}]", invocationOnMock.getArguments()[0]);
             return mockIterable;
         });
@@ -386,7 +386,7 @@ public class DocDBRecordHandlerTest
 
         when(mockCollection.find()).thenReturn(mockIterable);
         when(mockIterable.limit(anyInt())).thenReturn(mockIterable);
-        when(mockIterable.maxScan(anyInt())).thenReturn(mockIterable);
+        Mockito.lenient().when(mockIterable.maxScan(anyInt())).thenReturn(mockIterable);
         when(mockIterable.batchSize(anyInt())).thenReturn(mockIterable);
         when(mockIterable.iterator()).thenReturn(new StubbingCursor(documents.iterator()));
 
@@ -394,11 +394,11 @@ public class DocDBRecordHandlerTest
         GetTableResponse res = mdHandler.doGetTable(allocator, req);
         logger.info("doGetTable - {}", res);
 
-        when(mockCollection.find(any(Document.class))).thenAnswer((InvocationOnMock invocationOnMock) -> {
+        when(mockCollection.find(nullable(Document.class))).thenAnswer((InvocationOnMock invocationOnMock) -> {
             logger.info("doReadRecordsNoSpill: query[{}]", invocationOnMock.getArguments()[0]);
             return mockIterable;
         });
-        when(mockIterable.projection(any(Document.class))).thenAnswer((InvocationOnMock invocationOnMock) -> {
+        when(mockIterable.projection(nullable(Document.class))).thenAnswer((InvocationOnMock invocationOnMock) -> {
             logger.info("doReadRecordsNoSpill: projection[{}]", invocationOnMock.getArguments()[0]);
             return mockIterable;
         });

--- a/athena-docdb/src/test/java/com/amazonaws/athena/connectors/docdb/SchemaUtilsTest.java
+++ b/athena-docdb/src/test/java/com/amazonaws/athena/connectors/docdb/SchemaUtilsTest.java
@@ -36,8 +36,8 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyObject;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -56,8 +56,8 @@ public class SchemaUtilsTest
         MongoDatabase mockDatabase = mock(MongoDatabase.class);
         MongoCollection mockCollection = mock(MongoCollection.class);
         FindIterable mockIterable = mock(FindIterable.class);
-        when(mockClient.getDatabase(anyObject())).thenReturn(mockDatabase);
-        when(mockDatabase.getCollection(anyObject())).thenReturn(mockCollection);
+        when(mockClient.getDatabase(any())).thenReturn(mockDatabase);
+        when(mockDatabase.getCollection(any())).thenReturn(mockCollection);
         when(mockCollection.find()).thenReturn(mockIterable);
         when(mockIterable.limit(anyInt())).thenReturn(mockIterable);
         when(mockIterable.maxScan(anyInt())).thenReturn(mockIterable);
@@ -119,8 +119,8 @@ public class SchemaUtilsTest
         MongoDatabase mockDatabase = mock(MongoDatabase.class);
         MongoCollection mockCollection = mock(MongoCollection.class);
         FindIterable mockIterable = mock(FindIterable.class);
-        when(mockClient.getDatabase(anyObject())).thenReturn(mockDatabase);
-        when(mockDatabase.getCollection(anyObject())).thenReturn(mockCollection);
+        when(mockClient.getDatabase(any())).thenReturn(mockDatabase);
+        when(mockDatabase.getCollection(any())).thenReturn(mockCollection);
         when(mockCollection.find()).thenReturn(mockIterable);
         when(mockIterable.limit(anyInt())).thenReturn(mockIterable);
         when(mockIterable.maxScan(anyInt())).thenReturn(mockIterable);
@@ -171,8 +171,8 @@ public class SchemaUtilsTest
         MongoDatabase mockDatabase = mock(MongoDatabase.class);
         MongoCollection mockCollection = mock(MongoCollection.class);
         FindIterable mockIterable = mock(FindIterable.class);
-        when(mockClient.getDatabase(anyObject())).thenReturn(mockDatabase);
-        when(mockDatabase.getCollection(anyObject())).thenReturn(mockCollection);
+        when(mockClient.getDatabase(any())).thenReturn(mockDatabase);
+        when(mockDatabase.getCollection(any())).thenReturn(mockCollection);
         when(mockCollection.find()).thenReturn(mockIterable);
         when(mockIterable.limit(anyInt())).thenReturn(mockIterable);
         when(mockIterable.maxScan(anyInt())).thenReturn(mockIterable);

--- a/athena-dynamodb/pom.xml
+++ b/athena-dynamodb/pom.xml
@@ -13,6 +13,7 @@
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
             <version>2022.47.1</version>
+            <classifier>withdep</classifier>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
@@ -41,7 +42,7 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
-            <version>2.1</version>
+            <version>2.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -56,7 +57,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <version>${log4j2Version}</version>
             <scope>runtime</scope>
         </dependency>
@@ -127,7 +128,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>${mvn.shade.plugin.version}</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <filters>
@@ -142,7 +143,7 @@
                     </filters>
                     <transformers>
                         <!-- This transformer is here to concatenate log4j2 cache during shading -->
-                        <transformer implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer">
+                        <transformer implementation="com.github.edwgiz.maven_shade_plugin.log4j2_cache_transformer.PluginsCacheFileTransformer">
 </transformer>
                     </transformers>
                 </configuration>
@@ -150,7 +151,7 @@
                     <dependency>
                         <groupId>com.github.edwgiz</groupId>
                         <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
-                        <version>2.8.1</version>
+                        <version>${log4j2.cachefile.transformer.version}</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DDBPredicateUtilsTest.java
+++ b/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DDBPredicateUtilsTest.java
@@ -32,7 +32,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DDBTypeUtilsTest.java
+++ b/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DDBTypeUtilsTest.java
@@ -40,7 +40,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.arrow.vector.types.pojo.Field;

--- a/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBMetadataHandlerTest.java
+++ b/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBMetadataHandlerTest.java
@@ -68,7 +68,7 @@ import org.junit.Test;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -109,7 +109,7 @@ import static com.amazonaws.athena.connectors.dynamodb.constants.DynamoDBConstan
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 /**

--- a/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBRecordHandlerTest.java
+++ b/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBRecordHandlerTest.java
@@ -63,7 +63,7 @@ import org.junit.Test;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -93,7 +93,7 @@ import static com.amazonaws.services.dynamodbv2.document.ItemUtils.toAttributeVa
 import static com.amazonaws.util.json.Jackson.toJsonString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/athena-elasticsearch/pom.xml
+++ b/athena-elasticsearch/pom.xml
@@ -13,6 +13,7 @@
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
             <version>2022.47.1</version>
+            <classifier>withdep</classifier>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
                 <exclusion>
@@ -39,7 +40,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <version>${log4j2Version}</version>
             <scope>runtime</scope>
         </dependency>
@@ -153,7 +154,7 @@
         <dependency>
             <groupId>org.elasticsearch.client</groupId>
             <artifactId>elasticsearch-rest-client</artifactId>
-            <version>8.5.2</version>
+            <version>8.5.3</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.elasticsearch.client/elasticsearch-rest-high-level-client -->
         <dependency>
@@ -171,13 +172,13 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.13</version>
+            <version>${apache.httpclient.version}</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.mockito/mockito-core -->
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.3.3</version>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/junit/junit -->
@@ -200,7 +201,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>${mvn.shade.plugin.version}</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <filters>
@@ -215,7 +216,7 @@
                     </filters>
                     <transformers>
                         <!-- This transformer is here to concatenate log4j2 cache during shading -->
-                        <transformer implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer">
+                        <transformer implementation="com.github.edwgiz.maven_shade_plugin.log4j2_cache_transformer.PluginsCacheFileTransformer">
 </transformer>
                     </transformers>
                 </configuration>
@@ -223,7 +224,7 @@
                     <dependency>
                         <groupId>com.github.edwgiz</groupId>
                         <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
-                        <version>2.8.1</version>
+                        <version>${log4j2.cachefile.transformer.version}</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/CacheableAwsRestHighLevelClientTest.java
+++ b/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/CacheableAwsRestHighLevelClientTest.java
@@ -33,7 +33,7 @@ import java.io.IOException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.mockito.Mockito.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 /**

--- a/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchMetadataHandlerTest.java
+++ b/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchMetadataHandlerTest.java
@@ -54,7 +54,7 @@ import java.util.*;
 import static com.amazonaws.athena.connector.lambda.metadata.ListTablesRequest.UNLIMITED_PAGE_SIZE_VALUE;
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.anyString;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.when;
 
 /**
@@ -94,7 +94,7 @@ public class ElasticsearchMetadataHandlerTest
         logger.info("setUpBefore - enter");
 
         allocator = new BlockAllocatorImpl();
-        when(clientFactory.getOrCreateClient(anyString())).thenReturn(mockClient);
+        when(clientFactory.getOrCreateClient(nullable(String.class))).thenReturn(mockClient);
 
         logger.info("setUpBefore - exit");
     }
@@ -350,7 +350,7 @@ public class ElasticsearchMetadataHandlerTest
         LinkedHashMap<String, Object> index = (LinkedHashMap<String, Object>) mapping.get("mishmash");
         LinkedHashMap<String, Object> mappings = (LinkedHashMap<String, Object>) index.get("mappings");
 
-        when(mockClient.getMapping(anyString())).thenReturn(mappings);
+        when(mockClient.getMapping(nullable(String.class))).thenReturn(mappings);
 
         // Get real mapping.
         when(domainMapProvider.getDomainMap(null)).thenReturn(ImmutableMap.of("movies",
@@ -405,7 +405,7 @@ public class ElasticsearchMetadataHandlerTest
         String endpoint = "https://search-movies-ne3fcqzfipy6jcrew2wca6kyqu.us-east-1.es.amazonaws.com";
         when(domainMapProvider.getDomainMap(null)).thenReturn(ImmutableMap.of(domain, endpoint));
 
-        when(mockClient.getShardIds(anyString(), anyLong())).thenReturn(ImmutableSet
+        when(mockClient.getShardIds(nullable(String.class), anyLong())).thenReturn(ImmutableSet
                 .of(new Integer(0), new Integer(1), new Integer(2)));
 
         // Instantiate handler

--- a/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchRecordHandlerTest.java
+++ b/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchRecordHandlerTest.java
@@ -62,7 +62,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -82,9 +81,8 @@ import java.util.UUID;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
@@ -277,7 +275,7 @@ public class ElasticsearchRecordHandlerTest
 
         allocator = new BlockAllocatorImpl();
 
-        when(amazonS3.putObject(anyObject()))
+        when(amazonS3.putObject(any()))
                 .thenAnswer((InvocationOnMock invocationOnMock) -> {
                     InputStream inputStream = ((PutObjectRequest) invocationOnMock.getArguments()[0]).getInputStream();
                     ByteHolder byteHolder = new ByteHolder();
@@ -289,7 +287,7 @@ public class ElasticsearchRecordHandlerTest
                     return mock(PutObjectResult.class);
                 });
 
-        when(amazonS3.getObject(Matchers.anyString(), Matchers.anyString()))
+        when(amazonS3.getObject(nullable(String.class), nullable(String.class)))
                 .thenAnswer((InvocationOnMock invocationOnMock) -> {
                     S3Object mockObject = mock(S3Object.class);
                     ByteHolder byteHolder;
@@ -310,7 +308,7 @@ public class ElasticsearchRecordHandlerTest
                 .add("movies", "https://search-movies-ne3fcqzfipy6jcrew2wca6kyqu.us-east-1.es.amazonaws.com")
                 .build();
 
-        when(clientFactory.getOrCreateClient(anyString())).thenReturn(mockClient);
+        when(clientFactory.getOrCreateClient(nullable(String.class))).thenReturn(mockClient);
         when(mockClient.getDocument(any())).thenReturn(document1, document2);
         when(mockClient.search(any(), any())).thenReturn(mockResponse);
         when(mockScrollResponse.getHits()).thenReturn(null);

--- a/athena-example/pom.xml
+++ b/athena-example/pom.xml
@@ -13,6 +13,7 @@
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
             <version>2022.47.1</version>
+            <classifier>withdep</classifier>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
                 <exclusion>
@@ -33,7 +34,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <version>${log4j2Version}</version>
             <scope>runtime</scope>
         </dependency>
@@ -70,7 +71,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>${mvn.shade.plugin.version}</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <filters>
@@ -85,7 +86,7 @@
                     </filters>
                     <transformers>
                         <!-- This transformer is here to concatenate log4j2 cache during shading -->
-                        <transformer implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer">
+                        <transformer implementation="com.github.edwgiz.maven_shade_plugin.log4j2_cache_transformer.PluginsCacheFileTransformer">
 </transformer>
                     </transformers>
                 </configuration>
@@ -93,7 +94,7 @@
                     <dependency>
                         <groupId>com.github.edwgiz</groupId>
                         <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
-                        <version>2.8.1</version>
+                        <version>${log4j2.cachefile.transformer.version}</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/athena-example/src/test/java/com/amazonaws/athena/connectors/example/ExampleRecordHandlerTest.java
+++ b/athena-example/src/test/java/com/amazonaws/athena/connectors/example/ExampleRecordHandlerTest.java
@@ -58,7 +58,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -108,8 +108,8 @@ public class ExampleRecordHandlerTest
         awsSecretsManager = mock(AWSSecretsManager.class);
         athena = mock(AmazonAthena.class);
 
-        when(amazonS3.doesObjectExist(anyString(), anyString())).thenReturn(true);
-        when(amazonS3.getObject(anyString(), anyString()))
+        when(amazonS3.doesObjectExist(nullable(String.class), nullable(String.class))).thenReturn(true);
+        when(amazonS3.getObject(nullable(String.class), nullable(String.class)))
                 .thenAnswer(new Answer<Object>()
                 {
                     @Override

--- a/athena-federation-integ-test/pom.xml
+++ b/athena-federation-integ-test/pom.xml
@@ -95,7 +95,7 @@
         <dependency>
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
-            <version>1.4</version>
+            <version>${commons.cli.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -109,7 +109,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <version>${log4j2Version}</version>
             <scope>runtime</scope>
         </dependency>
@@ -206,7 +206,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>${mvn.checkstyle.version}</version>
                 <configuration>
                     <configLocation>checkstyle.xml</configLocation>
                     <encoding>UTF-8</encoding>
@@ -227,7 +227,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>${mvn.shade.plugin.version}</version>
                 <configuration>
                     <shadedArtifactAttached>true</shadedArtifactAttached>
                     <filters>
@@ -242,7 +242,7 @@
                     </filters>
                     <transformers>
                         <!-- This transformer is here to concatenate log4j2 cache during shading -->
-                        <transformer implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer">
+                        <transformer implementation="com.github.edwgiz.maven_shade_plugin.log4j2_cache_transformer.PluginsCacheFileTransformer">
 </transformer>
                     </transformers>
                 </configuration>
@@ -250,7 +250,7 @@
                     <dependency>
                         <groupId>com.github.edwgiz</groupId>
                         <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
-                        <version>2.8.1</version>
+                        <version>${log4j2.cachefile.transformer.version}</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/athena-federation-sdk-tools/pom.xml
+++ b/athena-federation-sdk-tools/pom.xml
@@ -15,6 +15,7 @@
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
             <version>2022.47.1</version>
+            <classifier>withdep</classifier>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
                 <exclusion>
@@ -26,7 +27,7 @@
         <dependency>
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
-            <version>1.4</version>
+            <version>${commons.cli.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -40,7 +41,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <version>${log4j2Version}</version>
             <scope>runtime</scope>
         </dependency>
@@ -68,7 +69,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>${mvn.checkstyle.version}</version>
                 <configuration>
                     <configLocation>checkstyle.xml</configLocation>
                     <encoding>UTF-8</encoding>
@@ -89,7 +90,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>${mvn.shade.plugin.version}</version>
                 <configuration>
                     <shadedArtifactAttached>true</shadedArtifactAttached>
                     <filters>
@@ -104,7 +105,7 @@
                     </filters>
                     <transformers>
                         <!-- This transformer is here to concatenate log4j2 cache during shading -->
-                        <transformer implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer">
+                        <transformer implementation="com.github.edwgiz.maven_shade_plugin.log4j2_cache_transformer.PluginsCacheFileTransformer">
 </transformer>
                     </transformers>
                 </configuration>
@@ -112,7 +113,7 @@
                     <dependency>
                         <groupId>com.github.edwgiz</groupId>
                         <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
-                        <version>2.8.1</version>
+                        <version>${log4j2.cachefile.transformer.version}</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/athena-federation-sdk/pom.xml
+++ b/athena-federation-sdk/pom.xml
@@ -213,7 +213,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <version>${log4j2Version}</version>
             <scope>test</scope>
         </dependency>
@@ -238,7 +238,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.67</version>
+            <version>1.70</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -263,8 +263,14 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.10.19</version>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-reflect</artifactId>
+            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -290,7 +296,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.2.2</version>
+                <version>${mvn.jar.plugin.version}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -302,7 +308,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>${mvn.checkstyle.version}</version>
                 <configuration>
                     <configLocation>checkstyle.xml</configLocation>
                     <encoding>UTF-8</encoding>
@@ -348,7 +354,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>${mvn.shade.plugin.version}</version>
                 <configuration>
                     <shadedArtifactAttached>true</shadedArtifactAttached>
                     <filters>
@@ -363,7 +369,7 @@
                     </filters>
                     <transformers>
                         <!-- This transformer is here to concatenate log4j2 cache during shading -->
-                        <transformer implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer">
+                        <transformer implementation="com.github.edwgiz.maven_shade_plugin.log4j2_cache_transformer.PluginsCacheFileTransformer">
 </transformer>
                     </transformers>
                 </configuration>
@@ -371,7 +377,7 @@
                     <dependency>
                         <groupId>com.github.edwgiz</groupId>
                         <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
-                        <version>2.8.1</version>
+                        <version>${log4j2.cachefile.transformer.version}</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/S3BlockSpiller.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/S3BlockSpiller.java
@@ -315,7 +315,7 @@ public class S3BlockSpiller
         }
         try {
             ObjectMapper mapper = new ObjectMapper();
-            TypeReference<Map<String, String>> typeRef = new TypeReference<Map<String, String>>(){};
+            TypeReference<Map<String, String>> typeRef = new TypeReference<Map<String, String>>() {};
             Map<String, String> headers = mapper.readValue(headersFromEnvStr, typeRef);
             for (Map.Entry<String, String> entry : headers.entrySet()) {
                 String oldValue = request.putCustomRequestHeader(entry.getKey(), entry.getValue());

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/handlers/SerDeVersion.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/handlers/SerDeVersion.java
@@ -28,7 +28,7 @@ package com.amazonaws.athena.connector.lambda.handlers;
  */
 public class SerDeVersion
 {
-    private SerDeVersion(){}
+    private SerDeVersion() {}
 
     public static final int SERDE_VERSION = 2;
 }

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/FederatedIdentitySerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/FederatedIdentitySerDe.java
@@ -45,7 +45,7 @@ public final class FederatedIdentitySerDe
     private static final String GROUPS_FIELD = "groups";
     // new fields should only be appended to the end for forwards compatibility
 
-    private FederatedIdentitySerDe(){}
+    private FederatedIdentitySerDe() {}
 
     public static final class Serializer extends BaseSerializer<FederatedIdentity>
     {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/PingRequestSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/PingRequestSerDe.java
@@ -42,7 +42,7 @@ public final class PingRequestSerDe
     private static final String QUERY_ID_FIELD = "queryId";
     // new fields should only be appended to the end for backwards compatibility
 
-    private PingRequestSerDe(){}
+    private PingRequestSerDe() {}
 
     public static class Serializer extends TypedSerializer<FederationRequest>
     {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/PingResponseSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/PingResponseSerDe.java
@@ -41,7 +41,7 @@ public final class PingResponseSerDe
     private static final String SERDE_VERSION_FIELD = "serDeVersion";
     // new fields should only be appended to the end for forwards compatibility
 
-    private PingResponseSerDe(){}
+    private PingResponseSerDe() {}
 
     public static final class Serializer extends TypedSerializer<FederationResponse>
     {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/VersionedObjectMapperFactory.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/VersionedObjectMapperFactory.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 public class VersionedObjectMapperFactory
 {
-    private VersionedObjectMapperFactory(){}
+    private VersionedObjectMapperFactory() {}
 
     /**
      * Creates an {@link ObjectMapper} using the current SDK SerDe version.

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/AllOrNoneValueSetSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/AllOrNoneValueSetSerDe.java
@@ -39,7 +39,7 @@ public final class AllOrNoneValueSetSerDe
     private static final String ALL_FIELD = "all";
     private static final String NULL_ALLOWED_FIELD = "nullAllowed";
 
-    private AllOrNoneValueSetSerDe(){}
+    private AllOrNoneValueSetSerDe() {}
 
     public static final class Serializer extends TypedSerializer<ValueSet>
     {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/ArrowRecordBatchSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/ArrowRecordBatchSerDe.java
@@ -51,7 +51,7 @@ import static java.util.Objects.requireNonNull;
 @Deprecated
 public final class ArrowRecordBatchSerDe
 {
-    private ArrowRecordBatchSerDe(){}
+    private ArrowRecordBatchSerDe() {}
 
     static final class Serializer extends BaseSerializer<ArrowRecordBatch>
     {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/ArrowTypeSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/ArrowTypeSerDe.java
@@ -42,7 +42,7 @@ import java.io.IOException;
 
 public final class ArrowTypeSerDe
 {
-    private ArrowTypeSerDe(){}
+    private ArrowTypeSerDe() {}
 
     public static final class Serializer extends DelegatingSerializer<ArrowType>
     {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/BlockSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/BlockSerDe.java
@@ -56,7 +56,7 @@ public final class BlockSerDe
     private static final String SCHEMA_FIELD_NAME = "schema";
     private static final String BATCH_FIELD_NAME = "records";
 
-    public BlockSerDe(){}
+    public BlockSerDe() {}
 
     public static final class Serializer extends BaseSerializer<Block>
     {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/ConstraintsSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/ConstraintsSerDe.java
@@ -39,7 +39,7 @@ public final class ConstraintsSerDe
 {
     private static final String SUMMARY_FIELD = "summary";
 
-    private ConstraintsSerDe(){}
+    private ConstraintsSerDe() {}
 
     public static final class Serializer extends BaseSerializer<Constraints>
     {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/EncryptionKeySerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/EncryptionKeySerDe.java
@@ -34,7 +34,7 @@ public final class EncryptionKeySerDe
     private static final String KEY_FIELD = "key";
     private static final String NONCE_FIELD = "nonce";
 
-    private EncryptionKeySerDe(){}
+    private EncryptionKeySerDe() {}
 
     public static final class Serializer extends BaseSerializer<EncryptionKey>
     {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/EquatableValueSetSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/EquatableValueSetSerDe.java
@@ -40,7 +40,7 @@ public final class EquatableValueSetSerDe
     private static final String WHITELIST_FIELD = "whiteList";
     private static final String NULL_ALLOWED_FIELD = "nullAllowed";
 
-    private EquatableValueSetSerDe(){}
+    private EquatableValueSetSerDe() {}
 
     public static final class Serializer extends TypedSerializer<ValueSet>
     {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/FederationRequestSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/FederationRequestSerDe.java
@@ -29,7 +29,7 @@ import com.google.common.collect.ImmutableSet;
 
 public final class FederationRequestSerDe
 {
-    private FederationRequestSerDe(){}
+    private FederationRequestSerDe() {}
 
     public static final class Serializer extends DelegatingSerializer<FederationRequest>
     {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/FederationResponseSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/FederationResponseSerDe.java
@@ -29,7 +29,7 @@ import com.google.common.collect.ImmutableSet;
 
 public final class FederationResponseSerDe
 {
-    private FederationResponseSerDe(){}
+    private FederationResponseSerDe() {}
 
     public static final class Serializer extends DelegatingSerializer<FederationResponse>
     {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/GetSplitsRequestSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/GetSplitsRequestSerDe.java
@@ -49,7 +49,7 @@ public final class GetSplitsRequestSerDe
     private static final String CONSTRAINTS_FIELD = "constraints";
     private static final String CONTINUATION_TOKEN_FIELD = "continuationToken";
 
-    private GetSplitsRequestSerDe(){}
+    private GetSplitsRequestSerDe() {}
 
     public static final class Serializer extends MetadataRequestSerializer
     {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/GetSplitsResponseSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/GetSplitsResponseSerDe.java
@@ -41,7 +41,7 @@ public final class GetSplitsResponseSerDe
     private static final String SPLITS_FIELD = "splits";
     private static final String CONTINUATION_TOKEN_FIELD = "continuationToken";
 
-    private GetSplitsResponseSerDe(){}
+    private GetSplitsResponseSerDe() {}
 
     public static final class Serializer extends TypedSerializer<FederationResponse>
     {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/GetTableLayoutRequestSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/GetTableLayoutRequestSerDe.java
@@ -48,7 +48,7 @@ public final class GetTableLayoutRequestSerDe
     private static final String SCHEMA_FIELD = "schema";
     private static final String PARTITION_COLS_FIELD = "partitionColumns";
 
-    private GetTableLayoutRequestSerDe(){}
+    private GetTableLayoutRequestSerDe() {}
 
     public static final class Serializer extends MetadataRequestSerializer
     {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/GetTableLayoutResponseSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/GetTableLayoutResponseSerDe.java
@@ -41,7 +41,7 @@ public final class GetTableLayoutResponseSerDe
     private static final String TABLE_NAME_FIELD = "tableName";
     private static final String PARTITIONS_FIELD = "partitions";
 
-    private GetTableLayoutResponseSerDe(){}
+    private GetTableLayoutResponseSerDe() {}
 
     public static final class Serializer extends TypedSerializer<FederationResponse>
     {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/GetTableRequestSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/GetTableRequestSerDe.java
@@ -38,7 +38,7 @@ public final class GetTableRequestSerDe
 {
     private static final String TABLE_NAME_FIELD = "tableName";
 
-    private GetTableRequestSerDe(){}
+    private GetTableRequestSerDe() {}
 
     public static final class Serializer extends MetadataRequestSerializer
     {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/GetTableResponseSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/GetTableResponseSerDe.java
@@ -43,7 +43,7 @@ public final class GetTableResponseSerDe
     private static final String SCHEMA_FIELD = "schema";
     private static final String PARTITION_COLUMNS_FIELD = "partitionColumns";
 
-    private GetTableResponseSerDe(){}
+    private GetTableResponseSerDe() {}
 
     public static final class Serializer extends TypedSerializer<FederationResponse>
     {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/LambdaFunctionExceptionSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/LambdaFunctionExceptionSerDe.java
@@ -44,7 +44,7 @@ public class LambdaFunctionExceptionSerDe
     private static final String CAUSE_FIELD = "cause";
     private static final String STACK_TRACE_FIELD = "stackTrace";
 
-    private LambdaFunctionExceptionSerDe(){}
+    private LambdaFunctionExceptionSerDe() {}
 
     public static final class Deserializer extends BaseDeserializer<LambdaFunctionException>
     {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/ListSchemasRequestSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/ListSchemasRequestSerDe.java
@@ -39,7 +39,7 @@ public final class ListSchemasRequestSerDe
     private static final String QUERY_ID_FIELD = "queryId";
     private static final String CATALOG_NAME_FIELD = "catalogName";
 
-    private ListSchemasRequestSerDe(){}
+    private ListSchemasRequestSerDe() {}
 
     public static final class Serializer extends MetadataRequestSerializer
     {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/ListSchemasResponseSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/ListSchemasResponseSerDe.java
@@ -36,7 +36,7 @@ public final class ListSchemasResponseSerDe
     private static final String CATALOG_NAME_FIELD = "catalogName";
     private static final String SCHEMAS_FIELD = "schemas";
 
-    private ListSchemasResponseSerDe(){}
+    private ListSchemasResponseSerDe() {}
 
     public static final class Serializer extends TypedSerializer<FederationResponse>
     {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/ListTablesRequestSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/ListTablesRequestSerDe.java
@@ -44,7 +44,7 @@ public final class ListTablesRequestSerDe
     private static final String PAGE_SIZE_FIELD = "pageSize";
     private static final String NEXT_TOKEN_FIELD = "nextToken";
 
-    private ListTablesRequestSerDe(){}
+    private ListTablesRequestSerDe() {}
 
     public static final class Serializer extends MetadataRequestSerializer
     {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/ListTablesResponseSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/ListTablesResponseSerDe.java
@@ -41,7 +41,7 @@ public final class ListTablesResponseSerDe
     private static final String CATALOG_NAME_FIELD = "catalogName";
     private static final String NEXT_TOKEN_FIELD = "nextToken";
 
-    private ListTablesResponseSerDe(){}
+    private ListTablesResponseSerDe() {}
 
     public static final class Serializer extends TypedSerializer<FederationResponse>
     {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/MarkerSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/MarkerSerDe.java
@@ -39,7 +39,7 @@ public final class MarkerSerDe
     private static final String BOUND_FIELD = "bound";
     private static final String NULL_VALUE_FIELD = "nullValue";
 
-    private MarkerSerDe(){}
+    private MarkerSerDe() {}
 
     public static final class Serializer extends BaseSerializer<Marker>
     {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/ObjectMapperFactoryV2.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/ObjectMapperFactoryV2.java
@@ -69,7 +69,7 @@ public class ObjectMapperFactoryV2
         SERIALIZER_FACTORY = new StrictSerializerFactory(config);
     }
 
-    private ObjectMapperFactoryV2(){}
+    private ObjectMapperFactoryV2() {}
 
     /**
      * Custom SerializerFactory that *only* uses the custom serializers that we inject into the {@link ObjectMapper}.

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/RangeSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/RangeSerDe.java
@@ -37,7 +37,7 @@ public final class RangeSerDe
     private static final String LOW_FIELD = "low";
     private static final String HIGH_FIELD = "high";
 
-    private RangeSerDe(){}
+    private RangeSerDe() {}
 
     public static final class Serializer extends BaseSerializer<Range>
     {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/ReadRecordsRequestSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/ReadRecordsRequestSerDe.java
@@ -51,7 +51,7 @@ public final class ReadRecordsRequestSerDe
     private static final String MAX_BLOCK_SIZE_FIELD = "maxBlockSize";
     private static final String MAX_INLINE_BLOCK_SIZE_FIELD = "maxInlineBlockSize";
 
-    private ReadRecordsRequestSerDe(){}
+    private ReadRecordsRequestSerDe() {}
 
     public static final class Serializer extends TypedSerializer<FederationRequest>
     {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/ReadRecordsResponseSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/ReadRecordsResponseSerDe.java
@@ -39,7 +39,7 @@ public final class ReadRecordsResponseSerDe
     private static final String CATALOG_NAME_FIELD = "catalogName";
     private static final String RECORDS_FIELD = "records";
 
-    private ReadRecordsResponseSerDe(){}
+    private ReadRecordsResponseSerDe() {}
 
     public static final class Serializer extends TypedSerializer<FederationResponse>
     {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/RemoteReadRecordsResponseSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/RemoteReadRecordsResponseSerDe.java
@@ -45,7 +45,7 @@ public final class RemoteReadRecordsResponseSerDe
     private static final String REMOTE_BLOCKS_FIELD = "remoteBlocks";
     private static final String ENCRYPTION_KEY_FIELD = "encryptionKey";
 
-    private RemoteReadRecordsResponseSerDe(){}
+    private RemoteReadRecordsResponseSerDe() {}
 
     public static final class Serializer extends TypedSerializer<FederationResponse>
     {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/S3SpillLocationSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/S3SpillLocationSerDe.java
@@ -36,7 +36,7 @@ public final class S3SpillLocationSerDe
     private static final String KEY_FIELD = "key";
     private static final String DIRECTORY_FIELD = "directory";
 
-    private S3SpillLocationSerDe(){}
+    private S3SpillLocationSerDe() {}
 
     public static final class Serializer extends TypedSerializer<SpillLocation>
     {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/SchemaSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/SchemaSerDe.java
@@ -46,7 +46,7 @@ import java.nio.channels.Channels;
 @Deprecated
 public final class SchemaSerDe
 {
-    private SchemaSerDe(){}
+    private SchemaSerDe() {}
 
     public static class Serializer extends BaseSerializer<Schema>
     {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/SortedRangeSetSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/SortedRangeSetSerDe.java
@@ -42,7 +42,7 @@ public final class SortedRangeSetSerDe
     private static final String RANGES_FIELD = "ranges";
     private static final String NULL_ALLOWED_FIELD = "nullAllowed";
 
-    private SortedRangeSetSerDe(){}
+    private SortedRangeSetSerDe() {}
 
     public static final class Serializer extends TypedSerializer<ValueSet>
     {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/SpillLocationSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/SpillLocationSerDe.java
@@ -26,7 +26,7 @@ import com.google.common.collect.ImmutableSet;
 
 public final class SpillLocationSerDe
 {
-    private SpillLocationSerDe(){}
+    private SpillLocationSerDe() {}
 
     public static final class Serializer extends DelegatingSerializer<SpillLocation>
     {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/SplitSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/SplitSerDe.java
@@ -42,7 +42,7 @@ public final class SplitSerDe
     private static final String ENCRYPTION_KEY_FIELD = "encryptionKey";
     private static final String PROPERTIES_FIELD = "properties";
 
-    private SplitSerDe(){}
+    private SplitSerDe() {}
 
     public static final class Serializer extends BaseSerializer<Split>
     {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/TableNameSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/TableNameSerDe.java
@@ -34,7 +34,7 @@ public final class TableNameSerDe
     private static final String SCHEMA_NAME_FIELD = "schemaName";
     private static final String TABLE_NAME_FIELD = "tableName";
 
-    private TableNameSerDe(){}
+    private TableNameSerDe() {}
 
     public static final class Serializer extends BaseSerializer<TableName>
     {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/UserDefinedFunctionRequestSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/UserDefinedFunctionRequestSerDe.java
@@ -46,7 +46,7 @@ public final class UserDefinedFunctionRequestSerDe
     private static final String METHOD_NAME_FIELD = "methodName";
     private static final String FUNCTION_TYPE_FIELD = "functionType";
 
-    private UserDefinedFunctionRequestSerDe(){}
+    private UserDefinedFunctionRequestSerDe() {}
 
     public static final class Serializer extends TypedSerializer<FederationRequest>
     {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/UserDefinedFunctionResponseSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/UserDefinedFunctionResponseSerDe.java
@@ -39,7 +39,7 @@ public final class UserDefinedFunctionResponseSerDe
     private static final String RECORDS_FIELD = "records";
     private static final String METHOD_NAME_FIELD = "methodName";
 
-    private UserDefinedFunctionResponseSerDe(){}
+    private UserDefinedFunctionResponseSerDe() {}
 
     public static final class Serializer extends TypedSerializer<FederationResponse>
     {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/ValueSetSerDe.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v2/ValueSetSerDe.java
@@ -26,7 +26,7 @@ import com.google.common.collect.ImmutableSet;
 
 public class ValueSetSerDe
 {
-    private ValueSetSerDe(){}
+    private ValueSetSerDe() {}
 
     public static final class Serializer extends DelegatingSerializer<ValueSet>
     {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v3/ObjectMapperFactoryV3.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v3/ObjectMapperFactoryV3.java
@@ -99,7 +99,7 @@ public class ObjectMapperFactoryV3
         SERIALIZER_FACTORY = new StrictSerializerFactory(config);
     }
 
-    private ObjectMapperFactoryV3(){}
+    private ObjectMapperFactoryV3() {}
 
     /**
      * Custom SerializerFactory that *only* uses the custom serializers that we inject into the {@link ObjectMapper}.

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v3/SchemaSerDeV3.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/serde/v3/SchemaSerDeV3.java
@@ -39,7 +39,7 @@ import java.nio.channels.Channels;
 
 public final class SchemaSerDeV3 implements VersionedSerDe
 {
-    SchemaSerDeV3(){}
+    SchemaSerDeV3() {}
 
     public static final class Serializer extends BaseSerializer<Schema> implements VersionedSerDe.Serializer<Schema>
     {

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/QueryStatusCheckerTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/QueryStatusCheckerTest.java
@@ -31,7 +31,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.OngoingStubbing;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,7 +41,7 @@ import java.util.Random;
 
 import static com.amazonaws.athena.connector.lambda.handlers.AthenaExceptionFilter.ATHENA_EXCEPTION_FILTER;
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/data/S3BlockSpillerTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/data/S3BlockSpillerTest.java
@@ -40,7 +40,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,9 +50,9 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
@@ -132,7 +132,7 @@ public class S3BlockSpillerTest
 
         ArgumentCaptor<PutObjectRequest> argument = ArgumentCaptor.forClass(PutObjectRequest.class);
 
-        when(mockS3.putObject(anyObject()))
+        when(mockS3.putObject(any()))
                 .thenAnswer(new Answer<Object>()
                 {
                     @Override

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/examples/ExampleRecordHandlerTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/examples/ExampleRecordHandlerTest.java
@@ -78,8 +78,8 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -148,7 +148,7 @@ public class ExampleRecordHandlerTest
         awsSecretsManager = mock(AWSSecretsManager.class);
         athena = mock(AmazonAthena.class);
 
-        when(amazonS3.putObject(anyObject()))
+        when(amazonS3.putObject(any()))
                 .thenAnswer(new Answer<Object>()
                 {
                     @Override
@@ -163,7 +163,7 @@ public class ExampleRecordHandlerTest
                     }
                 });
 
-        when(amazonS3.getObject(anyString(), anyString()))
+        when(amazonS3.getObject(nullable(String.class), nullable(String.class)))
                 .thenAnswer(new Answer<Object>()
                 {
                     @Override

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/handlers/CompositeHandlerTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/handlers/CompositeHandlerTest.java
@@ -55,7 +55,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
-import org.mockito.internal.util.reflection.Whitebox;
+import org.powermock.reflect.Whitebox;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,7 +64,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.UUID;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -100,30 +101,30 @@ public class CompositeHandlerTest
                 .addField("col1", new ArrowType.Int(32, true))
                 .build();
 
-        when(mockMetadataHandler.doGetTableLayout(any(BlockAllocatorImpl.class), any(GetTableLayoutRequest.class)))
+        when(mockMetadataHandler.doGetTableLayout(nullable(BlockAllocatorImpl.class), nullable(GetTableLayoutRequest.class)))
                 .thenReturn(new GetTableLayoutResponse("catalog",
                         new TableName("schema", "table"),
                         BlockUtils.newBlock(allocator, "col1", Types.MinorType.BIGINT.getType(), 1L)));
 
-        when(mockMetadataHandler.doListTables(any(BlockAllocatorImpl.class), any(ListTablesRequest.class)))
+        when(mockMetadataHandler.doListTables(nullable(BlockAllocatorImpl.class), nullable(ListTablesRequest.class)))
                 .thenReturn(new ListTablesResponse("catalog",
                         Collections.singletonList(new TableName("schema", "table")), null));
 
-        when(mockMetadataHandler.doGetTable(any(BlockAllocatorImpl.class), any(GetTableRequest.class)))
+        when(mockMetadataHandler.doGetTable(nullable(BlockAllocatorImpl.class), nullable(GetTableRequest.class)))
                 .thenReturn(new GetTableResponse("catalog",
                         new TableName("schema", "table"),
                         SchemaBuilder.newBuilder().addStringField("col1").build()));
 
-        when(mockMetadataHandler.doListSchemaNames(any(BlockAllocatorImpl.class), any(ListSchemasRequest.class)))
+        when(mockMetadataHandler.doListSchemaNames(nullable(BlockAllocatorImpl.class), nullable(ListSchemasRequest.class)))
                 .thenReturn(new ListSchemasResponse("catalog", Collections.singleton("schema1")));
 
-        when(mockMetadataHandler.doGetSplits(any(BlockAllocatorImpl.class), any(GetSplitsRequest.class)))
+        when(mockMetadataHandler.doGetSplits(nullable(BlockAllocatorImpl.class), nullable(GetSplitsRequest.class)))
                 .thenReturn(new GetSplitsResponse("catalog", Split.newBuilder(null, null).build()));
 
-        when(mockMetadataHandler.doPing(any(PingRequest.class)))
+        when(mockMetadataHandler.doPing(nullable(PingRequest.class)))
                 .thenReturn(new PingResponse("catalog", "queryId", "type", 23, 2));
 
-        when(mockRecordHandler.doReadRecords(any(BlockAllocatorImpl.class), any(ReadRecordsRequest.class)))
+        when(mockRecordHandler.doReadRecords(nullable(BlockAllocatorImpl.class), nullable(ReadRecordsRequest.class)))
                 .thenReturn(new ReadRecordsResponse("catalog",
                         BlockUtils.newEmptyBlock(allocator, "col", new ArrowType.Int(32, true))));
 
@@ -159,7 +160,7 @@ public class CompositeHandlerTest
         );
         compositeHandler.handleRequest(allocator, req, new ByteArrayOutputStream(), objectMapper);
         verify(mockRecordHandler, times(1))
-                .doReadRecords(any(BlockAllocator.class), any(ReadRecordsRequest.class));
+                .doReadRecords(nullable(BlockAllocator.class), nullable(ReadRecordsRequest.class));
     }
 
     @Test
@@ -169,7 +170,7 @@ public class CompositeHandlerTest
         ListSchemasRequest req = mock(ListSchemasRequest.class);
         when(req.getRequestType()).thenReturn(MetadataRequestType.LIST_SCHEMAS);
         compositeHandler.handleRequest(allocator, req, new ByteArrayOutputStream(), objectMapper);
-        verify(mockMetadataHandler, times(1)).doListSchemaNames(any(BlockAllocatorImpl.class), any(ListSchemasRequest.class));
+        verify(mockMetadataHandler, times(1)).doListSchemaNames(nullable(BlockAllocatorImpl.class), nullable(ListSchemasRequest.class));
     }
 
     @Test
@@ -179,7 +180,7 @@ public class CompositeHandlerTest
         ListTablesRequest req = mock(ListTablesRequest.class);
         when(req.getRequestType()).thenReturn(MetadataRequestType.LIST_TABLES);
         compositeHandler.handleRequest(allocator, req, new ByteArrayOutputStream(), objectMapper);
-        verify(mockMetadataHandler, times(1)).doListTables(any(BlockAllocatorImpl.class), any(ListTablesRequest.class));
+        verify(mockMetadataHandler, times(1)).doListTables(nullable(BlockAllocatorImpl.class), nullable(ListTablesRequest.class));
     }
 
     @Test
@@ -189,7 +190,7 @@ public class CompositeHandlerTest
         GetTableRequest req = mock(GetTableRequest.class);
         when(req.getRequestType()).thenReturn(MetadataRequestType.GET_TABLE);
         compositeHandler.handleRequest(allocator, req, new ByteArrayOutputStream(), objectMapper);
-        verify(mockMetadataHandler, times(1)).doGetTable(any(BlockAllocatorImpl.class), any(GetTableRequest.class));
+        verify(mockMetadataHandler, times(1)).doGetTable(nullable(BlockAllocatorImpl.class), nullable(GetTableRequest.class));
     }
 
     @Test
@@ -199,7 +200,7 @@ public class CompositeHandlerTest
         GetTableLayoutRequest req = mock(GetTableLayoutRequest.class);
         when(req.getRequestType()).thenReturn(MetadataRequestType.GET_TABLE_LAYOUT);
         compositeHandler.handleRequest(allocator, req, new ByteArrayOutputStream(), objectMapper);
-        verify(mockMetadataHandler, times(1)).doGetTableLayout(any(BlockAllocatorImpl.class), any(GetTableLayoutRequest.class));
+        verify(mockMetadataHandler, times(1)).doGetTableLayout(nullable(BlockAllocatorImpl.class), nullable(GetTableLayoutRequest.class));
     }
 
     @Test
@@ -209,10 +210,10 @@ public class CompositeHandlerTest
         GetSplitsRequest req = mock(GetSplitsRequest.class);
         when(req.getRequestType()).thenReturn(MetadataRequestType.GET_SPLITS);
         SpillLocationVerifier mockVerifier = mock(SpillLocationVerifier.class);
-        doNothing().when(mockVerifier).checkBucketAuthZ(any(String.class));
+        doNothing().when(mockVerifier).checkBucketAuthZ(nullable(String.class));
         Whitebox.setInternalState(mockMetadataHandler, "verifier", mockVerifier);
         compositeHandler.handleRequest(allocator, req, new ByteArrayOutputStream(), objectMapper);
-        verify(mockMetadataHandler, times(1)).doGetSplits(any(BlockAllocatorImpl.class), any(GetSplitsRequest.class));
+        verify(mockMetadataHandler, times(1)).doGetSplits(nullable(BlockAllocatorImpl.class), nullable(GetSplitsRequest.class));
     }
 
     @Test
@@ -223,6 +224,6 @@ public class CompositeHandlerTest
         when(req.getCatalogName()).thenReturn("catalog");
         when(req.getQueryId()).thenReturn("queryId");
         compositeHandler.handleRequest(allocator, req, new ByteArrayOutputStream(), objectMapper);
-        verify(mockMetadataHandler, times(1)).doPing(any(PingRequest.class));
+        verify(mockMetadataHandler, times(1)).doPing(nullable(PingRequest.class));
     }
 }

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/handlers/GlueMetadataHandlerTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/handlers/GlueMetadataHandlerTest.java
@@ -63,8 +63,9 @@ import org.junit.Test;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -85,7 +86,7 @@ import static com.amazonaws.athena.connector.lambda.handlers.GlueMetadataHandler
 import static com.amazonaws.athena.connector.lambda.handlers.GlueMetadataHandler.populateSourceTableNameIfAvailable;
 import static com.amazonaws.athena.connector.lambda.metadata.ListTablesRequest.UNLIMITED_PAGE_SIZE_VALUE;
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -173,7 +174,7 @@ public class GlueMetadataHandlerTest
         allocator = new BlockAllocatorImpl();
 
         // doListTables pagination.
-        when(mockGlue.getTables(any(GetTablesRequest.class)))
+        when(mockGlue.getTables(nullable(GetTablesRequest.class)))
                 .thenAnswer((InvocationOnMock invocationOnMock) ->
                 {
                     GetTablesRequest request = (GetTablesRequest) invocationOnMock.getArguments()[0];
@@ -223,7 +224,7 @@ public class GlueMetadataHandlerTest
         databases.add(new Database().withName("db1"));
         databases.add(new Database().withName("db2"));
 
-        when(mockGlue.getDatabases(any(GetDatabasesRequest.class)))
+        when(mockGlue.getDatabases(nullable(GetDatabasesRequest.class)))
                 .thenAnswer((InvocationOnMock invocationOnMock) ->
                 {
                     GetDatabasesRequest request = (GetDatabasesRequest) invocationOnMock.getArguments()[0];
@@ -249,7 +250,7 @@ public class GlueMetadataHandlerTest
         assertEquals(databases.stream().map(next -> next.getName()).collect(Collectors.toList()),
                 new ArrayList<>(res.getSchemas()));
 
-        verify(mockGlue, times(2)).getDatabases(any(GetDatabasesRequest.class));
+        verify(mockGlue, times(2)).getDatabases(nullable(GetDatabasesRequest.class));
     }
 
     @Test
@@ -334,12 +335,12 @@ public class GlueMetadataHandlerTest
         Table mockTable = mock(Table.class);
         StorageDescriptor mockSd = mock(StorageDescriptor.class);
 
-        when(mockTable.getName()).thenReturn(table);
+        Mockito.lenient().when(mockTable.getName()).thenReturn(table);
         when(mockTable.getStorageDescriptor()).thenReturn(mockSd);
         when(mockTable.getParameters()).thenReturn(expectedParams);
         when(mockSd.getColumns()).thenReturn(columns);
 
-        when(mockGlue.getTable(any(com.amazonaws.services.glue.model.GetTableRequest.class)))
+        when(mockGlue.getTable(nullable(com.amazonaws.services.glue.model.GetTableRequest.class)))
                 .thenAnswer((InvocationOnMock invocationOnMock) ->
                 {
                     com.amazonaws.services.glue.model.GetTableRequest request =
@@ -417,12 +418,12 @@ public class GlueMetadataHandlerTest
         Table mockTable = mock(Table.class);
         StorageDescriptor mockSd = mock(StorageDescriptor.class);
 
-        when(mockTable.getName()).thenReturn(table);
+        Mockito.lenient().when(mockTable.getName()).thenReturn(table);
         when(mockTable.getStorageDescriptor()).thenReturn(mockSd);
         when(mockTable.getParameters()).thenReturn(expectedParams);
         when(mockSd.getColumns()).thenReturn(columns);
 
-        when(mockGlue.getTable(any(com.amazonaws.services.glue.model.GetTableRequest.class)))
+        when(mockGlue.getTable(nullable(com.amazonaws.services.glue.model.GetTableRequest.class)))
                 .thenAnswer((InvocationOnMock invocationOnMock) ->
                 {
                     com.amazonaws.services.glue.model.GetTableRequest request =

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/security/CacheableSecretsManagerTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/security/CacheableSecretsManagerTest.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
@@ -64,9 +64,9 @@ public class CacheableSecretsManagerTest
         verifyNoMoreInteractions(mockSecretsManager);
         reset(mockSecretsManager);
 
-        when(mockSecretsManager.getSecretValue(any(GetSecretValueRequest.class)))
+        when(mockSecretsManager.getSecretValue(nullable(GetSecretValueRequest.class)))
                 .thenAnswer((InvocationOnMock invocation) -> {
-                    GetSecretValueRequest request = invocation.getArgumentAt(0, GetSecretValueRequest.class);
+                    GetSecretValueRequest request = invocation.getArgument(0, GetSecretValueRequest.class);
                     if (request.getSecretId().equalsIgnoreCase("test")) {
                         return new GetSecretValueResult().withSecretString("value2");
                     }
@@ -83,24 +83,24 @@ public class CacheableSecretsManagerTest
         for (int i = 0; i < CachableSecretsManager.MAX_CACHE_SIZE; i++) {
             cachableSecretsManager.addCacheEntry("test" + i, "value" + i, System.currentTimeMillis());
         }
-        when(mockSecretsManager.getSecretValue(any(GetSecretValueRequest.class)))
+        when(mockSecretsManager.getSecretValue(nullable(GetSecretValueRequest.class)))
                 .thenAnswer((InvocationOnMock invocation) -> {
-                    GetSecretValueRequest request = invocation.getArgumentAt(0, GetSecretValueRequest.class);
+                    GetSecretValueRequest request = invocation.getArgument(0, GetSecretValueRequest.class);
                     return new GetSecretValueResult().withSecretString(request.getSecretId() + "_value");
                 });
 
         assertEquals("test_value", cachableSecretsManager.getSecret("test"));
         assertEquals("test0_value", cachableSecretsManager.getSecret("test0"));
 
-        verify(mockSecretsManager, times(2)).getSecretValue(any(GetSecretValueRequest.class));
+        verify(mockSecretsManager, times(2)).getSecretValue(nullable(GetSecretValueRequest.class));
     }
 
     @Test
     public void resolveSecrets()
     {
-        when(mockSecretsManager.getSecretValue(any(GetSecretValueRequest.class)))
+        when(mockSecretsManager.getSecretValue(nullable(GetSecretValueRequest.class)))
                 .thenAnswer((InvocationOnMock invocation) -> {
-                    GetSecretValueRequest request = invocation.getArgumentAt(0, GetSecretValueRequest.class);
+                    GetSecretValueRequest request = invocation.getArgument(0, GetSecretValueRequest.class);
                     String result = request.getSecretId();
                     if (result.equalsIgnoreCase("unknown")) {
                         throw new RuntimeException("Unknown secret!");

--- a/athena-google-bigquery/pom.xml
+++ b/athena-google-bigquery/pom.xml
@@ -70,28 +70,39 @@
         <dependency>
             <groupId>nl.jqno.equalsverifier</groupId>
             <artifactId>equalsverifier</artifactId>
-            <version>3.5.5</version>
+            <version>3.12.2</version>
+            <scope>test</scope>
+        </dependency>
+        <!--
+          This is purposefully using a legacy version because these tests
+          rely on powermock and it will break on a later version.
+          Eventually we should fix the test code to not rely on powermock.
+        -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.legacy.version}</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.powermock/powermock-module-junit4 -->
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
-            <version>2.0.9</version>
+            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.powermock/powermock-api-mockito2 -->
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-api-mockito2</artifactId>
-            <version>2.0.9</version>
+            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.powermock/powermock-core -->
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-core</artifactId>
-            <version>2.0.9</version>
+            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -100,7 +111,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>${mvn.shade.plugin.version}</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <filters>
@@ -115,7 +126,7 @@
                     </filters>
                     <transformers>
                         <!-- This transformer is here to concatenate log4j2 cache during shading -->
-                        <transformer implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer">
+                        <transformer implementation="com.github.edwgiz.maven_shade_plugin.log4j2_cache_transformer.PluginsCacheFileTransformer">
 </transformer>
                     </transformers>
                 </configuration>
@@ -123,7 +134,7 @@
                     <dependency>
                         <groupId>com.github.edwgiz</groupId>
                         <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
-                        <version>2.8.1</version>
+                        <version>${log4j2.cachefile.transformer.version}</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryCompositeHandlerTest.java
+++ b/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryCompositeHandlerTest.java
@@ -39,7 +39,9 @@ import java.io.IOException;
 import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.anyString;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 
 
 @RunWith(PowerMockRunner.class)
@@ -81,12 +83,12 @@ public class BigQueryCompositeHandlerTest {
                 "  \"client_email\": \"mockabc@mockprojectid.iam.gserviceaccount.com\",\n" +
                 "  \"client_id\": \"000000000000000000000\"\n" +
                 "}");
-        Mockito.when(secretsManager.getSecretValue(Mockito.any())).thenReturn(getSecretValueResult);
+        Mockito.when(secretsManager.getSecretValue(any())).thenReturn(getSecretValueResult);
         PowerMockito.mockStatic(ServiceAccountCredentials.class);
-        PowerMockito.when(ServiceAccountCredentials.fromStream(Mockito.any())).thenReturn(serviceAccountCredentials);
+        PowerMockito.when(ServiceAccountCredentials.fromStream(any())).thenReturn(serviceAccountCredentials);
 
         PowerMockito.mockStatic(System.class);
-        PowerMockito.when(System.getenv(anyString())).thenReturn("test");
+        PowerMockito.when(System.getenv(nullable(String.class))).thenReturn("test");
 
         PowerMockito.mockStatic(BigQueryOptions.Builder.class);
         PowerMockito.when(builder.build()).thenReturn(bigQueryOptions);

--- a/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryMetadataHandlerTest.java
+++ b/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryMetadataHandlerTest.java
@@ -47,7 +47,7 @@ import static com.amazonaws.athena.connector.lambda.metadata.ListTablesRequest.U
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -66,7 +66,6 @@ public class BigQueryMetadataHandlerTest
     BigQuery bigQuery;
 
     private BigQueryMetadataHandler bigQueryMetadataHandler;
-    private int UNLIMITED_PAGE_SIZE_VALUE = 50;
     private BlockAllocator blockAllocator;
     private FederatedIdentity federatedIdentity;
     private Job job;
@@ -81,7 +80,7 @@ public class BigQueryMetadataHandlerTest
         federatedIdentity = Mockito.mock(FederatedIdentity.class);
         job = mock(Job.class);
         jobStatus = mock(JobStatus.class);
-        when(bigQuery.create(any(JobInfo.class), any())).thenReturn(job);
+        when(bigQuery.create(nullable(JobInfo.class), any())).thenReturn(job);
         when(job.waitFor(any())).thenReturn(job);
         when(job.getStatus()).thenReturn(jobStatus);
 
@@ -100,7 +99,7 @@ public class BigQueryMetadataHandlerTest
         final int numDatasets = 5;
         BigQueryPage<Dataset> datasetPage =
                 new BigQueryPage<>(BigQueryTestUtils.getDatasetList(BigQueryTestUtils.PROJECT_1_NAME, numDatasets));
-        when(bigQuery.listDatasets(anyString(), any(BigQuery.DatasetListOption.class))).thenReturn(datasetPage);
+        when(bigQuery.listDatasets(nullable(String.class), nullable(BigQuery.DatasetListOption.class))).thenReturn(datasetPage);
 
         //This will test case insenstivity
         ListSchemasRequest request = new ListSchemasRequest(federatedIdentity,
@@ -118,7 +117,7 @@ public class BigQueryMetadataHandlerTest
         final int numDatasets = 5;
         BigQueryPage<Dataset> datasetPage =
                 new BigQueryPage<>(BigQueryTestUtils.getDatasetList(BigQueryTestUtils.PROJECT_1_NAME, numDatasets));
-        when(bigQuery.listDatasets(anyString())).thenReturn(datasetPage);
+        when(bigQuery.listDatasets(nullable(String.class))).thenReturn(datasetPage);
 
         //Get the first dataset name.
         String datasetName = datasetPage.iterateAll().iterator().next().getDatasetId().getDataset();
@@ -133,7 +132,11 @@ public class BigQueryMetadataHandlerTest
                 QUERY_ID, BigQueryTestUtils.PROJECT_1_NAME.toLowerCase(),
                 datasetName, null, UNLIMITED_PAGE_SIZE_VALUE);
 
-        when(bigQuery.listTables(any(DatasetId.class), any(BigQuery.TableListOption.class))).thenReturn(tablesPage);
+        // This commented out line was used when the wrong UNLIMITED_PAGE_SIZE_VALUE was set, which
+        // triggered a method invocation to the same name but different signature.
+        //when(bigQuery.listTables(nullable(DatasetId.class), nullable(BigQuery.TableListOption.class))).thenReturn(tablesPage);
+
+        when(bigQuery.listTables(nullable(DatasetId.class))).thenReturn(tablesPage);
         ListTablesResponse tableNames = bigQueryMetadataHandler.doListTables(blockAllocator, listTablesRequest);
         assertNotNull(tableNames);
         assertEquals("Schema count does not match!", numTables, tableNames.getTables().size());
@@ -146,7 +149,7 @@ public class BigQueryMetadataHandlerTest
         final int numDatasets = 5;
         BigQueryPage<Dataset> datasetPage =
                 new BigQueryPage<>(BigQueryTestUtils.getDatasetList(BigQueryTestUtils.PROJECT_1_NAME, numDatasets));
-        when(bigQuery.listDatasets(anyString())).thenReturn(datasetPage);
+        when(bigQuery.listDatasets(nullable(String.class))).thenReturn(datasetPage);
 
         //Get the first dataset name.
         String datasetName = datasetPage.iterateAll().iterator().next().getDatasetId().getDataset();
@@ -159,7 +162,7 @@ public class BigQueryMetadataHandlerTest
 
         String tableName = tablesPage.iterateAll().iterator().next().getTableId().getTable();
 
-        when(bigQuery.listTables(any(DatasetId.class))).thenReturn(tablesPage);
+        when(bigQuery.listTables(nullable(DatasetId.class))).thenReturn(tablesPage);
 
         Schema tableSchema = BigQueryTestUtils.getTestSchema();
         StandardTableDefinition tableDefinition = StandardTableDefinition.newBuilder()
@@ -168,7 +171,7 @@ public class BigQueryMetadataHandlerTest
         Table table = mock(Table.class);
         when(table.getTableId()).thenReturn(TableId.of(BigQueryTestUtils.PROJECT_1_NAME, datasetName, tableName));
         when(table.getDefinition()).thenReturn(tableDefinition);
-        when(bigQuery.getTable(any(TableId.class))).thenReturn(table);
+        when(bigQuery.getTable(nullable(TableId.class))).thenReturn(table);
 
         //Make the call
         GetTableRequest getTableRequest = new GetTableRequest(federatedIdentity,
@@ -221,7 +224,7 @@ public class BigQueryMetadataHandlerTest
         final int numDatasets = 5;
         BigQueryPage<Dataset> datasetPage =
                 new BigQueryPage<>(BigQueryTestUtils.getDatasetList(BigQueryTestUtils.PROJECT_1_NAME, numDatasets));
-        when(bigQuery.listDatasets(anyString())).thenReturn(datasetPage);
+        when(bigQuery.listDatasets(nullable(String.class))).thenReturn(datasetPage);
 
         ListSchemasRequest request = new ListSchemasRequest(federatedIdentity,
                 QUERY_ID, BigQueryTestUtils.PROJECT_1_NAME.toLowerCase());

--- a/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryRecordHandlerTest.java
+++ b/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryRecordHandlerTest.java
@@ -64,9 +64,12 @@ import java.io.InputStream;
 import java.util.*;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 
 @RunWith(PowerMockRunner.class)
 @PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*",
@@ -142,9 +145,9 @@ public class BigQueryRecordHandlerTest
 
         //Mock the BigQuery Client to return Datasets, and Table Schema information.
         BigQueryPage<Dataset> datasets = new BigQueryPage<Dataset>(BigQueryTestUtils.getDatasetList(BigQueryTestUtils.PROJECT_1_NAME, 2));
-        when(bigQuery.listDatasets(any(String.class))).thenReturn(datasets);
+        when(bigQuery.listDatasets(nullable(String.class))).thenReturn(datasets);
         BigQueryPage<Table> tables = new BigQueryPage<Table>(BigQueryTestUtils.getTableList(BigQueryTestUtils.PROJECT_1_NAME, "dataset1", 2));
-        when(bigQuery.listTables(any(DatasetId.class))).thenReturn(tables);
+        when(bigQuery.listTables(nullable(DatasetId.class))).thenReturn(tables);
 
         //The class we want to test.
         bigQueryRecordHandler = new BigQueryRecordHandler(amazonS3, awsSecretsManager, athena);
@@ -175,7 +178,7 @@ public class BigQueryRecordHandlerTest
                 0)) {   //This is ignored when directly calling readWithConstraints.
             //Always return try for the evaluator to keep all rows.
             ConstraintEvaluator evaluator = mock(ConstraintEvaluator.class);
-            when(evaluator.apply(any(String.class), any(Object.class))).thenAnswer(
+            when(evaluator.apply(nullable(String.class), any())).thenAnswer(
                     (InvocationOnMock invocationOnMock) -> {
                         return true;
                     }
@@ -201,7 +204,7 @@ public class BigQueryRecordHandlerTest
             Job mockBigQueryJob = mock(Job.class);
             when(mockBigQueryJob.isDone()).thenReturn(false).thenReturn(true);
             when(mockBigQueryJob.getQueryResults()).thenReturn(result);
-            when(bigQuery.create(any(JobInfo.class))).thenReturn(mockBigQueryJob);
+            when(bigQuery.create(nullable(JobInfo.class))).thenReturn(mockBigQueryJob);
 
             QueryStatusChecker queryStatusChecker = mock(QueryStatusChecker.class);
             when(queryStatusChecker.isQueryRunning()).thenReturn(true);
@@ -209,7 +212,7 @@ public class BigQueryRecordHandlerTest
             //Execute the test
             bigQueryRecordHandler.readWithConstraint(spillWriter, request, queryStatusChecker);
             PowerMockito.mockStatic(System.class);
-            PowerMockito.when(System.getenv(anyString())).thenReturn("test");
+            PowerMockito.when(System.getenv(nullable(String.class))).thenReturn("test");
             logger.info("Project Name: "+BigQueryUtils.getProjectName(request.getCatalogName()));
 
             //Ensure that there was a spill so that we can read the spilled block.
@@ -246,7 +249,7 @@ public class BigQueryRecordHandlerTest
                 0)) {   //This is ignored when directly calling readWithConstraints.
             //Always return try for the evaluator to keep all rows.
             ConstraintEvaluator evaluator = mock(ConstraintEvaluator.class);
-            when(evaluator.apply(any(String.class), any(Object.class))).thenAnswer(
+            when(evaluator.apply(nullable(String.class), any())).thenAnswer(
                     (InvocationOnMock invocationOnMock) -> {
                         return true;
                     }
@@ -272,7 +275,7 @@ public class BigQueryRecordHandlerTest
             Job mockBigQueryJob = mock(Job.class);
             when(mockBigQueryJob.isDone()).thenReturn(false).thenReturn(true);
             when(mockBigQueryJob.getQueryResults()).thenReturn(result);
-            when(bigQuery.create(any(JobInfo.class))).thenReturn(mockBigQueryJob);
+            when(bigQuery.create(nullable(JobInfo.class))).thenReturn(mockBigQueryJob);
 
             QueryStatusChecker queryStatusChecker = mock(QueryStatusChecker.class);
             when(queryStatusChecker.isQueryRunning()).thenReturn(true);
@@ -280,7 +283,7 @@ public class BigQueryRecordHandlerTest
             //Execute the test
             bigQueryRecordHandler.readWithConstraint(spillWriter, request, queryStatusChecker);
             PowerMockito.mockStatic(System.class);
-            PowerMockito.when(System.getenv(anyString())).thenReturn("test");
+            PowerMockito.when(System.getenv(nullable(String.class))).thenReturn("test");
             logger.info("Project Name: "+BigQueryUtils.getProjectName(request.getCatalogName()));
 
         }
@@ -288,7 +291,7 @@ public class BigQueryRecordHandlerTest
     //Mocks the S3 client by storing any putObjects() and returning the object when getObject() is called.
     private void mockS3Client()
     {
-        when(amazonS3.putObject(anyObject()))
+        when(amazonS3.putObject(any()))
                 .thenAnswer((InvocationOnMock invocationOnMock) -> {
                     InputStream inputStream = ((PutObjectRequest) invocationOnMock.getArguments()[0]).getInputStream();
                     ByteHolder byteHolder = new ByteHolder();
@@ -297,7 +300,7 @@ public class BigQueryRecordHandlerTest
                     return mock(PutObjectResult.class);
                 });
 
-        when(amazonS3.getObject(anyString(), anyString()))
+        when(amazonS3.getObject(nullable(String.class), nullable(String.class)))
                 .thenAnswer((InvocationOnMock invocationOnMock) -> {
                     S3Object mockObject = mock(S3Object.class);
                     ByteHolder byteHolder = mockS3Storage.get(0);

--- a/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryUtilsTest.java
+++ b/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryUtilsTest.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.when;
 
 @RunWith(PowerMockRunner.class)
@@ -59,11 +60,11 @@ public class BigQueryUtilsTest {
 
         //Mock the BigQuery Client to return Datasets, and Table Schema information.
         datasets = new BigQueryPage<Dataset>(BigQueryTestUtils.getDatasetList(BigQueryTestUtils.PROJECT_1_NAME, 2));
-        when(bigQuery.listDatasets(any(String.class))).thenReturn(datasets);
+        when(bigQuery.listDatasets(nullable(String.class))).thenReturn(datasets);
         //Get the first dataset name.
         datasetName = datasets.iterateAll().iterator().next().getDatasetId().getDataset();
         tables = new BigQueryPage<Table>(BigQueryTestUtils.getTableList(BigQueryTestUtils.PROJECT_1_NAME, "dataset1", 2));
-        when(bigQuery.listTables(any(DatasetId.class))).thenReturn(tables);
+        when(bigQuery.listTables(nullable(DatasetId.class))).thenReturn(tables);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/athena-hbase/pom.xml
+++ b/athena-hbase/pom.xml
@@ -9,8 +9,8 @@
     <artifactId>athena-hbase</artifactId>
     <version>2022.47.1</version>
     <properties>
-        <jetty.version>9.4.49.v20220914</jetty.version>
-        <hbase.version>2.5.1</hbase.version>
+        <jetty.version>11.0.13</jetty.version>
+        <hbase.version>2.5.2-hadoop3</hbase.version>
     </properties>
     <dependencies>
         <dependency>
@@ -22,6 +22,7 @@
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
             <version>2022.47.1</version>
+            <classifier>withdep</classifier>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
                 <exclusion>
@@ -34,6 +35,7 @@
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
             <version>2022.47.1</version>
+            <classifier>withdep</classifier>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awscdk/emr -->
@@ -73,7 +75,7 @@
         <dependency>
             <groupId>org.codehaus.jettison</groupId>
             <artifactId>jettison</artifactId>
-            <version>1.5.2</version>
+            <version>1.5.3</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
@@ -118,7 +120,7 @@
         <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
-            <version>3.5.10</version>
+            <version>3.8.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
@@ -210,7 +212,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.13</version>
+            <version>${apache.httpclient.version}</version>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
                 <exclusion>
@@ -254,12 +256,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>${mvn.shade.plugin.version}</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <transformers>
                         <!-- This transformer is here to concatenate log4j2 cache during shading -->
-                        <transformer implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer">
+                        <transformer implementation="com.github.edwgiz.maven_shade_plugin.log4j2_cache_transformer.PluginsCacheFileTransformer">
 </transformer>
                     </transformers>
                 </configuration>
@@ -267,7 +269,7 @@
                     <dependency>
                         <groupId>com.github.edwgiz</groupId>
                         <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
-                        <version>2.8.1</version>
+                        <version>${log4j2.cachefile.transformer.version}</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/athena-hbase/src/test/java/com/amazonaws/athena/connectors/hbase/HbaseFieldResolverTest.java
+++ b/athena-hbase/src/test/java/com/amazonaws/athena/connectors/hbase/HbaseFieldResolverTest.java
@@ -26,7 +26,7 @@ import org.apache.hadoop.hbase.client.Result;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -42,7 +42,7 @@ public class HbaseFieldResolverTest
         Result mockResult = mock(Result.class);
         HbaseFieldResolver resolver = HbaseFieldResolver.resolver(false, family);
 
-        when(mockResult.getValue(any(byte[].class), any(byte[].class))).thenReturn(expectedValue.getBytes());
+        when(mockResult.getValue(nullable(byte[].class), nullable(byte[].class))).thenReturn(expectedValue.getBytes());
         Object result = resolver.getFieldValue(field, mockResult);
         assertEquals(expectedValue, result);
     }

--- a/athena-hbase/src/test/java/com/amazonaws/athena/connectors/hbase/HbaseMetadataHandlerTest.java
+++ b/athena-hbase/src/test/java/com/amazonaws/athena/connectors/hbase/HbaseMetadataHandlerTest.java
@@ -60,7 +60,7 @@ import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -74,10 +74,9 @@ import java.util.Set;
 
 import static com.amazonaws.athena.connector.lambda.metadata.ListTablesRequest.UNLIMITED_PAGE_SIZE_VALUE;
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -121,7 +120,7 @@ public class HbaseMetadataHandlerTest
                 "spillBucket",
                 "spillPrefix");
 
-        when(mockConnFactory.getOrCreateConn(anyString())).thenReturn(mockClient);
+        when(mockConnFactory.getOrCreateConn(nullable(String.class))).thenReturn(mockClient);
 
         allocator = new BlockAllocatorImpl();
     }
@@ -201,7 +200,7 @@ public class HbaseMetadataHandlerTest
         ResultScanner mockScanner = mock(ResultScanner.class);
         when(mockScanner.iterator()).thenReturn(results.iterator());
 
-        when(mockClient.scanTable(anyObject(), any(Scan.class), anyObject())).thenAnswer((InvocationOnMock invocationOnMock) -> {
+        when(mockClient.scanTable(any(), nullable(Scan.class), any())).thenAnswer((InvocationOnMock invocationOnMock) -> {
             ResultProcessor processor = (ResultProcessor) invocationOnMock.getArguments()[2];
             return processor.scan(mockScanner);
         });

--- a/athena-hbase/src/test/java/com/amazonaws/athena/connectors/hbase/HbaseRecordHandlerTest.java
+++ b/athena-hbase/src/test/java/com/amazonaws/athena/connectors/hbase/HbaseRecordHandlerTest.java
@@ -71,7 +71,7 @@ import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -91,9 +91,8 @@ import static com.amazonaws.athena.connectors.hbase.HbaseMetadataHandler.REGION_
 import static com.amazonaws.athena.connectors.hbase.HbaseMetadataHandler.REGION_NAME_FIELD;
 import static com.amazonaws.athena.connectors.hbase.HbaseMetadataHandler.START_KEY_FIELD;
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -135,13 +134,13 @@ public class HbaseRecordHandlerTest
     {
         logger.info("{}: enter", testName.getMethodName());
 
-        when(mockConnFactory.getOrCreateConn(anyString())).thenReturn(mockClient);
+        when(mockConnFactory.getOrCreateConn(nullable(String.class))).thenReturn(mockClient);
 
         allocator = new BlockAllocatorImpl();
 
         amazonS3 = mock(AmazonS3.class);
 
-        when(amazonS3.putObject(anyObject()))
+        when(amazonS3.putObject(any()))
                 .thenAnswer((InvocationOnMock invocationOnMock) -> {
                     InputStream inputStream = ((PutObjectRequest) invocationOnMock.getArguments()[0]).getInputStream();
                     ByteHolder byteHolder = new ByteHolder();
@@ -153,7 +152,7 @@ public class HbaseRecordHandlerTest
                     return mock(PutObjectResult.class);
                 });
 
-        when(amazonS3.getObject(anyString(), anyString()))
+        when(amazonS3.getObject(nullable(String.class), nullable(String.class)))
                 .thenAnswer((InvocationOnMock invocationOnMock) -> {
                     S3Object mockObject = mock(S3Object.class);
                     ByteHolder byteHolder;
@@ -189,7 +188,7 @@ public class HbaseRecordHandlerTest
         ResultScanner mockScanner = mock(ResultScanner.class);
         when(mockScanner.iterator()).thenReturn(results.iterator());
 
-        when(mockClient.scanTable(anyObject(), any(Scan.class), anyObject())).thenAnswer((InvocationOnMock invocationOnMock) -> {
+        when(mockClient.scanTable(any(), nullable(Scan.class), any())).thenAnswer((InvocationOnMock invocationOnMock) -> {
             ResultProcessor processor = (ResultProcessor) invocationOnMock.getArguments()[2];
             return processor.scan(mockScanner);
         });
@@ -242,7 +241,7 @@ public class HbaseRecordHandlerTest
         ResultScanner mockScanner = mock(ResultScanner.class);
         when(mockScanner.iterator()).thenReturn(results.iterator());
 
-        when(mockClient.scanTable(anyObject(), any(Scan.class), anyObject())).thenAnswer((InvocationOnMock invocationOnMock) -> {
+        when(mockClient.scanTable(any(), nullable(Scan.class), any())).thenAnswer((InvocationOnMock invocationOnMock) -> {
             ResultProcessor processor = (ResultProcessor) invocationOnMock.getArguments()[2];
             return processor.scan(mockScanner);
         });

--- a/athena-hbase/src/test/java/com/amazonaws/athena/connectors/hbase/HbaseSchemaUtilsTest.java
+++ b/athena-hbase/src/test/java/com/amazonaws/athena/connectors/hbase/HbaseSchemaUtilsTest.java
@@ -47,8 +47,8 @@ import static com.amazonaws.athena.connectors.hbase.TestUtils.makeResult;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyObject;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -67,7 +67,7 @@ public class HbaseSchemaUtilsTest
         HBaseConnection mockConnection = mock(HBaseConnection.class);
         ResultScanner mockScanner = mock(ResultScanner.class);
         when(mockScanner.iterator()).thenReturn(results.iterator());
-        when(mockConnection.scanTable(anyObject(), any(Scan.class), anyObject())).thenAnswer((InvocationOnMock invocationOnMock) -> {
+        when(mockConnection.scanTable(any(), nullable(Scan.class), any())).thenAnswer((InvocationOnMock invocationOnMock) -> {
             ResultProcessor processor = (ResultProcessor) invocationOnMock.getArguments()[2];
             return processor.scan(mockScanner);
         });
@@ -87,7 +87,7 @@ public class HbaseSchemaUtilsTest
         }
         assertEquals(expectedFields.size(), actualFields.size());
 
-        verify(mockConnection, times(1)).scanTable(anyObject(), any(Scan.class), any(ResultProcessor.class));
+        verify(mockConnection, times(1)).scanTable(any(), nullable(Scan.class), nullable(ResultProcessor.class));
         verify(mockScanner, times(1)).iterator();
     }
 

--- a/athena-hbase/src/test/java/com/amazonaws/athena/connectors/hbase/TestUtils.java
+++ b/athena-hbase/src/test/java/com/amazonaws/athena/connectors/hbase/TestUtils.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.hbase.HRegionInfo;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.client.Result;
 import org.mockito.invocation.InvocationOnMock;
+import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,7 +35,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -131,28 +132,28 @@ public class TestUtils
         Map<String, String> valueMap = new HashMap<>();
         for (int i = 0; i < values.length; i += 3) {
             Cell mockCell = mock(Cell.class);
-            when(mockCell.getFamilyArray()).thenReturn(values[i].getBytes());
-            when(mockCell.getFamilyOffset()).thenReturn(0);
-            when(mockCell.getFamilyLength()).thenReturn((byte)values[i].getBytes().length);
+            Mockito.lenient().when(mockCell.getFamilyArray()).thenReturn(values[i].getBytes());
+            Mockito.lenient().when(mockCell.getFamilyOffset()).thenReturn(0);
+            Mockito.lenient().when(mockCell.getFamilyLength()).thenReturn((byte)values[i].getBytes().length);
 
-            when(mockCell.getQualifierArray()).thenReturn(values[i + 1].getBytes());
-            when(mockCell.getQualifierOffset()).thenReturn(0);
-            when(mockCell.getQualifierLength()).thenReturn(values[i + 1].getBytes().length);
+            Mockito.lenient().when(mockCell.getQualifierArray()).thenReturn(values[i + 1].getBytes());
+            Mockito.lenient().when(mockCell.getQualifierOffset()).thenReturn(0);
+            Mockito.lenient().when(mockCell.getQualifierLength()).thenReturn(values[i + 1].getBytes().length);
 
-            when(mockCell.getValueArray()).thenReturn(values[i + 2].getBytes());
-            when(mockCell.getValueOffset()).thenReturn(0);
-            when(mockCell.getValueLength()).thenReturn(values[i + 2].getBytes().length);
+            Mockito.lenient().when(mockCell.getValueArray()).thenReturn(values[i + 2].getBytes());
+            Mockito.lenient().when(mockCell.getValueOffset()).thenReturn(0);
+            Mockito.lenient().when(mockCell.getValueLength()).thenReturn(values[i + 2].getBytes().length);
 
             valueMap.put(values[i] + ":" + values[i + 1], values[i + 2]);
             result.add(mockCell);
         }
 
         Result mockResult = mock(Result.class);
-        when(mockResult.listCells()).thenReturn(result);
-        when(mockResult.getValue(any(byte[].class), any(byte[].class)))
+        Mockito.lenient().when(mockResult.listCells()).thenReturn(result);
+        Mockito.lenient().when(mockResult.getValue(nullable(byte[].class), nullable(byte[].class)))
                 .thenAnswer((InvocationOnMock invocation) -> {
-                    String family = new String(invocation.getArgumentAt(0, byte[].class));
-                    String column = new String(invocation.getArgumentAt(1, byte[].class));
+                    String family = new String(invocation.getArgument(0, byte[].class));
+                    String column = new String(invocation.getArgument(1, byte[].class));
                     String key = family + ":" + column;
                     if (!valueMap.containsKey(key)) {
                         return null;

--- a/athena-hbase/src/test/java/com/amazonaws/athena/connectors/hbase/connection/HBaseConnectionTest.java
+++ b/athena-hbase/src/test/java/com/amazonaws/athena/connectors/hbase/connection/HBaseConnectionTest.java
@@ -42,9 +42,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -144,14 +143,14 @@ public class HBaseConnectionTest
     {
         logger.info("listTableNamesByNamespace: enter");
         when(mockConnection.getAdmin()).thenReturn(mockAdmin);
-        when(mockAdmin.listTableNamesByNamespace(anyString())).thenReturn(new TableName[] {});
+        when(mockAdmin.listTableNamesByNamespace(nullable(String.class))).thenReturn(new TableName[] {});
 
         TableName[] result = connection.listTableNamesByNamespace("schemaName");
         assertNotNull(result);
         assertTrue(connection.isHealthy());
         assertEquals(0, connection.getRetries());
         verify(mockConnection, atLeastOnce()).getAdmin();
-        verify(mockAdmin, atLeastOnce()).listTableNamesByNamespace(anyObject());
+        verify(mockAdmin, atLeastOnce()).listTableNamesByNamespace(any());
         logger.info("listTableNamesByNamespace: exit");
     }
 
@@ -174,14 +173,14 @@ public class HBaseConnectionTest
                 return mockAdmin;
             }
         });
-        when(mockAdmin.listTableNamesByNamespace(anyString())).thenReturn(new TableName[] {});
+        when(mockAdmin.listTableNamesByNamespace(nullable(String.class))).thenReturn(new TableName[] {});
 
         TableName[] result = connection.listTableNamesByNamespace("schemaName");
         assertNotNull(result);
         assertTrue(connection.isHealthy());
         assertEquals(1, connection.getRetries());
         verify(mockConnection, atLeastOnce()).getAdmin();
-        verify(mockAdmin, atLeastOnce()).listTableNamesByNamespace(anyObject());
+        verify(mockAdmin, atLeastOnce()).listTableNamesByNamespace(any());
         logger.info("listTableNamesByNamespaceWithRetry: exit");
     }
 
@@ -209,14 +208,14 @@ public class HBaseConnectionTest
     {
         logger.info("getTableRegions: enter");
         when(mockConnection.getAdmin()).thenReturn(mockAdmin);
-        when(mockAdmin.getTableRegions(anyObject())).thenReturn(new ArrayList<>());
+        when(mockAdmin.getTableRegions(any())).thenReturn(new ArrayList<>());
 
         List<HRegionInfo> result = connection.getTableRegions(null);
         assertNotNull(result);
         assertTrue(connection.isHealthy());
         assertEquals(0, connection.getRetries());
         verify(mockConnection, atLeastOnce()).getAdmin();
-        verify(mockAdmin, atLeastOnce()).getTableRegions(anyObject());
+        verify(mockAdmin, atLeastOnce()).getTableRegions(any());
         logger.info("getTableRegions: exit");
     }
 
@@ -239,14 +238,14 @@ public class HBaseConnectionTest
                 return mockAdmin;
             }
         });
-        when(mockAdmin.getTableRegions(anyObject())).thenReturn(new ArrayList<>());
+        when(mockAdmin.getTableRegions(any())).thenReturn(new ArrayList<>());
 
         List<HRegionInfo> result = connection.getTableRegions(null);
         assertNotNull(result);
         assertTrue(connection.isHealthy());
         assertEquals(1, connection.getRetries());
         verify(mockConnection, atLeastOnce()).getAdmin();
-        verify(mockAdmin, atLeastOnce()).getTableRegions(anyObject());
+        verify(mockAdmin, atLeastOnce()).getTableRegions(any());
         logger.info("getTableRegionsWithRetry: exit");
     }
 
@@ -273,8 +272,8 @@ public class HBaseConnectionTest
             throws IOException
     {
         logger.info("scanTable: enter");
-        when(mockConnection.getTable(any(org.apache.hadoop.hbase.TableName.class))).thenReturn(mockTable);
-        when(mockTable.getScanner(any(Scan.class))).thenReturn(mockScanner);
+        when(mockConnection.getTable(nullable(org.apache.hadoop.hbase.TableName.class))).thenReturn(mockTable);
+        when(mockTable.getScanner(nullable(Scan.class))).thenReturn(mockScanner);
 
         TableName tableName = org.apache.hadoop.hbase.TableName.valueOf("schema1", "table1");
         boolean result = connection.scanTable(tableName, mock(Scan.class), (ResultScanner scanner) -> scanner != null);
@@ -282,8 +281,8 @@ public class HBaseConnectionTest
         assertTrue(result);
         assertTrue(connection.isHealthy());
         assertEquals(0, connection.getRetries());
-        verify(mockConnection, atLeastOnce()).getTable(anyObject());
-        verify(mockTable, atLeastOnce()).getScanner(any(Scan.class));
+        verify(mockConnection, atLeastOnce()).getTable(any());
+        verify(mockTable, atLeastOnce()).getScanner(nullable(Scan.class));
         logger.info("scanTable: exit");
     }
 
@@ -292,8 +291,8 @@ public class HBaseConnectionTest
             throws IOException
     {
         logger.info("scanTableWithRetry: enter");
-        when(mockConnection.getTable(any(org.apache.hadoop.hbase.TableName.class))).thenReturn(mockTable);
-        when(mockTable.getScanner(any(Scan.class))).thenAnswer(new Answer()
+        when(mockConnection.getTable(nullable(org.apache.hadoop.hbase.TableName.class))).thenReturn(mockTable);
+        when(mockTable.getScanner(nullable(Scan.class))).thenAnswer(new Answer()
         {
             private int count = 0;
 
@@ -314,8 +313,8 @@ public class HBaseConnectionTest
         assertTrue(result);
         assertTrue(connection.isHealthy());
         assertEquals(1, connection.getRetries());
-        verify(mockConnection, atLeastOnce()).getTable(anyObject());
-        verify(mockTable, atLeastOnce()).getScanner(any(Scan.class));
+        verify(mockConnection, atLeastOnce()).getTable(any());
+        verify(mockTable, atLeastOnce()).getScanner(nullable(Scan.class));
         logger.info("scanTableWithRetry: exit");
     }
 
@@ -324,8 +323,8 @@ public class HBaseConnectionTest
             throws IOException
     {
         logger.info("scanTableRetriesExhausted: enter");
-        when(mockConnection.getTable(any(org.apache.hadoop.hbase.TableName.class))).thenReturn(mockTable);
-        when(mockTable.getScanner(any(Scan.class))).thenThrow(new RuntimeException("Retryable"));
+        when(mockConnection.getTable(nullable(org.apache.hadoop.hbase.TableName.class))).thenReturn(mockTable);
+        when(mockTable.getScanner(nullable(Scan.class))).thenThrow(new RuntimeException("Retryable"));
         TableName tableName = org.apache.hadoop.hbase.TableName.valueOf("schema1", "table1");
 
         try {
@@ -337,8 +336,8 @@ public class HBaseConnectionTest
 
         assertFalse(connection.isHealthy());
         assertEquals(3, connection.getRetries());
-        verify(mockConnection, atLeastOnce()).getTable(anyObject());
-        verify(mockTable, atLeastOnce()).getScanner(any(Scan.class));
+        verify(mockConnection, atLeastOnce()).getTable(any());
+        verify(mockTable, atLeastOnce()).getScanner(nullable(Scan.class));
         logger.info("scanTableRetriesExhausted: exit");
     }
 
@@ -347,8 +346,8 @@ public class HBaseConnectionTest
             throws IOException
     {
         logger.info("scanTable: enter");
-        when(mockConnection.getTable(any(org.apache.hadoop.hbase.TableName.class))).thenReturn(mockTable);
-        when(mockTable.getScanner(any(Scan.class))).thenReturn(mockScanner);
+        when(mockConnection.getTable(nullable(org.apache.hadoop.hbase.TableName.class))).thenReturn(mockTable);
+        when(mockTable.getScanner(nullable(Scan.class))).thenReturn(mockScanner);
 
         TableName tableName = org.apache.hadoop.hbase.TableName.valueOf("schema1", "table1");
         try {
@@ -363,8 +362,8 @@ public class HBaseConnectionTest
 
         assertTrue(connection.isHealthy());
         assertEquals(0, connection.getRetries());
-        verify(mockConnection, atLeastOnce()).getTable(anyObject());
-        verify(mockTable, atLeastOnce()).getScanner(any(Scan.class));
+        verify(mockConnection, atLeastOnce()).getTable(any());
+        verify(mockTable, atLeastOnce()).getScanner(nullable(Scan.class));
         logger.info("scanTable: exit");
     }
 

--- a/athena-hortonworks-hive/pom.xml
+++ b/athena-hortonworks-hive/pom.xml
@@ -35,24 +35,35 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
+        <!--
+          This is purposefully using a legacy version because these tests
+          rely on powermock and it will break on a later version.
+          Eventually we should fix the test code to not rely on powermock.
+        -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.legacy.version}</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
-            <version>2.0.9</version>
+            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.powermock/powermock-api-mockito2 -->
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-api-mockito2</artifactId>
-            <version>2.0.9</version>
+            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.powermock/powermock-core -->
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-core</artifactId>
-            <version>2.0.9</version>
+            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-rds -->
@@ -72,7 +83,7 @@
         <dependency>
             <groupId>com.github.stefanbirkner</groupId>
             <artifactId>system-rules</artifactId>
-            <version>1.19.0</version>
+            <version>${test.system.rules.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -81,7 +92,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>${mvn.shade.plugin.version}</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <filters>
@@ -96,7 +107,7 @@
                     </filters>
                     <transformers>
                         <!-- This transformer is here to concatenate log4j2 cache during shading -->
-                        <transformer implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer">
+                        <transformer implementation="com.github.edwgiz.maven_shade_plugin.log4j2_cache_transformer.PluginsCacheFileTransformer">
 </transformer>
                     </transformers>
                 </configuration>
@@ -104,7 +115,7 @@
                     <dependency>
                         <groupId>com.github.edwgiz</groupId>
                         <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
-                        <version>2.8.1</version>
+                        <version>${log4j2.cachefile.transformer.version}</version>
                     </dependency>
                 </dependencies>
                 <executions>
@@ -138,7 +149,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>${mvn.checkstyle.version}</version>
                 <configuration>
                     <configLocation>checkstyle.xml</configLocation>
                     <encoding>UTF-8</encoding>

--- a/athena-hortonworks-hive/src/test/java/com/amazonaws/athena/connectors/hortonworks/HiveMetadataHandlerTest.java
+++ b/athena-hortonworks-hive/src/test/java/com/amazonaws/athena/connectors/hortonworks/HiveMetadataHandlerTest.java
@@ -45,6 +45,8 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 
 public class HiveMetadataHandlerTest
         extends TestBase {
@@ -71,7 +73,7 @@ public class HiveMetadataHandlerTest
         this.blockAllocator = Mockito.mock(BlockAllocator.class);
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class, Mockito.RETURNS_DEEP_STUBS);
         this.connection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);
-        Mockito.when(this.jdbcConnectionFactory.getConnection(Mockito.any(JdbcCredentialProvider.class))).thenReturn(this.connection);
+        Mockito.when(this.jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(this.connection);
         this.secretsManager = Mockito.mock(AWSSecretsManager.class);
         this.athena = Mockito.mock(AmazonAthena.class);
         Mockito.when(this.secretsManager.getSecretValue(Mockito.eq(new GetSecretValueRequest().withSecretId("testSecret")))).thenReturn(new GetSecretValueResult().withSecretString("{\"username\": \"testUser\", \"password\": \"testPassword\"}"));
@@ -113,7 +115,7 @@ public class HiveMetadataHandlerTest
         int[] types3 = {Types.VARCHAR};
         Object[][] values4 = {{"PARTITIONED:true"}};
         ResultSet resultSet2 = mockResultSet(columns3, types3, values4, new AtomicInteger(-1));
-        Mockito.when(jdbcConnectionFactory.getConnection(Mockito.any(JdbcCredentialProvider.class))).thenReturn(connection);
+        Mockito.when(jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(connection);
         String tableName =getTableLayoutRequest.getTableName().getTableName().toUpperCase();
         final String getPartitionExistsSql = "show table extended like "  + tableName;
         final String getPartitionDetailsSql = "show partitions "  + getTableLayoutRequest.getTableName().getTableName().toUpperCase();
@@ -157,7 +159,7 @@ public class HiveMetadataHandlerTest
         String[] columns2 = {"Partition"};
         int[] types2 = {Types.VARCHAR};
         Object[][] values1 = {};
-        Mockito.when(jdbcConnectionFactory.getConnection(Mockito.any(JdbcCredentialProvider.class))).thenReturn(connection);
+        Mockito.when(jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(connection);
         String tableName =getTableLayoutRequest.getTableName().getTableName().toUpperCase();
         final String getPartitionDetailsSql = "show partitions "  + getTableLayoutRequest.getTableName().getTableName().toUpperCase();
         Statement statement1 = Mockito.mock(Statement.class);
@@ -190,7 +192,7 @@ public class HiveMetadataHandlerTest
         GetTableLayoutRequest getTableLayoutRequest = new GetTableLayoutRequest(this.federatedIdentity, "testQueryId", "testCatalogName", tableName, constraints, partitionSchema, partitionCols);
         Connection connection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);
         JdbcConnectionFactory jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
-        Mockito.when(jdbcConnectionFactory.getConnection(Mockito.any(JdbcCredentialProvider.class))).thenReturn(connection);
+        Mockito.when(jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(connection);
         Mockito.when(connection.getMetaData().getSearchStringEscape()).thenThrow(new SQLException());
         HiveMetadataHandler implalaMetadataHandler = new HiveMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, jdbcConnectionFactory);
         implalaMetadataHandler.doGetTableLayout(Mockito.mock(BlockAllocator.class), getTableLayoutRequest);
@@ -220,7 +222,7 @@ public class HiveMetadataHandlerTest
         String[] columns2 = {"Partition"};
         int[] types2 = {Types.VARCHAR};
         Object[][] values1 = {{value2},{value3}};
-        Mockito.when(jdbcConnectionFactory.getConnection(Mockito.any(JdbcCredentialProvider.class))).thenReturn(connection);
+        Mockito.when(jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(connection);
         String tableName =getTableLayoutRequest.getTableName().getTableName().toUpperCase();
         final String getPartitionExistsSql = "show table extended like "  + tableName;
         final String getPartitionDetailsSql = "show partitions "  + getTableLayoutRequest.getTableName().getTableName().toUpperCase();
@@ -295,18 +297,20 @@ public class HiveMetadataHandlerTest
         Assert.assertEquals(inputTableName, getTableResponse.getTableName());
         Assert.assertEquals("testCatalog", getTableResponse.getCatalogName());
     }
+
     @Test
     public void doGetTableNoColumns() throws Exception
     {
         TableName inputTableName = new TableName("testSchema", "testTable");
         this.hiveMetadataHandler.doGetTable(this.blockAllocator, new GetTableRequest(this.federatedIdentity, "testQueryId", "testCatalog", inputTableName));
     }
-    @Test
+
+    @Test(expected = SQLException.class)
     public void doGetTableSQLException()
             throws Exception
     {
         TableName inputTableName = new TableName("testSchema", "testTable");
-        Mockito.when(this.connection.getMetaData().getColumns(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString()))
+        Mockito.when(this.connection.getMetaData().getColumns(nullable(String.class), nullable(String.class), nullable(String.class), nullable(String.class)))
                 .thenThrow(new SQLException());
         this.hiveMetadataHandler.doGetTable(this.blockAllocator, new GetTableRequest(this.federatedIdentity, "testQueryId", "testCatalog", inputTableName));
     }

--- a/athena-hortonworks-hive/src/test/java/com/amazonaws/athena/connectors/hortonworks/HiveMuxMetadataHandlerTest.java
+++ b/athena-hortonworks-hive/src/test/java/com/amazonaws/athena/connectors/hortonworks/HiveMuxMetadataHandlerTest.java
@@ -46,6 +46,7 @@ import com.amazonaws.athena.connector.lambda.metadata.ListTablesRequest;
 import com.amazonaws.services.athena.AmazonAthena;
 import com.amazonaws.services.secretsmanager.AWSSecretsManager;
 
+import static org.mockito.ArgumentMatchers.nullable;
 
 public class HiveMuxMetadataHandlerTest
 {
@@ -154,7 +155,7 @@ public class HiveMuxMetadataHandlerTest
         GetTableLayoutRequest getTableLayoutRequest = Mockito.mock(GetTableLayoutRequest.class);
         Mockito.when(getTableLayoutRequest.getCatalogName()).thenReturn("metaHive");
         this.jdbcMetadataHandler.getPartitions(Mockito.mock(BlockWriter.class), getTableLayoutRequest, queryStatusChecker);
-        Mockito.verify(this.hiveMetadataHandler, Mockito.times(1)).getPartitions(Mockito.any(BlockWriter.class), Mockito.eq(getTableLayoutRequest), Mockito.eq(queryStatusChecker));
+        Mockito.verify(this.hiveMetadataHandler, Mockito.times(1)).getPartitions(nullable(BlockWriter.class), Mockito.eq(getTableLayoutRequest), Mockito.eq(queryStatusChecker));
     }
 
     @Test

--- a/athena-hortonworks-hive/src/test/java/com/amazonaws/athena/connectors/hortonworks/HiveQueryStringBuilderTest.java
+++ b/athena-hortonworks-hive/src/test/java/com/amazonaws/athena/connectors/hortonworks/HiveQueryStringBuilderTest.java
@@ -24,7 +24,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @SuppressWarnings("deprecation")
 @RunWith(MockitoJUnitRunner.class)

--- a/athena-hortonworks-hive/src/test/java/com/amazonaws/athena/connectors/hortonworks/HiveRecordHandlerTest.java
+++ b/athena-hortonworks-hive/src/test/java/com/amazonaws/athena/connectors/hortonworks/HiveRecordHandlerTest.java
@@ -54,6 +54,8 @@ import com.amazonaws.services.secretsmanager.model.GetSecretValueResult;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 
 public class HiveRecordHandlerTest
 {
@@ -75,7 +77,7 @@ public class HiveRecordHandlerTest
         Mockito.when(this.secretsManager.getSecretValue(Mockito.eq(new GetSecretValueRequest().withSecretId("testSecret")))).thenReturn(new GetSecretValueResult().withSecretString("{\"username\": \"testUser\", \"password\": \"testPassword\"}"));
         this.connection = Mockito.mock(Connection.class);
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
-        Mockito.when(this.jdbcConnectionFactory.getConnection(Mockito.mock(JdbcCredentialProvider.class))).thenReturn(this.connection);
+        Mockito.when(this.jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(this.connection);
         jdbcSplitQueryBuilder = new HiveQueryStringBuilder("`");
         final DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", HiveConstants.HIVE_NAME,
                 "hive2://jdbc:hive2://54.89.6.2:10000/authena;AuthMech=3;UID=hive;PWD=hive");
@@ -126,7 +128,7 @@ public class HiveRecordHandlerTest
                 .put("testCol2", valueSet2)
                 .build());
         PreparedStatement expectedPreparedStatement = Mockito.mock(PreparedStatement.class);
-        Mockito.when(this.connection.prepareStatement(Mockito.anyString())).thenReturn(expectedPreparedStatement);
+        Mockito.when(this.connection.prepareStatement(nullable(String.class))).thenReturn(expectedPreparedStatement);
         PreparedStatement preparedStatement = this.hiveRecordHandler.buildSplitSql(this.connection, "testCatalogName", tableName, schema, constraints, split);
         Assert.assertEquals(expectedPreparedStatement, preparedStatement);
     }

--- a/athena-jdbc/pom.xml
+++ b/athena-jdbc/pom.xml
@@ -94,6 +94,7 @@
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
             <version>2022.47.1</version>
+            <classifier>withdep</classifier>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
                 <exclusion>
@@ -157,7 +158,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <version>${log4j2Version}</version>
             <scope>runtime</scope>
         </dependency>
@@ -210,7 +211,7 @@
         <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
-            <version>4.5.3</version>
+            <version>4.7.3</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>
@@ -219,7 +220,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.2.2</version>
+                <version>${mvn.jar.plugin.version}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -231,7 +232,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>${mvn.shade.plugin.version}</version>
                 <configuration>
                     <createDependencyReducedPom>true</createDependencyReducedPom>
                     <shadeTestJar>true</shadeTestJar>
@@ -247,7 +248,7 @@
                     </filters>
                     <transformers>
                         <!-- This transformer is here to concatenate log4j2 cache during shading -->
-                        <transformer implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer">
+                        <transformer implementation="com.github.edwgiz.maven_shade_plugin.log4j2_cache_transformer.PluginsCacheFileTransformer">
 </transformer>
                     </transformers>
                 </configuration>
@@ -255,7 +256,7 @@
                     <dependency>
                         <groupId>com.github.edwgiz</groupId>
                         <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
-                        <version>2.8.1</version>
+                        <version>${log4j2.cachefile.transformer.version}</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/MultiplexingJdbcMetadataHandlerTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/MultiplexingJdbcMetadataHandlerTest.java
@@ -41,6 +41,8 @@ import org.mockito.Mockito;
 import java.util.Collections;
 import java.util.Map;
 
+import static org.mockito.ArgumentMatchers.nullable;
+
 public class MultiplexingJdbcMetadataHandlerTest
 {
     private Map<String, JdbcMetadataHandler> metadataHandlerMap;
@@ -57,7 +59,7 @@ public class MultiplexingJdbcMetadataHandlerTest
     {
         //this.allocator = Mockito.mock(BlockAllocator.class);
         this.allocator = new BlockAllocatorImpl();
-        //Mockito.when(this.allocator.createBlock(Mockito.any(Schema.class))).thenReturn(Mockito.mock(Block.class));
+        //Mockito.when(this.allocator.createBlock(nullable(Schema.class))).thenReturn(Mockito.mock(Block.class));
         this.fakeDatabaseHandler = Mockito.mock(JdbcMetadataHandler.class);
         this.metadataHandlerMap = Collections.singletonMap("fakedatabase", this.fakeDatabaseHandler);
         this.secretsManager = Mockito.mock(AWSSecretsManager.class);
@@ -131,7 +133,7 @@ public class MultiplexingJdbcMetadataHandlerTest
         GetTableLayoutRequest getTableLayoutRequest = Mockito.mock(GetTableLayoutRequest.class);
         Mockito.when(getTableLayoutRequest.getCatalogName()).thenReturn("fakedatabase");
         this.jdbcMetadataHandler.getPartitions(Mockito.mock(BlockWriter.class), getTableLayoutRequest, queryStatusChecker);
-        Mockito.verify(this.fakeDatabaseHandler, Mockito.times(1)).getPartitions(Mockito.any(BlockWriter.class), Mockito.eq(getTableLayoutRequest), Mockito.eq(queryStatusChecker));
+        Mockito.verify(this.fakeDatabaseHandler, Mockito.times(1)).getPartitions(nullable(BlockWriter.class), Mockito.eq(getTableLayoutRequest), Mockito.eq(queryStatusChecker));
     }
 
     @Test

--- a/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/TestBase.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/TestBase.java
@@ -27,6 +27,9 @@ import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+
 public class TestBase
 {
     protected ResultSet mockResultSet(String[] columnNames, int[] columnTypes, Object[][] rows, AtomicInteger rowNumber)
@@ -43,7 +46,7 @@ public class TestBase
                     return rowNumber.getAndIncrement() + 1 < rows.length;
                 });
 
-        Mockito.when(resultSet.getInt(Mockito.any())).thenAnswer((Answer<Integer>) invocation -> {
+        Mockito.when(resultSet.getInt(any())).thenAnswer((Answer<Integer>) invocation -> {
             Object argument = invocation.getArguments()[0];
 
             if (argument instanceof Integer) {
@@ -59,7 +62,7 @@ public class TestBase
             }
         });
 
-        Mockito.when(resultSet.getString(Mockito.any())).thenAnswer((Answer<String>) invocation -> {
+        Mockito.when(resultSet.getString(any())).thenAnswer((Answer<String>) invocation -> {
             Object argument = invocation.getArguments()[0];
             if (argument instanceof Integer) {
                 int colIndex = (Integer) argument - 1;
@@ -76,8 +79,8 @@ public class TestBase
 
         if (columnTypes != null) {
             Mockito.when(resultSet.getMetaData().getColumnCount()).thenReturn(columnNames.length);
-            Mockito.when(resultSet.getMetaData().getColumnDisplaySize(Mockito.anyInt())).thenReturn(10);
-            Mockito.when(resultSet.getMetaData().getColumnType(Mockito.anyInt())).thenAnswer((Answer<Integer>) invocation -> columnTypes[(Integer) invocation.getArguments()[0] - 1]);
+            Mockito.when(resultSet.getMetaData().getColumnDisplaySize(anyInt())).thenReturn(10);
+            Mockito.when(resultSet.getMetaData().getColumnType(anyInt())).thenAnswer((Answer<Integer>) invocation -> columnTypes[(Integer) invocation.getArguments()[0] - 1]);
         }
 
         return resultSet;

--- a/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcRecordHandlerTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcRecordHandlerTest.java
@@ -64,6 +64,9 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
+
 public class JdbcRecordHandlerTest
         extends TestBase
 {
@@ -84,7 +87,7 @@ public class JdbcRecordHandlerTest
     {
         this.connection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
-        Mockito.when(this.jdbcConnectionFactory.getConnection(Mockito.any(JdbcCredentialProvider.class))).thenReturn(this.connection);
+        Mockito.when(this.jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(this.connection);
         this.amazonS3 = Mockito.mock(AmazonS3.class);
         this.secretsManager = Mockito.mock(AWSSecretsManager.class);
         this.athena = Mockito.mock(AmazonAthena.class);
@@ -111,7 +114,7 @@ public class JdbcRecordHandlerTest
             throws Exception
     {
         ConstraintEvaluator constraintEvaluator = Mockito.mock(ConstraintEvaluator.class);
-        Mockito.when(constraintEvaluator.apply(Mockito.anyString(), Mockito.any())).thenReturn(true);
+        Mockito.when(constraintEvaluator.apply(nullable(String.class), any())).thenReturn(true);
 
         TableName inputTableName = new TableName("testSchema", "testTable");
         SchemaBuilder expectedSchemaBuilder = SchemaBuilder.newBuilder();
@@ -140,7 +143,7 @@ public class JdbcRecordHandlerTest
         BlockSpiller s3Spiller = new S3BlockSpiller(this.amazonS3, spillConfig, allocator, fieldSchema, constraintEvaluator);
         ReadRecordsRequest readRecordsRequest = new ReadRecordsRequest(this.federatedIdentity, "testCatalog", "testQueryId", inputTableName, fieldSchema, splitBuilder.build(), constraints, 1024, 1024);
 
-        Mockito.when(amazonS3.putObject(Mockito.any())).thenAnswer((Answer<PutObjectResult>) invocation -> {
+        Mockito.when(amazonS3.putObject(any())).thenAnswer((Answer<PutObjectResult>) invocation -> {
             ByteArrayInputStream byteArrayInputStream = (ByteArrayInputStream) ((PutObjectRequest) invocation.getArguments()[0]).getInputStream();
             int n = byteArrayInputStream.available();
             byte[] bytes = new byte[n];

--- a/athena-msk/pom.xml
+++ b/athena-msk/pom.xml
@@ -37,6 +37,7 @@
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
             <version>2022.47.1</version>
+            <classifier>withdep</classifier>
             <scope>test</scope>
             <exclusions>
             </exclusions>
@@ -62,40 +63,46 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!--
+          This is purposefully using a legacy version because these tests
+          rely on powermock and it will break on a later version.
+          Eventually we should fix the test code to not rely on powermock.
+        -->
         <dependency>
-            <groupId>com.github.stefanbirkner</groupId>
-            <artifactId>system-rules</artifactId>
-            <version>1.2.0</version>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.legacy.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>uk.org.webcompere</groupId>
-            <artifactId>system-stubs-junit4</artifactId>
-            <version>1.1.0</version>
+            <groupId>com.github.stefanbirkner</groupId>
+            <artifactId>system-rules</artifactId>
+            <version>${test.system.rules.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
             <version>2022.47.1</version>
+            <classifier>withdep</classifier>
          </dependency>
         <!-- Powermock depedency -->
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
-            <version>2.0.9</version>
+            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-api-mockito2</artifactId>
-            <version>2.0.9</version>
+            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-core</artifactId>
-            <version>2.0.9</version>
+            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -112,7 +119,7 @@
         <dependency>
             <groupId>org.junit.support</groupId>
             <artifactId>testng-engine</artifactId>
-            <version>1.0.1</version>
+            <version>1.0.4</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -121,7 +128,7 @@
            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>${mvn.shade.plugin.version}</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <filters>
@@ -136,7 +143,7 @@
                     </filters>
                     <transformers>
                         <!-- This transformer is here to concatenate log4j2 cache during shading -->
-                        <transformer implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer">
+                        <transformer implementation="com.github.edwgiz.maven_shade_plugin.log4j2_cache_transformer.PluginsCacheFileTransformer">
                         </transformer>
                     </transformers>
                 </configuration>
@@ -144,7 +151,7 @@
                     <dependency>
                         <groupId>com.github.edwgiz</groupId>
                         <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
-                        <version>2.8.1</version>
+                        <version>${log4j2.cachefile.transformer.version}</version>
                     </dependency>
                 </dependencies>
                 <executions>
@@ -159,7 +166,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>${maven.compiler.plugin.version}</version>
                 <configuration>
                     <forceJavacCompilerUse>true</forceJavacCompilerUse>
                 </configuration>

--- a/athena-msk/src/test/java/com/amazonaws/athena/connectors/msk/AmazonMskCompositeHandlerTest.java
+++ b/athena-msk/src/test/java/com/amazonaws/athena/connectors/msk/AmazonMskCompositeHandlerTest.java
@@ -32,9 +32,9 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import uk.org.webcompere.systemstubs.rules.EnvironmentVariablesRule;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
 
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
@@ -49,7 +49,7 @@ public class AmazonMskCompositeHandlerTest {
     }
 
     @Rule
-    public EnvironmentVariablesRule environmentVariables = new EnvironmentVariablesRule();
+    public EnvironmentVariables environmentVariables = new EnvironmentVariables();
 
     @Mock
     KafkaConsumer<String, String> kafkaConsumer;
@@ -69,7 +69,7 @@ public class AmazonMskCompositeHandlerTest {
         mockStatic(AWSSecretsManagerClientBuilder.class);
         PowerMockito.when(AWSSecretsManagerClientBuilder.defaultClient()).thenReturn(secretsManager);
         mockStatic(System.class);
-        PowerMockito.when(System.getenv(anyString())).thenReturn("test");
+        PowerMockito.when(System.getenv(nullable(String.class))).thenReturn("test");
         mockStatic(AmazonMskUtils.class);
         PowerMockito.when(AmazonMskUtils.getKafkaConsumer()).thenReturn(kafkaConsumer);
         amazonMskCompositeHandler = new AmazonMskCompositeHandler();

--- a/athena-msk/src/test/java/com/amazonaws/athena/connectors/msk/AmazonMskMetadataHandlerTest.java
+++ b/athena-msk/src/test/java/com/amazonaws/athena/connectors/msk/AmazonMskMetadataHandlerTest.java
@@ -49,7 +49,7 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import uk.org.webcompere.systemstubs.rules.EnvironmentVariablesRule;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -58,6 +58,7 @@ import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -76,7 +77,7 @@ public class AmazonMskMetadataHandlerTest {
     private Constraints constraints;
 
     @Rule
-    public EnvironmentVariablesRule environmentVariables = new EnvironmentVariablesRule();
+    public EnvironmentVariables environmentVariables = new EnvironmentVariables();
 
     @Mock
     AWSGlue awsGlue;
@@ -163,8 +164,8 @@ public class AmazonMskMetadataHandlerTest {
                 "}");
         PowerMockito.mockStatic(AWSGlueClientBuilder.class);
         PowerMockito.when(AWSGlueClientBuilder.defaultClient()).thenReturn(awsGlue);
-        PowerMockito.when(awsGlue.getSchema(Mockito.any())).thenReturn(getSchemaResult);
-        PowerMockito.when(awsGlue.getSchemaVersion(Mockito.any())).thenReturn(getSchemaVersionResult);
+        PowerMockito.when(awsGlue.getSchema(any())).thenReturn(getSchemaResult);
+        PowerMockito.when(awsGlue.getSchemaVersion(any())).thenReturn(getSchemaVersionResult);
         GetTableRequest getTableRequest = new GetTableRequest(federatedIdentity, QUERY_ID, "kafka", new TableName("default", "testtable"));
         GetTableResponse getTableResponse = amazonMskMetadataHandler.doGetTable(blockAllocator, getTableRequest);
         assertEquals(1, getTableResponse.getSchema().getFields().size());

--- a/athena-msk/src/test/java/com/amazonaws/athena/connectors/msk/AmazonMskRecordHandlerTest.java
+++ b/athena-msk/src/test/java/com/amazonaws/athena/connectors/msk/AmazonMskRecordHandlerTest.java
@@ -60,7 +60,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.*;
 
 @RunWith(PowerMockRunner.class)
@@ -147,7 +149,7 @@ public class AmazonMskRecordHandlerTest {
         PowerMockito.when(AmazonMskUtils.createSplitParam(anyMap())).thenReturn(splitParameters);
 
         ConstraintEvaluator evaluator = mock(ConstraintEvaluator.class);
-        when(evaluator.apply(any(String.class), any(Object.class))).thenAnswer(
+        when(evaluator.apply(nullable(String.class), any())).thenAnswer(
                 (InvocationOnMock invocationOnMock) -> {
                     return true;
                 }

--- a/athena-mysql/pom.xml
+++ b/athena-mysql/pom.xml
@@ -63,7 +63,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>${mvn.shade.plugin.version}</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <filters>
@@ -78,7 +78,7 @@
                     </filters>
                     <transformers>
                         <!-- This transformer is here to concatenate log4j2 cache during shading -->
-                        <transformer implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer">
+                        <transformer implementation="com.github.edwgiz.maven_shade_plugin.log4j2_cache_transformer.PluginsCacheFileTransformer">
 </transformer>
                     </transformers>
                 </configuration>
@@ -86,7 +86,7 @@
                     <dependency>
                         <groupId>com.github.edwgiz</groupId>
                         <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
-                        <version>2.8.1</version>
+                        <version>${log4j2.cachefile.transformer.version}</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/athena-mysql/src/test/java/com/amazonaws/athena/connectors/mysql/MySqlMetadataHandlerTest.java
+++ b/athena-mysql/src/test/java/com/amazonaws/athena/connectors/mysql/MySqlMetadataHandlerTest.java
@@ -63,6 +63,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import static com.amazonaws.athena.connectors.mysql.MySqlConstants.MYSQL_NAME;
+import static org.mockito.ArgumentMatchers.nullable;
 
 public class MySqlMetadataHandlerTest
         extends TestBase
@@ -82,7 +83,7 @@ public class MySqlMetadataHandlerTest
     {
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         this.connection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);
-        Mockito.when(this.jdbcConnectionFactory.getConnection(Mockito.any(JdbcCredentialProvider.class))).thenReturn(this.connection);
+        Mockito.when(this.jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(this.connection);
         this.secretsManager = Mockito.mock(AWSSecretsManager.class);
         this.athena = Mockito.mock(AmazonAthena.class);
         Mockito.when(this.secretsManager.getSecretValue(Mockito.eq(new GetSecretValueRequest().withSecretId("testSecret")))).thenReturn(new GetSecretValueResult().withSecretString("{\"username\": \"testUser\", \"password\": \"testPassword\"}"));
@@ -194,7 +195,7 @@ public class MySqlMetadataHandlerTest
 
         Connection connection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);
         JdbcConnectionFactory jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
-        Mockito.when(jdbcConnectionFactory.getConnection(Mockito.any(JdbcCredentialProvider.class))).thenReturn(connection);
+        Mockito.when(jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(connection);
         Mockito.when(connection.getMetaData().getSearchStringEscape()).thenThrow(new SQLException());
         MySqlMetadataHandler mySqlMetadataHandler = new MySqlMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, jdbcConnectionFactory);
 

--- a/athena-mysql/src/test/java/com/amazonaws/athena/connectors/mysql/MySqlMuxJdbcMetadataHandlerTest.java
+++ b/athena-mysql/src/test/java/com/amazonaws/athena/connectors/mysql/MySqlMuxJdbcMetadataHandlerTest.java
@@ -41,6 +41,8 @@ import org.mockito.Mockito;
 import java.util.Collections;
 import java.util.Map;
 
+import static org.mockito.ArgumentMatchers.nullable;
+
 public class MySqlMuxJdbcMetadataHandlerTest
 {
     private Map<String, JdbcMetadataHandler> metadataHandlerMap;
@@ -57,7 +59,7 @@ public class MySqlMuxJdbcMetadataHandlerTest
     {
         //this.allocator = Mockito.mock(BlockAllocator.class);
         this.allocator = new BlockAllocatorImpl();
-        //Mockito.when(this.allocator.createBlock(Mockito.any(Schema.class))).thenReturn(Mockito.mock(Block.class));
+        //Mockito.when(this.allocator.createBlock(nullable(Schema.class))).thenReturn(Mockito.mock(Block.class));
         this.mySqlMetadataHandler = Mockito.mock(MySqlMetadataHandler.class);
         this.metadataHandlerMap = Collections.singletonMap("fakedatabase", this.mySqlMetadataHandler);
         this.secretsManager = Mockito.mock(AWSSecretsManager.class);
@@ -131,7 +133,7 @@ public class MySqlMuxJdbcMetadataHandlerTest
         GetTableLayoutRequest getTableLayoutRequest = Mockito.mock(GetTableLayoutRequest.class);
         Mockito.when(getTableLayoutRequest.getCatalogName()).thenReturn("fakedatabase");
         this.jdbcMetadataHandler.getPartitions(Mockito.mock(BlockWriter.class), getTableLayoutRequest, queryStatusChecker);
-        Mockito.verify(this.mySqlMetadataHandler, Mockito.times(1)).getPartitions(Mockito.any(BlockWriter.class), Mockito.eq(getTableLayoutRequest), Mockito.eq(queryStatusChecker));
+        Mockito.verify(this.mySqlMetadataHandler, Mockito.times(1)).getPartitions(nullable(BlockWriter.class), Mockito.eq(getTableLayoutRequest), Mockito.eq(queryStatusChecker));
     }
 
     @Test

--- a/athena-mysql/src/test/java/com/amazonaws/athena/connectors/mysql/MySqlRecordHandlerTest.java
+++ b/athena-mysql/src/test/java/com/amazonaws/athena/connectors/mysql/MySqlRecordHandlerTest.java
@@ -50,6 +50,7 @@ import java.sql.SQLException;
 import java.util.Collections;
 
 import static com.amazonaws.athena.connectors.mysql.MySqlConstants.MYSQL_NAME;
+import static org.mockito.ArgumentMatchers.nullable;
 
 public class MySqlRecordHandlerTest
 {
@@ -70,7 +71,7 @@ public class MySqlRecordHandlerTest
         this.athena = Mockito.mock(AmazonAthena.class);
         this.connection = Mockito.mock(Connection.class);
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
-        Mockito.when(this.jdbcConnectionFactory.getConnection(Mockito.mock(JdbcCredentialProvider.class))).thenReturn(this.connection);
+        Mockito.when(this.jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(this.connection);
         jdbcSplitQueryBuilder = new MySqlQueryStringBuilder("`");
         final DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", MYSQL_NAME,
                 "mysql://jdbc:mysql://hostname/user=A&password=B");

--- a/athena-neptune/pom.xml
+++ b/athena-neptune/pom.xml
@@ -17,6 +17,7 @@
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
             <version>2022.47.1</version>
+            <classifier>withdep</classifier>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
                 <exclusion>
@@ -131,7 +132,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <version>${log4j2Version}</version>
             <scope>runtime</scope>
         </dependency>
@@ -168,7 +169,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>${mvn.shade.plugin.version}</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <filters>
@@ -183,7 +184,7 @@
                     </filters>
                     <transformers>
                         <!-- This transformer is here to concatenate log4j2 cache during shading -->
-                        <transformer implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer">
+                        <transformer implementation="com.github.edwgiz.maven_shade_plugin.log4j2_cache_transformer.PluginsCacheFileTransformer">
 </transformer>
                     </transformers>
                 </configuration>
@@ -191,7 +192,7 @@
                     <dependency>
                         <groupId>com.github.edwgiz</groupId>
                         <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
-                        <version>2.8.1</version>
+                        <version>${log4j2.cachefile.transformer.version}</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/athena-neptune/src/test/java/com/amazonaws/athena/connectors/neptune/NeptuneMetadataHandlerTest.java
+++ b/athena-neptune/src/test/java/com/amazonaws/athena/connectors/neptune/NeptuneMetadataHandlerTest.java
@@ -54,11 +54,11 @@ import java.util.Map;
 import static org.junit.Assert.*;
 
 import static com.amazonaws.athena.connector.lambda.metadata.ListTablesRequest.UNLIMITED_PAGE_SIZE_VALUE;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class NeptuneMetadataHandlerTest extends TestBase {
@@ -128,7 +128,7 @@ public class NeptuneMetadataHandlerTest extends TestBase {
 
         ListTablesRequest req = new ListTablesRequest(IDENTITY, "queryId", "default",
                 "default", null, UNLIMITED_PAGE_SIZE_VALUE);
-        when(glue.getTables(any(GetTablesRequest.class))).thenReturn(tableResult);
+        when(glue.getTables(nullable(GetTablesRequest.class))).thenReturn(tableResult);
 
         ListTablesResponse res = handler.doListTables(allocator, req);
 
@@ -170,7 +170,7 @@ public class NeptuneMetadataHandlerTest extends TestBase {
         GetTableResult getTableResult = new GetTableResult();
         getTableResult.setTable(table);
 
-        when(glue.getTable(any(com.amazonaws.services.glue.model.GetTableRequest.class))).thenReturn(getTableResult);
+        when(glue.getTable(nullable(com.amazonaws.services.glue.model.GetTableRequest.class))).thenReturn(getTableResult);
 
         GetTableResponse res = handler.doGetTable(allocator, req);
 

--- a/athena-neptune/src/test/java/com/amazonaws/athena/connectors/neptune/NeptuneRecordHandlerTest.java
+++ b/athena-neptune/src/test/java/com/amazonaws/athena/connectors/neptune/NeptuneRecordHandlerTest.java
@@ -21,9 +21,8 @@ package com.amazonaws.athena.connectors.neptune;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -72,7 +71,7 @@ import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -149,7 +148,7 @@ public class NeptuneRecordHandlerTest extends TestBase {
                 awsSecretsManager = mock(AWSSecretsManager.class);
                 athena = mock(AmazonAthena.class);
 
-                when(amazonS3.putObject(anyObject()))
+                when(amazonS3.putObject(any()))
                                 .thenAnswer((InvocationOnMock invocationOnMock) -> {
                                         InputStream inputStream = ((PutObjectRequest) invocationOnMock.getArguments()[0]).getInputStream();
                                         ByteHolder byteHolder = new ByteHolder();
@@ -161,7 +160,7 @@ public class NeptuneRecordHandlerTest extends TestBase {
                                         return mock(PutObjectResult.class);
                                 });
 
-                when(amazonS3.getObject(anyString(), anyString())).thenAnswer((InvocationOnMock invocationOnMock) -> {
+                when(amazonS3.getObject(nullable(String.class), nullable(String.class))).thenAnswer((InvocationOnMock invocationOnMock) -> {
                         S3Object mockObject = mock(S3Object.class);
                         ByteHolder byteHolder;
                         synchronized (mockS3Storage) {
@@ -187,7 +186,7 @@ public class NeptuneRecordHandlerTest extends TestBase {
                 Client client = mock(Client.class);
 
                 when(neptuneConnection.getNeptuneClientConnection()).thenReturn(client);
-                when(neptuneConnection.getTraversalSource(any(Client.class))).thenReturn(graphTraversalSource);
+                when(neptuneConnection.getTraversalSource(nullable(Client.class))).thenReturn(graphTraversalSource);
 
                 // Build Tinker Pop Graph
                 TinkerGraph tinkerGraph = TinkerGraph.open();

--- a/athena-oracle/pom.xml
+++ b/athena-oracle/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>com.oracle.database.jdbc</groupId>
             <artifactId>ojdbc8</artifactId>
-            <version>21.3.0.0</version>
+            <version>21.8.0.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-rds -->
         <dependency>
@@ -46,25 +46,36 @@
             <version>${aws-cdk.version}</version>
             <scope>test</scope>
         </dependency>
+        <!--
+          This is purposefully using a legacy version because these tests
+          rely on powermock and it will break on a later version.
+          Eventually we should fix the test code to not rely on powermock.
+        -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.legacy.version}</version>
+            <scope>test</scope>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/org.powermock/powermock-module-junit4 -->
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
-            <version>2.0.9</version>
+            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.powermock/powermock-api-mockito2 -->
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-api-mockito2</artifactId>
-            <version>2.0.9</version>
+            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.powermock/powermock-core -->
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-core</artifactId>
-            <version>2.0.9</version>
+            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -73,7 +84,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>${mvn.shade.plugin.version}</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <filters>
@@ -88,7 +99,7 @@
                     </filters>
                     <transformers>
                         <!-- This transformer is here to concatenate log4j2 cache during shading -->
-                        <transformer implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer">
+                        <transformer implementation="com.github.edwgiz.maven_shade_plugin.log4j2_cache_transformer.PluginsCacheFileTransformer">
 </transformer>
                     </transformers>
                 </configuration>
@@ -96,7 +107,7 @@
                     <dependency>
                         <groupId>com.github.edwgiz</groupId>
                         <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
-                        <version>2.8.1</version>
+                        <version>${log4j2.cachefile.transformer.version}</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/athena-oracle/src/test/java/com/amazonaws/athena/connectors/oracle/OracleMetadataHandlerTest.java
+++ b/athena-oracle/src/test/java/com/amazonaws/athena/connectors/oracle/OracleMetadataHandlerTest.java
@@ -61,6 +61,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import static com.amazonaws.athena.connectors.oracle.OracleConstants.ORACLE_NAME;
+import static org.mockito.ArgumentMatchers.nullable;
 
 public class OracleMetadataHandlerTest
         extends TestBase
@@ -81,7 +82,7 @@ public class OracleMetadataHandlerTest
     {
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class, Mockito.RETURNS_DEEP_STUBS);
         this.connection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);
-        Mockito.when(this.jdbcConnectionFactory.getConnection(Mockito.any(JdbcCredentialProvider.class))).thenReturn(this.connection);
+        Mockito.when(this.jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(this.connection);
         this.secretsManager = Mockito.mock(AWSSecretsManager.class);
         this.athena = Mockito.mock(AmazonAthena.class);
         Mockito.when(this.secretsManager.getSecretValue(Mockito.eq(new GetSecretValueRequest().withSecretId("testSecret")))).thenReturn(new GetSecretValueResult().withSecretString("{\"username\": \"testUser\", \"password\": \"testPassword\"}"));
@@ -191,7 +192,7 @@ public class OracleMetadataHandlerTest
 
         Connection connection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);
         JdbcConnectionFactory jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
-        Mockito.when(jdbcConnectionFactory.getConnection(Mockito.any(JdbcCredentialProvider.class))).thenReturn(connection);
+        Mockito.when(jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(connection);
         Mockito.when(connection.getMetaData().getSearchStringEscape()).thenThrow(new SQLException());
         OracleMetadataHandler oracleMetadataHandler = new OracleMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, jdbcConnectionFactory);
 

--- a/athena-oracle/src/test/java/com/amazonaws/athena/connectors/oracle/OracleMuxJdbcMetadataHandlerTest.java
+++ b/athena-oracle/src/test/java/com/amazonaws/athena/connectors/oracle/OracleMuxJdbcMetadataHandlerTest.java
@@ -43,6 +43,8 @@ import org.mockito.Mockito;
 import java.util.Collections;
 import java.util.Map;
 
+import static org.mockito.ArgumentMatchers.nullable;
+
 public class OracleMuxJdbcMetadataHandlerTest
 {
     private Map<String, JdbcMetadataHandler> metadataHandlerMap;
@@ -59,7 +61,7 @@ public class OracleMuxJdbcMetadataHandlerTest
     {
         //this.allocator = Mockito.mock(BlockAllocator.class);
         this.allocator = new BlockAllocatorImpl();
-        //Mockito.when(this.allocator.createBlock(Mockito.any(Schema.class))).thenReturn(Mockito.mock(Block.class));
+        //Mockito.when(this.allocator.createBlock(nullable(Schema.class))).thenReturn(Mockito.mock(Block.class));
         this.oracleMetadataHandler = Mockito.mock(OracleMetadataHandler.class);
         this.metadataHandlerMap = Collections.singletonMap("fakedatabase", this.oracleMetadataHandler);
         this.secretsManager = Mockito.mock(AWSSecretsManager.class);
@@ -133,7 +135,7 @@ public class OracleMuxJdbcMetadataHandlerTest
         GetTableLayoutRequest getTableLayoutRequest = Mockito.mock(GetTableLayoutRequest.class);
         Mockito.when(getTableLayoutRequest.getCatalogName()).thenReturn("fakedatabase");
         this.jdbcMetadataHandler.getPartitions(Mockito.mock(BlockWriter.class), getTableLayoutRequest, queryStatusChecker);
-        Mockito.verify(this.oracleMetadataHandler, Mockito.times(1)).getPartitions(Mockito.any(BlockWriter.class), Mockito.eq(getTableLayoutRequest), Mockito.eq(queryStatusChecker));
+        Mockito.verify(this.oracleMetadataHandler, Mockito.times(1)).getPartitions(nullable(BlockWriter.class), Mockito.eq(getTableLayoutRequest), Mockito.eq(queryStatusChecker));
     }
 
     @Test

--- a/athena-oracle/src/test/java/com/amazonaws/athena/connectors/oracle/OracleRecordHandlerTest.java
+++ b/athena-oracle/src/test/java/com/amazonaws/athena/connectors/oracle/OracleRecordHandlerTest.java
@@ -50,6 +50,7 @@ import java.sql.SQLException;
 import java.util.Collections;
 
 import static com.amazonaws.athena.connectors.oracle.OracleConstants.ORACLE_NAME;
+import static org.mockito.ArgumentMatchers.nullable;
 
 public class OracleRecordHandlerTest
 {
@@ -71,7 +72,7 @@ public class OracleRecordHandlerTest
         this.athena = Mockito.mock(AmazonAthena.class);
         this.connection = Mockito.mock(Connection.class);
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
-        Mockito.when(this.jdbcConnectionFactory.getConnection(Mockito.mock(JdbcCredentialProvider.class))).thenReturn(this.connection);
+        Mockito.when(this.jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(this.connection);
         jdbcSplitQueryBuilder = new OracleQueryStringBuilder(ORACLE_QUOTE_CHARACTER);
         final DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", ORACLE_NAME,
                 "oracle://jdbc:oracle:thin:username/password@//127.0.0.1:1521/orcl");

--- a/athena-postgresql/pom.xml
+++ b/athena-postgresql/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.4.3</version>
+            <version>42.5.1</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-rds -->
         <dependency>
@@ -53,7 +53,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>${mvn.shade.plugin.version}</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <filters>
@@ -68,7 +68,7 @@
                     </filters>
                     <transformers>
                         <!-- This transformer is here to concatenate log4j2 cache during shading -->
-                        <transformer implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer">
+                        <transformer implementation="com.github.edwgiz.maven_shade_plugin.log4j2_cache_transformer.PluginsCacheFileTransformer">
 </transformer>
                     </transformers>
                 </configuration>
@@ -76,7 +76,7 @@
                     <dependency>
                         <groupId>com.github.edwgiz</groupId>
                         <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
-                        <version>2.8.1</version>
+                        <version>${log4j2.cachefile.transformer.version}</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/athena-postgresql/src/test/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlMetadataHandlerTest.java
+++ b/athena-postgresql/src/test/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlMetadataHandlerTest.java
@@ -70,6 +70,8 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import static org.mockito.ArgumentMatchers.nullable;
+
 public class PostGreSqlMetadataHandlerTest
         extends TestBase
 {
@@ -90,7 +92,7 @@ public class PostGreSqlMetadataHandlerTest
     {
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         this.connection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);
-        Mockito.when(this.jdbcConnectionFactory.getConnection(Mockito.any(JdbcCredentialProvider.class))).thenReturn(this.connection);
+        Mockito.when(this.jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(this.connection);
         this.secretsManager = Mockito.mock(AWSSecretsManager.class);
         Mockito.when(this.secretsManager.getSecretValue(Mockito.eq(new GetSecretValueRequest().withSecretId("testSecret")))).thenReturn(new GetSecretValueResult().withSecretString("{\"username\": \"testUser\", \"password\": \"testPassword\"}"));
         this.postGreSqlMetadataHandler = new PostGreSqlMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, this.jdbcConnectionFactory);
@@ -204,7 +206,7 @@ public class PostGreSqlMetadataHandlerTest
 
         Connection connection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);
         JdbcConnectionFactory jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
-        Mockito.when(jdbcConnectionFactory.getConnection(Mockito.any(JdbcCredentialProvider.class))).thenReturn(connection);
+        Mockito.when(jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(connection);
         Mockito.when(connection.getMetaData().getSearchStringEscape()).thenThrow(new SQLException());
         PostGreSqlMetadataHandler postGreSqlMetadataHandler = new PostGreSqlMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, jdbcConnectionFactory);
 

--- a/athena-postgresql/src/test/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlMuxJdbcMetadataHandlerTest.java
+++ b/athena-postgresql/src/test/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlMuxJdbcMetadataHandlerTest.java
@@ -41,6 +41,8 @@ import org.mockito.Mockito;
 import java.util.Collections;
 import java.util.Map;
 
+import static org.mockito.ArgumentMatchers.nullable;
+
 public class PostGreSqlMuxJdbcMetadataHandlerTest
 {
     private Map<String, JdbcMetadataHandler> metadataHandlerMap;
@@ -57,7 +59,7 @@ public class PostGreSqlMuxJdbcMetadataHandlerTest
     {
         //this.allocator = Mockito.mock(BlockAllocator.class);
         this.allocator = new BlockAllocatorImpl();
-        //Mockito.when(this.allocator.createBlock(Mockito.any(Schema.class))).thenReturn(Mockito.mock(Block.class));
+        //Mockito.when(this.allocator.createBlock(nullable(Schema.class))).thenReturn(Mockito.mock(Block.class));
         this.postGreSqlMetadataHandler = Mockito.mock(PostGreSqlMetadataHandler.class);
         this.metadataHandlerMap = Collections.singletonMap("postgres", this.postGreSqlMetadataHandler);
         this.secretsManager = Mockito.mock(AWSSecretsManager.class);
@@ -131,7 +133,7 @@ public class PostGreSqlMuxJdbcMetadataHandlerTest
         GetTableLayoutRequest getTableLayoutRequest = Mockito.mock(GetTableLayoutRequest.class);
         Mockito.when(getTableLayoutRequest.getCatalogName()).thenReturn("postgres");
         this.jdbcMetadataHandler.getPartitions(Mockito.mock(BlockWriter.class), getTableLayoutRequest, queryStatusChecker);
-        Mockito.verify(this.postGreSqlMetadataHandler, Mockito.times(1)).getPartitions(Mockito.any(BlockWriter.class), Mockito.eq(getTableLayoutRequest), Mockito.eq(queryStatusChecker));
+        Mockito.verify(this.postGreSqlMetadataHandler, Mockito.times(1)).getPartitions(nullable(BlockWriter.class), Mockito.eq(getTableLayoutRequest), Mockito.eq(queryStatusChecker));
     }
 
     @Test

--- a/athena-postgresql/src/test/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlRecordHandlerTest.java
+++ b/athena-postgresql/src/test/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlRecordHandlerTest.java
@@ -57,6 +57,8 @@ import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
 import static com.amazonaws.athena.connectors.postgresql.PostGreSqlConstants.POSTGRES_NAME;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 
 public class PostGreSqlRecordHandlerTest extends TestBase
 {
@@ -79,7 +81,7 @@ public class PostGreSqlRecordHandlerTest extends TestBase
         this.athena = Mockito.mock(AmazonAthena.class);
         this.connection = Mockito.mock(Connection.class);
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
-        Mockito.when(this.jdbcConnectionFactory.getConnection(Mockito.mock(JdbcCredentialProvider.class))).thenReturn(this.connection);
+        Mockito.when(this.jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(this.connection);
         jdbcSplitQueryBuilder = new PostGreSqlQueryStringBuilder("\"");
         final DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", POSTGRES_NAME,
                 "postgres://jdbc:postgresql://hostname/user=A&password=B");

--- a/athena-redis/pom.xml
+++ b/athena-redis/pom.xml
@@ -94,6 +94,7 @@
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
             <version>2022.47.1</version>
+            <classifier>withdep</classifier>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
                 <exclusion>
@@ -105,7 +106,7 @@
         <dependency>
             <groupId>io.lettuce</groupId>
             <artifactId>lettuce-core</artifactId>
-            <version>6.2.1.RELEASE</version>
+            <version>6.2.2.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -145,7 +146,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <version>${log4j2Version}</version>
             <scope>runtime</scope>
         </dependency>
@@ -173,7 +174,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>${mvn.shade.plugin.version}</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <filters>
@@ -188,7 +189,7 @@
                     </filters>
                     <transformers>
                         <!-- This transformer is here to concatenate log4j2 cache during shading -->
-                        <transformer implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer">
+                        <transformer implementation="com.github.edwgiz.maven_shade_plugin.log4j2_cache_transformer.PluginsCacheFileTransformer">
 </transformer>
                     </transformers>
                 </configuration>
@@ -196,7 +197,7 @@
                     <dependency>
                         <groupId>com.github.edwgiz</groupId>
                         <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
-                        <version>2.8.1</version>
+                        <version>${log4j2.cachefile.transformer.version}</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/athena-redshift/pom.xml
+++ b/athena-redshift/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.amazon.redshift</groupId>
             <artifactId>redshift-jdbc42-no-awssdk</artifactId>
-            <version>1.2.34.1058</version>
+            <version>1.2.55.1083</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
@@ -66,7 +66,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>${mvn.shade.plugin.version}</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <filters>
@@ -81,7 +81,7 @@
                     </filters>
                     <transformers>
                         <!-- This transformer is here to concatenate log4j2 cache during shading -->
-                        <transformer implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer">
+                        <transformer implementation="com.github.edwgiz.maven_shade_plugin.log4j2_cache_transformer.PluginsCacheFileTransformer">
 </transformer>
                     </transformers>
                 </configuration>
@@ -89,7 +89,7 @@
                     <dependency>
                         <groupId>com.github.edwgiz</groupId>
                         <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
-                        <version>2.8.1</version>
+                        <version>${log4j2.cachefile.transformer.version}</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/athena-redshift/src/test/java/com/amazonaws/athena/connectors/redshift/RedshiftMetadataHandlerTest.java
+++ b/athena-redshift/src/test/java/com/amazonaws/athena/connectors/redshift/RedshiftMetadataHandlerTest.java
@@ -71,6 +71,8 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import static org.mockito.ArgumentMatchers.nullable;
+
 public class RedshiftMetadataHandlerTest
         extends TestBase
 {
@@ -91,7 +93,7 @@ public class RedshiftMetadataHandlerTest
     {
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         this.connection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);
-        Mockito.when(this.jdbcConnectionFactory.getConnection(Mockito.any(JdbcCredentialProvider.class))).thenReturn(this.connection);
+        Mockito.when(this.jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(this.connection);
         this.secretsManager = Mockito.mock(AWSSecretsManager.class);
         Mockito.when(this.secretsManager.getSecretValue(Mockito.eq(new GetSecretValueRequest().withSecretId("testSecret")))).thenReturn(new GetSecretValueResult().withSecretString("{\"username\": \"testUser\", \"password\": \"testPassword\"}"));
         this.redshiftMetadataHandler = new RedshiftMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, this.jdbcConnectionFactory);
@@ -205,7 +207,7 @@ public class RedshiftMetadataHandlerTest
 
         Connection connection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);
         JdbcConnectionFactory jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
-        Mockito.when(jdbcConnectionFactory.getConnection(Mockito.any(JdbcCredentialProvider.class))).thenReturn(connection);
+        Mockito.when(jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(connection);
         Mockito.when(connection.getMetaData().getSearchStringEscape()).thenThrow(new SQLException());
         RedshiftMetadataHandler redshiftMetadataHandler = new RedshiftMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, jdbcConnectionFactory);
 

--- a/athena-redshift/src/test/java/com/amazonaws/athena/connectors/redshift/RedshiftMuxJdbcMetadataHandlerTest.java
+++ b/athena-redshift/src/test/java/com/amazonaws/athena/connectors/redshift/RedshiftMuxJdbcMetadataHandlerTest.java
@@ -41,6 +41,8 @@ import org.mockito.Mockito;
 import java.util.Collections;
 import java.util.Map;
 
+import static org.mockito.ArgumentMatchers.nullable;
+
 public class RedshiftMuxJdbcMetadataHandlerTest
 {
     private Map<String, JdbcMetadataHandler> metadataHandlerMap;
@@ -57,7 +59,7 @@ public class RedshiftMuxJdbcMetadataHandlerTest
     {
         //this.allocator = Mockito.mock(BlockAllocator.class);
         this.allocator = new BlockAllocatorImpl();
-        //Mockito.when(this.allocator.createBlock(Mockito.any(Schema.class))).thenReturn(Mockito.mock(Block.class));
+        //Mockito.when(this.allocator.createBlock(nullable(Schema.class))).thenReturn(Mockito.mock(Block.class));
         this.redshiftMetadataHandler = Mockito.mock(RedshiftMetadataHandler.class);
         this.metadataHandlerMap = Collections.singletonMap("redshift", this.redshiftMetadataHandler);
         this.secretsManager = Mockito.mock(AWSSecretsManager.class);
@@ -131,7 +133,7 @@ public class RedshiftMuxJdbcMetadataHandlerTest
         GetTableLayoutRequest getTableLayoutRequest = Mockito.mock(GetTableLayoutRequest.class);
         Mockito.when(getTableLayoutRequest.getCatalogName()).thenReturn("redshift");
         this.jdbcMetadataHandler.getPartitions(Mockito.mock(BlockWriter.class), getTableLayoutRequest, queryStatusChecker);
-        Mockito.verify(this.redshiftMetadataHandler, Mockito.times(1)).getPartitions(Mockito.any(BlockWriter.class), Mockito.eq(getTableLayoutRequest), Mockito.eq(queryStatusChecker));
+        Mockito.verify(this.redshiftMetadataHandler, Mockito.times(1)).getPartitions(nullable(BlockWriter.class), Mockito.eq(getTableLayoutRequest), Mockito.eq(queryStatusChecker));
     }
 
     @Test

--- a/athena-redshift/src/test/java/com/amazonaws/athena/connectors/redshift/RedshiftRecordHandlerTest.java
+++ b/athena-redshift/src/test/java/com/amazonaws/athena/connectors/redshift/RedshiftRecordHandlerTest.java
@@ -59,6 +59,7 @@ import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
 import static com.amazonaws.athena.connectors.redshift.RedshiftConstants.REDSHIFT_NAME;
+import static org.mockito.ArgumentMatchers.nullable;
 
 public class RedshiftRecordHandlerTest
         extends TestBase
@@ -82,7 +83,7 @@ public class RedshiftRecordHandlerTest
         this.athena = Mockito.mock(AmazonAthena.class);
         this.connection = Mockito.mock(Connection.class);
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
-        Mockito.when(this.jdbcConnectionFactory.getConnection(Mockito.mock(JdbcCredentialProvider.class))).thenReturn(this.connection);
+        Mockito.when(this.jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(this.connection);
         jdbcSplitQueryBuilder = new PostGreSqlQueryStringBuilder("\"");
         final DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", REDSHIFT_NAME,
                 "redshift://jdbc:redshift://hostname/user=A&password=B");

--- a/athena-saphana/pom.xml
+++ b/athena-saphana/pom.xml
@@ -41,25 +41,36 @@
             <version>${aws-cdk.version}</version>
             <scope>test</scope>
         </dependency>
+        <!--
+          This is purposefully using a legacy version because these tests
+          rely on powermock and it will break on a later version.
+          Eventually we should fix the test code to not rely on powermock.
+        -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.legacy.version}</version>
+            <scope>test</scope>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/org.powermock/powermock-module-junit4 -->
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
-            <version>2.0.9</version>
+            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.powermock/powermock-api-mockito2 -->
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-api-mockito2</artifactId>
-            <version>2.0.9</version>
+            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.powermock/powermock-core -->
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-core</artifactId>
-            <version>2.0.9</version>
+            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -74,7 +85,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>${mvn.shade.plugin.version}</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <filters>
@@ -89,7 +100,7 @@
                     </filters>
                     <transformers>
                         <!-- This transformer is here to concatenate log4j2 cache during shading -->
-                        <transformer implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer">
+                        <transformer implementation="com.github.edwgiz.maven_shade_plugin.log4j2_cache_transformer.PluginsCacheFileTransformer">
 </transformer>
                     </transformers>
                 </configuration>
@@ -97,7 +108,7 @@
                     <dependency>
                         <groupId>com.github.edwgiz</groupId>
                         <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
-                        <version>2.8.1</version>
+                        <version>${log4j2.cachefile.transformer.version}</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/athena-saphana/src/test/java/com/amazonaws/athena/connectors/saphana/SaphanaMetadataHandlerTest.java
+++ b/athena-saphana/src/test/java/com/amazonaws/athena/connectors/saphana/SaphanaMetadataHandlerTest.java
@@ -53,6 +53,10 @@ import com.amazonaws.services.athena.AmazonAthena;
 import com.amazonaws.services.secretsmanager.AWSSecretsManager;
 import com.amazonaws.services.secretsmanager.model.GetSecretValueRequest;
 import com.amazonaws.services.secretsmanager.model.GetSecretValueResult;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
+
 public class SaphanaMetadataHandlerTest
         extends TestBase
 {
@@ -74,7 +78,7 @@ public class SaphanaMetadataHandlerTest
     {
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class, Mockito.RETURNS_DEEP_STUBS);
         this.connection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);
-        Mockito.when(this.jdbcConnectionFactory.getConnection(Mockito.any(JdbcCredentialProvider.class))).thenReturn(this.connection);
+        Mockito.when(this.jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(this.connection);
         this.secretsManager = Mockito.mock(AWSSecretsManager.class);
         this.athena = Mockito.mock(AmazonAthena.class);
         Mockito.when(this.secretsManager.getSecretValue(Mockito.eq(new GetSecretValueRequest().withSecretId("testSecret")))).thenReturn(new GetSecretValueResult().withSecretString("{\"username\": \"testUser\", \"password\": \"testPassword\"}"));
@@ -183,7 +187,7 @@ public class SaphanaMetadataHandlerTest
 
         Connection connection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);
         JdbcConnectionFactory jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
-        Mockito.when(jdbcConnectionFactory.getConnection(Mockito.any(JdbcCredentialProvider.class))).thenReturn(connection);
+        Mockito.when(jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(connection);
         Mockito.when(connection.getMetaData().getSearchStringEscape()).thenThrow(new SQLException());
         SaphanaMetadataHandler saphanaMetadataHandler = new SaphanaMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, jdbcConnectionFactory);
 
@@ -344,12 +348,12 @@ public class SaphanaMetadataHandlerTest
         Assert.assertEquals(expectedSplits, actualSplits);
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test(expected = SQLException.class)
     public void doGetTableSQLException()
             throws Exception
     {
         TableName inputTableName = new TableName("testSchema", "testTable");
-        Mockito.when(this.connection.getMetaData().getColumns(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString()))
+        Mockito.when(this.connection.getMetaData().getColumns(nullable(String.class), nullable(String.class), nullable(String.class), nullable(String.class)))
                 .thenThrow(new SQLException());
         this.saphanaMetadataHandler.doGetTable(this.blockAllocator, new GetTableRequest(this.federatedIdentity, "testQueryId", "testCatalog", inputTableName));
     }

--- a/athena-saphana/src/test/java/com/amazonaws/athena/connectors/saphana/SaphanaMuxJdbcMetadataHandlerTest.java
+++ b/athena-saphana/src/test/java/com/amazonaws/athena/connectors/saphana/SaphanaMuxJdbcMetadataHandlerTest.java
@@ -37,6 +37,7 @@ import org.mockito.Mockito;
 import java.util.Collections;
 import java.util.Map;
 
+import static org.mockito.ArgumentMatchers.nullable;
 
 public class SaphanaMuxJdbcMetadataHandlerTest {
 
@@ -54,7 +55,7 @@ public class SaphanaMuxJdbcMetadataHandlerTest {
     {
         //this.allocator = Mockito.mock(BlockAllocator.class);
         this.allocator = new BlockAllocatorImpl();
-        //Mockito.when(this.allocator.createBlock(Mockito.any(Schema.class))).thenReturn(Mockito.mock(Block.class));
+        //Mockito.when(this.allocator.createBlock(nullable(Schema.class))).thenReturn(Mockito.mock(Block.class));
         this.saphanaMetadataHandler = Mockito.mock(SaphanaMetadataHandler.class);
         this.metadataHandlerMap = Collections.singletonMap("fakedatabase", this.saphanaMetadataHandler);
         this.secretsManager = Mockito.mock(AWSSecretsManager.class);
@@ -127,7 +128,7 @@ public class SaphanaMuxJdbcMetadataHandlerTest {
         GetTableLayoutRequest getTableLayoutRequest = Mockito.mock(GetTableLayoutRequest.class);
         Mockito.when(getTableLayoutRequest.getCatalogName()).thenReturn("fakedatabase");
         this.jdbcMetadataHandler.getPartitions(Mockito.mock(BlockWriter.class), getTableLayoutRequest, queryStatusChecker);
-        Mockito.verify(this.saphanaMetadataHandler, Mockito.times(1)).getPartitions(Mockito.any(BlockWriter.class), Mockito.eq(getTableLayoutRequest), Mockito.eq(queryStatusChecker));
+        Mockito.verify(this.saphanaMetadataHandler, Mockito.times(1)).getPartitions(nullable(BlockWriter.class), Mockito.eq(getTableLayoutRequest), Mockito.eq(queryStatusChecker));
     }
 
     @Test

--- a/athena-saphana/src/test/java/com/amazonaws/athena/connectors/saphana/SaphanaQueryStringBuilderTest.java
+++ b/athena-saphana/src/test/java/com/amazonaws/athena/connectors/saphana/SaphanaQueryStringBuilderTest.java
@@ -24,7 +24,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/athena-saphana/src/test/java/com/amazonaws/athena/connectors/saphana/SaphanaRecordHandlerTest.java
+++ b/athena-saphana/src/test/java/com/amazonaws/athena/connectors/saphana/SaphanaRecordHandlerTest.java
@@ -45,6 +45,9 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.Collections;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
+
 public class SaphanaRecordHandlerTest
 {
     private SaphanaRecordHandler saphanaRecordHandler;
@@ -64,7 +67,7 @@ public class SaphanaRecordHandlerTest
         this.athena = Mockito.mock(AmazonAthena.class);
         this.connection = Mockito.mock(Connection.class);
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
-        Mockito.when(this.jdbcConnectionFactory.getConnection(Mockito.mock(JdbcCredentialProvider.class))).thenReturn(this.connection);
+        Mockito.when(this.jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(this.connection);
         jdbcSplitQueryBuilder = new SaphanaQueryStringBuilder("`");
         final DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", SaphanaConstants.SAPHANA_NAME,
                 "saphana://jdbc:saphana://115.113.87.100/TMODE=ANSI,CHARSET=UTF8,DATABASE=TEST,USER=DBC,PASSWORD=DBC");
@@ -146,7 +149,7 @@ public class SaphanaRecordHandlerTest
                 .build());
 
         PreparedStatement expectedPreparedStatement = Mockito.mock(PreparedStatement.class);
-        Mockito.when(this.connection.prepareStatement(Mockito.anyString())).thenReturn(expectedPreparedStatement);
+        Mockito.when(this.connection.prepareStatement(nullable(String.class))).thenReturn(expectedPreparedStatement);
         PreparedStatement preparedStatement = this.saphanaRecordHandler.buildSplitSql(this.connection, "testCatalogName", tableName, schema, constraints, split);
 
         Assert.assertEquals(expectedPreparedStatement, preparedStatement);

--- a/athena-snowflake/pom.xml
+++ b/athena-snowflake/pom.xml
@@ -35,13 +35,7 @@
         <dependency>
             <groupId>com.github.stefanbirkner</groupId>
             <artifactId>system-rules</artifactId>
-            <version>1.2.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>uk.org.webcompere</groupId>
-            <artifactId>system-stubs-junit4</artifactId>
-            <version>1.1.0</version>
+            <version>${test.system.rules.version}</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-rds -->
@@ -58,25 +52,36 @@
             <version>${aws-cdk.version}</version>
             <scope>test</scope>
         </dependency>
+        <!--
+          This is purposefully using a legacy version because these tests
+          rely on powermock and it will break on a later version.
+          Eventually we should fix the test code to not rely on powermock.
+        -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.legacy.version}</version>
+            <scope>test</scope>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/org.powermock/powermock-module-junit4 -->
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
-            <version>2.0.9</version>
+            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.powermock/powermock-api-mockito2 -->
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-api-mockito2</artifactId>
-            <version>2.0.9</version>
+            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.powermock/powermock-core -->
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-core</artifactId>
-            <version>2.0.9</version>
+            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -85,7 +90,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>${mvn.shade.plugin.version}</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <filters>
@@ -100,7 +105,7 @@
                     </filters>
                     <transformers>
                         <!-- This transformer is here to concatenate log4j2 cache during shading -->
-                        <transformer implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer">
+                        <transformer implementation="com.github.edwgiz.maven_shade_plugin.log4j2_cache_transformer.PluginsCacheFileTransformer">
 </transformer>
                     </transformers>
                 </configuration>
@@ -108,7 +113,7 @@
                     <dependency>
                         <groupId>com.github.edwgiz</groupId>
                         <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
-                        <version>2.8.1</version>
+                        <version>${log4j2.cachefile.transformer.version}</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/athena-snowflake/src/test/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMuxJdbcMetadataHandlerTest.java
+++ b/athena-snowflake/src/test/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMuxJdbcMetadataHandlerTest.java
@@ -37,6 +37,8 @@ import org.mockito.Mockito;
 import java.util.Collections;
 import java.util.Map;
 
+import static org.mockito.ArgumentMatchers.nullable;
+
 public class SnowflakeMuxJdbcMetadataHandlerTest
 {
     private Map<String, JdbcMetadataHandler> metadataHandlerMap;
@@ -125,7 +127,7 @@ public class SnowflakeMuxJdbcMetadataHandlerTest
         GetTableLayoutRequest getTableLayoutRequest = Mockito.mock(GetTableLayoutRequest.class);
         Mockito.when(getTableLayoutRequest.getCatalogName()).thenReturn("fakedatabase");
         this.jdbcMetadataHandler.getPartitions(Mockito.mock(BlockWriter.class), getTableLayoutRequest, queryStatusChecker);
-        Mockito.verify(this.snowflakeMetadataHandler, Mockito.times(1)).getPartitions(Mockito.any(BlockWriter.class), Mockito.eq(getTableLayoutRequest), Mockito.eq(queryStatusChecker));
+        Mockito.verify(this.snowflakeMetadataHandler, Mockito.times(1)).getPartitions(nullable(BlockWriter.class), Mockito.eq(getTableLayoutRequest), Mockito.eq(queryStatusChecker));
     }
 
     @Test

--- a/athena-snowflake/src/test/java/com/amazonaws/athena/connectors/snowflake/SnowflakeRecordHandlerTest.java
+++ b/athena-snowflake/src/test/java/com/amazonaws/athena/connectors/snowflake/SnowflakeRecordHandlerTest.java
@@ -50,6 +50,9 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.Collections;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
+
 public class SnowflakeRecordHandlerTest
 {
     private SnowflakeRecordHandler snowflakeRecordHandler;
@@ -69,7 +72,7 @@ public class SnowflakeRecordHandlerTest
         this.athena = Mockito.mock(AmazonAthena.class);
         this.connection = Mockito.mock(Connection.class);
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
-        Mockito.when(this.jdbcConnectionFactory.getConnection(Mockito.mock(JdbcCredentialProvider.class))).thenReturn(this.connection);
+        Mockito.when(this.jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(this.connection);
         jdbcSplitQueryBuilder = new SnowflakeQueryStringBuilder("`");
         final DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", SnowflakeConstants.SNOWFLAKE_NAME,
                 "snowflake://jdbc:snowflake://hostname/?warehouse=warehousename&db=dbname&schema=schemaname&user=xxx&password=xxx");
@@ -130,7 +133,7 @@ public class SnowflakeRecordHandlerTest
                 .build());
 
         PreparedStatement expectedPreparedStatement = Mockito.mock(PreparedStatement.class);
-        Mockito.when(this.connection.prepareStatement(Mockito.anyString())).thenReturn(expectedPreparedStatement);
+        Mockito.when(this.connection.prepareStatement(nullable(String.class))).thenReturn(expectedPreparedStatement);
         PreparedStatement preparedStatement = this.snowflakeRecordHandler.buildSplitSql(this.connection, "testCatalogName", tableName, schema, constraints, split);
 
         Assert.assertEquals(expectedPreparedStatement, preparedStatement);

--- a/athena-sqlserver/pom.xml
+++ b/athena-sqlserver/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>
-            <version>9.2.1.jre11</version>
+            <version>${mssql.jdbc.version}</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-rds -->
         <dependency>
@@ -46,22 +46,33 @@
             <version>${aws-cdk.version}</version>
             <scope>test</scope>
         </dependency>
+        <!--
+          This is purposefully using a legacy version because these tests
+          rely on powermock and it will break on a later version.
+          Eventually we should fix the test code to not rely on powermock.
+        -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.legacy.version}</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-api-mockito2</artifactId>
-            <version>2.0.9</version>
+            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-core</artifactId>
-            <version>2.0.9</version>
+            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
-            <version>2.0.9</version>
+            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -70,7 +81,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>${mvn.shade.plugin.version}</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <filters>
@@ -85,7 +96,7 @@
                     </filters>
                     <transformers>
                         <!-- This transformer is here to concatenate log4j2 cache during shading -->
-                        <transformer implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer">
+                        <transformer implementation="com.github.edwgiz.maven_shade_plugin.log4j2_cache_transformer.PluginsCacheFileTransformer">
 </transformer>
                     </transformers>
                 </configuration>
@@ -93,7 +104,7 @@
                     <dependency>
                         <groupId>com.github.edwgiz</groupId>
                         <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
-                        <version>2.8.1</version>
+                        <version>${log4j2.cachefile.transformer.version}</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/athena-sqlserver/src/test/java/com/amazonaws/athena/connectors/sqlserver/SqlServerMetadataHandlerTest.java
+++ b/athena-sqlserver/src/test/java/com/amazonaws/athena/connectors/sqlserver/SqlServerMetadataHandlerTest.java
@@ -68,6 +68,9 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
+
 public class SqlServerMetadataHandlerTest
         extends TestBase
 {
@@ -91,7 +94,7 @@ public class SqlServerMetadataHandlerTest
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class, Mockito.RETURNS_DEEP_STUBS);
         this.connection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);
         logger.info(" this.connection.."+ this.connection);
-        Mockito.when(this.jdbcConnectionFactory.getConnection(Mockito.any(JdbcCredentialProvider.class))).thenReturn(this.connection);
+        Mockito.when(this.jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(this.connection);
         this.secretsManager = Mockito.mock(AWSSecretsManager.class);
         this.athena = Mockito.mock(AmazonAthena.class);
         Mockito.when(this.secretsManager.getSecretValue(Mockito.eq(new GetSecretValueRequest().withSecretId("testSecret")))).thenReturn(new GetSecretValueResult().withSecretString("{\"user\": \"testUser\", \"password\": \"testPassword\"}"));
@@ -215,7 +218,7 @@ public class SqlServerMetadataHandlerTest
 
         Connection connection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);
         JdbcConnectionFactory jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
-        Mockito.when(jdbcConnectionFactory.getConnection(Mockito.any(JdbcCredentialProvider.class))).thenReturn(connection);
+        Mockito.when(jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(connection);
         Mockito.when(connection.getMetaData().getSearchStringEscape()).thenThrow(new SQLException());
         SqlServerMetadataHandler sqlServerMetadataHandler = new SqlServerMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, jdbcConnectionFactory);
 

--- a/athena-sqlserver/src/test/java/com/amazonaws/athena/connectors/sqlserver/SqlServerMuxMetadataHandlerTest.java
+++ b/athena-sqlserver/src/test/java/com/amazonaws/athena/connectors/sqlserver/SqlServerMuxMetadataHandlerTest.java
@@ -41,6 +41,8 @@ import org.mockito.Mockito;
 import java.util.Collections;
 import java.util.Map;
 
+import static org.mockito.ArgumentMatchers.nullable;
+
 public class SqlServerMuxMetadataHandlerTest
 {
     private Map<String, JdbcMetadataHandler> metadataHandlerMap;
@@ -128,7 +130,7 @@ public class SqlServerMuxMetadataHandlerTest
         GetTableLayoutRequest getTableLayoutRequest = Mockito.mock(GetTableLayoutRequest.class);
         Mockito.when(getTableLayoutRequest.getCatalogName()).thenReturn("fakedatabase");
         this.jdbcMetadataHandler.getPartitions(Mockito.mock(BlockWriter.class), getTableLayoutRequest, queryStatusChecker);
-        Mockito.verify(this.sqlServerMetadataHandler, Mockito.times(1)).getPartitions(Mockito.any(BlockWriter.class), Mockito.eq(getTableLayoutRequest), Mockito.eq(queryStatusChecker));
+        Mockito.verify(this.sqlServerMetadataHandler, Mockito.times(1)).getPartitions(nullable(BlockWriter.class), Mockito.eq(getTableLayoutRequest), Mockito.eq(queryStatusChecker));
     }
 
     @Test

--- a/athena-sqlserver/src/test/java/com/amazonaws/athena/connectors/sqlserver/SqlServerRecordHandlerTest.java
+++ b/athena-sqlserver/src/test/java/com/amazonaws/athena/connectors/sqlserver/SqlServerRecordHandlerTest.java
@@ -48,6 +48,8 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.Collections;
 
+import static org.mockito.ArgumentMatchers.nullable;
+
 public class SqlServerRecordHandlerTest
 {
     private SqlServerRecordHandler sqlServerRecordHandler;
@@ -68,7 +70,7 @@ public class SqlServerRecordHandlerTest
         this.athena = Mockito.mock(AmazonAthena.class);
         this.connection = Mockito.mock(Connection.class);
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
-        Mockito.when(this.jdbcConnectionFactory.getConnection(Mockito.mock(JdbcCredentialProvider.class))).thenReturn(this.connection);
+        Mockito.when(this.jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(this.connection);
         jdbcSplitQueryBuilder = new SqlServerQueryStringBuilder("`");
         final DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", SqlServerConstants.NAME,
                 "sqlserver://jdbc:sqlserver://hostname;databaseName=fakedatabase");

--- a/athena-synapse/pom.xml
+++ b/athena-synapse/pom.xml
@@ -30,12 +30,12 @@
         <dependency>
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>
-            <version>9.2.1.jre11</version>
+            <version>${mssql.jdbc.version}</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>msal4j</artifactId>
-            <version>1.13.0</version>
+            <version>1.13.3</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.datatype</groupId>
@@ -73,28 +73,39 @@
             <version>${aws-cdk.version}</version>
             <scope>test</scope>
         </dependency>
+        <!--
+          This is purposefully using a legacy version because these tests
+          rely on powermock and it will break on a later version.
+          Eventually we should fix the test code to not rely on powermock.
+        -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.legacy.version}</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-api-mockito2</artifactId>
-            <version>2.0.9</version>
+            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-core</artifactId>
-            <version>2.0.9</version>
+            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
-            <version>2.0.9</version>
+            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>ST4</artifactId>
-            <version>4.3.1</version>
+            <version>${antlr.st4.version}</version>
         </dependency>
     </dependencies>
     <build>
@@ -102,7 +113,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>${mvn.shade.plugin.version}</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <filters>
@@ -117,7 +128,7 @@
                     </filters>
                     <transformers>
                         <!-- This transformer is here to concatenate log4j2 cache during shading -->
-                        <transformer implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer">
+                        <transformer implementation="com.github.edwgiz.maven_shade_plugin.log4j2_cache_transformer.PluginsCacheFileTransformer">
 </transformer>
                     </transformers>
                 </configuration>
@@ -125,7 +136,7 @@
                     <dependency>
                         <groupId>com.github.edwgiz</groupId>
                         <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
-                        <version>2.8.1</version>
+                        <version>${log4j2.cachefile.transformer.version}</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/SynapseMetadataHandlerTest.java
+++ b/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/SynapseMetadataHandlerTest.java
@@ -67,6 +67,9 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
+
 public class SynapseMetadataHandlerTest
         extends TestBase
 {
@@ -88,7 +91,7 @@ public class SynapseMetadataHandlerTest
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class, Mockito.RETURNS_DEEP_STUBS);
         this.connection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);
         logger.info(" this.connection.."+ this.connection);
-        Mockito.when(this.jdbcConnectionFactory.getConnection(Mockito.any(JdbcCredentialProvider.class))).thenReturn(this.connection);
+        Mockito.when(this.jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(this.connection);
         this.secretsManager = Mockito.mock(AWSSecretsManager.class);
         this.athena = Mockito.mock(AmazonAthena.class);
         Mockito.when(this.secretsManager.getSecretValue(Mockito.eq(new GetSecretValueRequest().withSecretId("testSecret")))).thenReturn(new GetSecretValueResult().withSecretString("{\"user\": \"testUser\", \"password\": \"testPassword\"}"));
@@ -123,7 +126,7 @@ public class SynapseMetadataHandlerTest
 
         Statement st = Mockito.mock(Statement.class);
         Mockito.when(this.connection.createStatement()).thenReturn(st);
-        Mockito.when(st.executeQuery(Mockito.anyString())).thenReturn(resultSet);
+        Mockito.when(st.executeQuery(nullable(String.class))).thenReturn(resultSet);
 
         GetTableLayoutResponse getTableLayoutResponse = this.synapseMetadataHandler.doGetTableLayout(blockAllocator, getTableLayoutRequest);
 
@@ -156,7 +159,7 @@ public class SynapseMetadataHandlerTest
 
         Statement st = Mockito.mock(Statement.class);
         Mockito.when(this.connection.createStatement()).thenReturn(st);
-        Mockito.when(st.executeQuery(Mockito.anyString())).thenReturn(resultSet);
+        Mockito.when(st.executeQuery(nullable(String.class))).thenReturn(resultSet);
 
         GetTableLayoutResponse getTableLayoutResponse = this.synapseMetadataHandler.doGetTableLayout(blockAllocator, getTableLayoutRequest);
 
@@ -188,7 +191,7 @@ public class SynapseMetadataHandlerTest
 
         Connection connection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);
         JdbcConnectionFactory jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
-        Mockito.when(jdbcConnectionFactory.getConnection(Mockito.any(JdbcCredentialProvider.class))).thenReturn(connection);
+        Mockito.when(jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(connection);
         Mockito.when(connection.getMetaData().getSearchStringEscape()).thenThrow(new SQLException());
         SynapseMetadataHandler synapseMetadataHandler = new SynapseMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, jdbcConnectionFactory);
 
@@ -211,7 +214,7 @@ public class SynapseMetadataHandlerTest
 
         Statement st = Mockito.mock(Statement.class);
         Mockito.when(this.connection.createStatement()).thenReturn(st);
-        Mockito.when(st.executeQuery(Mockito.anyString())).thenReturn(resultSet);
+        Mockito.when(st.executeQuery(nullable(String.class))).thenReturn(resultSet);
 
         Schema partitionSchema = this.synapseMetadataHandler.getPartitionSchema("testCatalogName");
         Set<String> partitionCols = partitionSchema.getFields().stream().map(Field::getName).collect(Collectors.toSet());
@@ -263,7 +266,7 @@ public class SynapseMetadataHandlerTest
 
         Statement st = Mockito.mock(Statement.class);
         Mockito.when(this.connection.createStatement()).thenReturn(st);
-        Mockito.when(st.executeQuery(Mockito.anyString())).thenReturn(resultSet);
+        Mockito.when(st.executeQuery(nullable(String.class))).thenReturn(resultSet);
 
         Schema partitionSchema = this.synapseMetadataHandler.getPartitionSchema("testCatalogName");
         Set<String> partitionCols = partitionSchema.getFields().stream().map(Field::getName).collect(Collectors.toSet());
@@ -301,7 +304,7 @@ public class SynapseMetadataHandlerTest
 
         Statement st = Mockito.mock(Statement.class);
         Mockito.when(this.connection.createStatement()).thenReturn(st);
-        Mockito.when(st.executeQuery(Mockito.anyString())).thenReturn(resultSet);
+        Mockito.when(st.executeQuery(nullable(String.class))).thenReturn(resultSet);
 
         GetTableLayoutResponse getTableLayoutResponse = this.synapseMetadataHandler.doGetTableLayout(blockAllocator, getTableLayoutRequest);
 
@@ -352,7 +355,7 @@ public class SynapseMetadataHandlerTest
         Schema expected = expectedSchemaBuilder.build();
 
         PreparedStatement stmt = Mockito.mock(PreparedStatement.class);
-        Mockito.when(connection.prepareStatement(Mockito.anyString())).thenReturn(stmt);
+        Mockito.when(connection.prepareStatement(nullable(String.class))).thenReturn(stmt);
         Mockito.when(stmt.executeQuery()).thenReturn(resultSet);
 
         Mockito.when(connection.getMetaData().getURL()).thenReturn("jdbc:sqlserver://hostname;databaseName=fakedatabase");
@@ -386,7 +389,7 @@ public class SynapseMetadataHandlerTest
         ResultSet resultSet2 = mockResultSet(columns, types2, values2, new AtomicInteger(-1));
 
         PreparedStatement stmt = Mockito.mock(PreparedStatement.class);
-        Mockito.when(connection.prepareStatement(Mockito.anyString())).thenReturn(stmt);
+        Mockito.when(connection.prepareStatement(nullable(String.class))).thenReturn(stmt);
         Mockito.when(stmt.executeQuery()).thenReturn(resultSet);
 
         Mockito.when(connection.getMetaData().getURL()).thenReturn("jdbc:sqlserver://hostname-ondemand;databaseName=fakedatabase");

--- a/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/SynapseMuxMetadataHandlerTest.java
+++ b/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/SynapseMuxMetadataHandlerTest.java
@@ -41,6 +41,8 @@ import org.mockito.Mockito;
 import java.util.Collections;
 import java.util.Map;
 
+import static org.mockito.ArgumentMatchers.nullable;
+
 public class SynapseMuxMetadataHandlerTest
 {
     private Map<String, JdbcMetadataHandler> metadataHandlerMap;
@@ -129,7 +131,7 @@ public class SynapseMuxMetadataHandlerTest
         GetTableLayoutRequest getTableLayoutRequest = Mockito.mock(GetTableLayoutRequest.class);
         Mockito.when(getTableLayoutRequest.getCatalogName()).thenReturn("fakedatabase");
         this.jdbcMetadataHandler.getPartitions(Mockito.mock(BlockWriter.class), getTableLayoutRequest, queryStatusChecker);
-        Mockito.verify(this.synapseMetadataHandler, Mockito.times(1)).getPartitions(Mockito.any(BlockWriter.class), Mockito.eq(getTableLayoutRequest), Mockito.eq(queryStatusChecker));
+        Mockito.verify(this.synapseMetadataHandler, Mockito.times(1)).getPartitions(nullable(BlockWriter.class), Mockito.eq(getTableLayoutRequest), Mockito.eq(queryStatusChecker));
     }
 
     @Test

--- a/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/SynapseRecordHandlerTest.java
+++ b/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/SynapseRecordHandlerTest.java
@@ -48,6 +48,9 @@ import java.sql.SQLException;
 import java.util.Collections;
 import java.util.Map;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
+
 public class SynapseRecordHandlerTest
 {
     private SynapseRecordHandler synapseRecordHandler;
@@ -67,7 +70,7 @@ public class SynapseRecordHandlerTest
         this.athena = Mockito.mock(AmazonAthena.class);
         this.connection = Mockito.mock(Connection.class);
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
-        Mockito.when(this.jdbcConnectionFactory.getConnection(Mockito.mock(JdbcCredentialProvider.class))).thenReturn(this.connection);
+        Mockito.when(this.jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(this.connection);
         jdbcSplitQueryBuilder = new SynapseQueryStringBuilder("`");
         final DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", SynapseConstants.NAME,
                 "synapse://jdbc:sqlserver://hostname;databaseName=fakedatabase");
@@ -140,7 +143,7 @@ public class SynapseRecordHandlerTest
 
         Constraints constraints = Mockito.mock(Constraints.class);
         PreparedStatement expectedPreparedStatement = Mockito.mock(PreparedStatement.class);
-        Mockito.when(this.connection.prepareStatement(Mockito.anyString())).thenReturn(expectedPreparedStatement);
+        Mockito.when(this.connection.prepareStatement(nullable(String.class))).thenReturn(expectedPreparedStatement);
         this.synapseRecordHandler.buildSplitSql(this.connection, "testCatalogName", tableName, schema, constraints, split);
 
         Mockito.when(split.getProperties()).thenReturn(Map.of("PARTITION_BOUNDARY_FROM", " ", "PARTITION_NUMBER", "1", "PARTITION_COLUMN", "testCol1", "PARTITION_BOUNDARY_TO", "100000"));

--- a/athena-teradata/pom.xml
+++ b/athena-teradata/pom.xml
@@ -41,31 +41,42 @@
             <version>${aws-cdk.version}</version>
             <scope>test</scope>
         </dependency>
+        <!--
+          This is purposefully using a legacy version because these tests
+          rely on powermock and it will break on a later version.
+          Eventually we should fix the test code to not rely on powermock.
+        -->
         <dependency>
-            <groupId>uk.org.webcompere</groupId>
-            <artifactId>system-stubs-junit4</artifactId>
-            <version>1.1.0</version>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.legacy.version}</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.powermock/powermock-module-junit4 -->
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
-            <version>2.0.9</version>
+            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.powermock/powermock-api-mockito2 -->
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-api-mockito2</artifactId>
-            <version>2.0.9</version>
+            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.powermock/powermock-core -->
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-core</artifactId>
-            <version>2.0.9</version>
+            <version>${powermock.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.stefanbirkner</groupId>
+            <artifactId>system-rules</artifactId>
+            <version>${test.system.rules.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -74,7 +85,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>${mvn.shade.plugin.version}</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <filters>
@@ -89,7 +100,7 @@
                     </filters>
                     <transformers>
                         <!-- This transformer is here to concatenate log4j2 cache during shading -->
-                        <transformer implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer">
+                        <transformer implementation="com.github.edwgiz.maven_shade_plugin.log4j2_cache_transformer.PluginsCacheFileTransformer">
 </transformer>
                     </transformers>
                 </configuration>
@@ -97,7 +108,7 @@
                     <dependency>
                         <groupId>com.github.edwgiz</groupId>
                         <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
-                        <version>2.8.1</version>
+                        <version>${log4j2.cachefile.transformer.version}</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/athena-teradata/src/test/java/com/amazonaws/athena/connectors/teradata/TeradataMuxJdbcMetadataHandlerTest.java
+++ b/athena-teradata/src/test/java/com/amazonaws/athena/connectors/teradata/TeradataMuxJdbcMetadataHandlerTest.java
@@ -37,6 +37,7 @@ import org.mockito.Mockito;
 import java.util.Collections;
 import java.util.Map;
 
+import static org.mockito.ArgumentMatchers.nullable;
 
 public class TeradataMuxJdbcMetadataHandlerTest {
 
@@ -125,7 +126,7 @@ public class TeradataMuxJdbcMetadataHandlerTest {
         GetTableLayoutRequest getTableLayoutRequest = Mockito.mock(GetTableLayoutRequest.class);
         Mockito.when(getTableLayoutRequest.getCatalogName()).thenReturn("fakedatabase");
         this.jdbcMetadataHandler.getPartitions(Mockito.mock(BlockWriter.class), getTableLayoutRequest, queryStatusChecker);
-        Mockito.verify(this.teradataMetadataHandler, Mockito.times(1)).getPartitions(Mockito.any(BlockWriter.class), Mockito.eq(getTableLayoutRequest), Mockito.eq(queryStatusChecker));
+        Mockito.verify(this.teradataMetadataHandler, Mockito.times(1)).getPartitions(nullable(BlockWriter.class), Mockito.eq(getTableLayoutRequest), Mockito.eq(queryStatusChecker));
     }
 
     @Test

--- a/athena-teradata/src/test/java/com/amazonaws/athena/connectors/teradata/TeradataRecordHandlerTest.java
+++ b/athena-teradata/src/test/java/com/amazonaws/athena/connectors/teradata/TeradataRecordHandlerTest.java
@@ -45,6 +45,9 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.Collections;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
+
 public class TeradataRecordHandlerTest
 {
     private TeradataRecordHandler teradataRecordHandler;
@@ -64,7 +67,7 @@ public class TeradataRecordHandlerTest
         this.athena = Mockito.mock(AmazonAthena.class);
         this.connection = Mockito.mock(Connection.class);
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
-        Mockito.when(this.jdbcConnectionFactory.getConnection(Mockito.mock(JdbcCredentialProvider.class))).thenReturn(this.connection);
+        Mockito.when(this.jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(this.connection);
         jdbcSplitQueryBuilder = new TeradataQueryStringBuilder("`");
         final DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", TeradataConstants.TERADATA_NAME,
                 "teradata://jdbc:teradata://115.113.87.100/TMODE=ANSI,CHARSET=UTF8,DATABASE=TEST,USER=DBC,PASSWORD=DBC");
@@ -146,7 +149,7 @@ public class TeradataRecordHandlerTest
                 .build());
 
         PreparedStatement expectedPreparedStatement = Mockito.mock(PreparedStatement.class);
-        Mockito.when(this.connection.prepareStatement(Mockito.anyString())).thenReturn(expectedPreparedStatement);
+        Mockito.when(this.connection.prepareStatement(nullable(String.class))).thenReturn(expectedPreparedStatement);
         PreparedStatement preparedStatement = this.teradataRecordHandler.buildSplitSql(this.connection, "testCatalogName", tableName, schema, constraints, split);
 
         Assert.assertEquals(expectedPreparedStatement, preparedStatement);

--- a/athena-timestream/pom.xml
+++ b/athena-timestream/pom.xml
@@ -13,6 +13,7 @@
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
             <version>2022.47.1</version>
+            <classifier>withdep</classifier>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
                 <exclusion>
@@ -25,6 +26,7 @@
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
             <version>2022.47.1</version>
+            <classifier>withdep</classifier>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awscdk/timestream -->
@@ -61,7 +63,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <version>${log4j2Version}</version>
             <scope>runtime</scope>
         </dependency>
@@ -98,7 +100,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>${mvn.shade.plugin.version}</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <filters>
@@ -113,7 +115,7 @@
                     </filters>
                     <transformers>
                         <!-- This transformer is here to concatenate log4j2 cache during shading -->
-                        <transformer implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer">
+                        <transformer implementation="com.github.edwgiz.maven_shade_plugin.log4j2_cache_transformer.PluginsCacheFileTransformer">
 </transformer>
                     </transformers>
                 </configuration>
@@ -121,7 +123,7 @@
                     <dependency>
                         <groupId>com.github.edwgiz</groupId>
                         <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
-                        <version>2.8.1</version>
+                        <version>${log4j2.cachefile.transformer.version}</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/athena-timestream/src/test/java/com/amazonaws/athena/connectors/timestream/TimestreamMetadataHandlerTest.java
+++ b/athena-timestream/src/test/java/com/amazonaws/athena/connectors/timestream/TimestreamMetadataHandlerTest.java
@@ -66,7 +66,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -79,8 +79,8 @@ import java.util.List;
 import static com.amazonaws.athena.connector.lambda.handlers.GlueMetadataHandler.VIEW_METADATA_FIELD;
 import static com.amazonaws.athena.connector.lambda.metadata.ListTablesRequest.UNLIMITED_PAGE_SIZE_VALUE;
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -136,8 +136,8 @@ public class TimestreamMetadataHandlerTest
     {
         logger.info("doListSchemaNames - enter");
 
-        when(mockTsMeta.listDatabases(any(ListDatabasesRequest.class))).thenAnswer((InvocationOnMock invocation) -> {
-            ListDatabasesRequest request = invocation.getArgumentAt(0, ListDatabasesRequest.class);
+        when(mockTsMeta.listDatabases(nullable(ListDatabasesRequest.class))).thenAnswer((InvocationOnMock invocation) -> {
+            ListDatabasesRequest request = invocation.getArgument(0, ListDatabasesRequest.class);
 
             String newNextToken = null;
             List<Database> databases = new ArrayList<>();
@@ -168,7 +168,7 @@ public class TimestreamMetadataHandlerTest
         logger.info("doListSchemaNames - {}", res.getSchemas());
 
         assertEquals(1000, res.getSchemas().size());
-        verify(mockTsMeta, times(3)).listDatabases(any(ListDatabasesRequest.class));
+        verify(mockTsMeta, times(3)).listDatabases(nullable(ListDatabasesRequest.class));
         Iterator<String> schemaItr = res.getSchemas().iterator();
         for (int i = 0; i < 1000; i++) {
             assertEquals("database_" + i, schemaItr.next());
@@ -183,10 +183,10 @@ public class TimestreamMetadataHandlerTest
     {
         logger.info("doListTables - enter");
 
-        when(mockTsMeta.listTables(any(com.amazonaws.services.timestreamwrite.model.ListTablesRequest.class)))
+        when(mockTsMeta.listTables(nullable(com.amazonaws.services.timestreamwrite.model.ListTablesRequest.class)))
                 .thenAnswer((InvocationOnMock invocation) -> {
                     com.amazonaws.services.timestreamwrite.model.ListTablesRequest request =
-                            invocation.getArgumentAt(0, com.amazonaws.services.timestreamwrite.model.ListTablesRequest.class);
+                            invocation.getArgument(0, com.amazonaws.services.timestreamwrite.model.ListTablesRequest.class);
 
                     String newNextToken = null;
                     List<Table> tables = new ArrayList<>();
@@ -219,7 +219,7 @@ public class TimestreamMetadataHandlerTest
 
         assertEquals(1000, res.getTables().size());
         verify(mockTsMeta, times(3))
-                .listTables(any(com.amazonaws.services.timestreamwrite.model.ListTablesRequest.class));
+                .listTables(nullable(com.amazonaws.services.timestreamwrite.model.ListTablesRequest.class));
 
         Iterator<TableName> schemaItr = res.getTables().iterator();
         for (int i = 0; i < 1000; i++) {
@@ -237,11 +237,11 @@ public class TimestreamMetadataHandlerTest
     {
         logger.info("doGetTable - enter");
 
-        when(mockGlue.getTable(any(com.amazonaws.services.glue.model.GetTableRequest.class)))
+        when(mockGlue.getTable(nullable(com.amazonaws.services.glue.model.GetTableRequest.class)))
                 .thenReturn(mock(GetTableResult.class));
 
-        when(mockTsQuery.query(any(QueryRequest.class))).thenAnswer((InvocationOnMock invocation) -> {
-            QueryRequest request = invocation.getArgumentAt(0, QueryRequest.class);
+        when(mockTsQuery.query(nullable(QueryRequest.class))).thenAnswer((InvocationOnMock invocation) -> {
+            QueryRequest request = invocation.getArgument(0, QueryRequest.class);
             assertEquals("DESCRIBE \"default\".\"table1\"", request.getQueryString());
             List<Row> rows = new ArrayList<>();
 
@@ -293,8 +293,8 @@ public class TimestreamMetadataHandlerTest
     {
         logger.info("doGetTable - enter");
 
-        when(mockGlue.getTable(any(com.amazonaws.services.glue.model.GetTableRequest.class))).thenAnswer((InvocationOnMock invocation) -> {
-            com.amazonaws.services.glue.model.GetTableRequest request = invocation.getArgumentAt(0,
+        when(mockGlue.getTable(nullable(com.amazonaws.services.glue.model.GetTableRequest.class))).thenAnswer((InvocationOnMock invocation) -> {
+            com.amazonaws.services.glue.model.GetTableRequest request = invocation.getArgument(0,
                     com.amazonaws.services.glue.model.GetTableRequest.class);
 
             List<Column> columns = new ArrayList<>();
@@ -339,8 +339,8 @@ public class TimestreamMetadataHandlerTest
     {
         logger.info("doGetTimeSeriesTableGlue - enter");
 
-        when(mockGlue.getTable(any(com.amazonaws.services.glue.model.GetTableRequest.class))).thenAnswer((InvocationOnMock invocation) -> {
-            com.amazonaws.services.glue.model.GetTableRequest request = invocation.getArgumentAt(0,
+        when(mockGlue.getTable(nullable(com.amazonaws.services.glue.model.GetTableRequest.class))).thenAnswer((InvocationOnMock invocation) -> {
+            com.amazonaws.services.glue.model.GetTableRequest request = invocation.getArgument(0,
                     com.amazonaws.services.glue.model.GetTableRequest.class);
 
             List<Column> columns = new ArrayList<>();

--- a/athena-timestream/src/test/java/com/amazonaws/athena/connectors/timestream/TimestreamRecordHandlerTest.java
+++ b/athena-timestream/src/test/java/com/amazonaws/athena/connectors/timestream/TimestreamRecordHandlerTest.java
@@ -61,7 +61,7 @@ import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -81,9 +81,8 @@ import static com.amazonaws.athena.connectors.timestream.TestUtils.makeMockQuery
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -143,7 +142,7 @@ public class TimestreamRecordHandlerTest
 
         amazonS3 = mock(AmazonS3.class);
 
-        when(amazonS3.putObject(anyObject()))
+        when(amazonS3.putObject(any()))
                 .thenAnswer((InvocationOnMock invocationOnMock) -> {
                     InputStream inputStream = ((PutObjectRequest) invocationOnMock.getArguments()[0]).getInputStream();
                     ByteHolder byteHolder = new ByteHolder();
@@ -154,7 +153,7 @@ public class TimestreamRecordHandlerTest
                     return mock(PutObjectResult.class);
                 });
 
-        when(amazonS3.getObject(anyString(), anyString()))
+        when(amazonS3.getObject(nullable(String.class), nullable(String.class)))
                 .thenAnswer((InvocationOnMock invocationOnMock) -> {
                     S3Object mockObject = mock(S3Object.class);
                     ByteHolder byteHolder;
@@ -196,7 +195,7 @@ public class TimestreamRecordHandlerTest
         String expectedQuery = "SELECT measure_name, measure_value::double, az, time, hostname, region FROM \"my_schema\".\"my_table\" WHERE (\"az\" IN ('us-east-1a','us-east-1b'))";
 
         QueryResult mockResult = makeMockQueryResult(schemaForRead, numRowsGenerated);
-        when(mockClient.query(any(QueryRequest.class)))
+        when(mockClient.query(nullable(QueryRequest.class)))
                 .thenAnswer((Answer<QueryResult>) invocationOnMock -> {
                             QueryRequest request = (QueryRequest) invocationOnMock.getArguments()[0];
                             assertEquals(expectedQuery, request.getQueryString().replace("\n", ""));
@@ -251,7 +250,7 @@ public class TimestreamRecordHandlerTest
         String expectedQuery = "SELECT measure_name, measure_value::double, az, time, hostname, region FROM \"my_schema\".\"my_table\" WHERE (\"az\" IN ('us-east-1a','us-east-1b'))";
 
         QueryResult mockResult = makeMockQueryResult(schemaForRead, 100_000);
-        when(mockClient.query(any(QueryRequest.class)))
+        when(mockClient.query(nullable(QueryRequest.class)))
                 .thenAnswer((Answer<QueryResult>) invocationOnMock -> {
                             QueryRequest request = (QueryRequest) invocationOnMock.getArguments()[0];
                             assertEquals(expectedQuery, request.getQueryString().replace("\n", ""));
@@ -325,7 +324,7 @@ public class TimestreamRecordHandlerTest
         String expectedQuery = "WITH t1 AS ( select measure_name, az,sum(\"measure_value::double\") as value, count(*) as num_samples from \"my_schema\".\"my_table\" group by measure_name, az )  SELECT measure_name, az, value, num_samples FROM t1 WHERE (\"az\" IN ('us-east-1a','us-east-1b'))";
 
         QueryResult mockResult = makeMockQueryResult(schemaForReadView, 1_000);
-        when(mockClient.query(any(QueryRequest.class)))
+        when(mockClient.query(nullable(QueryRequest.class)))
                 .thenAnswer((Answer<QueryResult>) invocationOnMock -> {
                             QueryRequest request = (QueryRequest) invocationOnMock.getArguments()[0];
                             assertEquals(expectedQuery, request.getQueryString().replace("\n", ""));
@@ -392,7 +391,7 @@ public class TimestreamRecordHandlerTest
         String expectedQuery = "WITH t1 AS ( select az, hostname, region,  CREATE_TIME_SERIES(time, measure_value::double) as cpu_utilization from \"my_schema\".\"my_table\" WHERE measure_name = 'cpu_utilization' GROUP BY measure_name, az, hostname, region )  SELECT region, az, hostname, cpu_utilization FROM t1 WHERE (\"az\" IN ('us-east-1a','us-east-1b'))";
 
         QueryResult mockResult = makeMockQueryResult(schemaForReadView, 1_000);
-        when(mockClient.query(any(QueryRequest.class)))
+        when(mockClient.query(nullable(QueryRequest.class)))
                 .thenAnswer((Answer<QueryResult>) invocationOnMock -> {
                             QueryRequest request = (QueryRequest) invocationOnMock.getArguments()[0];
                             assertEquals("actual: " + request.getQueryString(), expectedQuery, request.getQueryString().replace("\n", ""));

--- a/athena-tpcds/pom.xml
+++ b/athena-tpcds/pom.xml
@@ -13,6 +13,7 @@
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
             <version>2022.47.1</version>
+            <classifier>withdep</classifier>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
                 <exclusion>
@@ -38,7 +39,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <version>${log4j2Version}</version>
             <scope>runtime</scope>
         </dependency>
@@ -66,7 +67,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>${mvn.shade.plugin.version}</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <filters>
@@ -81,7 +82,7 @@
                     </filters>
                     <transformers>
                         <!-- This transformer is here to concatenate log4j2 cache during shading -->
-                        <transformer implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer">
+                        <transformer implementation="com.github.edwgiz.maven_shade_plugin.log4j2_cache_transformer.PluginsCacheFileTransformer">
 </transformer>
                     </transformers>
                 </configuration>
@@ -89,7 +90,7 @@
                     <dependency>
                         <groupId>com.github.edwgiz</groupId>
                         <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
-                        <version>2.8.1</version>
+                        <version>${log4j2.cachefile.transformer.version}</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/athena-tpcds/src/test/java/com/amazonaws/athena/connectors/tpcds/TPCDSMetadataHandlerTest.java
+++ b/athena-tpcds/src/test/java/com/amazonaws/athena/connectors/tpcds/TPCDSMetadataHandlerTest.java
@@ -51,7 +51,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/athena-tpcds/src/test/java/com/amazonaws/athena/connectors/tpcds/TPCDSRecordHandlerTest.java
+++ b/athena-tpcds/src/test/java/com/amazonaws/athena/connectors/tpcds/TPCDSRecordHandlerTest.java
@@ -60,7 +60,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -77,8 +77,8 @@ import static com.amazonaws.athena.connectors.tpcds.TPCDSMetadataHandler.SPLIT_N
 import static com.amazonaws.athena.connectors.tpcds.TPCDSMetadataHandler.SPLIT_SCALE_FACTOR_FIELD;
 import static com.amazonaws.athena.connectors.tpcds.TPCDSMetadataHandler.SPLIT_TOTAL_NUMBER_FIELD;
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -126,7 +126,7 @@ public class TPCDSRecordHandlerTest
         handler = new TPCDSRecordHandler(mockS3, mockSecretsManager, mockAthena);
         spillReader = new S3BlockSpillReader(mockS3, allocator);
 
-        when(mockS3.putObject(anyObject()))
+        when(mockS3.putObject(any()))
                 .thenAnswer((InvocationOnMock invocationOnMock) ->
                 {
                     synchronized (mockS3Storage) {
@@ -138,7 +138,7 @@ public class TPCDSRecordHandlerTest
                     }
                 });
 
-        when(mockS3.getObject(anyString(), anyString()))
+        when(mockS3.getObject(nullable(String.class), nullable(String.class)))
                 .thenAnswer((InvocationOnMock invocationOnMock) ->
                 {
                     synchronized (mockS3Storage) {

--- a/athena-udfs/pom.xml
+++ b/athena-udfs/pom.xml
@@ -13,6 +13,7 @@
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
             <version>2022.47.1</version>
+            <classifier>withdep</classifier>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
                 <exclusion>
@@ -33,7 +34,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <version>${log4j2Version}</version>
             <scope>runtime</scope>
         </dependency>
@@ -61,7 +62,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>${mvn.shade.plugin.version}</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <filters>
@@ -76,7 +77,7 @@
                     </filters>
                     <transformers>
                         <!-- This transformer is here to concatenate log4j2 cache during shading -->
-                        <transformer implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer">
+                        <transformer implementation="com.github.edwgiz.maven_shade_plugin.log4j2_cache_transformer.PluginsCacheFileTransformer">
 </transformer>
                     </transformers>
                 </configuration>
@@ -84,7 +85,7 @@
                     <dependency>
                         <groupId>com.github.edwgiz</groupId>
                         <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
-                        <version>2.8.1</version>
+                        <version>${log4j2.cachefile.transformer.version}</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/athena-vertica/pom.xml
+++ b/athena-vertica/pom.xml
@@ -13,6 +13,7 @@
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
             <version>2022.47.1</version>
+            <classifier>withdep</classifier>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
                 <exclusion>
@@ -33,7 +34,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <version>${log4j2Version}</version>
             <scope>runtime</scope>
         </dependency>
@@ -58,12 +59,12 @@
         <dependency>
             <groupId>com.vertica.jdbc</groupId>
             <artifactId>vertica-jdbc</artifactId>
-            <version>10.0.1-0</version>
+            <version>12.0.2-0</version>
         </dependency>
         <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>ST4</artifactId>
-            <version>4.3.1</version>
+            <version>${antlr.st4.version}</version>
         </dependency>
     </dependencies>
     <build>
@@ -80,7 +81,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>${mvn.shade.plugin.version}</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <filters>
@@ -95,7 +96,7 @@
                     </filters>
                     <transformers>
                         <!-- This transformer is here to concatenate log4j2 cache during shading -->
-                        <transformer implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer">
+                        <transformer implementation="com.github.edwgiz.maven_shade_plugin.log4j2_cache_transformer.PluginsCacheFileTransformer">
 </transformer>
                     </transformers>
                 </configuration>
@@ -103,7 +104,7 @@
                     <dependency>
                         <groupId>com.github.edwgiz</groupId>
                         <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
-                        <version>2.8.1</version>
+                        <version>${log4j2.cachefile.transformer.version}</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/athena-vertica/src/test/java/com/amazonaws/athena/connectors/vertica/TestBase.java
+++ b/athena-vertica/src/test/java/com/amazonaws/athena/connectors/vertica/TestBase.java
@@ -28,6 +28,9 @@ import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+
 public class TestBase {
        // protected static final FederatedIdentity IDENTITY = new FederatedIdentity("id", "principal", "account");
         protected static final String QUERY_ID = "query_id";
@@ -53,7 +56,7 @@ public class TestBase {
                                 return rowNumber.getAndIncrement() + 1 < rows.length;
                         });
 
-                Mockito.when(resultSet.getInt(Mockito.any())).thenAnswer((Answer<Integer>) invocation -> {
+                Mockito.lenient().when(resultSet.getInt(any())).thenAnswer((Answer<Integer>) invocation -> {
                         Object argument = invocation.getArguments()[0];
 
                         if (argument instanceof Integer) {
@@ -69,7 +72,7 @@ public class TestBase {
                         }
                 });
 
-                Mockito.when(resultSet.getString(Mockito.any())).thenAnswer((Answer<String>) invocation -> {
+                Mockito.when(resultSet.getString(any())).thenAnswer((Answer<String>) invocation -> {
                         Object argument = invocation.getArguments()[0];
                         if (argument instanceof Integer) {
                                 int colIndex = (Integer) argument - 1;
@@ -86,8 +89,8 @@ public class TestBase {
 
                 if (columnTypes != null) {
                         Mockito.when(resultSet.getMetaData().getColumnCount()).thenReturn(columnNames.length);
-                        Mockito.when(resultSet.getMetaData().getColumnDisplaySize(Mockito.anyInt())).thenReturn(10);
-                        Mockito.when(resultSet.getMetaData().getColumnType(Mockito.anyInt())).thenAnswer((Answer<Integer>) invocation -> columnTypes[(Integer) invocation.getArguments()[0] - 1]);
+                        Mockito.lenient().when(resultSet.getMetaData().getColumnDisplaySize(anyInt())).thenReturn(10);
+                        Mockito.lenient().when(resultSet.getMetaData().getColumnType(anyInt())).thenAnswer((Answer<Integer>) invocation -> columnTypes[(Integer) invocation.getArguments()[0] - 1]);
                 }
                 return resultSet;
         }

--- a/athena-vertica/src/test/java/com/amazonaws/athena/connectors/vertica/VerticaMetadataHandlerTest.java
+++ b/athena-vertica/src/test/java/com/amazonaws/athena/connectors/vertica/VerticaMetadataHandlerTest.java
@@ -50,7 +50,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.stringtemplate.v4.ST;
@@ -62,8 +62,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static com.amazonaws.athena.connector.lambda.metadata.ListTablesRequest.UNLIMITED_PAGE_SIZE_VALUE;
 import static org.junit.Assert.*;
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 
 @RunWith(MockitoJUnitRunner.class)
 
@@ -120,8 +120,8 @@ public class VerticaMetadataHandlerTest extends TestBase
         this.queryStatusChecker = Mockito.mock(QueryStatusChecker.class);
         this.amazonS3 = Mockito.mock(AmazonS3.class);
 
-        Mockito.when(this.secretsManager.getSecretValue(Mockito.eq(new GetSecretValueRequest().withSecretId("testSecret")))).thenReturn(new GetSecretValueResult().withSecretString("{\"username\": \"testUser\", \"password\": \"testPassword\"}"));
-        Mockito.when(this.verticaConnectionFactory.getOrCreateConn(anyString())).thenReturn(connection);
+        Mockito.lenient().when(this.secretsManager.getSecretValue(Mockito.eq(new GetSecretValueRequest().withSecretId("testSecret")))).thenReturn(new GetSecretValueResult().withSecretString("{\"username\": \"testUser\", \"password\": \"testPassword\"}"));
+        Mockito.when(this.verticaConnectionFactory.getOrCreateConn(nullable(String.class))).thenReturn(connection);
         Mockito.when(connection.getMetaData()).thenReturn(databaseMetaData);
         Mockito.when(amazonS3.getRegion()).thenReturn(Region.US_West_2);
 
@@ -261,7 +261,7 @@ public class VerticaMetadataHandlerTest extends TestBase
         Mockito.when(connection.getMetaData().getColumns(null, "schema1",
                 "table1", null)).thenReturn(resultSet);
 
-        Mockito.when(queryFactory.createVerticaExportQueryBuilder()).thenReturn(new VerticaExportQueryBuilder(new ST("templateVerticaExportQuery")));
+        Mockito.lenient().when(queryFactory.createVerticaExportQueryBuilder()).thenReturn(new VerticaExportQueryBuilder(new ST("templateVerticaExportQuery")));
         Mockito.when(verticaMetadataHandlerMocked.getS3ExportBucket()).thenReturn("testS3Bucket");
 
         try {
@@ -352,9 +352,9 @@ public class VerticaMetadataHandlerTest extends TestBase
 
 
         Mockito.when(verticaMetadataHandlerMocked.getS3ExportBucket()).thenReturn("testS3Bucket");
-        Mockito.when(listObjectsRequest.withBucketName(anyString())).thenReturn(listObjectsRequestObj);
-        Mockito.when(listObjectsRequest.withPrefix(anyString())).thenReturn(listObjectsRequestObj);
-        Mockito.when(amazonS3.listObjects(any(ListObjectsRequest.class))).thenReturn(objectListing);
+        Mockito.lenient().when(listObjectsRequest.withBucketName(nullable(String.class))).thenReturn(listObjectsRequestObj);
+        Mockito.lenient().when(listObjectsRequest.withPrefix(nullable(String.class))).thenReturn(listObjectsRequestObj);
+        Mockito.when(amazonS3.listObjects(nullable(ListObjectsRequest.class))).thenReturn(objectListing);
         Mockito.when(objectListing.getObjectSummaries()).thenReturn(s3ObjectSummariesList);
 
         GetSplitsRequest originalReq = new GetSplitsRequest(this.federatedIdentity, "queryId", "catalog_name",

--- a/athena-vertica/src/test/java/com/amazonaws/athena/connectors/vertica/VerticaSchemaUtilsTest.java
+++ b/athena-vertica/src/test/java/com/amazonaws/athena/connectors/vertica/VerticaSchemaUtilsTest.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
 import java.sql.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.nullable;
 
 public class VerticaSchemaUtilsTest extends TestBase
 {
@@ -50,7 +50,7 @@ public class VerticaSchemaUtilsTest extends TestBase
         VerticaConnectionFactory verticaConnectionFactory = Mockito.mock(VerticaConnectionFactory.class);
         this.tableName = Mockito.mock(TableName.class);
 
-        Mockito.when(verticaConnectionFactory.getOrCreateConn(anyString())).thenReturn(connection);
+        Mockito.when(verticaConnectionFactory.getOrCreateConn(nullable(String.class))).thenReturn(connection);
         Mockito.when(connection.getMetaData()).thenReturn(databaseMetaData);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,25 +11,39 @@
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
-        <aws-sdk.version>1.12.353</aws-sdk.version>
+        <maven.compiler.plugin.version>3.10.1</maven.compiler.plugin.version>
+        <aws-sdk.version>1.12.362</aws-sdk.version>
         <aws.lambda-java-core.version>1.2.2</aws.lambda-java-core.version>
         <aws.lambda-java-log4j2.version>1.5.1</aws.lambda-java-log4j2.version>
-        <aws-cdk.version>1.181.1</aws-cdk.version>
+        <aws-cdk.version>1.182.0</aws-cdk.version>
         <jsii.version>1.72.0</jsii.version>
-        <slf4j-log4j.version>1.7.36</slf4j-log4j.version>
-        <mockito.version>1.10.19</mockito.version>
-        <junit.version>4.13.1</junit.version>
-        <jqwik.version>1.6.3</jqwik.version>
-        <assertj.version>3.22.0</assertj.version>
-        <testng.version>7.6.1</testng.version>
+        <slf4j-log4j.version>2.0.5</slf4j-log4j.version>
+        <mockito.legacy.version>3.3.3</mockito.legacy.version>
+        <mockito.version>4.9.0</mockito.version>
+        <powermock.version>2.0.9</powermock.version>
+        <junit.version>4.13.2</junit.version>
+        <jqwik.version>1.7.1</jqwik.version>
+        <assertj.version>3.23.1</assertj.version>
+        <testng.version>7.7.0</testng.version>
         <fasterxml.jackson.version>2.14.1</fasterxml.jackson.version>
         <surefire.failsafe.version>3.0.0-M7</surefire.failsafe.version>
-        <log4j2Version>2.17.1</log4j2Version>
+        <log4j2Version>2.19.0</log4j2Version>
         <apache.arrow.version>10.0.1</apache.arrow.version>
-        <netty.version>4.1.81.Final</netty.version>
+        <netty.version>4.1.85.Final</netty.version>
         <guava.version>31.1-jre</guava.version>
-        <protobuf3.version>3.21.10</protobuf3.version>
+        <protobuf3.version>3.21.11</protobuf3.version>
+        <antlr.st4.version>4.3.4</antlr.st4.version>
+        <log4j2.cachefile.transformer.version>2.15</log4j2.cachefile.transformer.version>
+        <apache.httpclient.version>4.5.14</apache.httpclient.version>
+        <mssql.jdbc.version>11.2.1.jre11</mssql.jdbc.version>
+        <commons.cli.version>1.5.0</commons.cli.version>
+        <test.system.rules.version>1.19.0</test.system.rules.version>
+        <!-- These are mvn on purpose to not conflict with the maven.* namespace -->
+        <mvn.checkstyle.version>3.2.0</mvn.checkstyle.version>
+        <mvn.shade.plugin.version>3.4.1</mvn.shade.plugin.version>
+        <mvn.source.plugin.version>3.2.1</mvn.source.plugin.version>
+        <mvn.javadoc.plugin.version>3.4.1</mvn.javadoc.plugin.version>
+        <mvn.jar.plugin.version>3.3.0</mvn.jar.plugin.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -167,7 +181,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
@@ -193,7 +207,7 @@
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>7.3.2</version>
+                <version>7.4.1</version>
                 <executions>
                     <execution>
                         <goals>
@@ -205,7 +219,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>${mvn.shade.plugin.version}</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -250,7 +264,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>${mvn.checkstyle.version}</version>
                 <configuration>
                     <configLocation>checkstyle.xml</configLocation>
                     <encoding>UTF-8</encoding>
@@ -329,7 +343,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>${mvn.javadoc.plugin.version}</version>
                 <configuration>
                     <failOnError>false</failOnError>
                     <notimestamp>true</notimestamp>
@@ -355,7 +369,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.1.1</version>
+                        <version>${mvn.javadoc.plugin.version}</version>
                         <configuration>
                             <failOnError>false</failOnError>
                             <notimestamp>true</notimestamp>
@@ -372,7 +386,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>3.2.0</version>
+                        <version>${mvn.source.plugin.version}</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
@@ -385,7 +399,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.6</version>
+                        <version>3.0.1</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -406,7 +420,7 @@
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.8</version>
+                        <version>1.6.13</version>
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>ossrh</serverId>


### PR DESCRIPTION
dependabot has a bunch of dependency upgrade suggestions here:
https://github.com/awslabs/aws-athena-query-federation/network/updates/542125681

This patch upgrades them all at once rather than wait for dependabot to submit these pull
requests one at a time since dependabot has a limit of 5 requests at a time and
each pull request takes time to build.

Changes made:
  - Fixes because of complaints from the style checker (mostly about `(){}` -> `() {}`)

  - Mockito interface changes (`any*` doesn't mean any instance of the
    type + null anymore, it only means any instance of that type).
    See: https://github.com/mockito/mockito/issues/185
    To make the test code perform as it did prior, I switched usages
    of `any*` to `nullable`, except for cases where it was
    `any()` which remains the same because those `any()` still matches
    against nulls.

  - Remove unnecessary webcompere dependency

  - Also fixed some tests that weren't correctly expressing their
    exception class expectation before.
      - In all of these cases, the code was explicitly mocking some
        inner function call to throw SQLException, but the test expected
        some other exception type, which is wrong since the test is
        explicitly trying to get that mocked function to be hit.

  - Fixed a test case inside the BigQueryMetadataHandlerTest.
      - The test was both importing it and setting it inside the test class.
          - I removed the one being set inside the test class.
      - Also required changing the test to expect the right method signature
        to be invoked after it was fixed.