### PR TITLE
athena-gcs: eliminate reliance on external environment variables

### DIFF
--- a/athena-gcs/athena-gcs.yaml
+++ b/athena-gcs/athena-gcs.yaml
@@ -58,8 +58,6 @@ Resources:
           spill_bucket: !Ref SpillBucket
           spill_prefix: !Ref SpillPrefix
           secret_manager_gcp_creds_name: !Ref GCSSecretName
-          SSL_CERT_FILE: '/tmp/cacert.pem'
-          GOOGLE_APPLICATION_CREDENTIALS: '/tmp/service-account.json'
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.gcs.GcsCompositeHandler"
       CodeUri: "./target/athena-gcs.zip"

--- a/athena-gcs/pom.xml
+++ b/athena-gcs/pom.xml
@@ -22,6 +22,11 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna-platform</artifactId>
+            <version>5.13.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j-log4j.version}</version>

--- a/athena-gcs/src/main/java/com/amazonaws/athena/connectors/gcs/GcsCompositeHandler.java
+++ b/athena-gcs/src/main/java/com/amazonaws/athena/connectors/gcs/GcsCompositeHandler.java
@@ -30,6 +30,7 @@ import java.security.cert.CertificateEncodingException;
 
 import static com.amazonaws.athena.connectors.gcs.GcsUtil.installCaCertificate;
 import static com.amazonaws.athena.connectors.gcs.GcsUtil.installGoogleCredentialsJsonFile;
+import static com.amazonaws.athena.connectors.gcs.GcsUtil.setupNativeEnvironmentVariables;
 
 /**
  * Boilerplate composite handler that allows us to use a single Lambda function for both
@@ -48,5 +49,6 @@ public class GcsCompositeHandler
         super(new GcsMetadataHandler(allocator), new GcsRecordHandler(allocator));
         installCaCertificate();
         installGoogleCredentialsJsonFile();
+        setupNativeEnvironmentVariables();
     }
 }

--- a/athena-gcs/src/main/java/com/amazonaws/athena/connectors/gcs/GcsConstants.java
+++ b/athena-gcs/src/main/java/com/amazonaws/athena/connectors/gcs/GcsConstants.java
@@ -45,6 +45,7 @@ public class GcsConstants
      * to retrieve ssl certificate location
      */
     public static final String SSL_CERT_FILE_LOCATION = "SSL_CERT_FILE";
+    public static final String SSL_CERT_FILE_LOCATION_VALUE = "/tmp/cacert.pem";
 
     /**
      * A file name constant to store the GCP service account's credential JSON
@@ -52,6 +53,7 @@ public class GcsConstants
      * to retrieve metadata and fetch data
      */
     public static final String GOOGLE_SERVICE_ACCOUNT_JSON_TEMP_FILE_LOCATION = "GOOGLE_APPLICATION_CREDENTIALS";
+    public static final String GOOGLE_SERVICE_ACCOUNT_JSON_TEMP_FILE_LOCATION_VALUE = "/tmp/service-account.json";
 
     /**
      * Glue Table classification to specify type of the data a Glue Table represents.

--- a/athena-gcs/src/test/java/com/amazonaws/athena/connectors/gcs/GcsCompositeHandlerTest.java
+++ b/athena-gcs/src/test/java/com/amazonaws/athena/connectors/gcs/GcsCompositeHandlerTest.java
@@ -68,8 +68,6 @@ public class GcsCompositeHandlerTest {
     public void setUp()
     {
         environmentVariables.set("gcs_credential_key", "gcs_credential_keys");
-        environmentVariables.set("SSL_CERT_FILE", "/tmp/cacert.pem");
-        environmentVariables.set("GOOGLE_APPLICATION_CREDENTIALS","/tmp/service-account.json");
     }
 
     @Test


### PR DESCRIPTION
Uses jna to set the environment for native calls and avoids any possibility of users setting the wrong values.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
