### PR TITLE
Simplify MuxCompositeHandler usage for single connections

### DIFF
--- a/athena-cloudera-hive/src/main/java/com/amazonaws/athena/connectors/cloudera/HiveMuxCompositeHandler.java
+++ b/athena-cloudera-hive/src/main/java/com/amazonaws/athena/connectors/cloudera/HiveMuxCompositeHandler.java
@@ -19,17 +19,17 @@
  */
 package com.amazonaws.athena.connectors.cloudera;
 
-import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
+import com.amazonaws.athena.connectors.jdbc.MultiplexingJdbcCompositeHandler;
 
 /**
  * Boilerplate composite handler that allows us to use a single Lambda function for both
  * Metadata and Data. In this case we just compose {@link HiveMuxMetadataHandler} and {@link HiveMuxRecordHandler}.
  */
 public class HiveMuxCompositeHandler
-        extends CompositeHandler
+        extends MultiplexingJdbcCompositeHandler
 {
-    public HiveMuxCompositeHandler()
+    public HiveMuxCompositeHandler() throws java.lang.ReflectiveOperationException
     {
-        super(new HiveMuxMetadataHandler(), new HiveMuxRecordHandler());
+        super(HiveMuxMetadataHandler.class, HiveMuxRecordHandler.class, HiveMetadataHandler.class, HiveRecordHandler.class);
     }
 }

--- a/athena-cloudera-impala/src/main/java/com/amazonaws/athena/connectors/cloudera/ImpalaMuxCompositeHandler.java
+++ b/athena-cloudera-impala/src/main/java/com/amazonaws/athena/connectors/cloudera/ImpalaMuxCompositeHandler.java
@@ -19,17 +19,17 @@
  */
 package com.amazonaws.athena.connectors.cloudera;
 
-import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
+import com.amazonaws.athena.connectors.jdbc.MultiplexingJdbcCompositeHandler;
 
 /**
  * Boilerplate composite handler that allows us to use a single Lambda function for both
  * Metadata and Data. In this case we just compose {@link ImpalaMuxMetadataHandler} and {@link ImpalaMuxRecordHandler}.
  */
 public class ImpalaMuxCompositeHandler
-        extends CompositeHandler
+        extends MultiplexingJdbcCompositeHandler
 {
-    public ImpalaMuxCompositeHandler()
+    public ImpalaMuxCompositeHandler() throws java.lang.ReflectiveOperationException
     {
-        super(new ImpalaMuxMetadataHandler(), new ImpalaMuxRecordHandler());
+        super(ImpalaMuxMetadataHandler.class, ImpalaMuxRecordHandler.class, ImpalaMetadataHandler.class, ImpalaRecordHandler.class);
     }
 }

--- a/athena-datalakegen2/src/main/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2MuxCompositeHandler.java
+++ b/athena-datalakegen2/src/main/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2MuxCompositeHandler.java
@@ -19,16 +19,16 @@
  */
 package com.amazonaws.athena.connectors.datalakegen2;
 
-import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
+import com.amazonaws.athena.connectors.jdbc.MultiplexingJdbcCompositeHandler;
 
 /**
  * Boilerplate composite handler that allows us to use a single Lambda function for both
  * Metadata and Data. In this case we just compose {@link DataLakeGen2MuxMetadataHandler} and {@link DataLakeGen2MuxRecordHandler}.
  */
-public class DataLakeGen2MuxCompositeHandler extends CompositeHandler
+public class DataLakeGen2MuxCompositeHandler extends MultiplexingJdbcCompositeHandler
 {
-    public DataLakeGen2MuxCompositeHandler()
+    public DataLakeGen2MuxCompositeHandler() throws java.lang.ReflectiveOperationException
     {
-        super(new DataLakeGen2MuxMetadataHandler(), new DataLakeGen2MuxRecordHandler());
+        super(DataLakeGen2MuxMetadataHandler.class, DataLakeGen2MuxRecordHandler.class, DataLakeGen2MetadataHandler.class, DataLakeGen2RecordHandler.class);
     }
 }

