### PR TITLE
[Feature] athena-neptune: add optional parameter for custom neptune query execution timeout

### DIFF
--- a/athena-neptune/athena-neptune.yaml
+++ b/athena-neptune/athena-neptune.yaml
@@ -71,7 +71,11 @@ Parameters:
     Type: String
   PermissionsBoundaryARN:
     Description: "(Optional) An IAM policy ARN to use as the PermissionsBoundary for the created Lambda function's execution role"
-    Default: ''
+    Default: ""
+    Type: String
+  NeptuneQueryExecutionTimeout:
+    Description: "Query execution timeout for neptune graph traversals. This will override the cluster parameter group option `neptune_query_timeout`"
+    Default: "120000"
     Type: String
 
 Conditions:
@@ -94,6 +98,7 @@ Resources:
           neptune_graphtype: !Ref NeptuneGraphType
           SERVICE_REGION: !Ref AWS::Region
           enable_caseinsensitivematch: !Ref EnableCaseInsensitiveMatch
+          query_execution_timeout: !Ref NeptuneQueryExecutionTimeout
       FunctionName: !Ref AthenaCatalogName
       Handler: "com.amazonaws.athena.connectors.neptune.NeptuneCompositeHandler"
       CodeUri: "./target/athena-neptune-2022.47.1.jar"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This will allow a custom per-query execution timeout as defined [here](https://docs.aws.amazon.com/neptune/latest/userguide/best-practices-gremlin-java-per-query-timeout.html). You can enable it by adding an environment variable called 
`query_execution_timeout` and giving it a value (in ms) for the timeout. This will override the cluster parameter group option `neptune_query_timeout`. If no environment variable is provided, then the  cluster parameter group option `neptune_query_timeout` will still be enforced.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
