### PR TITLE
fix null pointer on timestream

### DIFF
--- a/athena-timestream/src/main/java/com/amazonaws/athena/connectors/timestream/TimestreamRecordHandler.java
+++ b/athena-timestream/src/main/java/com/amazonaws/athena/connectors/timestream/TimestreamRecordHandler.java
@@ -143,14 +143,26 @@ public class TimestreamRecordHandler
             switch (Types.getMinorTypeForArrowType(nextField.getType())) {
                 case VARCHAR:
                     builder.withExtractor(nextField.getName(), (VarCharExtractor) (Object context, NullableVarCharHolder value) -> {
-                        value.isSet = 1;
-                        value.value = ((Row) context).getData().get(curFieldNum).getScalarValue();
+                        String stringValue = ((Row) context).getData().get(curFieldNum).getScalarValue();
+                        if (stringValue != null) {
+                            value.isSet = 1;
+                            value.value = stringValue;
+                        }
+                        else {
+                            value.isSet = 0;
+                        }
                     });
                     break;
                 case FLOAT8:
                     builder.withExtractor(nextField.getName(), (Float8Extractor) (Object context, NullableFloat8Holder value) -> {
-                        value.isSet = 1;
-                        value.value = Double.valueOf(((Row) context).getData().get(curFieldNum).getScalarValue());
+                        String doubleValue = ((Row) context).getData().get(curFieldNum).getScalarValue();
+                        if (doubleValue != null) {
+                            value.isSet = 1;
+                            value.value = Double.valueOf(doubleValue);
+                        }
+                        else {
+                            value.isSet = 0;
+                        }
                     });
                     break;
                 case BIT:
@@ -161,14 +173,26 @@ public class TimestreamRecordHandler
                     break;
                 case BIGINT:
                     builder.withExtractor(nextField.getName(), (BigIntExtractor) (Object context, NullableBigIntHolder value) -> {
-                        value.isSet = 1;
-                        value.value = Long.valueOf(((Row) context).getData().get(curFieldNum).getScalarValue());
+                        String longValue = ((Row) context).getData().get(curFieldNum).getScalarValue();
+                        if (longValue != null) {
+                            value.isSet = 1;
+                            value.value = Long.valueOf(longValue);
+                        }
+                        else {
+                            value.isSet = 0;
+                        }
                     });
                     break;
                 case DATEMILLI:
                     builder.withExtractor(nextField.getName(), (DateMilliExtractor) (Object context, NullableDateMilliHolder value) -> {
-                        value.isSet = 1;
-                        value.value = TIMESTAMP_FORMATTER.parse(((Row) context).getData().get(curFieldNum).getScalarValue()).getTime();
+                        String dateMilliValue = ((Row) context).getData().get(curFieldNum).getScalarValue();
+                        if (dateMilliValue != null) {
+                            value.isSet = 1;
+                            value.value = TIMESTAMP_FORMATTER.parse(dateMilliValue).getTime();
+                        }
+                        else {
+                            value.isSet = 0;
+                        }
                     });
                     break;
                 case LIST:


### PR DESCRIPTION
Fixing null pointer exception on timestream. Previously, we always set this `value.isSet = 1` regardless if we actually have data or not



If we have a union of schema, this will give us a null pointer exception when one of the fields doesn't exist in a row.

Example:
row1:
{"Dimensions": [{"Name":"host","Value":"aaa"}],"MeasureName":"cpu_utilization","MeasureValue":"77.8","MeasureValueType":"DOUBLE","Time":"1673931494255"}

row2:
{"Dimensions": [{"Name":"host","Value":"aaa"}],"MeasureName":"comment","MeasureValue":"bbb","MeasureValueType":"VARCHAR","Time":"1673931494255"}

We will have a union schema in table as 
|host|measure_name|time|measure_value::double|measure_value::varchar|
|-|-|-|-|-|


For row 1, it doesn't have `measure_value::varchar` field and will result a null pointer exception. 


Below is the result from Athena after the patch

|#|host|measure_name|time|measure_value::double|measure_value::varchar|
|-|-|-|-|-|-|
|2|aaa|comment|2023-01-20 03:48:14.000||bbb|
|1|aaa|cpu_utilization|2023-01-20 03:48:14.000|77.8|| 