--- a/athena-db2/src/main/java/com/amazonaws/athena/connectors/db2/Db2MuxCompositeHandler.java
+++ b/athena-db2/src/main/java/com/amazonaws/athena/connectors/db2/Db2MuxCompositeHandler.java
@@ -19,19 +19,19 @@
  */
 package com.amazonaws.athena.connectors.db2;
 
-import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
+import com.amazonaws.athena.connectors.jdbc.MultiplexingJdbcCompositeHandler;
 
 /**
  * Boilerplate composite handler that allows us to use a single Lambda function for both
  * Metadata and Data. In this case we just compose {@link Db2MuxMetadataHandler} and {@link Db2MuxRecordHandler}.
  */
-public class Db2MuxCompositeHandler extends CompositeHandler
+public class Db2MuxCompositeHandler extends MultiplexingJdbcCompositeHandler
 {
     /**
      * Constructs objects of type CompositeHandler.
      */
-    public Db2MuxCompositeHandler()
+    public Db2MuxCompositeHandler() throws java.lang.ReflectiveOperationException
     {
-        super(new Db2MuxMetadataHandler(), new Db2MuxRecordHandler());
+        super(Db2MuxMetadataHandler.class, Db2MuxRecordHandler.class, Db2MetadataHandler.class, Db2RecordHandler.class);
     }
 }

--- a/athena-hortonworks-hive/src/main/java/com/amazonaws/athena/connectors/hortonworks/HiveMuxCompositeHandler.java
+++ b/athena-hortonworks-hive/src/main/java/com/amazonaws/athena/connectors/hortonworks/HiveMuxCompositeHandler.java
@@ -19,17 +19,17 @@
  */
 package com.amazonaws.athena.connectors.hortonworks;
 
-import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
+import com.amazonaws.athena.connectors.jdbc.MultiplexingJdbcCompositeHandler;
 
 /**
  * Boilerplate composite handler that allows us to use a single Lambda function for both
  * Metadata and Data. In this case we just compose {@link HiveMuxMetadataHandler} and {@link HiveMuxRecordHandler}.
  */
 public class HiveMuxCompositeHandler
-        extends CompositeHandler
+        extends MultiplexingJdbcCompositeHandler
 {
-    public HiveMuxCompositeHandler()
+    public HiveMuxCompositeHandler() throws java.lang.ReflectiveOperationException
     {
-        super(new HiveMuxMetadataHandler(), new HiveMuxRecordHandler());
+        super(HiveMuxMetadataHandler.class, HiveMuxRecordHandler.class, HiveMetadataHandler.class, HiveRecordHandler.class);
     }
 }

--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/MultiplexingJdbcCompositeHandler.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/MultiplexingJdbcCompositeHandler.java
@@ -1,0 +1,48 @@
+/*-
+ * #%L
+ * athena-jdbc
+ * %%
+ * Copyright (C) 2019 - 2023 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.jdbc;
+
+import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
+import com.amazonaws.athena.connectors.jdbc.manager.JdbcMetadataHandler;
+import com.amazonaws.athena.connectors.jdbc.manager.JdbcRecordHandler;
+
+/**
+ * Boilerplate composite handler that allows us to use a single Lambda function for both
+ * Metadata and Data.
+ * Automatically chooses to use either the Mux*Handlers or normal *Handlers
+ * depending on if catalog connection strings are being used.
+ */
+public class MultiplexingJdbcCompositeHandler
+        extends CompositeHandler
+{
+    private static final boolean hasCatalogConnections = System.getenv().keySet().stream().anyMatch(k ->
+        k.endsWith(com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionConfigBuilder.CONNECTION_STRING_PROPERTY_SUFFIX));
+
+    public MultiplexingJdbcCompositeHandler(
+        Class<? extends MultiplexingJdbcMetadataHandler> muxMetadataHandlerClass,
+        Class<? extends MultiplexingJdbcRecordHandler> muxRecordHandlerClass,
+        Class<? extends JdbcMetadataHandler> metadataHandlerClass,
+        Class<? extends JdbcRecordHandler> recordHandlerClass) throws java.lang.ReflectiveOperationException
+    {
+        super(
+            hasCatalogConnections ? muxMetadataHandlerClass.getConstructor().newInstance() : metadataHandlerClass.getConstructor().newInstance(),
+            hasCatalogConnections ? muxRecordHandlerClass.getConstructor().newInstance() : recordHandlerClass.getConstructor().newInstance());
+    }
+}

