### PR TITLE
Run the build workflow only for push

### DIFF
--- a/.github/workflows/maven_push.yml
+++ b/.github/workflows/maven_push.yml
@@ -1,6 +1,6 @@
 name: Java CI Push
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   build:


### PR DESCRIPTION
Running the build workflow for both push and pull request open is redundant and is a waste of time.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
