### PR TITLE
bump_versions/common.py: use gh cli instead of curl

### DIFF
--- a/tools/bump_versions/common.py
+++ b/tools/bump_versions/common.py
@@ -6,8 +6,8 @@ from bs4 import BeautifulSoup
 def get_new_version():
     # Get latest release version
     previous_release_version = subprocess.check_output(['''
-        curl -s https://api.github.com/repos/awslabs/aws-athena-query-federation/releases/latest |
-        grep "tag_name" | sed 's/.*"v\(.*\)".*/\\1/g'
+        gh release -R awslabs/aws-athena-query-federation list --exclude-drafts --exclude-pre-releases -L 1 |
+        sed 's/.*\s\+Latest\s\+v\(.*\)\s\+.*/\\1/g'
     '''], shell=True).decode("utf-8")
 
     # Generate the version without iteration for this week


### PR DESCRIPTION
Hitting the http public api isn't reliable because of throttling issues with it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