--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/connection/DatabaseConnectionConfigBuilder.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/connection/DatabaseConnectionConfigBuilder.java
@@ -34,7 +34,7 @@ import java.util.regex.Pattern;
  */
 public class DatabaseConnectionConfigBuilder
 {
-    private static final String CONNECTION_STRING_PROPERTY_SUFFIX = "_connection_string";
+    public static final String CONNECTION_STRING_PROPERTY_SUFFIX = "_connection_string";
     public static final String DEFAULT_CONNECTION_STRING_PROPERTY = "default";
     private static final int MUX_CATALOG_LIMIT = 100;
 

--- a/athena-mysql/src/main/java/com/amazonaws/athena/connectors/mysql/MySqlMuxCompositeHandler.java
+++ b/athena-mysql/src/main/java/com/amazonaws/athena/connectors/mysql/MySqlMuxCompositeHandler.java
@@ -19,17 +19,17 @@
  */
 package com.amazonaws.athena.connectors.mysql;
 
-import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
+import com.amazonaws.athena.connectors.jdbc.MultiplexingJdbcCompositeHandler;
 
 /**
  * Boilerplate composite handler that allows us to use a single Lambda function for both
  * Metadata and Data. In this case we just compose {@link MySqlMuxMetadataHandler} and {@link MySqlMuxRecordHandler}.
  */
 public class MySqlMuxCompositeHandler
-        extends CompositeHandler
+        extends MultiplexingJdbcCompositeHandler
 {
-    public MySqlMuxCompositeHandler()
+    public MySqlMuxCompositeHandler() throws java.lang.ReflectiveOperationException
     {
-        super(new MySqlMuxMetadataHandler(), new MySqlMuxRecordHandler());
+        super(MySqlMuxMetadataHandler.class, MySqlMuxRecordHandler.class, MySqlMetadataHandler.class, MySqlRecordHandler.class);
     }
 }

--- a/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleMuxCompositeHandler.java
+++ b/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleMuxCompositeHandler.java
@@ -19,17 +19,17 @@
  */
 package com.amazonaws.athena.connectors.oracle;
 
-import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
+import com.amazonaws.athena.connectors.jdbc.MultiplexingJdbcCompositeHandler;
 
 /**
  * Boilerplate composite handler that allows us to use a single Lambda function for both
  * Metadata and Data. In this case we just compose {@link OracleMuxMetadataHandler} and {@link OracleMuxRecordHandler}.
  */
 public class OracleMuxCompositeHandler
-        extends CompositeHandler
+        extends MultiplexingJdbcCompositeHandler
 {
-    public OracleMuxCompositeHandler()
+    public OracleMuxCompositeHandler() throws java.lang.ReflectiveOperationException
     {
-        super(new OracleMuxMetadataHandler(), new OracleMuxRecordHandler());
+        super(OracleMuxMetadataHandler.class, OracleMuxRecordHandler.class, OracleMetadataHandler.class, OracleRecordHandler.class);
     }
 }

--- a/athena-postgresql/src/main/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlMuxCompositeHandler.java
+++ b/athena-postgresql/src/main/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlMuxCompositeHandler.java
@@ -19,17 +19,17 @@
  */
 package com.amazonaws.athena.connectors.postgresql;
 
-import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
+import com.amazonaws.athena.connectors.jdbc.MultiplexingJdbcCompositeHandler;
 
 /**
  * Boilerplate composite handler that allows us to use a single Lambda function for both
  * Metadata and Data. In this case we just compose {@link PostGreSqlMuxMetadataHandler} and {@link PostGreSqlMuxRecordHandler}.
  */
 public class PostGreSqlMuxCompositeHandler
-        extends CompositeHandler
+        extends MultiplexingJdbcCompositeHandler
 {
-    public PostGreSqlMuxCompositeHandler()
+    public PostGreSqlMuxCompositeHandler() throws java.lang.ReflectiveOperationException
     {
-        super(new PostGreSqlMuxMetadataHandler(), new PostGreSqlMuxRecordHandler());
+        super(PostGreSqlMuxMetadataHandler.class, PostGreSqlMuxRecordHandler.class, PostGreSqlMetadataHandler.class, PostGreSqlRecordHandler.class);
     }
 }

--- a/athena-redshift/src/main/java/com/amazonaws/athena/connectors/redshift/RedshiftMuxCompositeHandler.java
+++ b/athena-redshift/src/main/java/com/amazonaws/athena/connectors/redshift/RedshiftMuxCompositeHandler.java
@@ -19,17 +19,17 @@
  */
 package com.amazonaws.athena.connectors.redshift;
 
-import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
+import com.amazonaws.athena.connectors.jdbc.MultiplexingJdbcCompositeHandler;
 
 /**
  * Boilerplate composite handler that allows us to use a single Lambda function for both
  * Metadata and Data. In this case we just compose {@link RedshiftMuxMetadataHandler} and {@link RedshiftMuxRecordHandler}.
  */
 public class RedshiftMuxCompositeHandler
-        extends CompositeHandler
+        extends MultiplexingJdbcCompositeHandler
 {
-    public RedshiftMuxCompositeHandler()
+    public RedshiftMuxCompositeHandler() throws java.lang.ReflectiveOperationException
     {
-        super(new RedshiftMuxMetadataHandler(), new RedshiftMuxRecordHandler());
+        super(RedshiftMuxMetadataHandler.class, RedshiftMuxRecordHandler.class, RedshiftMetadataHandler.class, RedshiftRecordHandler.class);
     }
 }

--- a/athena-saphana/src/main/java/com/amazonaws/athena/connectors/saphana/SaphanaMuxCompositeHandler.java
+++ b/athena-saphana/src/main/java/com/amazonaws/athena/connectors/saphana/SaphanaMuxCompositeHandler.java
@@ -21,17 +21,17 @@
  */
 package com.amazonaws.athena.connectors.saphana;
 
-import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
+import com.amazonaws.athena.connectors.jdbc.MultiplexingJdbcCompositeHandler;
 
 /**
  * Boilerplate composite handler that allows us to use a single Lambda function for both
  * Metadata and Data. In this case we just compose {@link SaphanaMuxMetadataHandler} and {@link SaphanaMuxRecordHandler}.
  */
 public class SaphanaMuxCompositeHandler
-        extends CompositeHandler
+        extends MultiplexingJdbcCompositeHandler
 {
-    public SaphanaMuxCompositeHandler()
+    public SaphanaMuxCompositeHandler() throws java.lang.ReflectiveOperationException
     {
-        super(new SaphanaMuxMetadataHandler(), new SaphanaMuxRecordHandler());
+        super(SaphanaMuxMetadataHandler.class, SaphanaMuxRecordHandler.class, SaphanaMetadataHandler.class, SaphanaRecordHandler.class);
     }
 }

--- a/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMuxCompositeHandler.java
+++ b/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMuxCompositeHandler.java
@@ -21,17 +21,17 @@
  */
 package com.amazonaws.athena.connectors.snowflake;
 
-import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
+import com.amazonaws.athena.connectors.jdbc.MultiplexingJdbcCompositeHandler;
 
 /**
  * Boilerplate composite handler that allows us to use a single Lambda function for both
  * Metadata and Data. In this case we just compose {@link SnowflakeMuxMetadataHandler} and {@link SnowflakeMuxRecordHandler}.
  */
 public class SnowflakeMuxCompositeHandler
-        extends CompositeHandler
+        extends MultiplexingJdbcCompositeHandler
 {
-    public SnowflakeMuxCompositeHandler()
+    public SnowflakeMuxCompositeHandler() throws java.lang.ReflectiveOperationException
     {
-        super(new SnowflakeMuxMetadataHandler(), new SnowflakeMuxRecordHandler());
+        super(SnowflakeMuxMetadataHandler.class, SnowflakeMuxRecordHandler.class, SnowflakeMetadataHandler.class, SnowflakeRecordHandler.class);
     }
 }

--- a/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerMuxCompositeHandler.java
+++ b/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerMuxCompositeHandler.java
@@ -20,17 +20,17 @@
 
 package com.amazonaws.athena.connectors.sqlserver;
 
-import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
+import com.amazonaws.athena.connectors.jdbc.MultiplexingJdbcCompositeHandler;
 
 /**
  * Boilerplate composite handler that allows us to use a single Lambda function for both
  * Metadata and Data. In this case we just compose {@link SqlServerMuxMetadataHandler} and {@link SqlServerMuxRecordHandler}.
  */
 public class SqlServerMuxCompositeHandler
-        extends CompositeHandler
+        extends MultiplexingJdbcCompositeHandler
 {
-    public SqlServerMuxCompositeHandler()
+    public SqlServerMuxCompositeHandler() throws java.lang.ReflectiveOperationException
     {
-        super(new SqlServerMuxMetadataHandler(), new SqlServerMuxRecordHandler());
+        super(SqlServerMuxMetadataHandler.class, SqlServerMuxRecordHandler.class, SqlServerMetadataHandler.class, SqlServerRecordHandler.class);
     }
 }

--- a/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseMuxCompositeHandler.java
+++ b/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseMuxCompositeHandler.java
@@ -19,17 +19,17 @@
  */
 package com.amazonaws.athena.connectors.synapse;
 
-import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
+import com.amazonaws.athena.connectors.jdbc.MultiplexingJdbcCompositeHandler;
 
 /**
  * Boilerplate composite handler that allows us to use a single Lambda function for both
  * Metadata and Data. In this case we just compose {@link SynapseMuxMetadataHandler} and {@link SynapseMuxRecordHandler}.
  */
 public class SynapseMuxCompositeHandler
-        extends CompositeHandler
+        extends MultiplexingJdbcCompositeHandler
 {
-    public SynapseMuxCompositeHandler()
+    public SynapseMuxCompositeHandler() throws java.lang.ReflectiveOperationException
     {
-        super(new SynapseMuxMetadataHandler(), new SynapseMuxRecordHandler());
+        super(SynapseMuxMetadataHandler.class, SynapseMuxRecordHandler.class, SynapseMetadataHandler.class, SynapseRecordHandler.class);
     }
 }

--- a/athena-teradata/src/main/java/com/amazonaws/athena/connectors/teradata/TeradataMuxCompositeHandler.java
+++ b/athena-teradata/src/main/java/com/amazonaws/athena/connectors/teradata/TeradataMuxCompositeHandler.java
@@ -19,17 +19,17 @@
  */
 package com.amazonaws.athena.connectors.teradata;
 
-import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
+import com.amazonaws.athena.connectors.jdbc.MultiplexingJdbcCompositeHandler;
 
 /**
  * Boilerplate composite handler that allows us to use a single Lambda function for both
  * Metadata and Data. In this case we just compose {@link TeradataMuxMetadataHandler} and {@link TeradataMuxRecordHandler}.
  */
 public class TeradataMuxCompositeHandler
-        extends CompositeHandler
+        extends MultiplexingJdbcCompositeHandler
 {
-    public TeradataMuxCompositeHandler()
+    public TeradataMuxCompositeHandler() throws java.lang.ReflectiveOperationException
     {
-        super(new TeradataMuxMetadataHandler(), new TeradataMuxRecordHandler());
+        super(TeradataMuxMetadataHandler.class, TeradataMuxRecordHandler.class, TeradataMetadataHandler.class, TeradataRecordHandler.class);
     }
 }


### PR DESCRIPTION
In the situation where there is only a `default` connection specified, just use the non mux versions of the handlers.

This allows the user to not have to set a `<datasource_name>_connection_string` and only have the `default` connection string specified.

This patch addresses issues: #827, #683



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
