### PR TITLE
Filter exposed DynamoDB tables

### DIFF
--- a/athena-dynamodb/athena-dynamodb.yaml
+++ b/athena-dynamodb/athena-dynamodb.yaml
@@ -44,6 +44,10 @@ Parameters:
     Description: "(Optional) By default any data that is spilled to S3 is encrypted using AES-GCM and a randomly generated key. Setting a KMS Key ID allows your Lambda function to use KMS for key generation for a stronger source of encryption keys."
     Type: String
     Default: ""
+  IncludedDynamoDBTables:
+    Description: "(Optional) By default all tables are exposed to Athena, to limit the tables provide a comma separated list of tables to expose"
+    Default: ""
+    Type: String
   PermissionsBoundaryARN:
     Description: "(Optional) An IAM policy ARN to use as the PermissionsBoundary for the created Lambda function's execution role"
     Default: ''
@@ -64,6 +68,7 @@ Resources:
           spill_bucket: !Ref SpillBucket
           spill_prefix: !Ref SpillPrefix
           kms_key_id: !If [HasKMSKeyId, !Ref KMSKeyId, !Ref "AWS::NoValue"]
+          included_dynamodb_tables: !Ref IncludedDynamoDBTables
       FunctionName: !Ref AthenaCatalogName
       Handler: "com.amazonaws.athena.connectors.dynamodb.DynamoDBCompositeHandler"
       CodeUri: "./target/athena-dynamodb-2022.47.1.jar"

--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBMetadataHandler.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBMetadataHandler.java
@@ -61,6 +61,7 @@ import com.amazonaws.services.glue.model.Table;
 import com.amazonaws.services.secretsmanager.AWSSecretsManager;
 import com.amazonaws.util.json.Jackson;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.Field;
@@ -238,7 +239,7 @@ public class DynamoDBMetadataHandler
     @VisibleForTesting
     List<TableName> filterDyanmoDbTables(List<TableName> allDynamoDBTables)
     {
-        if (environment.getVariable(INCLUDED_DDB_TABLES_ENV) != null) {
+        if (!Strings.isNullOrEmpty(environment.getVariable(INCLUDED_DDB_TABLES_ENV))) {
             Set<String> includedDynamoDbTables = Arrays.stream(environment.getVariable(INCLUDED_DDB_TABLES_ENV).split(","))
                     .map(tableName -> tableName.toLowerCase(Locale.ENGLISH).trim()).collect(Collectors.toSet());
             return allDynamoDBTables.stream().filter(name -> includedDynamoDbTables.contains(name.getTableName())).collect(Collectors.toList());

--- a/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBMetadataHandlerTest.java
+++ b/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBMetadataHandlerTest.java
@@ -251,6 +251,26 @@ public class DynamoDBMetadataHandlerTest
         List<TableName> allDynamoDbTables = List.of(TEST_TABLE_NAME, TEST_TABLE_3_NAME);
 
         {
+            List<TableName> filteredDynamoDbTables = handler.filterDyanmoDbTables(allDynamoDbTables);
+
+            assertThat(filteredDynamoDbTables, iterableWithSize(2));
+            assertThat(filteredDynamoDbTables, hasItem(TEST_TABLE_NAME));
+            assertThat(filteredDynamoDbTables, hasItem(TEST_TABLE_3_NAME));
+        }
+
+        {
+            when(env.getVariable(INCLUDED_DDB_TABLES_ENV)).thenReturn("");
+
+            List<TableName> filteredDynamoDbTables = handler.filterDyanmoDbTables(allDynamoDbTables);
+
+            assertThat(filteredDynamoDbTables, iterableWithSize(2));
+            assertThat(filteredDynamoDbTables, hasItem(TEST_TABLE_NAME));
+            assertThat(filteredDynamoDbTables, hasItem(TEST_TABLE_3_NAME));
+        }
+
+        reset(env);
+
+        {
             when(env.getVariable(INCLUDED_DDB_TABLES_ENV)).thenReturn(TEST_TABLE);
 
             List<TableName> filteredDynamoDbTables = handler.filterDyanmoDbTables(allDynamoDbTables);


### PR DESCRIPTION
Issue #606 

*Description of changes:*
Follow-up on the previous PR #607 which was not finished, I implemented this in a simple and backward compatible way.

If the environment variable which is exposed as stack parameter is set, only this listed tables are included. If unset, all tables are exposed to Athena like before.

The tables are matched on a lower-cased basis, because of #15, although I'm not sure about the reasons for this behaviour.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
