### PR TITLE
Added logic to handle Unbounded Numeric type, by setting precision an…

### DIFF
--- a/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcArrowTypeConverterTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcArrowTypeConverterTest.java
@@ -39,6 +39,7 @@ public class JdbcArrowTypeConverterTest
         Assert.assertEquals(Types.MinorType.FLOAT4.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.FLOAT, 0, 0));
         Assert.assertEquals(Types.MinorType.FLOAT8.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.DOUBLE, 0, 0));
         Assert.assertEquals(new ArrowType.Decimal(5, 3), JdbcArrowTypeConverter.toArrowType(java.sql.Types.DECIMAL, 5, 3));
+        Assert.assertEquals(new ArrowType.Decimal(38, 0), JdbcArrowTypeConverter.toArrowType(java.sql.Types.NUMERIC, 0, 0));
         Assert.assertEquals(Types.MinorType.VARCHAR.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.CHAR, 0, 0));
         Assert.assertEquals(Types.MinorType.VARCHAR.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.NCHAR, 0, 0));
         Assert.assertEquals(Types.MinorType.VARCHAR.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.VARCHAR, 0, 0));

--- a/athena-postgresql/athena-postgresql.yaml
+++ b/athena-postgresql/athena-postgresql.yaml
@@ -57,6 +57,10 @@ Parameters:
     Description: "(Optional) An IAM policy ARN to use as the PermissionsBoundary for the created Lambda function's execution role"
     Default: ''
     Type: String
+  DefaultScale:
+    Description: "(Optional) Default value for scale of type Numeric, representing the decimal digits in the fractional part, to the right of the decimal point."
+    Default: 0
+    Type: Number
 Conditions:
   HasPermissionsBoundary: !Not [ !Equals [ !Ref PermissionsBoundaryARN, "" ] ]
 Resources:
@@ -69,6 +73,7 @@ Resources:
           spill_bucket: !Ref SpillBucket
           spill_prefix: !Ref SpillPrefix
           default: !Ref DefaultConnectionString
+          default_scale: !Ref DefaultScale
       FunctionName: !Ref LambdaFunctionName
       Handler: !Sub "com.amazonaws.athena.connectors.postgresql.${CompositeHandler}"
       CodeUri: "./target/athena-postgresql-2022.47.1.jar"


### PR DESCRIPTION
**Issue #, if available:**

*[BUG] Incompatible mapping for postgres numeric columns with connector Athena.JDBC https://github.com/awslabs/aws-athena-query-federation/issues/360*

Numeric data type that is initialized with no parameters in Postgres, gets converted into JDBC type Decimal with precision 0 and scale 0. 

In Athena the Decimal type has 2 parameters: Precision and Scale.
- **Precision** has the bounds of [1, 38]
- **Scale** (optional, default value is 0) can't be greater than precision.

**Description of changes:**

Added logic that lets user set default value for scale and checks for whether the Numeric type from Postrges has *precision* and *scale* unspecified, when converting JDBC type to Arrow type and sets parameters to default values if needs resolving.

Queries will no longer fail, because unbounded numeric type values will be properly converted. Logic also checks and only affects NUMERIC data type.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.