### PR TITLE
Cut release for v2023.01.1

### DIFF
--- a/athena-arrow-java-dist/pom.xml
+++ b/athena-arrow-java-dist/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-athena-query-federation</artifactId>
-        <version>2022.47.1</version>
+        <version>2023.01.1</version>
     </parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>athena-arrow-java-dist</artifactId>
-    <version>2022.47.1</version>
+    <version>2023.01.1</version>
     <packaging>pom</packaging>
     <name>athena-arrow-java-dist</name>
     <!-- Source: https://github.com/henrymai/arrow/commits/apache-arrow-10.0.1-amzn -->

--- a/athena-aws-cmdb/athena-aws-cmdb.yaml
+++ b/athena-aws-cmdb/athena-aws-cmdb.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.47.1
+    SemanticVersion: 2023.01.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AthenaCatalogName:
@@ -53,7 +53,7 @@ Resources:
           spill_prefix: !Ref SpillPrefix
       FunctionName: !Ref AthenaCatalogName
       Handler: "com.amazonaws.athena.connectors.aws.cmdb.AwsCmdbCompositeHandler"
-      CodeUri: "./target/athena-aws-cmdb-2022.47.1.jar"
+      CodeUri: "./target/athena-aws-cmdb-2023.01.1.jar"
       Description: "Enables Amazon Athena to communicate with various AWS Services, making your resource inventories accessible via SQL."
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-aws-cmdb/pom.xml
+++ b/athena-aws-cmdb/pom.xml
@@ -3,16 +3,16 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.47.1</version>
+        <version>2023.01.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-aws-cmdb</artifactId>
-    <version>2022.47.1</version>
+    <version>2023.01.1</version>
     <dependencies>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <classifier>withdep</classifier>
         </dependency>
         <dependency>

--- a/athena-cloudera-hive/athena-cloudera-hive.yaml
+++ b/athena-cloudera-hive/athena-cloudera-hive.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.47.1
+    SemanticVersion: 2023.01.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   LambdaFunctionName:
@@ -66,7 +66,7 @@ Resources:
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.cloudera.HiveMuxCompositeHandler"
-      CodeUri: "./target/athena-cloudera-hive-2022.47.1.jar"
+      CodeUri: "./target/athena-cloudera-hive-2023.01.1.jar"
       Description: "Enables Amazon Athena to communicate with Coludera Hive using JDBC"
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-cloudera-hive/pom.xml
+++ b/athena-cloudera-hive/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.47.1</version>
+        <version>2023.01.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-cloudera-hive</artifactId>
-    <version>2022.47.1</version>
+    <version>2023.01.1</version>
     <properties>
         <clouderaVersion>2.6.15.1018</clouderaVersion>
     </properties>
@@ -15,13 +15,13 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
         </dependency>
         <dependency>
             <groupId>Hive</groupId>
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/athena-cloudera-impala/athena-cloudera-impala.yaml
+++ b/athena-cloudera-impala/athena-cloudera-impala.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.47.1
+    SemanticVersion: 2023.01.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   LambdaFunctionName:
@@ -71,7 +71,7 @@ Resources:
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.cloudera.ImpalaMuxCompositeHandler"
-      CodeUri: "./target/athena-cloudera-impala-2022.47.1.jar"
+      CodeUri: "./target/athena-cloudera-impala-2023.01.1.jar"
       Description: "Enables Amazon Athena to communicate with Cloudera Impala using JDBC"
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-cloudera-impala/pom.xml
+++ b/athena-cloudera-impala/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.47.1</version>
+        <version>2023.01.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-cloudera-impala</artifactId>
-    <version>2022.47.1</version>
+    <version>2023.01.1</version>
     <properties>
         <clouderaVersion>2.6.29.1035</clouderaVersion>
     </properties>
@@ -15,13 +15,13 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
         </dependency>
         <dependency>
             <groupId>Impala</groupId>
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/athena-cloudwatch-metrics/athena-cloudwatch-metrics.yaml
+++ b/athena-cloudwatch-metrics/athena-cloudwatch-metrics.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.47.1
+    SemanticVersion: 2023.01.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AthenaCatalogName:
@@ -53,7 +53,7 @@ Resources:
           spill_prefix: !Ref SpillPrefix
       FunctionName: !Ref AthenaCatalogName
       Handler: "com.amazonaws.athena.connectors.cloudwatch.metrics.MetricsCompositeHandler"
