### PR TITLE
athena-saphana: use maven-assembly-plugin again

### DIFF
--- a/athena-saphana/athena-saphana.yaml
+++ b/athena-saphana/athena-saphana.yaml
@@ -60,7 +60,7 @@ Resources:
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.saphana.SaphanaMuxCompositeHandler"
-      CodeUri: "./target/athena-saphana-2022.47.1.jar"
+      CodeUri: "./target/athena-saphana.zip"
       Description: "Enables Amazon Athena to communicate with Teradata using JDBC"
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-saphana/pom.xml
+++ b/athena-saphana/pom.xml
@@ -83,40 +83,23 @@
     <build>
         <plugins>
             <plugin>
+                <!-- maven-assembly is required for the saphana connector because maven-shade will run into an issue where the saphana jdbc driver will error out on java versions -->
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>${mvn.shade.plugin.version}</version>
-                <configuration>
-                    <createDependencyReducedPom>false</createDependencyReducedPom>
-                    <filters>
-                        <filter>
-                            <artifact>*:*</artifact>
-                            <excludes>
-                                <exclude>META-INF/*.SF</exclude>
-                                <exclude>META-INF/*.DSA</exclude>
-                                <exclude>META-INF/*.RSA</exclude>
-                            </excludes>
-                        </filter>
-                    </filters>
-                    <transformers>
-                        <!-- This transformer is here to concatenate log4j2 cache during shading -->
-                        <transformer implementation="com.github.edwgiz.maven_shade_plugin.log4j2_cache_transformer.PluginsCacheFileTransformer">
-</transformer>
-                    </transformers>
-                </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>com.github.edwgiz</groupId>
-                        <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
-                        <version>${log4j2.cachefile.transformer.version}</version>
-                    </dependency>
-                </dependencies>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.4.2</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
                         <goals>
-                            <goal>shade</goal>
+                            <goal>single</goal>
                         </goals>
+                        <configuration>
+                            <appendAssemblyId>false</appendAssemblyId>
+                            <descriptors>
+                                <descriptor>assembly.xml</descriptor>
+                            </descriptors>
+                            <finalName>${project.artifactId}</finalName>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
There's an issue with the maven-shade-plugin with the saphana jdbc driver not being able to load at runtime because of java versions.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
