### PR TITLE
athena-msk: Fix bugs with Glue request pagination

### DIFF
--- a/athena-msk/README.md
+++ b/athena-msk/README.md
@@ -2,4 +2,4 @@
 
 This connector enables Amazon Athena to access your kafka clusters.
 
-Documentation has moved [here].
+Documentation has moved [here](https://docs.aws.amazon.com/athena/latest/ug/connectors-msk.html).

--- a/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/AmazonMskMetadataHandler.java
+++ b/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/AmazonMskMetadataHandler.java
@@ -99,8 +99,8 @@ public class AmazonMskMetadataHandler extends MetadataHandler
         var start = glue.listRegistries(listRequest);
         List<String> registries = Stream.iterate(
             start,
-            r -> r == start || r.getNextToken() != null,
-            r -> glue.listRegistries(listRequest.withNextToken(r.getNextToken())))
+            r -> r != null,
+            r -> (r.getNextToken() == null) ? null : glue.listRegistries(listRequest.withNextToken(r.getNextToken())))
                 .flatMap(r -> r.getRegistries().stream())
                 .filter(r -> r.getDescription() != null && r.getDescription().contains(REGISTRY_MARKER))
                 .map(r -> r.getRegistryName())
@@ -149,8 +149,8 @@ public class AmazonMskMetadataHandler extends MetadataHandler
             var start = glue.listSchemas(listRequest);
             List<TableName> tableNames = Stream.iterate(
                 start,
-                r -> r == start || r.getNextToken() != null,
-                r -> glue.listSchemas(listRequest.withNextToken(r.getNextToken())))
+                r -> r != null,
+                r -> (r.getNextToken() == null) ? null : glue.listSchemas(listRequest.withNextToken(r.getNextToken())))
                     .flatMap(r -> r.getSchemas().stream())
                     .limit(MAX_RESULTS + 1)
                     .map(schemaListItem -> schemaListItem.getSchemaName())
@@ -189,8 +189,8 @@ public class AmazonMskMetadataHandler extends MetadataHandler
         var start = glue.listRegistries(listRequest);
         var result = Stream.iterate(
             start,
-            r -> (r == start) || (r.getNextToken() != null),
-            r -> glue.listRegistries(listRequest.withNextToken(r.getNextToken())))
+            r -> r != null,
+            r -> (r.getNextToken() == null) ? null : glue.listRegistries(listRequest.withNextToken(r.getNextToken())))
                 .flatMap(r -> r.getRegistries().stream())
                 .filter(r -> r.getDescription() != null && r.getDescription().contains(REGISTRY_MARKER))
                 .map(r -> r.getRegistryName())
@@ -212,8 +212,8 @@ public class AmazonMskMetadataHandler extends MetadataHandler
         var start = glue.listSchemas(listSchemasRequest);
         var result = Stream.iterate(
             start,
-            r -> (r == start) || (r.getNextToken() != null),
-            r -> glue.listSchemas(listSchemasRequest.withNextToken(r.getNextToken())))
+            r -> r != null,
+            r -> (r.getNextToken() == null) ? null : glue.listSchemas(listSchemasRequest.withNextToken(r.getNextToken())))
                 .flatMap(r -> r.getSchemas().stream())
                 .map(schemaListItem -> schemaListItem.getSchemaName())
                 .filter(glueSchemaName -> glueSchemaName.equalsIgnoreCase(glueSchemaNameIn))


### PR DESCRIPTION
Fixes the following bugs:
  - When there is only one page (only start), we would fire an additional extraneous glue query before Stream.iterate() would terminate.

  - When there are multiple pages, the last page would be missing, because Stream.iterate excludes the last result that violates the iteration condition.

The fix is to have Stream.iterate() terminate only after the last page is included by changing the logic such that we just don't fire a request when the nextToken() is null by returning null in that situation to have Stream.iterate() terminate on that condition instead (which would exclude the terminating null from our Stream as well).

Also added link to the README.md


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
