### PR TITLE
athena-dynamodb: Added logic to handle Null value within List or Set

### DIFF
--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/util/DDBTypeUtils.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/util/DDBTypeUtils.java
@@ -114,17 +114,21 @@ public final class DDBTypeUtils
             }
             else {
                 Iterator iterator = ((Collection) value).iterator();
-                Object firstValue = iterator.next();
-                Class<?> aClass = firstValue.getClass();
+                Object previousValue = iterator.next();
                 boolean allElementsAreSameType = true;
                 while (iterator.hasNext()) {
-                    if (!aClass.equals(iterator.next().getClass())) {
+                    Object currentValue = iterator.next();
+                    // null is considered the same as any prior type
+                    if (previousValue != null && currentValue != null && !previousValue.getClass().equals(currentValue.getClass())) {
                         allElementsAreSameType = false;
                         break;
                     }
+                    // only update the previousValue if the currentValue is not null otherwise we will end
+                    // up inferring the type as null if the currentValue is null and is the last value.
+                    previousValue = (currentValue == null) ? previousValue : currentValue;
                 }
                 if (allElementsAreSameType) {
-                    child = inferArrowField(key + ".element", firstValue);
+                    child = inferArrowField(key + ".element", previousValue);
                 }
                 else {
                     logger.warn("Automatic schema inference encountered List or Set {} containing multiple element types. Falling back to VARCHAR representation of elements", key);

--- a/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DDBTypeUtilsTest.java
+++ b/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DDBTypeUtilsTest.java
@@ -75,7 +75,6 @@ public class DDBTypeUtilsTest
         ddbRecordMetadata = mock(DDBRecordMetadata.class);
     }
 
-
     @Test
     public void makeDecimalExtractorTest()
             throws Exception
@@ -165,7 +164,21 @@ public class DDBTypeUtilsTest
         assertEquals("Extracted results are not as expected!", expectedResults, extractedResults);
         logger.info("makeBitExtractorTest - exit");
     }
+    
+    @Test
+    public void inferArrowFieldListWithNullTest() throws Exception
+    {
+        var inputArray = new java.util.ArrayList<String>();
+        inputArray.add("value1");
+        inputArray.add(null);
+        inputArray.add("value3");
 
+        Field testField = DDBTypeUtils.inferArrowField("asdf", inputArray);
+
+        assertEquals("Type does not match!", ArrowType.List.INSTANCE, testField.getType());
+        assertEquals("Children Length Off!", 1, testField.getChildren().size());
+        assertEquals("Wrong Child Type!", ArrowType.Utf8.INSTANCE, testField.getChildren().get(0).getType());
+    }
 
     private Map<String, Object> testField(Schema mapping, Map<String, AttributeValue> values)
             throws Exception


### PR DESCRIPTION
*Issue #, if available:*
Customer has one table which has a column that consists of a few structs and arrays and when using DynamoDB Connector,  is receiving "NullpointerException", which is preventing customer from accessing any of the DynamoDB tables in Athena.

*Description of changes:*
Treat nulls properly: nulls are effectively the same type as any other element in the List.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