-      CodeUri: "./target/athena-cloudwatch-metrics-2022.47.1.jar"
+      CodeUri: "./target/athena-cloudwatch-metrics-2023.01.1.jar"
       Description: "Enables Amazon Athena to communicate with Cloudwatch Metrics, making your metrics data accessible via SQL"
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-cloudwatch-metrics/pom.xml
+++ b/athena-cloudwatch-metrics/pom.xml
@@ -3,16 +3,16 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.47.1</version>
+        <version>2023.01.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-cloudwatch-metrics</artifactId>
-    <version>2022.47.1</version>
+    <version>2023.01.1</version>
     <dependencies>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <classifier>withdep</classifier>
         </dependency>
         <dependency>

--- a/athena-cloudwatch/athena-cloudwatch.yaml
+++ b/athena-cloudwatch/athena-cloudwatch.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.47.1
+    SemanticVersion: 2023.01.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AthenaCatalogName:
@@ -66,7 +66,7 @@ Resources:
           kms_key_id: !If [HasKMSKeyId, !Ref KMSKeyId, !Ref "AWS::NoValue"]
       FunctionName: !Ref AthenaCatalogName
       Handler: "com.amazonaws.athena.connectors.cloudwatch.CloudwatchCompositeHandler"
-      CodeUri: "./target/athena-cloudwatch-2022.47.1.jar"
+      CodeUri: "./target/athena-cloudwatch-2023.01.1.jar"
       Description: "Enables Amazon Athena to communicate with Cloudwatch, making your log accessible via SQL"
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-cloudwatch/pom.xml
+++ b/athena-cloudwatch/pom.xml
@@ -3,22 +3,22 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.47.1</version>
+        <version>2023.01.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-cloudwatch</artifactId>
-    <version>2022.47.1</version>
+    <version>2023.01.1</version>
     <dependencies>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <classifier>withdep</classifier>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awscdk/logs -->

--- a/athena-datalakegen2/athena-datalakegen2.yaml
+++ b/athena-datalakegen2/athena-datalakegen2.yaml
@@ -12,7 +12,7 @@ Metadata:
       - athena-federation
       - jdbc
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.47.1
+    SemanticVersion: 2023.01.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   LambdaFunctionName:
@@ -68,7 +68,7 @@ Resources:
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.datalakegen2.DataLakeGen2MuxCompositeHandler"
-      CodeUri: "./target/athena-datalakegen2-2022.47.1.jar"
+      CodeUri: "./target/athena-datalakegen2-2023.01.1.jar"
       Description: "Enables Amazon Athena to communicate with DataLake Gen2 using JDBC"
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-datalakegen2/pom.xml
+++ b/athena-datalakegen2/pom.xml
@@ -3,27 +3,27 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.47.1</version>
+        <version>2023.01.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-datalakegen2</artifactId>
-    <version>2022.47.1</version>
+    <version>2023.01.1</version>
     <dependencies>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/athena-db2/athena-db2.yaml
+++ b/athena-db2/athena-db2.yaml
@@ -13,7 +13,7 @@ Metadata:
       - athena-federation
       - jdbc
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.47.1
+    SemanticVersion: 2023.01.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   LambdaFunctionName:
@@ -69,7 +69,7 @@ Resources:
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.db2.Db2MuxCompositeHandler"
-      CodeUri: "./target/athena-db2-2022.47.1.jar"
+      CodeUri: "./target/athena-db2-2023.01.1.jar"
       Description: "Enables Amazon Athena to communicate with DB2 using JDBC"
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-db2/pom.xml
+++ b/athena-db2/pom.xml
@@ -3,27 +3,27 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.47.1</version>
+        <version>2023.01.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-db2</artifactId>
-    <version>2022.47.1</version>
+    <version>2023.01.1</version>
     <dependencies>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/athena-docdb/athena-docdb.yaml
+++ b/athena-docdb/athena-docdb.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.47.1
+    SemanticVersion: 2023.01.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AthenaCatalogName:
@@ -67,7 +67,7 @@ Resources:
           default_docdb: !Ref DocDBConnectionString
       FunctionName: !Ref AthenaCatalogName
       Handler: "com.amazonaws.athena.connectors.docdb.DocDBCompositeHandler"
-      CodeUri: "./target/athena-docdb-2022.47.1.jar"
+      CodeUri: "./target/athena-docdb-2023.01.1.jar"
       Description: "Enables Amazon Athena to communicate with DocumentDB, making your DocumentDB data accessible via SQL."
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-docdb/pom.xml
+++ b/athena-docdb/pom.xml
@@ -3,16 +3,16 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.47.1</version>
+        <version>2023.01.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-docdb</artifactId>
-    <version>2022.47.1</version>
+    <version>2023.01.1</version>
     <dependencies>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <classifier>withdep</classifier>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-docdb -->

--- a/athena-dynamodb/athena-dynamodb.yaml
+++ b/athena-dynamodb/athena-dynamodb.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.47.1
+    SemanticVersion: 2023.01.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AthenaCatalogName:
@@ -66,7 +66,7 @@ Resources:
           kms_key_id: !If [HasKMSKeyId, !Ref KMSKeyId, !Ref "AWS::NoValue"]
       FunctionName: !Ref AthenaCatalogName
       Handler: "com.amazonaws.athena.connectors.dynamodb.DynamoDBCompositeHandler"
