### PR TITLE
Fix MSK connector issues

### DIFF
--- a/athena-msk/athena-msk.yaml
+++ b/athena-msk/athena-msk.yaml
@@ -65,9 +65,6 @@ Parameters:
     Description: 'The S3 bucket reference where keystore and truststore certificates are uploaded. Applicable for SSL auth'
     Default: ""
     Type: String
-  GlueRegistryArn:
-    Description: 'AWS GLUE registry ARN to be provided where topic schemas has been uploaded'
-    Type: String
   LambdaRoleARN:
     Description: "(Must for auth type IAM) A custom role to be used by the Connector lambda"
     Default: ""

--- a/athena-msk/pom.xml
+++ b/athena-msk/pom.xml
@@ -18,6 +18,13 @@
         <maven.compiler.target>11</maven.compiler.target>
     </properties>
     <dependencies>
+         <dependency>
+            <!-- Only use the simple logger for testing so that we can see the output -->
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j-log4j.version}</version>
+            <scope>test</scope>
+         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>

--- a/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/AmazonMskConstants.java
+++ b/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/AmazonMskConstants.java
@@ -23,15 +23,6 @@ public class AmazonMskConstants
 {
     public static final String KAFKA_SOURCE = "kafka";
     /**
-     * schema is set to default
-     */
-    public static final String KAFKA_SCHEMA = "default";
-    /**
-     * This is the glue registry ARN that user need to provide while deploying lambda.
-     * This glue registry will contain the mapping schemas
-     */
-    public static final String GLUE_REGISTRY_ARN = "glue_registry_arn";
-    /**
      * For SSL authentication, user need to give S3 bucket reference where the client truststore and keystore
      * files are uploaded.
      */

--- a/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/dto/TopicSchema.java
+++ b/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/dto/TopicSchema.java
@@ -21,30 +21,11 @@ package com.amazonaws.athena.connectors.msk.dto;
 
 public class TopicSchema
 {
-    String tableName;
-    String schemaName;
+    // This should be the Kafka topic name
     String topicName;
+
+    // This is the schema
     Message message = new Message();
-
-    public String getTableName()
-    {
-        return tableName;
-    }
-
-    public void setTableName(String tableName)
-    {
-        this.tableName = tableName;
-    }
-
-    public String getSchemaName()
-    {
-        return schemaName;
-    }
-
-    public void setSchemaName(String schemaName)
-    {
-        this.schemaName = schemaName;
-    }
 
     public String getTopicName()
     {

--- a/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/serde/MskJsonDeserializer.java
+++ b/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/serde/MskJsonDeserializer.java
@@ -19,11 +19,11 @@
  */
 package com.amazonaws.athena.connectors.msk.serde;
 
-import com.amazonaws.athena.connectors.msk.AmazonMskUtils;
 import com.amazonaws.athena.connectors.msk.dto.MSKField;
 import com.amazonaws.athena.connectors.msk.dto.Message;
 import com.amazonaws.athena.connectors.msk.dto.TopicResultSet;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,6 +33,9 @@ import java.nio.charset.StandardCharsets;
 public class MskJsonDeserializer extends MskDeserializer
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(MskJsonDeserializer.class);
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
     public MskJsonDeserializer(Schema schema)
     {
         super(schema);
@@ -52,9 +55,7 @@ public class MskJsonDeserializer extends MskDeserializer
 
         try {
             // Transforming the topic raw (json) data to JsonNode using ObjectMapper.
-            JsonNode json = AmazonMskUtils
-                    .getObjectMapper()
-                    .readValue(new String(data, StandardCharsets.UTF_8), JsonNode.class);
+            JsonNode json = objectMapper.readValue(new String(data, StandardCharsets.UTF_8), JsonNode.class);
 
             // Creating Field object for each fields in raw data.
             // Also putting additional information in fields from fields metadata.

--- a/athena-msk/src/test/java/com/amazonaws/athena/connectors/msk/AmazonMskRecordHandlerTest.java
+++ b/athena-msk/src/test/java/com/amazonaws/athena/connectors/msk/AmazonMskRecordHandlerTest.java
@@ -298,8 +298,6 @@ public class AmazonMskRecordHandlerTest {
 
     private TopicSchema createCsvTopicSchema() throws JsonProcessingException {
         String csv = "{" +
-                "\"tableName\":\"test\"," +
-                "\"schemaName\":\"default\"," +
                 "\"topicName\":\"test\"," +
                 "\"message\":{" +
                 "\"dataFormat\":\"csv\"," +

--- a/athena-msk/src/test/java/com/amazonaws/athena/connectors/msk/AmazonMskUtilsTest.java
+++ b/athena-msk/src/test/java/com/amazonaws/athena/connectors/msk/AmazonMskUtilsTest.java
@@ -195,21 +195,6 @@ public class AmazonMskUtilsTest {
     }
 
     @Test
-    public void testGetTopicListFromGlueRegistry() throws Exception {
-        List<SchemaListItem> schemaListItems = new ArrayList<>();
-        ListSchemasResult listSchemasResult = new ListSchemasResult();
-        SchemaListItem schemaListItem = new SchemaListItem();
-        schemaListItem.setSchemaName("testtable");
-        schemaListItems.add(schemaListItem);
-        listSchemasResult.setSchemas(schemaListItems);
-        PowerMockito.mockStatic(AWSGlueClientBuilder.class);
-        PowerMockito.when(AWSGlueClientBuilder.defaultClient()).thenReturn(awsGlue);
-        PowerMockito.when(awsGlue.listSchemas(any())).thenReturn(listSchemasResult);
-        List<String> topicList = AmazonMskUtils.getTopicListFromGlueRegistry();
-        assertEquals("testtable", topicList.get(0));
-    }
-
-    @Test
     public void testToArrowType(){
         assertEquals(new ArrowType.Bool(), toArrowType("BOOLEAN"));
         assertEquals(Types.MinorType.TINYINT.getType(), toArrowType("TINYINT"));

--- a/athena-msk/src/test/java/com/amazonaws/athena/connectors/msk/MskCsvDeserializerTest.java
+++ b/athena-msk/src/test/java/com/amazonaws/athena/connectors/msk/MskCsvDeserializerTest.java
@@ -63,8 +63,6 @@ public class MskCsvDeserializerTest extends MskAbstractDeserializerTest
     private TopicSchema createCsvTopicSchema() throws JsonProcessingException
     {
         String csv = "{" +
-                "\"tableName\":\"test\"," +
-                "\"schemaName\":\"default\"," +
                 "\"topicName\":\"test\"," +
                 "\"message\":{" +
                 "\"dataFormat\":\"csv\"," +

--- a/athena-msk/src/test/java/com/amazonaws/athena/connectors/msk/MskJsonDeserializerTest.java
+++ b/athena-msk/src/test/java/com/amazonaws/athena/connectors/msk/MskJsonDeserializerTest.java
@@ -62,8 +62,6 @@ public class MskJsonDeserializerTest extends MskAbstractDeserializerTest
     private TopicSchema createJsonTopicSchema() throws JsonProcessingException
     {
         String json = "{" +
-                "\"tableName\":\"test\"," +
-                "\"schemaName\":\"default\"," +
                 "\"topicName\":\"test\"," +
                 "\"message\":{" +
                 "\"dataFormat\":\"json\"," +


### PR DESCRIPTION
Normally Athena queries are of the following structure:
`SELECT * FROM <catalog name>.<schema name>.<table name>`

The previous version of this connector did not map this structure properly onto the structure for querying schemas in the Glue Schema Registry; specifically it did not leverage the `<schema name>` part of the query at all.

With this patch, this is how we map to the Glue Schema Registry now:
`SELECT * FROM <catalog name for msk>.<glue registry name>.<glue schema name>`

And then inside the Glue Schema, the "topicName" corresponds to the Kafka topic name.

This means that the registry ARN environment variable is no longer necessary and has been removed, since the registry is now contained in the query structure itself.

This means that we also had to properly implement `doListSchemaNames`, which was just returning `default` before, when it should actually be listing out the Glue registries. However, note that we will only list out Glue registries that have been "marked" for this connector.
  - To mark a Glue registry for this connector, make sure the string:
       `{AthenaFederationMSK}`
    is present within the `Description` of the Glue registry that you want to mark.

This patch also removes a lot of extraneous wrapping, also adds pagination support for various list* functions, and finally also adds case insensitive lookups into the Glue Schema Registry.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
