### PR TITLE
bump_versions/common.py: don't generate week with zero padding

### DIFF
--- a/tools/bump_versions/common.py
+++ b/tools/bump_versions/common.py
@@ -11,7 +11,7 @@ def get_new_version():
     '''], shell=True).decode("utf-8")
 
     # Generate the version without iteration for this week
-    new_version_without_iteration = datetime.datetime.now().strftime("%Y.%U")
+    new_version_without_iteration = datetime.datetime.now().strftime("%Y.%-U")
 
     # If the latest previous release version happened in the same week, bump the iteration
     if previous_release_version.startswith(new_version_without_iteration):


### PR DESCRIPTION
zero padding is breaking semantic versioning on SAR


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