-      CodeUri: "./target/athena-dynamodb-2022.47.1.jar"
+      CodeUri: "./target/athena-dynamodb-2023.01.1.jar"
       Description: "Enables Amazon Athena to communicate with DynamoDB, making your tables accessible via SQL"
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-dynamodb/pom.xml
+++ b/athena-dynamodb/pom.xml
@@ -3,22 +3,22 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.47.1</version>
+        <version>2023.01.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-dynamodb</artifactId>
-    <version>2022.47.1</version>
+    <version>2023.01.1</version>
     <dependencies>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <classifier>withdep</classifier>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -89,7 +89,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/athena-elasticsearch/athena-elasticsearch.yaml
+++ b/athena-elasticsearch/athena-elasticsearch.yaml
@@ -10,7 +10,7 @@ Metadata:
     ReadmeUrl: README.md
     Labels: ['athena-federation']
     HomePageUrl: https://github.com/awslabs/aws-athena-query-federation
-    SemanticVersion: 2022.47.1
+    SemanticVersion: 2023.01.1
     SourceCodeUrl: https://github.com/awslabs/aws-athena-query-federation
 
 # Parameters are CloudFormation features to pass input
@@ -103,7 +103,7 @@ Resources:
           query_scroll_timeout: !Ref QueryScrollTimeout
       FunctionName: !Sub "${AthenaCatalogName}"
       Handler: "com.amazonaws.athena.connectors.elasticsearch.ElasticsearchCompositeHandler"
-      CodeUri: "./target/athena-elasticsearch-2022.47.1.jar"
+      CodeUri: "./target/athena-elasticsearch-2023.01.1.jar"
       Description: "The Elasticsearch Lambda Connector provides Athena users the ability to query data stored on Elasticsearch clusters."
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-elasticsearch/pom.xml
+++ b/athena-elasticsearch/pom.xml
@@ -3,16 +3,16 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.47.1</version>
+        <version>2023.01.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-elasticsearch</artifactId>
-    <version>2022.47.1</version>
+    <version>2023.01.1</version>
     <dependencies>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <classifier>withdep</classifier>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -191,7 +191,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/athena-example/athena-example.yaml
+++ b/athena-example/athena-example.yaml
@@ -10,7 +10,7 @@ Metadata:
     ReadmeUrl: README.md
     Labels: ['athena-federation']
     HomePageUrl: https://github.com/awslabs/aws-athena-query-federation
-    SemanticVersion: 2022.47.1
+    SemanticVersion: 2023.01.1
     SourceCodeUrl: https://github.com/awslabs/aws-athena-query-federation
 
 # Parameters are CloudFormation features to pass input
@@ -55,7 +55,7 @@ Resources:
           data_bucket: !Ref DataBucket
       FunctionName: !Sub "${AthenaCatalogName}"
       Handler: "com.amazonaws.athena.connectors.example.ExampleCompositeHandler"
-      CodeUri: "./target/athena-example-2022.47.1.jar"
+      CodeUri: "./target/athena-example-2023.01.1.jar"
       Description: "A guided example for writing and deploying your own federated Amazon Athena connector for a custom source."
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-example/pom.xml
+++ b/athena-example/pom.xml
@@ -3,16 +3,16 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.47.1</version>
+        <version>2023.01.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-example</artifactId>
-    <version>2022.47.1</version>
+    <version>2023.01.1</version>
     <dependencies>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <classifier>withdep</classifier>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->

