### PR TITLE
Athena-msk: support for sasl ssl plain for managed kafka cluster like confluent cloud

### DIFF
--- a/athena-msk/athena-msk.yaml
+++ b/athena-msk/athena-msk.yaml
@@ -55,12 +55,21 @@ Parameters:
     Description: 'If set to ''false'' data spilled to S3 is encrypted with AES GCM'
     Default: 'false'
     Type: String
+  IsVPCAccess:
+    AllowedValues:
+      - true
+      - false
+    Default: false
+    Description: "If cluster is in VPC select true, [true, false] (default is false)"
+    Type: String
   SecurityGroupIds:
     Description: 'One or more SecurityGroup IDs corresponding to the SecurityGroup that should be applied to the Lambda function. (e.g. sg1,sg2,sg3)'
-    Type: 'List<AWS::EC2::SecurityGroup::Id>'
+    Type: CommaDelimitedList
+    Default: ""
   SubnetIds:
     Description: 'One or more Subnet IDs corresponding to the Subnet that the Lambda function can use to access you data source. (e.g. subnet1,subnet2)'
-    Type: 'List<AWS::EC2::Subnet::Id>'
+    Type: CommaDelimitedList
+    Default: ""
   CertificatesS3Reference:
     Description: 'The S3 bucket reference where keystore and truststore certificates are uploaded. Applicable for SSL auth'
     Default: ""
@@ -77,6 +86,7 @@ Parameters:
 Conditions:
   NotHasLambdaRole: !Equals [!Ref LambdaRoleARN, ""]
   HasPermissionsBoundary: !Not [ !Equals [ !Ref PermissionsBoundaryARN, "" ] ]
+  IsVPCAccessSelected: !Equals [!Ref IsVPCAccess, true]
 
 Resources:
   JdbcConnectorConfig:
@@ -100,8 +110,18 @@ Resources:
       MemorySize: !Ref LambdaMemory
       Role: !If [NotHasLambdaRole, !GetAtt FunctionRole.Arn, !Ref LambdaRoleARN]
       VpcConfig:
-        SecurityGroupIds: !Ref SecurityGroupIds
-        SubnetIds: !Ref SubnetIds
+        SecurityGroupIds:
+          !If
+          - IsVPCAccessSelected
+          -
+            !Ref SecurityGroupIds
+          - !Ref "AWS::NoValue"
+        SubnetIds:
+          !If
+          - IsVPCAccessSelected
+          -
+            !Ref SubnetIds
+          - !Ref "AWS::NoValue"
 
   FunctionRole:
     Condition: NotHasLambdaRole


### PR DESCRIPTION
*Issue #, INC00001094

Support for sasl ssl plain for managed kafka cluster like confluent cloud.
Support for msk connector without vpc setup.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
