### PR TITLE
BlockUtils: Fix epoch day calculation

### DIFF
--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/BlockUtils.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/BlockUtils.java
@@ -285,9 +285,8 @@ public class BlockUtils
                     break;
                 case DATEDAY:
                     if (value instanceof Date) {
-                        org.joda.time.Days days = org.joda.time.Days.daysBetween(EPOCH,
-                                new org.joda.time.DateTime(((Date) value).getTime()));
-                        ((DateDayVector) vector).setSafe(pos, days.getDays());
+                        var days = java.time.Duration.of(((Date) value).getTime(), java.time.temporal.ChronoUnit.MILLIS).toDays();
+                        ((DateDayVector) vector).setSafe(pos, new Long(days).intValue());
                     }
                     else if (value instanceof LocalDate) {
                         int days = (int) ((LocalDate) value).toEpochDay();
@@ -831,9 +830,8 @@ public class BlockUtils
                         dateDayWriter.writeNull();
                     }
                     else if (value instanceof Date) {
-                        org.joda.time.Days days = org.joda.time.Days.daysBetween(EPOCH,
-                                new org.joda.time.DateTime(((Date) value).getTime()));
-                        dateDayWriter.writeDateDay(days.getDays());
+                        var days = java.time.Duration.of(((Date) value).getTime(), java.time.temporal.ChronoUnit.MILLIS).toDays();
+                        dateDayWriter.writeDateDay(new Long(days).intValue());
                     }
                     else if (value instanceof LocalDate) {
                         int days = (int) ((LocalDate) value).toEpochDay();
@@ -1225,12 +1223,6 @@ public class BlockUtils
             default:
                 throw new IllegalArgumentException("Unknown type " + minorType);
         }
-    }
-
-    public static final org.joda.time.MutableDateTime EPOCH = new org.joda.time.MutableDateTime();
-
-    static {
-        EPOCH.setDate(0);
     }
 
     private BlockUtils() {}

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/data/BlockUtilsTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/data/BlockUtilsTest.java
@@ -132,11 +132,12 @@ public class BlockUtilsTest
     }
 
     @Test
-    public void fieldToString()
+    public void fieldToString() throws java.text.ParseException
     {
         Schema schema = SchemaBuilder.newBuilder()
                 .addField("col1", new ArrowType.Int(32, true))
                 .addField("col2", new ArrowType.Timestamp(org.apache.arrow.vector.types.TimeUnit.MILLISECOND, "UTC"))
+                .addField("col3", new ArrowType.Date(org.apache.arrow.vector.types.DateUnit.DAY))
                 .build();
 
         LocalDateTime ldt = LocalDateTime.of(2020, 03, 18, 12,54,29);
@@ -145,18 +146,17 @@ public class BlockUtilsTest
         Block block = allocator.createBlock(schema);
         BlockUtils.setValue(block.getFieldVector("col1"), 0, 10);
         BlockUtils.setValue(block.getFieldVector("col2"), 0, ldt);
+        BlockUtils.setValue(block.getFieldVector("col3"), 0, java.sql.Timestamp.valueOf(ldt));
 
         BlockUtils.setValue(block.getFieldVector("col1"), 1, 11);
         BlockUtils.setValue(block.getFieldVector("col2"), 1, ZonedDateTime.of(ldt, ZoneId.of("-05:00")));
+        BlockUtils.setValue(block.getFieldVector("col3"), 1, new java.text.SimpleDateFormat("yyyy-MM-dd").parse("2019-12-29"));
         block.setRowCount(2);
 
-        String expectedRows = "rows=2";
-        String expectedCol1 = "[10, 11]";
-        String expectedCol2 = "[2020-03-18T12:54:29Z[UTC], 2020-03-18T12:54:29-05:00]";
         String actual = block.toString();
-        assertTrue(actual.contains(expectedRows));
-        assertTrue(actual.contains(expectedCol1));
-        assertTrue(actual.contains(expectedCol2));
+        assertEquals(
+            "Block{rows=2, col1=[10, 11], col2=[2020-03-18T12:54:29Z[UTC], 2020-03-18T12:54:29-05:00], col3=[18339, 18259]}",
+            actual);
     }
 
     @Test


### PR DESCRIPTION
Simplifies the code to avoid using daysBetween to calculate the epoch days.

Also adds a test to prevent regressions in the future.

Test failure without the fix:
[ERROR] Failures:
[ERROR]   BlockUtilsTest.fieldToString:157 expected:<...], col3=[18339, 1825[9]]}> but was:<...], col3=[18339, 1825[8]]}>

The epoch days is off by 1 without the fix.

Credits go to @akuzin1 for testing and pinpointing where this problem was occurring.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