--- a/athena-federation-integ-test/README.md
+++ b/athena-federation-integ-test/README.md
@@ -36,7 +36,7 @@ in most **pom.xml** files (e.g.
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
-            <version>Current version of the SDK (e.g. 2022.47.1)</version>
+            <version>Current version of the SDK (e.g. 2023.01.1)</version>
             <scope>test</scope>
         </dependency>
 ```

--- a/athena-federation-integ-test/pom.xml
+++ b/athena-federation-integ-test/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.47.1</version>
+        <version>2023.01.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-federation-integ-test</artifactId>
-    <version>2022.47.1</version>
+    <version>2023.01.1</version>
     <packaging>jar</packaging>
     <name>Amazon Athena Query Federation Integ Test</name>
     <dependencies>

--- a/athena-federation-sdk-tools/pom.xml
+++ b/athena-federation-sdk-tools/pom.xml
@@ -3,18 +3,18 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.47.1</version>
+        <version>2023.01.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-federation-sdk-tools</artifactId>
     <packaging>jar</packaging>
     <name>Amazon Athena Query Federation SDK Tools</name>
-    <version>2022.47.1</version>
+    <version>2023.01.1</version>
     <dependencies>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <classifier>withdep</classifier>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->

--- a/athena-federation-sdk/athena-federation-sdk.yaml
+++ b/athena-federation-sdk/athena-federation-sdk.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.47.1
+    SemanticVersion: 2023.01.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AthenaCatalogName:
@@ -47,7 +47,7 @@ Resources:
           spill_prefix: !Ref SpillPrefix
       FunctionName: !Ref AthenaCatalogName
       Handler: "com.amazonaws.athena.connector.lambda.examples.ExampleCompositeHandler"
-      CodeUri: "./target/aws-athena-federation-sdk-2022.47.1-withdep.jar"
+      CodeUri: "./target/aws-athena-federation-sdk-2023.01.1-withdep.jar"
       Description: "This connector enables Amazon Athena to communicate with a randomly generated data source."
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-federation-sdk/pom.xml
+++ b/athena-federation-sdk/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-athena-query-federation</artifactId>
-        <version>2022.47.1</version>
+        <version>2023.01.1</version>
     </parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-athena-federation-sdk</artifactId>
-    <version>2022.47.1</version>
+    <version>2023.01.1</version>
     <packaging>jar</packaging>
     <name>Amazon Athena Query Federation SDK</name>
     <description>The Athena Query Federation SDK defines a set of interfaces and wire protocols that you can implement to enable Athena to delegate portions of it's query execution plan to code that you deploy/write.</description>

--- a/athena-google-bigquery/athena-google-bigquery.yaml
+++ b/athena-google-bigquery/athena-google-bigquery.yaml
@@ -13,7 +13,7 @@ Metadata:
       - Athena-Federation
       - Google-SDK
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.47.1
+    SemanticVersion: 2023.01.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   LambdaFunctionName:
@@ -80,7 +80,7 @@ Resources:
           concurrencyLimit: !Ref ConcurrencyLimit
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.google.bigquery.BigQueryCompositeHandler"
-      CodeUri: "./target/athena-google-bigquery-2022.47.1.jar"
+      CodeUri: "./target/athena-google-bigquery-2023.01.1.jar"
       Description: "Enables Amazon Athena to communicate with BigQuery using Google SDK"
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-google-bigquery/pom.xml
+++ b/athena-google-bigquery/pom.xml
@@ -3,27 +3,27 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.47.1</version>
+        <version>2023.01.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-google-bigquery</artifactId>
-    <version>2022.47.1</version>
+    <version>2023.01.1</version>
     <dependencies>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/athena-hbase/athena-hbase.yaml
+++ b/athena-hbase/athena-hbase.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.47.1
+    SemanticVersion: 2023.01.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AthenaCatalogName:
@@ -66,7 +66,7 @@ Resources:
           default_hbase: !Ref HBaseConnectionString
       FunctionName: !Ref AthenaCatalogName
       Handler: "com.amazonaws.athena.connectors.hbase.HbaseCompositeHandler"
-      CodeUri: "./target/athena-hbase-2022.47.1.jar"
+      CodeUri: "./target/athena-hbase-2023.01.1.jar"
       Description: "Enables Amazon Athena to communicate with HBase, making your HBase data accessible via SQL"
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-hbase/pom.xml
+++ b/athena-hbase/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.47.1</version>
+        <version>2023.01.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-hbase</artifactId>
-    <version>2022.47.1</version>
+    <version>2023.01.1</version>
     <properties>
         <jetty.version>11.0.13</jetty.version>
         <hbase.version>2.5.2-hadoop3</hbase.version>
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <classifier>withdep</classifier>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <classifier>withdep</classifier>
             <scope>test</scope>
         </dependency>

--- a/athena-hortonworks-hive/athena-hortonworks-hive.yaml
+++ b/athena-hortonworks-hive/athena-hortonworks-hive.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.47.1
+    SemanticVersion: 2023.01.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   LambdaFunctionName:
@@ -66,7 +66,7 @@ Resources:
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.hortonworks.HiveMuxCompositeHandler"
-      CodeUri: "./target/athena-hortonworks-hive-2022.47.1.jar"
+      CodeUri: "./target/athena-hortonworks-hive-2023.01.1.jar"
       Description: "Enables Amazon Athena to communicate with Hortonworks Hive using JDBC"
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-hortonworks-hive/pom.xml
+++ b/athena-hortonworks-hive/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.47.1</version>
+        <version>2023.01.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-hortonworks-hive</artifactId>
-    <version>2022.47.1</version>
+    <version>2023.01.1</version>
     <properties>
         <clouderaVersion>2.6.15.1018</clouderaVersion>
     </properties>
@@ -15,13 +15,13 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
         </dependency>
         <dependency>
             <groupId>Hive</groupId>
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/athena-jdbc/pom.xml
+++ b/athena-jdbc/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.47.1</version>
+        <version>2023.01.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-jdbc</artifactId>
-    <version>2022.47.1</version>
+    <version>2023.01.1</version>
     <dependencies>
         <dependency>
             <groupId>com.amazonaws</groupId>
@@ -93,7 +93,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <classifier>withdep</classifier>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
@@ -106,7 +106,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/athena-msk/athena-msk.yaml
+++ b/athena-msk/athena-msk.yaml
@@ -11,7 +11,7 @@ Metadata:
       - msk
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.47.1
+    SemanticVersion: 2023.01.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AuthType:
@@ -93,7 +93,7 @@ Resources:
           auth_type: !Ref AuthType
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.msk.AmazonMskCompositeHandler"
-      CodeUri: "./target/athena-msk-2022.47.1.jar"
+      CodeUri: "./target/athena-msk-2023.01.1.jar"
       Description: "Enables Amazon Athena to communicate with MSK and Kafka clusters"
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-msk/pom.xml
+++ b/athena-msk/pom.xml
@@ -1,30 +1,26 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="utf-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.47.1</version>
+        <version>2023.01.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-
     <artifactId>athena-msk</artifactId>
     <name>Athena MSK Connector</name>
-    <version>2022.47.1</version>
-
+    <version>2023.01.1</version>
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
     </properties>
     <dependencies>
-         <dependency>
+        <dependency>
             <!-- Only use the simple logger for testing so that we can see the output -->
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>${slf4j-log4j.version}</version>
             <scope>test</scope>
-         </dependency>
+        </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
@@ -72,11 +68,11 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <classifier>withdep</classifier>
             <scope>test</scope>
             <exclusions>
-            </exclusions>
+</exclusions>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -119,9 +115,9 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <classifier>withdep</classifier>
-         </dependency>
+        </dependency>
         <!-- Powermock depedency -->
         <dependency>
             <groupId>org.powermock</groupId>
@@ -161,7 +157,7 @@
     </dependencies>
     <build>
         <plugins>
-           <plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>${mvn.shade.plugin.version}</version>
@@ -180,7 +176,7 @@
                     <transformers>
                         <!-- This transformer is here to concatenate log4j2 cache during shading -->
                         <transformer implementation="com.github.edwgiz.maven_shade_plugin.log4j2_cache_transformer.PluginsCacheFileTransformer">
-                        </transformer>
+</transformer>
                     </transformers>
                 </configuration>
                 <dependencies>

--- a/athena-mysql/athena-mysql.yaml
+++ b/athena-mysql/athena-mysql.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.47.1
+    SemanticVersion: 2023.01.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   LambdaFunctionName:
@@ -66,7 +66,7 @@ Resources:
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.mysql.MySqlMuxCompositeHandler"
-      CodeUri: "./target/athena-mysql-2022.47.1.jar"
+      CodeUri: "./target/athena-mysql-2023.01.1.jar"
       Description: "Enables Amazon Athena to communicate with MySQL using JDBC"
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-mysql/pom.xml
+++ b/athena-mysql/pom.xml
@@ -3,27 +3,27 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.47.1</version>
+        <version>2023.01.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-mysql</artifactId>
-    <version>2022.47.1</version>
+    <version>2023.01.1</version>
     <dependencies>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/athena-neptune/athena-neptune.yaml
+++ b/athena-neptune/athena-neptune.yaml
@@ -10,7 +10,7 @@ Metadata:
     ReadmeUrl: README.md
     Labels: ['athena-federation','athena-neptune','neptune']
     HomePageUrl: https://github.com/awslabs/aws-athena-query-federation
-    SemanticVersion: 2022.47.1
+    SemanticVersion: 2023.01.1
     SourceCodeUrl: https://github.com/awslabs/aws-athena-query-federation
 
 Parameters:
@@ -96,7 +96,7 @@ Resources:
           enable_caseinsensitivematch: !Ref EnableCaseInsensitiveMatch
       FunctionName: !Ref AthenaCatalogName
       Handler: "com.amazonaws.athena.connectors.neptune.NeptuneCompositeHandler"
-      CodeUri: "./target/athena-neptune-2022.47.1.jar"
+      CodeUri: "./target/athena-neptune-2023.01.1.jar"
       Description: "Enables Amazon Athena to communicate with Neptune, making your Neptune graph data accessible via SQL."
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-neptune/pom.xml
+++ b/athena-neptune/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.47.1</version>
+        <version>2023.01.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-neptune</artifactId>
-    <version>2022.47.1</version>
+    <version>2023.01.1</version>
     <properties>
         <gremlinDriverVersion>3.6.1</gremlinDriverVersion>
         <neptune.sigv4.signer.version>2.4.0</neptune.sigv4.signer.version>
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <classifier>withdep</classifier>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->

--- a/athena-oracle/athena-oracle.yaml
+++ b/athena-oracle/athena-oracle.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.47.1
+    SemanticVersion: 2023.01.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   LambdaFunctionName:
@@ -66,7 +66,7 @@ Resources:
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.oracle.OracleMuxCompositeHandler"
-      CodeUri: "./target/athena-oracle-2022.47.1.jar"
+      CodeUri: "./target/athena-oracle-2023.01.1.jar"
       Description: "Enables Amazon Athena to communicate with ORACLE using JDBC"
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-oracle/pom.xml
+++ b/athena-oracle/pom.xml
@@ -3,27 +3,27 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.47.1</version>
+        <version>2023.01.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-oracle</artifactId>
-    <version>2022.47.1</version>
+    <version>2023.01.1</version>
     <dependencies>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/athena-postgresql/athena-postgresql.yaml
+++ b/athena-postgresql/athena-postgresql.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.47.1
+    SemanticVersion: 2023.01.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   LambdaFunctionName:
@@ -71,7 +71,7 @@ Resources:
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
       Handler: !Sub "com.amazonaws.athena.connectors.postgresql.${CompositeHandler}"
-      CodeUri: "./target/athena-postgresql-2022.47.1.jar"
+      CodeUri: "./target/athena-postgresql-2023.01.1.jar"
       Description: "Enables Amazon Athena to communicate with PostgreSQL using JDBC"
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-postgresql/pom.xml
+++ b/athena-postgresql/pom.xml
@@ -3,28 +3,28 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.47.1</version>
+        <version>2023.01.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-postgresql</artifactId>
-    <version>2022.47.1</version>
+    <version>2023.01.1</version>
     <packaging>jar</packaging>
     <dependencies>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/athena-redis/athena-redis.yaml
+++ b/athena-redis/athena-redis.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.47.1
+    SemanticVersion: 2023.01.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AthenaCatalogName:
@@ -62,7 +62,7 @@ Resources:
           spill_prefix: !Ref SpillPrefix
       FunctionName: !Ref AthenaCatalogName
       Handler: "com.amazonaws.athena.connectors.redis.RedisCompositeHandler"
-      CodeUri: "./target/athena-redis-2022.47.1.jar"
+      CodeUri: "./target/athena-redis-2023.01.1.jar"
       Description: "Enables Amazon Athena to communicate with Redis, making your Redis data accessible via SQL"
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-redis/pom.xml
+++ b/athena-redis/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.47.1</version>
+        <version>2023.01.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-redis</artifactId>
-    <version>2022.47.1</version>
+    <version>2023.01.1</version>
     <dependencies>
         <dependency>
             <groupId>com.amazonaws</groupId>
@@ -93,7 +93,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <classifier>withdep</classifier>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
@@ -141,7 +141,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/athena-redshift/athena-redshift.yaml
+++ b/athena-redshift/athena-redshift.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.47.1
+    SemanticVersion: 2023.01.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   LambdaFunctionName:
@@ -66,7 +66,7 @@ Resources:
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.redshift.RedshiftMuxCompositeHandler"
-      CodeUri: "./target/athena-redshift-2022.47.1.jar"
+      CodeUri: "./target/athena-redshift-2023.01.1.jar"
       Description: "Enables Amazon Athena to communicate with Redshift using JDBC"
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-redshift/pom.xml
+++ b/athena-redshift/pom.xml
@@ -3,21 +3,21 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.47.1</version>
+        <version>2023.01.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-redshift</artifactId>
-    <version>2022.47.1</version>
+    <version>2023.01.1</version>
     <dependencies>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-postgresql</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/athena-saphana/athena-saphana.yaml
+++ b/athena-saphana/athena-saphana.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.47.1
+    SemanticVersion: 2023.01.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   LambdaFunctionName:

--- a/athena-saphana/pom.xml
+++ b/athena-saphana/pom.xml
@@ -3,27 +3,27 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.47.1</version>
+        <version>2023.01.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-saphana</artifactId>
-    <version>2022.47.1</version>
+    <version>2023.01.1</version>
     <dependencies>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/athena-snowflake/athena-snowflake.yaml
+++ b/athena-snowflake/athena-snowflake.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.47.1
+    SemanticVersion: 2023.01.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   LambdaFunctionName:
@@ -66,7 +66,7 @@ Resources:
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.snowflake.SnowflakeMuxCompositeHandler"
-      CodeUri: "./target/athena-snowflake-2022.47.1.jar"
+      CodeUri: "./target/athena-snowflake-2023.01.1.jar"
       Description: "Enables Amazon Athena to communicate with Snowflake using JDBC"
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-snowflake/pom.xml
+++ b/athena-snowflake/pom.xml
@@ -3,27 +3,27 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.47.1</version>
+        <version>2023.01.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-snowflake</artifactId>
-    <version>2022.47.1</version>
+    <version>2023.01.1</version>
     <dependencies>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/athena-sqlserver/athena-sqlserver.yaml
+++ b/athena-sqlserver/athena-sqlserver.yaml
@@ -12,7 +12,7 @@ Metadata:
       - athena-federation
       - jdbc
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.47.1
+    SemanticVersion: 2023.01.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   LambdaFunctionName:
@@ -68,7 +68,7 @@ Resources:
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.sqlserver.SqlServerMuxCompositeHandler"
-      CodeUri: "./target/athena-sqlserver-2022.47.1.jar"
+      CodeUri: "./target/athena-sqlserver-2023.01.1.jar"
       Description: "Enables Amazon Athena to communicate with SQLSERVER using JDBC"
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-sqlserver/pom.xml
+++ b/athena-sqlserver/pom.xml
@@ -3,27 +3,27 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.47.1</version>
+        <version>2023.01.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-sqlserver</artifactId>
-    <version>2022.47.1</version>
+    <version>2023.01.1</version>
     <dependencies>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/athena-synapse/athena-synapse.yaml
+++ b/athena-synapse/athena-synapse.yaml
@@ -12,7 +12,7 @@ Metadata:
       - athena-federation
       - jdbc
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.47.1
+    SemanticVersion: 2023.01.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   LambdaFunctionName:
@@ -75,7 +75,7 @@ Resources:
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.synapse.SynapseMuxCompositeHandler"
-      CodeUri: "./target/athena-synapse-2022.47.1.jar"
+      CodeUri: "./target/athena-synapse-2023.01.1.jar"
       Description: "Enables Amazon Athena to communicate with SYNPASE using JDBC"
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-synapse/pom.xml
+++ b/athena-synapse/pom.xml
@@ -3,27 +3,27 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.47.1</version>
+        <version>2023.01.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-synapse</artifactId>
-    <version>2022.47.1</version>
+    <version>2023.01.1</version>
     <dependencies>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/athena-teradata/athena-teradata.yaml
+++ b/athena-teradata/athena-teradata.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.47.1
+    SemanticVersion: 2023.01.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   LambdaFunctionName:
@@ -76,7 +76,7 @@ Resources:
       Handler: "com.amazonaws.athena.connectors.teradata.TeradataMuxCompositeHandler"
       Layers:
         - !Ref LambdaJDBCLayername
-      CodeUri: "./target/athena-teradata-2022.47.1.jar"
+      CodeUri: "./target/athena-teradata-2023.01.1.jar"
       Description: "Enables Amazon Athena to communicate with Teradata using JDBC"
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-teradata/pom.xml
+++ b/athena-teradata/pom.xml
@@ -3,27 +3,27 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.47.1</version>
+        <version>2023.01.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-teradata</artifactId>
-    <version>2022.47.1</version>
+    <version>2023.01.1</version>
     <dependencies>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/athena-timestream/athena-timestream.yaml
+++ b/athena-timestream/athena-timestream.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.47.1
+    SemanticVersion: 2023.01.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AthenaCatalogName:
@@ -53,7 +53,7 @@ Resources:
           spill_prefix: !Ref SpillPrefix
       FunctionName: !Ref AthenaCatalogName
       Handler: "com.amazonaws.athena.connectors.timestream.TimestreamCompositeHandler"
-      CodeUri: "./target/athena-timestream-2022.47.1.jar"
+      CodeUri: "./target/athena-timestream-2023.01.1.jar"
       Description: "Enables Amazon Athena to communicate with Amazon Timestream, making your time series data accessible from Athena."
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-timestream/pom.xml
+++ b/athena-timestream/pom.xml
@@ -3,16 +3,16 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.47.1</version>
+        <version>2023.01.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-timestream</artifactId>
-    <version>2022.47.1</version>
+    <version>2023.01.1</version>
     <dependencies>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <classifier>withdep</classifier>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <classifier>withdep</classifier>
             <scope>test</scope>
         </dependency>

--- a/athena-tpcds/athena-tpcds.yaml
+++ b/athena-tpcds/athena-tpcds.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.47.1
+    SemanticVersion: 2023.01.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AthenaCatalogName:
@@ -53,7 +53,7 @@ Resources:
           spill_prefix: !Ref SpillPrefix
       FunctionName: !Ref AthenaCatalogName
       Handler: "com.amazonaws.athena.connectors.tpcds.TPCDSCompositeHandler"
-      CodeUri: "./target/athena-tpcds-2022.47.1.jar"
+      CodeUri: "./target/athena-tpcds-2023.01.1.jar"
       Description: "This connector enables Amazon Athena to communicate with a randomly generated TPC-DS data source."
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-tpcds/pom.xml
+++ b/athena-tpcds/pom.xml
@@ -3,16 +3,16 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.47.1</version>
+        <version>2023.01.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-tpcds</artifactId>
-    <version>2022.47.1</version>
+    <version>2023.01.1</version>
     <dependencies>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <classifier>withdep</classifier>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->

--- a/athena-udfs/athena-udfs.yaml
+++ b/athena-udfs/athena-udfs.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.47.1
+    SemanticVersion: 2023.01.1
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   LambdaFunctionName:
@@ -40,7 +40,7 @@ Resources:
     Properties:
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.udfs.AthenaUDFHandler"
-      CodeUri: "./target/athena-udfs-2022.47.1.jar"
+      CodeUri: "./target/athena-udfs-2023.01.1.jar"
       Description: "This connector enables Amazon Athena to leverage common UDFs made available via Lambda."
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-udfs/pom.xml
+++ b/athena-udfs/pom.xml
@@ -3,16 +3,16 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.47.1</version>
+        <version>2023.01.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-udfs</artifactId>
-    <version>2022.47.1</version>
+    <version>2023.01.1</version>
     <dependencies>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <classifier>withdep</classifier>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->

--- a/athena-vertica/athena-vertica.yaml
+++ b/athena-vertica/athena-vertica.yaml
@@ -10,7 +10,7 @@ Metadata:
     ReadmeUrl: README.md
     Labels: ['athena-federation']
     HomePageUrl: https://github.com/awslabs/aws-athena-query-federation
-    SemanticVersion: 2022.47.1
+    SemanticVersion: 2023.01.1
     SourceCodeUrl: https://github.com/awslabs/aws-athena-query-federation
 
 # Parameters are CloudFormation features to pass input
@@ -83,7 +83,7 @@ Resources:
 
       FunctionName: !Sub "${AthenaCatalogName}"
       Handler: "com.amazonaws.athena.connectors.vertica.VerticaCompositeHandler"
-      CodeUri: "./target/athena-vertica-2022.47.1.jar"
+      CodeUri: "./target/athena-vertica-2023.01.1.jar"
       Description: "Amazon Athena Vertica Connector"
       Runtime: java11
       Timeout: !Ref LambdaTimeout

--- a/athena-vertica/pom.xml
+++ b/athena-vertica/pom.xml
@@ -3,16 +3,16 @@
     <parent>
         <artifactId>aws-athena-query-federation</artifactId>
         <groupId>com.amazonaws</groupId>
-        <version>2022.47.1</version>
+        <version>2023.01.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>athena-vertica</artifactId>
-    <version>2022.47.1</version>
+    <version>2023.01.1</version>
     <dependencies>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>2022.47.1</version>
+            <version>2023.01.1</version>
             <classifier>withdep</classifier>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-athena-query-federation</artifactId>
     <packaging>pom</packaging>
-    <version>2022.47.1</version>
+    <version>2023.01.1</version>
     <name>AWS Athena Query Federation</name>
     <description>The Amazon Athena Query Federation SDK allows you to customize Amazon Athena with your own code.</description>
     <url>https://github.com/awslabs/aws-athena-query-federation</url>

--- a/tools/validate_connector.sh
+++ b/tools/validate_connector.sh
@@ -37,7 +37,7 @@ while true; do
     esac
 done
 
-VERSION=2022.47.1
+VERSION=2023.01.1
 
 dir=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 


### PR DESCRIPTION
  - athena-cloudera-impala: Add LambdaEncryptionKmsKeyARN
  - Bump dependency-check-maven from 7.4.3 to 7.4.4 (#945)
  - Simplify MuxCompositeHandler usage for single connections
  - Bump aws-sdk.version from 1.12.374 to 1.12.376 (#938)
  - Bump aws-cdk.version from 1.186.0 to 1.186.1 (#937)
  - athena-cloudera-impala: support querying tables across databases
  - Bump aws-sdk.version from 1.12.372 to 1.12.374 (#930)
  - Bump aws-cdk.version from 1.184.1 to 1.186.0 (#932)
  - mockito.legacy.version should stay at 3.3.3
  - Bump mockito-core from 4.10.0 to 4.11.0
  - Bump dependency-check-maven from 7.4.1 to 7.4.3 (#933)
  - Bump testng from 7.7.0 to 7.7.1 (#931)
  - Bump aws-cdk.version from 1.183.0 to 1.184.1 (#927)
  - Bump aws-sdk.version from 1.12.367 to 1.12.372 (#926)
  - bump_versions/common.py: grab latest release tag from github api

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
