### PR TITLE
athena-hbase/pom.xml: use netty.version

### DIFF
--- a/athena-hbase/pom.xml
+++ b/athena-hbase/pom.xml
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport</artifactId>
-            <version>4.1.85.Final</version>
+            <version>${netty.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>


### PR DESCRIPTION
athena-hbase/pom.xml: use netty.version

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
