### PR TITLE
Make source compatible with Java 8

### DIFF
--- a/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/AwsCmdbMetadataHandlerTest.java
+++ b/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/AwsCmdbMetadataHandlerTest.java
@@ -127,7 +127,7 @@ public class AwsCmdbMetadataHandlerTest
 
         when(mockTableProviderFactory.getSchemas()).thenReturn(schemas);
 
-        handler = new AwsCmdbMetadataHandler(mockTableProviderFactory, new LocalKeyFactory(), mockSecretsManager, mockAthena, bucket, prefix, java.util.Map.of());
+        handler = new AwsCmdbMetadataHandler(mockTableProviderFactory, new LocalKeyFactory(), mockSecretsManager, mockAthena, bucket, prefix, com.google.common.collect.ImmutableMap.of());
 
         verify(mockTableProviderFactory, times(1)).getTableProviders();
         verify(mockTableProviderFactory, times(1)).getSchemas();

--- a/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/AwsCmdbRecordHandlerTest.java
+++ b/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/AwsCmdbRecordHandlerTest.java
@@ -93,7 +93,7 @@ public class AwsCmdbRecordHandlerTest
         when(mockTableProviderFactory.getTableProviders())
                 .thenReturn(Collections.singletonMap(new TableName("schema", "table"), mockTableProvider));
 
-        handler = new AwsCmdbRecordHandler(mockS3, mockSecretsManager, mockAthena, mockTableProviderFactory, java.util.Map.of());
+        handler = new AwsCmdbRecordHandler(mockS3, mockSecretsManager, mockAthena, mockTableProviderFactory, com.google.common.collect.ImmutableMap.of());
 
         verify(mockTableProviderFactory, times(1)).getTableProviders();
         verifyNoMoreInteractions(mockTableProviderFactory);

--- a/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/TableProviderFactoryTest.java
+++ b/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/TableProviderFactoryTest.java
@@ -53,7 +53,7 @@ public class TableProviderFactoryTest
     @Mock
     private AmazonS3 amazonS3;
 
-    private TableProviderFactory factory = new TableProviderFactory(mockEc2, mockEmr, mockRds, amazonS3, java.util.Map.of());
+    private TableProviderFactory factory = new TableProviderFactory(mockEc2, mockEmr, mockRds, amazonS3, com.google.common.collect.ImmutableMap.of());
 
     @Test
     public void getTableProviders()

--- a/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/AbstractTableProviderTest.java
+++ b/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/AbstractTableProviderTest.java
@@ -219,7 +219,7 @@ public abstract class AbstractTableProviderTest
 
         setUpRead();
 
-        BlockSpiller spiller = new S3BlockSpiller(amazonS3, spillConfig, allocator, response.getSchema(), evaluator, java.util.Map.of());
+        BlockSpiller spiller = new S3BlockSpiller(amazonS3, spillConfig, allocator, response.getSchema(), evaluator, com.google.common.collect.ImmutableMap.of());
         provider.readWithConstraint(spiller, readRequest, queryStatusChecker);
 
         validateRead(response.getSchema(), blockSpillReader, spiller.getSpillLocations(), spillConfig.getEncryptionKey());

--- a/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/ec2/ImagesTableProviderTest.java
+++ b/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/ec2/ImagesTableProviderTest.java
@@ -86,7 +86,7 @@ public class ImagesTableProviderTest
 
     protected TableProvider setUpSource()
     {
-        return new ImagesTableProvider(mockEc2, java.util.Map.of());
+        return new ImagesTableProvider(mockEc2, com.google.common.collect.ImmutableMap.of());
     }
 
     @Override

--- a/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveMetadataHandlerTest.java
+++ b/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveMetadataHandlerTest.java
@@ -79,7 +79,7 @@ public class HiveMetadataHandlerTest
         this.secretsManager = Mockito.mock(AWSSecretsManager.class);
         this.athena = Mockito.mock(AmazonAthena.class);
         Mockito.when(this.secretsManager.getSecretValue(Mockito.eq(new GetSecretValueRequest().withSecretId("testSecret")))).thenReturn(new GetSecretValueResult().withSecretString("{\"username\": \"testUser\", \"password\": \"testPassword\"}"));
-        this.hiveMetadataHandler = new HiveMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, this.jdbcConnectionFactory, java.util.Map.of());
+        this.hiveMetadataHandler = new HiveMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, this.jdbcConnectionFactory, com.google.common.collect.ImmutableMap.of());
         this.federatedIdentity = Mockito.mock(FederatedIdentity.class);
 
     }
@@ -195,7 +195,7 @@ public class HiveMetadataHandlerTest
         JdbcConnectionFactory jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         Mockito.when(jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(connection);
         Mockito.when(connection.getMetaData().getSearchStringEscape()).thenThrow(new SQLException());
-        HiveMetadataHandler implalaMetadataHandler = new HiveMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, jdbcConnectionFactory, java.util.Map.of());
+        HiveMetadataHandler implalaMetadataHandler = new HiveMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, jdbcConnectionFactory, com.google.common.collect.ImmutableMap.of());
         implalaMetadataHandler.doGetTableLayout(Mockito.mock(BlockAllocator.class), getTableLayoutRequest);
     }
 

--- a/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveMuxMetadataHandlerTest.java
+++ b/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveMuxMetadataHandlerTest.java
@@ -74,7 +74,7 @@ public class HiveMuxMetadataHandlerTest
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", HiveConstants.HIVE_NAME,
                 "hive2://jdbc:hive2://54.89.6.2:10000/authena;AuthMech=3;${testSecret}", "testSecret");
-        this.jdbcMetadataHandler = new HiveMuxMetadataHandler(this.secretsManager, this.athena, this.jdbcConnectionFactory, this.metadataHandlerMap, databaseConnectionConfig, java.util.Map.of());
+        this.jdbcMetadataHandler = new HiveMuxMetadataHandler(this.secretsManager, this.athena, this.jdbcConnectionFactory, this.metadataHandlerMap, databaseConnectionConfig, com.google.common.collect.ImmutableMap.of());
     }
 
     @Test
@@ -116,7 +116,7 @@ public class HiveMuxMetadataHandlerTest
                 "hive2://jdbc:hive2://54.89.6.2:10000/authena;AuthMech=3;${testSecret}", "testSecret");
         try {
             new HiveMuxMetadataHandler(this.secretsManager, this.athena, this.jdbcConnectionFactory,
-                    metadataHandlersMap, databaseConnectionConfig, java.util.Map.of());
+                    metadataHandlersMap, databaseConnectionConfig, com.google.common.collect.ImmutableMap.of());
         } catch (Exception e) {
             e.getMessage();
             Assert.assertTrue(e.getMessage().contains("Max 100 catalogs supported in multiplexer."));

--- a/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveMuxRecordHandlerTest.java
+++ b/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveMuxRecordHandlerTest.java
@@ -71,7 +71,7 @@ public class HiveMuxRecordHandlerTest
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", HiveConstants.HIVE_NAME,
         		"hive2://jdbc:hive2://54.89.6.2:10000/authena;AuthMech=3;${testSecret}", "testSecret");
-        this.jdbcRecordHandler = new HiveMuxRecordHandler(this.amazonS3, this.secretsManager, this.athena, this.jdbcConnectionFactory, databaseConnectionConfig, this.recordHandlerMap, java.util.Map.of());
+        this.jdbcRecordHandler = new HiveMuxRecordHandler(this.amazonS3, this.secretsManager, this.athena, this.jdbcConnectionFactory, databaseConnectionConfig, this.recordHandlerMap, com.google.common.collect.ImmutableMap.of());
     }
 
     @Test
@@ -95,7 +95,7 @@ public class HiveMuxRecordHandlerTest
                 "hive2://jdbc:hive2://54.89.6.2:10000/authena;AuthMech=3;${testSecret}", "testSecret");
         try {
             new HiveMuxRecordHandler(this.amazonS3, this.secretsManager, this.athena,
-                    this.jdbcConnectionFactory, databaseConnectionConfig, recorddataHandlersMap, java.util.Map.of());
+                    this.jdbcConnectionFactory, databaseConnectionConfig, recorddataHandlersMap, com.google.common.collect.ImmutableMap.of());
         } catch (Exception e) {
             e.getMessage();
             Assert.assertTrue(e.getMessage().contains("Max 100 catalogs supported in multiplexer."));

--- a/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveRecordHandlerTest.java
+++ b/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveRecordHandlerTest.java
@@ -82,7 +82,7 @@ public class HiveRecordHandlerTest
         final DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", HiveConstants.HIVE_NAME,
                 "hive2://jdbc:hive2://54.89.6.2:10000/authena;AuthMech=3;UID=hive;PWD=hive");
 
-        this.hiveRecordHandler = new HiveRecordHandler(databaseConnectionConfig, amazonS3, secretsManager, athena, jdbcConnectionFactory, jdbcSplitQueryBuilder, java.util.Map.of());
+        this.hiveRecordHandler = new HiveRecordHandler(databaseConnectionConfig, amazonS3, secretsManager, athena, jdbcConnectionFactory, jdbcSplitQueryBuilder, com.google.common.collect.ImmutableMap.of());
     }
 
   

--- a/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaMetadataHandlerTest.java
+++ b/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaMetadataHandlerTest.java
@@ -76,7 +76,7 @@ public class ImpalaMetadataHandlerTest
         this.secretsManager = Mockito.mock(AWSSecretsManager.class);
         this.athena = Mockito.mock(AmazonAthena.class);
         Mockito.when(this.secretsManager.getSecretValue(Mockito.eq(new GetSecretValueRequest().withSecretId("testSecret")))).thenReturn(new GetSecretValueResult().withSecretString("{\"username\": \"testUser\", \"password\": \"testPassword\"}"));
-        this.impalaMetadataHandler = new ImpalaMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, this.jdbcConnectionFactory, java.util.Map.of());
+        this.impalaMetadataHandler = new ImpalaMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, this.jdbcConnectionFactory, com.google.common.collect.ImmutableMap.of());
         this.federatedIdentity = Mockito.mock(FederatedIdentity.class);
 
     }
@@ -186,7 +186,7 @@ public class ImpalaMetadataHandlerTest
         JdbcConnectionFactory jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         Mockito.when(jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(connection);
         Mockito.when(connection.getMetaData().getSearchStringEscape()).thenThrow(new SQLException());
-        ImpalaMetadataHandler implalaMetadataHandler = new ImpalaMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, jdbcConnectionFactory, java.util.Map.of());
+        ImpalaMetadataHandler implalaMetadataHandler = new ImpalaMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, jdbcConnectionFactory, com.google.common.collect.ImmutableMap.of());
         implalaMetadataHandler.doGetTableLayout(Mockito.mock(BlockAllocator.class), getTableLayoutRequest);
     }
 

--- a/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaMuxMetadataHandlerTest.java
+++ b/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaMuxMetadataHandlerTest.java
@@ -74,7 +74,7 @@ public class ImpalaMuxMetadataHandlerTest
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", ImpalaConstants.IMPALA_NAME,
                 "impala://jdbc:impala://54.89.6.2:10000/authena;AuthMech=3;${testSecret}", "testSecret");
-        this.jdbcMetadataHandler = new ImpalaMuxMetadataHandler(this.secretsManager, this.athena, this.jdbcConnectionFactory, this.metadataHandlerMap, databaseConnectionConfig, java.util.Map.of());
+        this.jdbcMetadataHandler = new ImpalaMuxMetadataHandler(this.secretsManager, this.athena, this.jdbcConnectionFactory, this.metadataHandlerMap, databaseConnectionConfig, com.google.common.collect.ImmutableMap.of());
     }
 
     @Test
@@ -117,7 +117,7 @@ public class ImpalaMuxMetadataHandlerTest
                 "hive2://jdbc:hive2://54.89.6.2:10000/authena;AuthMech=3;${testSecret}", "testSecret");
         try {
             new ImpalaMuxMetadataHandler(this.secretsManager, this.athena, this.jdbcConnectionFactory,
-                    metadataHandlersMap, databaseConnectionConfig, java.util.Map.of());
+                    metadataHandlersMap, databaseConnectionConfig, com.google.common.collect.ImmutableMap.of());
         } catch (Exception e) {
             e.getMessage();
             Assert.assertTrue(e.getMessage().contains("Max 100 catalogs supported in multiplexer."));

--- a/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaMuxRecordHandlerTest.java
+++ b/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaMuxRecordHandlerTest.java
@@ -71,7 +71,7 @@ public class ImpalaMuxRecordHandlerTest
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", ImpalaConstants.IMPALA_NAME,
         		"impala://jdbc:impala://54.89.6.2:10000/authena;AuthMech=3;${testSecret}", "testSecret");
-        this.jdbcRecordHandler = new ImpalaMuxRecordHandler(this.amazonS3, this.secretsManager, this.athena, this.jdbcConnectionFactory, databaseConnectionConfig, this.recordHandlerMap, java.util.Map.of());
+        this.jdbcRecordHandler = new ImpalaMuxRecordHandler(this.amazonS3, this.secretsManager, this.athena, this.jdbcConnectionFactory, databaseConnectionConfig, this.recordHandlerMap, com.google.common.collect.ImmutableMap.of());
     }
 
     @Test
@@ -95,7 +95,7 @@ public class ImpalaMuxRecordHandlerTest
                 "impala://jdbc:impala://54.89.6.2:10000/authena;AuthMech=3;${testSecret}", "testSecret");
         try {
             new ImpalaMuxRecordHandler(this.amazonS3, this.secretsManager, this.athena,
-                    this.jdbcConnectionFactory, databaseConnectionConfig, recorddataHandlersMap, java.util.Map.of());
+                    this.jdbcConnectionFactory, databaseConnectionConfig, recorddataHandlersMap, com.google.common.collect.ImmutableMap.of());
         } catch (Exception e) {
             e.getMessage();
             Assert.assertTrue(e.getMessage().contains("Max 100 catalogs supported in multiplexer."));

--- a/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaRecordHandlerTest.java
+++ b/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaRecordHandlerTest.java
@@ -84,7 +84,7 @@ public class ImpalaRecordHandlerTest
         final DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", ImpalaConstants.IMPALA_NAME,
                 "impala://jdbc:impala://54.89.6.2:10000/authena;{testSecret}","testSecret");
 
-        this.impalaRecordHandler = new ImpalaRecordHandler(databaseConnectionConfig, amazonS3, secretsManager, athena, jdbcConnectionFactory, jdbcSplitQueryBuilder, java.util.Map.of());
+        this.impalaRecordHandler = new ImpalaRecordHandler(databaseConnectionConfig, amazonS3, secretsManager, athena, jdbcConnectionFactory, jdbcSplitQueryBuilder, com.google.common.collect.ImmutableMap.of());
     }
 
     private ValueSet getSingleValueSet(Object value) {

--- a/athena-cloudwatch-metrics/src/test/java/com/amazonaws/athena/connectors/cloudwatch/metrics/MetricsMetadataHandlerTest.java
+++ b/athena-cloudwatch-metrics/src/test/java/com/amazonaws/athena/connectors/cloudwatch/metrics/MetricsMetadataHandlerTest.java
@@ -102,7 +102,7 @@ public class MetricsMetadataHandlerTest
     public void setUp()
             throws Exception
     {
-        handler = new MetricsMetadataHandler(mockMetrics, new LocalKeyFactory(), mockSecretsManager, mockAthena, "spillBucket", "spillPrefix", java.util.Map.of());
+        handler = new MetricsMetadataHandler(mockMetrics, new LocalKeyFactory(), mockSecretsManager, mockAthena, "spillBucket", "spillPrefix", com.google.common.collect.ImmutableMap.of());
         allocator = new BlockAllocatorImpl();
     }
 

--- a/athena-cloudwatch-metrics/src/test/java/com/amazonaws/athena/connectors/cloudwatch/metrics/MetricsRecordHandlerTest.java
+++ b/athena-cloudwatch-metrics/src/test/java/com/amazonaws/athena/connectors/cloudwatch/metrics/MetricsRecordHandlerTest.java
@@ -128,7 +128,7 @@ public class MetricsRecordHandlerTest
     {
         mockS3Storage = new ArrayList<>();
         allocator = new BlockAllocatorImpl();
-        handler = new MetricsRecordHandler(mockS3, mockSecretsManager, mockAthena, mockMetrics, java.util.Map.of());
+        handler = new MetricsRecordHandler(mockS3, mockSecretsManager, mockAthena, mockMetrics, com.google.common.collect.ImmutableMap.of());
         spillReader = new S3BlockSpillReader(mockS3, allocator);
 
         Mockito.lenient().when(mockS3.putObject(any()))

--- a/athena-cloudwatch/src/test/java/com/amazonaws/athena/connectors/cloudwatch/CloudwatchMetadataHandlerTest.java
+++ b/athena-cloudwatch/src/test/java/com/amazonaws/athena/connectors/cloudwatch/CloudwatchMetadataHandlerTest.java
@@ -112,7 +112,7 @@ public class CloudwatchMetadataHandlerTest
             return new DescribeLogGroupsResult().withLogGroups(new LogGroup().withLogGroupName("schema-1"),
                     new LogGroup().withLogGroupName("schema-20"));
         });
-        handler = new CloudwatchMetadataHandler(mockAwsLogs, new LocalKeyFactory(), mockSecretsManager, mockAthena, "spillBucket", "spillPrefix", java.util.Map.of());
+        handler = new CloudwatchMetadataHandler(mockAwsLogs, new LocalKeyFactory(), mockSecretsManager, mockAthena, "spillBucket", "spillPrefix", com.google.common.collect.ImmutableMap.of());
         allocator = new BlockAllocatorImpl();
     }
 

--- a/athena-cloudwatch/src/test/java/com/amazonaws/athena/connectors/cloudwatch/CloudwatchRecordHandlerTest.java
+++ b/athena-cloudwatch/src/test/java/com/amazonaws/athena/connectors/cloudwatch/CloudwatchRecordHandlerTest.java
@@ -112,7 +112,7 @@ public class CloudwatchRecordHandlerTest
 
         mockS3Storage = new ArrayList<>();
         allocator = new BlockAllocatorImpl();
-        handler = new CloudwatchRecordHandler(mockS3, mockSecretsManager, mockAthena, mockAwsLogs, java.util.Map.of());
+        handler = new CloudwatchRecordHandler(mockS3, mockSecretsManager, mockAthena, mockAwsLogs, com.google.common.collect.ImmutableMap.of());
         spillReader = new S3BlockSpillReader(mockS3, allocator);
 
         when(mockS3.putObject(any()))

--- a/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2MetadataHandlerTest.java
+++ b/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2MetadataHandlerTest.java
@@ -92,7 +92,7 @@ public class DataLakeGen2MetadataHandlerTest
         this.secretsManager = Mockito.mock(AWSSecretsManager.class);
         this.athena = Mockito.mock(AmazonAthena.class);
         Mockito.when(this.secretsManager.getSecretValue(Mockito.eq(new GetSecretValueRequest().withSecretId("testSecret")))).thenReturn(new GetSecretValueResult().withSecretString("{\"user\": \"testUser\", \"password\": \"testPassword\"}"));
-        this.dataLakeGen2MetadataHandler = new DataLakeGen2MetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, this.jdbcConnectionFactory, java.util.Map.of());
+        this.dataLakeGen2MetadataHandler = new DataLakeGen2MetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, this.jdbcConnectionFactory, com.google.common.collect.ImmutableMap.of());
         this.federatedIdentity = Mockito.mock(FederatedIdentity.class);
     }
 
@@ -146,7 +146,7 @@ public class DataLakeGen2MetadataHandlerTest
         JdbcConnectionFactory jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         Mockito.when(jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(connection);
         Mockito.when(connection.getMetaData().getSearchStringEscape()).thenThrow(new SQLException());
-        DataLakeGen2MetadataHandler dataLakeGen2MetadataHandler = new DataLakeGen2MetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, jdbcConnectionFactory, java.util.Map.of());
+        DataLakeGen2MetadataHandler dataLakeGen2MetadataHandler = new DataLakeGen2MetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, jdbcConnectionFactory, com.google.common.collect.ImmutableMap.of());
 
         dataLakeGen2MetadataHandler.doGetTableLayout(Mockito.mock(BlockAllocator.class), getTableLayoutRequest);
     }

--- a/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2MuxMetadataHandlerTest.java
+++ b/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2MuxMetadataHandlerTest.java
@@ -66,7 +66,7 @@ public class DataLakeGen2MuxMetadataHandlerTest
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", "fakedatabase",
                 "fakedatabase://jdbc:fakedatabase://hostname/${testSecret}", "testSecret");
-        this.jdbcMetadataHandler = new DataLakeGen2MuxMetadataHandler(this.secretsManager, this.athena, this.jdbcConnectionFactory, this.metadataHandlerMap, databaseConnectionConfig, java.util.Map.of());
+        this.jdbcMetadataHandler = new DataLakeGen2MuxMetadataHandler(this.secretsManager, this.athena, this.jdbcConnectionFactory, this.metadataHandlerMap, databaseConnectionConfig, com.google.common.collect.ImmutableMap.of());
     }
 
     @Test

--- a/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2MuxRecordHandlerTest.java
+++ b/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2MuxRecordHandlerTest.java
@@ -64,7 +64,7 @@ public class DataLakeGen2MuxRecordHandlerTest
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", DataLakeGen2Constants.NAME,
                 "datalakegentwo://jdbc:sqlserver://hostname/${testSecret}", "testSecret");
-        this.jdbcRecordHandler = new DataLakeGen2MuxRecordHandler(this.amazonS3, this.secretsManager, this.athena, this.jdbcConnectionFactory, databaseConnectionConfig, this.recordHandlerMap, java.util.Map.of());
+        this.jdbcRecordHandler = new DataLakeGen2MuxRecordHandler(this.amazonS3, this.secretsManager, this.athena, this.jdbcConnectionFactory, databaseConnectionConfig, this.recordHandlerMap, com.google.common.collect.ImmutableMap.of());
     }
 
     @Test

--- a/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeRecordHandlerTest.java
+++ b/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeRecordHandlerTest.java
@@ -74,7 +74,7 @@ public class DataLakeRecordHandlerTest
         final DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", DataLakeGen2Constants.NAME,
                 "datalakegentwo://jdbc:sqlserver://hostname;databaseName=fakedatabase");
 
-        this.dataLakeGen2RecordHandler = new DataLakeGen2RecordHandler(databaseConnectionConfig, amazonS3, secretsManager, athena, jdbcConnectionFactory, jdbcSplitQueryBuilder, java.util.Map.of());
+        this.dataLakeGen2RecordHandler = new DataLakeGen2RecordHandler(databaseConnectionConfig, amazonS3, secretsManager, athena, jdbcConnectionFactory, jdbcSplitQueryBuilder, com.google.common.collect.ImmutableMap.of());
     }
 
     private ValueSet getSingleValueSet(Object value) {

--- a/athena-db2/src/test/java/com/amazonaws/athena/connectors/db2/Db2MetadataHandlerTest.java
+++ b/athena-db2/src/test/java/com/amazonaws/athena/connectors/db2/Db2MetadataHandlerTest.java
@@ -95,7 +95,7 @@ public class Db2MetadataHandlerTest extends TestBase {
         this.secretsManager = Mockito.mock(AWSSecretsManager.class);
         this.athena = Mockito.mock(AmazonAthena.class);
         Mockito.when(this.secretsManager.getSecretValue(Mockito.eq(new GetSecretValueRequest().withSecretId("testSecret")))).thenReturn(new GetSecretValueResult().withSecretString("{\"user\": \"testUser\", \"password\": \"testPassword\"}"));
-        this.db2MetadataHandler = new Db2MetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, this.jdbcConnectionFactory, java.util.Map.of());
+        this.db2MetadataHandler = new Db2MetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, this.jdbcConnectionFactory, com.google.common.collect.ImmutableMap.of());
         this.federatedIdentity = Mockito.mock(FederatedIdentity.class);
         this.blockAllocator = new BlockAllocatorImpl();
     }
@@ -166,16 +166,16 @@ public class Db2MetadataHandlerTest extends TestBase {
         GetSplitsRequest getSplitsRequest = new GetSplitsRequest(this.federatedIdentity, "testQueryId", "testCatalogName", tableName, getTableLayoutResponse.getPartitions(), new ArrayList<>(partitionCols), constraints, null);
         GetSplitsResponse getSplitsResponse = this.db2MetadataHandler.doGetSplits(splitBlockAllocator, getSplitsRequest);
 
-        Set<Map<String, String>> expectedSplits = new HashSet<>();
-        expectedSplits.add(Map.ofEntries(
-                Map.entry(db2MetadataHandler.PARTITION_NUMBER, "0"),
-                Map.entry(db2MetadataHandler.PARTITIONING_COLUMN, "PC")));
-        expectedSplits.add(Map.ofEntries(
-                Map.entry(db2MetadataHandler.PARTITION_NUMBER, "1"),
-                Map.entry(db2MetadataHandler.PARTITIONING_COLUMN, "PC")));
-        expectedSplits.add(Map.ofEntries(
-                Map.entry(db2MetadataHandler.PARTITION_NUMBER, "2"),
-                Map.entry(db2MetadataHandler.PARTITIONING_COLUMN, "PC")));
+        Set<Map<String, String>> expectedSplits = com.google.common.collect.ImmutableSet.of(
+            com.google.common.collect.ImmutableMap.of(
+                db2MetadataHandler.PARTITION_NUMBER, "0",
+                db2MetadataHandler.PARTITIONING_COLUMN, "PC"),
+            com.google.common.collect.ImmutableMap.of(
+                db2MetadataHandler.PARTITION_NUMBER, "1",
+                db2MetadataHandler.PARTITIONING_COLUMN, "PC"),
+            com.google.common.collect.ImmutableMap.of(
+                db2MetadataHandler.PARTITION_NUMBER, "2",
+                db2MetadataHandler.PARTITIONING_COLUMN, "PC"));
 
         Assert.assertEquals(expectedSplits.size(), getSplitsResponse.getSplits().size());
         Set<Map<String, String>> actualSplits = getSplitsResponse.getSplits().stream().map(Split::getProperties).collect(Collectors.toSet());

--- a/athena-db2/src/test/java/com/amazonaws/athena/connectors/db2/Db2RecordHandlerTest.java
+++ b/athena-db2/src/test/java/com/amazonaws/athena/connectors/db2/Db2RecordHandlerTest.java
@@ -70,7 +70,7 @@ public class Db2RecordHandlerTest {
         jdbcSplitQueryBuilder = new Db2QueryStringBuilder("`");
         final DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", Db2Constants.NAME,
                 "dbtwo://jdbc:db2://hostname/fakedatabase:${testsecret}");
-        this.db2RecordHandler = new Db2RecordHandler(databaseConnectionConfig, amazonS3, secretsManager, athena, jdbcConnectionFactory, jdbcSplitQueryBuilder, java.util.Map.of());
+        this.db2RecordHandler = new Db2RecordHandler(databaseConnectionConfig, amazonS3, secretsManager, athena, jdbcConnectionFactory, jdbcSplitQueryBuilder, com.google.common.collect.ImmutableMap.of());
     }
 
     private ValueSet getSingleValueSet(Object value) {

--- a/athena-docdb/src/test/java/com/amazonaws/athena/connectors/docdb/DocDBMetadataHandlerTest.java
+++ b/athena-docdb/src/test/java/com/amazonaws/athena/connectors/docdb/DocDBMetadataHandlerTest.java
@@ -111,7 +111,7 @@ public class DocDBMetadataHandlerTest
 
         when(connectionFactory.getOrCreateConn(nullable(String.class))).thenReturn(mockClient);
 
-        handler = new DocDBMetadataHandler(awsGlue, connectionFactory, new LocalKeyFactory(), secretsManager, mockAthena, "spillBucket", "spillPrefix", java.util.Map.of());
+        handler = new DocDBMetadataHandler(awsGlue, connectionFactory, new LocalKeyFactory(), secretsManager, mockAthena, "spillBucket", "spillPrefix", com.google.common.collect.ImmutableMap.of());
         allocator = new BlockAllocatorImpl();
     }
 

--- a/athena-docdb/src/test/java/com/amazonaws/athena/connectors/docdb/DocDBRecordHandlerTest.java
+++ b/athena-docdb/src/test/java/com/amazonaws/athena/connectors/docdb/DocDBRecordHandlerTest.java
@@ -206,9 +206,9 @@ public class DocDBRecordHandlerTest
                     return mockObject;
                 });
 
-        handler = new DocDBRecordHandler(amazonS3, mockSecretsManager, mockAthena, connectionFactory, java.util.Map.of());
+        handler = new DocDBRecordHandler(amazonS3, mockSecretsManager, mockAthena, connectionFactory, com.google.common.collect.ImmutableMap.of());
         spillReader = new S3BlockSpillReader(amazonS3, allocator);
-        mdHandler = new DocDBMetadataHandler(awsGlue, connectionFactory, new LocalKeyFactory(), secretsManager, mockAthena, "spillBucket", "spillPrefix", java.util.Map.of());
+        mdHandler = new DocDBMetadataHandler(awsGlue, connectionFactory, new LocalKeyFactory(), secretsManager, mockAthena, "spillBucket", "spillPrefix", com.google.common.collect.ImmutableMap.of());
     }
 
     @After

--- a/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DDBTypeUtilsTest.java
+++ b/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DDBTypeUtilsTest.java
@@ -168,7 +168,7 @@ public class DDBTypeUtilsTest
     @Test
     public void inferArrowFieldListWithNullTest() throws Exception
     {
-        var inputArray = new java.util.ArrayList<String>();
+        java.util.ArrayList inputArray = new java.util.ArrayList<String>();
         inputArray.add("value1");
         inputArray.add(null);
         inputArray.add("value3");

--- a/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBMetadataHandlerTest.java
+++ b/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBMetadataHandlerTest.java
@@ -144,7 +144,7 @@ public class DynamoDBMetadataHandlerTest
 
         TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
         allocator = new BlockAllocatorImpl();
-        handler = new DynamoDBMetadataHandler(new LocalKeyFactory(), secretsManager, athena, "spillBucket", "spillPrefix", ddbClient, glueClient, java.util.Map.of());
+        handler = new DynamoDBMetadataHandler(new LocalKeyFactory(), secretsManager, athena, "spillBucket", "spillPrefix", ddbClient, glueClient, com.google.common.collect.ImmutableMap.of());
     }
 
     @After

--- a/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBRecordHandlerTest.java
+++ b/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBRecordHandlerTest.java
@@ -133,8 +133,8 @@ public class DynamoDBRecordHandlerTest
         logger.info("{}: enter", testName.getMethodName());
 
         allocator = new BlockAllocatorImpl();
-        handler = new DynamoDBRecordHandler(ddbClient, mock(AmazonS3.class), mock(AWSSecretsManager.class), mock(AmazonAthena.class), "source_type", java.util.Map.of());
-        metadataHandler = new DynamoDBMetadataHandler(new LocalKeyFactory(), secretsManager, athena, "spillBucket", "spillPrefix", ddbClient, glueClient, java.util.Map.of());
+        handler = new DynamoDBRecordHandler(ddbClient, mock(AmazonS3.class), mock(AWSSecretsManager.class), mock(AmazonAthena.class), "source_type", com.google.common.collect.ImmutableMap.of());
+        metadataHandler = new DynamoDBMetadataHandler(new LocalKeyFactory(), secretsManager, athena, "spillBucket", "spillPrefix", ddbClient, glueClient, com.google.common.collect.ImmutableMap.of());
     }
 
     @After

--- a/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/TestBase.java
+++ b/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/TestBase.java
@@ -89,7 +89,7 @@ public class TestBase
     public static void setupOnce() throws Exception
     {
         ddbClient = setupDatabase();
-        ThrottlingInvoker invoker = ThrottlingInvoker.newDefaultBuilder(EXCEPTION_FILTER, java.util.Map.of()).build();
+        ThrottlingInvoker invoker = ThrottlingInvoker.newDefaultBuilder(EXCEPTION_FILTER, com.google.common.collect.ImmutableMap.of()).build();
         schema = DDBTableUtils.peekTableForSchema(TEST_TABLE, invoker, ddbClient);
     }
 

--- a/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchMetadataHandlerTest.java
+++ b/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchMetadataHandlerTest.java
@@ -122,7 +122,7 @@ public class ElasticsearchMetadataHandlerTest
                 "domain2", "endpoint2","domain3", "endpoint3"));
 
         handler = new ElasticsearchMetadataHandler(awsGlue, new LocalKeyFactory(), awsSecretsManager, amazonAthena,
-                "spill-bucket", "spill-prefix", domainMapProvider, clientFactory, 10, java.util.Map.of());
+                "spill-bucket", "spill-prefix", domainMapProvider, clientFactory, 10, com.google.common.collect.ImmutableMap.of());
 
         ListSchemasRequest req = new ListSchemasRequest(fakeIdentity(), "queryId", "elasticsearch");
         ListSchemasResponse realDomains = handler.doListSchemaNames(allocator, req);
@@ -184,7 +184,7 @@ public class ElasticsearchMetadataHandlerTest
         when(domainMapProvider.getDomainMap(null)).thenReturn(ImmutableMap.of("movies",
                 "https://search-movies-ne3fcqzfipy6jcrew2wca6kyqu.us-east-1.es.amazonaws.com"));
         handler = new ElasticsearchMetadataHandler(awsGlue, new LocalKeyFactory(), awsSecretsManager, amazonAthena,
-                "spill-bucket", "spill-prefix", domainMapProvider, clientFactory, 10, java.util.Map.of());
+                "spill-bucket", "spill-prefix", domainMapProvider, clientFactory, 10, com.google.common.collect.ImmutableMap.of());
         when(mockClient.getAliases()).thenReturn(ImmutableSet.of("movies", ".kibana_1", "customer"));
 
         ListTablesRequest req = new ListTablesRequest(fakeIdentity(),
@@ -356,7 +356,7 @@ public class ElasticsearchMetadataHandlerTest
         when(domainMapProvider.getDomainMap(null)).thenReturn(ImmutableMap.of("movies",
                 "https://search-movies-ne3fcqzfipy6jcrew2wca6kyqu.us-east-1.es.amazonaws.com"));
         handler = new ElasticsearchMetadataHandler(awsGlue, new LocalKeyFactory(), awsSecretsManager, amazonAthena,
-                "spill-bucket", "spill-prefix", domainMapProvider, clientFactory, 10, java.util.Map.of());
+                "spill-bucket", "spill-prefix", domainMapProvider, clientFactory, 10, com.google.common.collect.ImmutableMap.of());
         GetTableRequest req = new GetTableRequest(fakeIdentity(), "queryId", "elasticsearch",
                 new TableName("movies", "mishmash"));
         GetTableResponse res = handler.doGetTable(allocator, req);
@@ -410,7 +410,7 @@ public class ElasticsearchMetadataHandlerTest
 
         // Instantiate handler
         handler = new ElasticsearchMetadataHandler(awsGlue, new LocalKeyFactory(), awsSecretsManager, amazonAthena,
-                "spill-bucket", "spill-prefix", domainMapProvider, clientFactory, 10, java.util.Map.of());
+                "spill-bucket", "spill-prefix", domainMapProvider, clientFactory, 10, com.google.common.collect.ImmutableMap.of());
 
         // Call doGetSplits()
         MetadataResponse rawResponse = handler.doGetSplits(allocator, req);
@@ -455,7 +455,7 @@ public class ElasticsearchMetadataHandlerTest
         logger.info("convertFieldTest: enter");
 
         handler = new ElasticsearchMetadataHandler(awsGlue, new LocalKeyFactory(), awsSecretsManager, amazonAthena,
-                "spill-bucket", "spill-prefix", domainMapProvider, clientFactory, 10, java.util.Map.of());
+                "spill-bucket", "spill-prefix", domainMapProvider, clientFactory, 10, com.google.common.collect.ImmutableMap.of());
 
         Field field = handler.convertField("myscaled", "SCALED_FLOAT(10.51)");
 

--- a/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchRecordHandlerTest.java
+++ b/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchRecordHandlerTest.java
@@ -314,7 +314,7 @@ public class ElasticsearchRecordHandlerTest
         when(mockScrollResponse.getHits()).thenReturn(null);
         when(mockClient.scroll(any(), any())).thenReturn(mockScrollResponse);
 
-        handler = new ElasticsearchRecordHandler(amazonS3, awsSecretsManager, athena, clientFactory, 720, 60, java.util.Map.of());
+        handler = new ElasticsearchRecordHandler(amazonS3, awsSecretsManager, athena, clientFactory, 720, 60, com.google.common.collect.ImmutableMap.of());
 
         logger.info("setUpBefore - exit");
     }

--- a/athena-example/src/test/java/com/amazonaws/athena/connectors/example/ExampleMetadataHandlerTest.java
+++ b/athena-example/src/test/java/com/amazonaws/athena/connectors/example/ExampleMetadataHandlerTest.java
@@ -75,7 +75,7 @@ public class ExampleMetadataHandlerTest
             mock(AmazonAthena.class),
             "spill-bucket",
             "spill-prefix",
-            java.util.Map.of());
+            com.google.common.collect.ImmutableMap.of());
 
     private boolean enableTests = System.getenv("publishing") != null &&
             System.getenv("publishing").equalsIgnoreCase("true");

--- a/athena-example/src/test/java/com/amazonaws/athena/connectors/example/ExampleRecordHandlerTest.java
+++ b/athena-example/src/test/java/com/amazonaws/athena/connectors/example/ExampleRecordHandlerTest.java
@@ -124,7 +124,7 @@ public class ExampleRecordHandlerTest
                     }
                 });
 
-        handler = new ExampleRecordHandler(amazonS3, awsSecretsManager, athena, java.util.Map.of());
+        handler = new ExampleRecordHandler(amazonS3, awsSecretsManager, athena, com.google.common.collect.ImmutableMap.of());
         spillReader = new S3BlockSpillReader(amazonS3, allocator);
     }
 

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/BlockUtils.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/BlockUtils.java
@@ -285,7 +285,7 @@ public class BlockUtils
                     break;
                 case DATEDAY:
                     if (value instanceof Date) {
-                        var days = java.time.Duration.of(((Date) value).getTime(), java.time.temporal.ChronoUnit.MILLIS).toDays();
+                        long days = java.time.Duration.of(((Date) value).getTime(), java.time.temporal.ChronoUnit.MILLIS).toDays();
                         ((DateDayVector) vector).setSafe(pos, new Long(days).intValue());
                     }
                     else if (value instanceof LocalDate) {
@@ -830,7 +830,7 @@ public class BlockUtils
                         dateDayWriter.writeNull();
                     }
                     else if (value instanceof Date) {
-                        var days = java.time.Duration.of(((Date) value).getTime(), java.time.temporal.ChronoUnit.MILLIS).toDays();
+                        long days = java.time.Duration.of(((Date) value).getTime(), java.time.temporal.ChronoUnit.MILLIS).toDays();
                         dateDayWriter.writeDateDay(new Long(days).intValue());
                     }
                     else if (value instanceof LocalDate) {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/handlers/GlueMetadataHandler.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/handlers/GlueMetadataHandler.java
@@ -153,7 +153,7 @@ public abstract class GlueMetadataHandler
         // we need to maintain backwards compatibility.
         //
         // Original comment: "Disable Glue if the env var is present and not explicitly set to "false""
-        var disabled = configOptions.get(DISABLE_GLUE) != null && !"false".equalsIgnoreCase(configOptions.get(DISABLE_GLUE));
+        boolean disabled = configOptions.get(DISABLE_GLUE) != null && !"false".equalsIgnoreCase(configOptions.get(DISABLE_GLUE));
 
         // null if the current instance does not want to leverage Glue for metadata
         awsGlue = disabled ? null : (AWSGlueClientBuilder.standard()

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/metadata/glue/DefaultGlueType.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/metadata/glue/DefaultGlueType.java
@@ -20,6 +20,8 @@ package com.amazonaws.athena.connector.lambda.metadata.glue;
  * #L%
  */
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 
@@ -30,8 +32,6 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static java.util.Map.entry;
-
 /**
  * Defines the default mapping of AWS Glue Data Catalog types to Apache Arrow types. You can override these by
  * overriding convertField(...) on GlueMetadataHandler.
@@ -39,25 +39,26 @@ import static java.util.Map.entry;
 public class DefaultGlueType
 {
     private static final String TIMESTAMPMILLITZ = "timestamptz";
-    private static final Set<String> NON_COMPARABALE_SET = Set.of("TIMESTAMPMILLITZ");
+    private static final Set<String> NON_COMPARABALE_SET = ImmutableSet.of("TIMESTAMPMILLITZ");
 
-    private static final Map<String, ArrowType> TYPE_MAP = Map.ofEntries(
-        entry("int", Types.MinorType.INT.getType()),
-        entry("varchar", Types.MinorType.VARCHAR.getType()),
-        entry("string", Types.MinorType.VARCHAR.getType()),
-        entry("bigint", Types.MinorType.BIGINT.getType()),
-        entry("double", Types.MinorType.FLOAT8.getType()),
-        entry("float", Types.MinorType.FLOAT4.getType()),
-        entry("smallint", Types.MinorType.SMALLINT.getType()),
-        entry("tinyint", Types.MinorType.TINYINT.getType()),
-        entry("boolean", Types.MinorType.BIT.getType()),
-        entry("binary", Types.MinorType.VARBINARY.getType()),
-        entry("timestamp", Types.MinorType.DATEMILLI.getType()),
-        entry("date", Types.MinorType.DATEDAY.getType()),
+    private static final Map<String, ArrowType> TYPE_MAP = new ImmutableMap.Builder<String, ArrowType>()
+        .put("int", Types.MinorType.INT.getType())
+        .put("varchar", Types.MinorType.VARCHAR.getType())
+        .put("string", Types.MinorType.VARCHAR.getType())
+        .put("bigint", Types.MinorType.BIGINT.getType())
+        .put("double", Types.MinorType.FLOAT8.getType())
+        .put("float", Types.MinorType.FLOAT4.getType())
+        .put("smallint", Types.MinorType.SMALLINT.getType())
+        .put("tinyint", Types.MinorType.TINYINT.getType())
+        .put("boolean", Types.MinorType.BIT.getType())
+        .put("binary", Types.MinorType.VARBINARY.getType())
+        .put("timestamp", Types.MinorType.DATEMILLI.getType())
+        .put("date", Types.MinorType.DATEDAY.getType())
         // ZoneId.systemDefault().getId() is just a place holder, each row will have a TZ value
         // otherwise fall back to the table configured default TZ
-        entry(TIMESTAMPMILLITZ, new ArrowType.Timestamp(
-                org.apache.arrow.vector.types.TimeUnit.MILLISECOND, ZoneId.systemDefault().getId())));
+        .put(TIMESTAMPMILLITZ, (ArrowType) new ArrowType.Timestamp(
+                org.apache.arrow.vector.types.TimeUnit.MILLISECOND, ZoneId.systemDefault().getId()))
+        .build();
 
     // decimal match examples:
     // decimal

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/metadata/glue/GlueFieldLexer.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/metadata/glue/GlueFieldLexer.java
@@ -21,6 +21,7 @@ package com.amazonaws.athena.connector.lambda.metadata.glue;
  */
 
 import com.amazonaws.athena.connector.lambda.data.FieldBuilder;
+import com.google.common.collect.ImmutableSet;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
@@ -48,7 +49,7 @@ public class GlueFieldLexer
 
     private static final String MAP = "map";
 
-    private static final Set<String> LIST_EQUIVALENTS = Set.of("array", "set");
+    private static final Set<String> LIST_EQUIVALENTS = ImmutableSet.of("array", "set");
 
     private static final BaseTypeMapper DEFAULT_TYPE_MAPPER = (String type) -> DefaultGlueType.toArrowType(type);
 

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/QueryStatusCheckerTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/QueryStatusCheckerTest.java
@@ -49,7 +49,7 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class QueryStatusCheckerTest
 {
-    private final ThrottlingInvoker athenaInvoker = ThrottlingInvoker.newDefaultBuilder(ATHENA_EXCEPTION_FILTER, java.util.Map.of()).build();
+    private final ThrottlingInvoker athenaInvoker = ThrottlingInvoker.newDefaultBuilder(ATHENA_EXCEPTION_FILTER, com.google.common.collect.ImmutableMap.of()).build();
 
     @Mock
     private AmazonAthena athena;

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/data/BlockTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/data/BlockTest.java
@@ -692,7 +692,7 @@ public class BlockTest
                             }
 
                             throw new RuntimeException("Unexpected field " + field.getName());
-                        }, Map.of());
+                        }, com.google.common.collect.ImmutableMap.of());
                     }
                     List<Field> children = vector.getField().getChildren();
                     Field keyValueStructField;

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/data/BlockUtilsPropertiesTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/data/BlockUtilsPropertiesTest.java
@@ -95,8 +95,8 @@ public class BlockUtilsPropertiesTest {
         CustomFieldVector customFieldVector = new CustomFieldVector(field);
         generator.generateValues(field, vector, customFieldVector);
 
-        Schema schema = new Schema(java.util.List.of(field));
-        VectorSchemaRoot inputSchemaRoot = new VectorSchemaRoot(schema, java.util.List.of(vector), 1);
+        Schema schema = new Schema(com.google.common.collect.ImmutableList.of(field));
+        VectorSchemaRoot inputSchemaRoot = new VectorSchemaRoot(schema, com.google.common.collect.ImmutableList.of(vector), 1);
 
         int valueCount = inputSchemaRoot.getVector(0).getValueCount();
         VectorSchemaRoot outputSchemaRoot = VectorSchemaRoot.create(inputSchemaRoot.getSchema(), allocator);

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/data/S3BlockSpillerTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/data/S3BlockSpillerTest.java
@@ -101,7 +101,7 @@ public class S3BlockSpillerTest
                 .withRequestId(requestId)
                 .build();
 
-        blockWriter = new S3BlockSpiller(mockS3, spillConfig, allocator, schema, ConstraintEvaluator.emptyEvaluator(), java.util.Map.of());
+        blockWriter = new S3BlockSpiller(mockS3, spillConfig, allocator, schema, ConstraintEvaluator.emptyEvaluator(), com.google.common.collect.ImmutableMap.of());
 
         expected = allocator.createBlock(schema);
         BlockUtils.setValue(expected.getFieldVector("col1"), 1, 100);

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/data/helpers/FieldsGenerator.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/data/helpers/FieldsGenerator.java
@@ -165,7 +165,7 @@ public class FieldsGenerator {
             Arbitrary<List<Field>> structField = Combinators.combine(keyField, valueField).as((key, value) ->
                 new Field(MapVector.DATA_VECTOR_NAME,
                     structType,
-                    List.of(key, value)
+                    com.google.common.collect.ImmutableList.of(key, value)
             )).list().ofSize(1);
             return structField;
         }

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/examples/ExampleMetadataHandlerTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/examples/ExampleMetadataHandlerTest.java
@@ -87,7 +87,7 @@ public class ExampleMetadataHandlerTest
                 mock(AmazonAthena.class),
                 "spill-bucket",
                 "spill-prefix",
-                java.util.Map.of());
+                com.google.common.collect.ImmutableMap.of());
         logger.info("setUpBefore - exit");
     }
 

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/examples/ExampleRecordHandlerTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/examples/ExampleRecordHandlerTest.java
@@ -180,7 +180,7 @@ public class ExampleRecordHandlerTest
                     }
                 });
 
-        recordService = new LocalHandler(allocator, amazonS3, awsSecretsManager, athena, java.util.Map.of());
+        recordService = new LocalHandler(allocator, amazonS3, awsSecretsManager, athena, com.google.common.collect.ImmutableMap.of());
         spillReader = new S3BlockSpillReader(amazonS3, allocator);
 
         logger.info("setUpBefore - exit");

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/handlers/GlueMetadataHandlerTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/handlers/GlueMetadataHandlerTest.java
@@ -151,7 +151,7 @@ public class GlueMetadataHandlerTest
                 "glue-test",
                 "spill-bucket",
                 "spill-prefix",
-                java.util.Map.of())
+                com.google.common.collect.ImmutableMap.of())
         {
             @Override
             public GetTableLayoutResponse doGetTableLayout(BlockAllocator blockAllocator, GetTableLayoutRequest request)

--- a/athena-gcs/src/main/java/com/amazonaws/athena/connectors/gcs/GcsMetadataHandler.java
+++ b/athena-gcs/src/main/java/com/amazonaws/athena/connectors/gcs/GcsMetadataHandler.java
@@ -172,7 +172,7 @@ public class GcsMetadataHandler
             //fetch schema from dataset api
             Schema schema = datasource.buildTableSchema(table, allocator);
             Map<String, String> columnNameMapping = getColumnNameMapping(table);
-            List<Column> partitionKeys = table.getPartitionKeys() == null ? List.of() : table.getPartitionKeys();
+            List<Column> partitionKeys = table.getPartitionKeys() == null ? com.google.common.collect.ImmutableList.of() : table.getPartitionKeys();
             Set<String> partitionCols = partitionKeys.stream()
                 .map(next -> columnNameMapping.getOrDefault(next.getName(), next.getName())).collect(Collectors.toSet());
             return new GetTableResponse(request.getCatalogName(), request.getTableName(), schema, partitionCols);

--- a/athena-gcs/src/main/java/com/amazonaws/athena/connectors/gcs/GcsRecordHandler.java
+++ b/athena-gcs/src/main/java/com/amazonaws/athena/connectors/gcs/GcsRecordHandler.java
@@ -118,7 +118,7 @@ public class GcsRecordHandler
         LOGGER.info("Reading records from the table {} under the schema {}", tableInfo.getTableName(), tableInfo.getSchemaName());
         Split split = recordsRequest.getSplit();
         List<String> fileList = new ObjectMapper()
-            .readValue(split.getProperty(GcsConstants.STORAGE_SPLIT_JSON).getBytes(StandardCharsets.UTF_8), new TypeReference<>(){});
+            .readValue(split.getProperty(GcsConstants.STORAGE_SPLIT_JSON).getBytes(StandardCharsets.UTF_8), new TypeReference<List<String>>(){});
         String classification = split.getProperty(CLASSIFICATION_GLUE_TABLE_PARAM);
         FileFormat format = FileFormat.valueOf(classification.toUpperCase());
         for (String file : fileList) {

--- a/athena-gcs/src/main/java/com/amazonaws/athena/connectors/gcs/common/PartitionUtil.java
+++ b/athena-gcs/src/main/java/com/amazonaws/athena/connectors/gcs/common/PartitionUtil.java
@@ -22,6 +22,7 @@ package com.amazonaws.athena.connectors.gcs.common;
 import com.amazonaws.services.glue.model.Column;
 import com.amazonaws.services.glue.model.Table;
 import org.apache.arrow.vector.FieldVector;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,10 +72,10 @@ public class PartitionUtil
      */
     public static Map<String, String> getPartitionColumnData(Table table, String partitionFolder)
     {
-        List<Column> partitionKeys = table.getPartitionKeys() == null ? List.of() : table.getPartitionKeys();
+        List<Column> partitionKeys = table.getPartitionKeys() == null ? com.google.common.collect.ImmutableList.of() : table.getPartitionKeys();
         return getRegExExpression(table).map(folderNameRegEx ->
             getPartitionColumnData(table.getParameters().get(PARTITION_PATTERN_KEY), partitionFolder, folderNameRegEx, partitionKeys))
-            .orElse(Map.of());
+            .orElse(com.google.common.collect.ImmutableMap.of());
     }
 
     /**
@@ -91,7 +92,7 @@ public class PartitionUtil
         Map<String, String> partitions = new java.util.TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         Matcher partitionPatternMatcher = PARTITION_PATTERN.matcher(partitionPattern);
         Matcher partitionFolderMatcher = Pattern.compile(folderNameRegEx).matcher(partitionFolder);
-        var partitionColumnsSet = partitionColumns.stream()
+        java.util.TreeSet<String> partitionColumnsSet = partitionColumns.stream()
                 .map(c -> c.getName())
                 .collect(Collectors.toCollection(() -> new java.util.TreeSet<>(String.CASE_INSENSITIVE_ORDER)));
         while (partitionFolderMatcher.find()) {
@@ -139,12 +140,12 @@ public class PartitionUtil
      */
     protected static Optional<String> getRegExExpression(Table table)
     {
-        List<Column> partitionColumns = table.getPartitionKeys() == null ? List.of() : table.getPartitionKeys();
+        List<Column> partitionColumns = table.getPartitionKeys() == null ? com.google.common.collect.ImmutableList.of() : table.getPartitionKeys();
         validatePartitionColumnTypes(partitionColumns);
         String partitionPattern = table.getParameters().get(PARTITION_PATTERN_KEY);
         // Check to see if there is a partition pattern configured for the Table by the user
         // if not, it returns empty value
-        if (partitionPattern == null || partitionPattern.isBlank()) {
+        if (partitionPattern == null || StringUtils.isBlank(partitionPattern)) {
             return Optional.empty();
         }
         return Optional.of(partitionPattern.replaceAll(PARTITION_PATTERN_REGEX, VARCHAR_OR_STRING_REGEX));

--- a/athena-gcs/src/main/java/com/amazonaws/athena/connectors/gcs/filter/FilterExpressionBuilder.java
+++ b/athena-gcs/src/main/java/com/amazonaws/athena/connectors/gcs/filter/FilterExpressionBuilder.java
@@ -59,10 +59,11 @@ public class FilterExpressionBuilder
                 if (!value1.isPresent() && !value2.isPresent()) {
                     return Optional.empty();
                 }
-                return Optional.of(
-                  java.util.stream.Stream.concat(value1.stream(), value2.stream()).flatMap(Set::stream).collect(Collectors.toSet()));
+                Set<String> value1Set = value1.orElse(java.util.Collections.emptySet());
+                Set<String> value2Set = value2.orElse(java.util.Collections.emptySet());
+                return Optional.of(com.google.common.collect.ImmutableSet.<String>builder().addAll(value1Set).addAll(value2Set).build());
             },
-            () -> new java.util.TreeMap<>(String.CASE_INSENSITIVE_ORDER)
+            () -> new java.util.TreeMap<String, Optional<Set<String>>>(String.CASE_INSENSITIVE_ORDER)
         ));
     }
 

--- a/athena-gcs/src/main/java/com/amazonaws/athena/connectors/gcs/storage/StorageMetadata.java
+++ b/athena-gcs/src/main/java/com/amazonaws/athena/connectors/gcs/storage/StorageMetadata.java
@@ -138,7 +138,7 @@ public class StorageMetadata
         LOGGER.info("Getting partition folder(s) for table {}.{}", tableInfo.getSchemaName(), tableInfo.getTableName());
         Table table = GcsUtil.getGlueTable(tableInfo, awsGlue);
         // Build expression only based on partition keys
-        List<Column> partitionColumns = table.getPartitionKeys() == null ? List.of() : table.getPartitionKeys();
+        List<Column> partitionColumns = table.getPartitionKeys() == null ? com.google.common.collect.ImmutableList.of() : table.getPartitionKeys();
         // getConstraintsForPartitionedColumns gives us a case insensitive mapping of column names to their value set
         Map<String, Optional<Set<String>>> columnValueConstraintMap = FilterExpressionBuilder.getConstraintsForPartitionedColumns(partitionColumns, constraints);
         LOGGER.info("columnValueConstraintMap for the request of {}.{} is \n{}", tableInfo.getSchemaName(), tableInfo.getTableName(), columnValueConstraintMap);

--- a/athena-gcs/src/test/java/com/amazonaws/athena/connectors/gcs/GcsCompositeHandlerTest.java
+++ b/athena-gcs/src/test/java/com/amazonaws/athena/connectors/gcs/GcsCompositeHandlerTest.java
@@ -65,7 +65,7 @@ public class GcsCompositeHandlerTest {
     {
         PowerMockito.mockStatic(AWSSecretsManagerClientBuilder.class);
         PowerMockito.when(AWSSecretsManagerClientBuilder.defaultClient()).thenReturn(secretsManager);
-        GetSecretValueResult getSecretValueResult = new GetSecretValueResult().withVersionStages(List.of("v1")).withSecretString("{\"gcs_credential_keys\": \"test\"}");
+        GetSecretValueResult getSecretValueResult = new GetSecretValueResult().withVersionStages(com.google.common.collect.ImmutableList.of("v1")).withSecretString("{\"gcs_credential_keys\": \"test\"}");
         Mockito.when(secretsManager.getSecretValue(Mockito.any())).thenReturn(getSecretValueResult);
         PowerMockito.mockStatic(ServiceAccountCredentials.class);
         PowerMockito.when(ServiceAccountCredentials.fromStream(Mockito.any())).thenReturn(serviceAccountCredentials);

--- a/athena-gcs/src/test/java/com/amazonaws/athena/connectors/gcs/GcsMetadataHandlerTest.java
+++ b/athena-gcs/src/test/java/com/amazonaws/athena/connectors/gcs/GcsMetadataHandlerTest.java
@@ -152,7 +152,7 @@ public class GcsMetadataHandlerTest
         PowerMockito.when(optionBuilder.build()).thenReturn(mockedOptions);
         PowerMockito.when(mockedOptions.getService()).thenReturn(storage);
         PowerMockito.when(storage.list(anyString(), Mockito.any())).thenReturn(tables);
-        PowerMockito.when(tables.iterateAll()).thenReturn(List.of(blob, blob1));
+        PowerMockito.when(tables.iterateAll()).thenReturn(com.google.common.collect.ImmutableList.of(blob, blob1));
         PowerMockito.when(blob.getName()).thenReturn("data.parquet");
         PowerMockito.when(blob.getSize()).thenReturn(10L);
         PowerMockito.when(blob1.getName()).thenReturn("birthday/year=2000/birth_month09/12/");
@@ -165,11 +165,11 @@ public class GcsMetadataHandlerTest
 
         mockStatic(AWSSecretsManagerClientBuilder.class);
         PowerMockito.when(AWSSecretsManagerClientBuilder.defaultClient()).thenReturn(secretsManager);
-        GetSecretValueResult getSecretValueResult = new GetSecretValueResult().withVersionStages(List.of("v1")).withSecretString("{\"gcs_credential_keys\": \"test\"}");
+        GetSecretValueResult getSecretValueResult = new GetSecretValueResult().withVersionStages(com.google.common.collect.ImmutableList.of("v1")).withSecretString("{\"gcs_credential_keys\": \"test\"}");
         Mockito.when(secretsManager.getSecretValue(Mockito.any())).thenReturn(getSecretValueResult);
         mockStatic(AWSGlueClientBuilder.class);
         PowerMockito.when(AWSGlueClientBuilder.defaultClient()).thenReturn(awsGlue);
-        gcsMetadataHandler = new GcsMetadataHandler(new LocalKeyFactory(), secretsManager, athena, "spillBucket", "spillPrefix", awsGlue, allocator, java.util.Map.of());
+        gcsMetadataHandler = new GcsMetadataHandler(new LocalKeyFactory(), secretsManager, athena, "spillBucket", "spillPrefix", awsGlue, allocator, com.google.common.collect.ImmutableMap.of());
         blockAllocator = new BlockAllocatorImpl();
         federatedIdentity = Mockito.mock(FederatedIdentity.class);
     }
@@ -245,7 +245,7 @@ public class GcsMetadataHandlerTest
         table.setStorageDescriptor(new StorageDescriptor()
                 .withLocation(LOCATION).withColumns(new Column().withName("name").withType("String")));
         table.setCatalogId(CATALOG);
-        List<Column> columns = List.of(
+        List<Column> columns = com.google.common.collect.ImmutableList.of(
                 createColumn("name", "String")
         );
         table.setPartitionKeys(columns);
@@ -276,7 +276,7 @@ public class GcsMetadataHandlerTest
         table.setStorageDescriptor(new StorageDescriptor()
                 .withLocation(LOCATION).withColumns(new Column()));
         table.setCatalogId(CATALOG);
-        List<Column> columns = List.of(
+        List<Column> columns = com.google.common.collect.ImmutableList.of(
                 createColumn("year", "varchar"),
                 createColumn("month", "varchar"),
                 createColumn("day", "varchar")
@@ -302,7 +302,7 @@ public class GcsMetadataHandlerTest
         Block partitions = BlockUtils.newBlock(blockAllocator, "year", Types.MinorType.VARCHAR.getType(), 2000);
         GetSplitsRequest request = new GetSplitsRequest(federatedIdentity,
                 QUERY_ID, CATALOG, TABLE_NAME,
-                partitions, List.of("year"), new Constraints(new HashMap<>()), null);
+                partitions, com.google.common.collect.ImmutableList.of("year"), new Constraints(new HashMap<>()), null);
         QueryStatusChecker queryStatusChecker = mock(QueryStatusChecker.class);
         when(queryStatusChecker.isQueryRunning()).thenReturn(true);
         GetTableResult getTableResult = mock(GetTableResult.class);
@@ -310,10 +310,10 @@ public class GcsMetadataHandlerTest
         when(storageDescriptor.getLocation()).thenReturn(LOCATION);
         Table table = mock(Table.class);
         when(table.getStorageDescriptor()).thenReturn(storageDescriptor);
-        when(table.getParameters()).thenReturn(Map.of(PARTITION_PATTERN_KEY, "year=${year}/", CLASSIFICATION_GLUE_TABLE_PARAM, PARQUET));
+        when(table.getParameters()).thenReturn(com.google.common.collect.ImmutableMap.of(PARTITION_PATTERN_KEY, "year=${year}/", CLASSIFICATION_GLUE_TABLE_PARAM, PARQUET));
         when(awsGlue.getTable(any())).thenReturn(getTableResult);
         when(getTableResult.getTable()).thenReturn(table);
-        List<Column> columns = List.of(
+        List<Column> columns = com.google.common.collect.ImmutableList.of(
                 createColumn("year", "varchar")
         );
         when(table.getPartitionKeys()).thenReturn(columns);

--- a/athena-gcs/src/test/java/com/amazonaws/athena/connectors/gcs/GcsRecordHandlerTest.java
+++ b/athena-gcs/src/test/java/com/amazonaws/athena/connectors/gcs/GcsRecordHandlerTest.java
@@ -161,14 +161,14 @@ public class GcsRecordHandlerTest
         PowerMockito.mockStatic(AmazonAthenaClientBuilder.class);
         PowerMockito.when(AmazonAthenaClientBuilder.defaultClient()).thenReturn(athena);
 
-        GetSecretValueResult getSecretValueResult = new GetSecretValueResult().withVersionStages(List.of("v1")).withSecretString("{\"athena_gcs_keys\": \"test\"}");
+        GetSecretValueResult getSecretValueResult = new GetSecretValueResult().withVersionStages(com.google.common.collect.ImmutableList.of("v1")).withSecretString("{\"athena_gcs_keys\": \"test\"}");
         when(secretsManager.getSecretValue(any())).thenReturn(getSecretValueResult);
         PowerMockito.mockStatic(GoogleCredentials.class);
         PowerMockito.when(GoogleCredentials.fromStream(any())).thenReturn(credentials);
         PowerMockito.when(credentials.createScoped((Collection<String>) any())).thenReturn(credentials);
         suppress(constructor(StorageMetadata.class, String.class));
         Schema schemaForRead = new Schema(GcsTestUtils.getTestSchemaFieldsArrow());
-        spillWriter = new S3BlockSpiller(amazonS3, spillConfig, allocator, schemaForRead, ConstraintEvaluator.emptyEvaluator(), java.util.Map.of());
+        spillWriter = new S3BlockSpiller(amazonS3, spillConfig, allocator, schemaForRead, ConstraintEvaluator.emptyEvaluator(), com.google.common.collect.ImmutableMap.of());
 
         // Mocking GcsUtil
         PowerMockito.mockStatic(GcsUtil.class);
@@ -176,7 +176,7 @@ public class GcsRecordHandlerTest
         PowerMockito.when(GcsUtil.createUri(anyString())).thenReturn( "file:" + parquetFile.getPath() + "/" + "person-data.parquet");
 
         // The class we want to test.
-        gcsRecordHandler = new GcsRecordHandler(bufferAllocator, java.util.Map.of());
+        gcsRecordHandler = new GcsRecordHandler(bufferAllocator, com.google.common.collect.ImmutableMap.of());
         LOGGER.info("Completed init.");
     }
 

--- a/athena-gcs/src/test/java/com/amazonaws/athena/connectors/gcs/common/PartitionUtilTest.java
+++ b/athena-gcs/src/test/java/com/amazonaws/athena/connectors/gcs/common/PartitionUtilTest.java
@@ -51,7 +51,7 @@ public class PartitionUtilTest
         table = mock(Table.class);
         when(table.getStorageDescriptor()).thenReturn(storageDescriptor);
 
-        List<Column> columns = List.of(
+        List<Column> columns = com.google.common.collect.ImmutableList.of(
                 createColumn("year", "bigint"),
                 createColumn("month", "int")
         );
@@ -61,7 +61,7 @@ public class PartitionUtilTest
     @Test(expected = IllegalArgumentException.class)
     public void testFolderNameRegExPatterExpectException()
     {
-        when(table.getParameters()).thenReturn(Map.of(PARTITION_PATTERN_KEY, "year=${year}/birth_month${month}/${day}"));
+        when(table.getParameters()).thenReturn(com.google.common.collect.ImmutableMap.of(PARTITION_PATTERN_KEY, "year=${year}/birth_month${month}/${day}"));
         Optional<String> optionalRegEx = PartitionUtil.getRegExExpression(table);
         assertTrue(optionalRegEx.isPresent());
     }
@@ -69,7 +69,7 @@ public class PartitionUtilTest
     @Test(expected = IllegalArgumentException.class)
     public void testFolderNameRegExPatter()
     {
-        when(table.getParameters()).thenReturn(Map.of(PARTITION_PATTERN_KEY, "year=${year}/birth_month${month}/"));
+        when(table.getParameters()).thenReturn(com.google.common.collect.ImmutableMap.of(PARTITION_PATTERN_KEY, "year=${year}/birth_month${month}/"));
         Optional<String> optionalRegEx = PartitionUtil.getRegExExpression(table);
         assertTrue(optionalRegEx.isPresent());
         assertFalse("Expression shouldn't contain a '{' character", optionalRegEx.get().contains("{"));
@@ -80,14 +80,14 @@ public class PartitionUtilTest
     public void dynamicFolderExpressionWithDigits()
     {
         // Odd index matches, otherwise doesn't
-        List<String> partitionFolders = List.of(
+        List<String> partitionFolders = com.google.common.collect.ImmutableList.of(
                 "state='Tamilnadu'/",
                 "year=2000/birth_month10/",
                 "zone=EST/",
                 "year=2001/birth_month01/",
                 "month01/"
         );
-        when(table.getParameters()).thenReturn(Map.of(PARTITION_PATTERN_KEY, "year=${year}/birth_month${month}/"));
+        when(table.getParameters()).thenReturn(com.google.common.collect.ImmutableMap.of(PARTITION_PATTERN_KEY, "year=${year}/birth_month${month}/"));
         Optional<String> optionalRegEx = PartitionUtil.getRegExExpression(table);
         assertTrue(optionalRegEx.isPresent());
         Pattern folderMatchPattern = Pattern.compile(optionalRegEx.get());
@@ -105,7 +105,7 @@ public class PartitionUtilTest
     public void dynamicFolderExpressionWithDefaultsDates()
     {
         // Odd index matches, otherwise doesn't
-        List<String> partitionFolders = List.of(
+        List<String> partitionFolders = com.google.common.collect.ImmutableList.of(
                 "year=2000/birth_month10/",
                 "creation_dt=2022-12-20/",
                 "zone=EST/",
@@ -113,8 +113,8 @@ public class PartitionUtilTest
                 "month01/"
         );
         // mock
-        when(table.getParameters()).thenReturn(Map.of(PARTITION_PATTERN_KEY, "creation_dt=${creation_dt}/"));
-        List<Column> columns = List.of(
+        when(table.getParameters()).thenReturn(com.google.common.collect.ImmutableMap.of(PARTITION_PATTERN_KEY, "creation_dt=${creation_dt}/"));
+        List<Column> columns = com.google.common.collect.ImmutableList.of(
                 createColumn("creation_dt", "date")
         );
         when(table.getPartitionKeys()).thenReturn(columns);
@@ -136,7 +136,7 @@ public class PartitionUtilTest
     public void dynamicFolderExpressionWithQuotedVarchar() // failed
     {
         // Odd index matches, otherwise doesn't
-        List<String> partitionFolders = List.of(
+        List<String> partitionFolders = com.google.common.collect.ImmutableList.of(
                 "year=2000/birth_month10/",
                 "state=\"Tamilnadu\"/",
                 "state='Tamilnadu'/",
@@ -145,8 +145,8 @@ public class PartitionUtilTest
                 "month01/"
         );
         // mock
-        when(table.getParameters()).thenReturn(Map.of(PARTITION_PATTERN_KEY, "state='${stateName}'/"));
-        List<Column> columns = List.of(
+        when(table.getParameters()).thenReturn(com.google.common.collect.ImmutableMap.of(PARTITION_PATTERN_KEY, "state='${stateName}'/"));
+        List<Column> columns = com.google.common.collect.ImmutableList.of(
                 createColumn("stateName", "string")
         );
         when(table.getPartitionKeys()).thenReturn(columns);
@@ -168,7 +168,7 @@ public class PartitionUtilTest
     public void dynamicFolderExpressionWithUnquotedVarchar()
     {
         // Odd index matches, otherwise doesn't
-        List<String> partitionFolders = List.of(
+        List<String> partitionFolders = com.google.common.collect.ImmutableList.of(
                 "year=2000/birth_month10/",
                 "state=Tamilnadu/",
                 "zone=EST/",
@@ -176,8 +176,8 @@ public class PartitionUtilTest
                 "month01/"
         );
         // mock
-        when(table.getParameters()).thenReturn(Map.of(PARTITION_PATTERN_KEY, "state=${stateName}/"));
-        List<Column> columns = List.of(
+        when(table.getParameters()).thenReturn(com.google.common.collect.ImmutableMap.of(PARTITION_PATTERN_KEY, "state=${stateName}/"));
+        List<Column> columns = com.google.common.collect.ImmutableList.of(
                 createColumn("stateName", "string")
         );
         when(table.getPartitionKeys()).thenReturn(columns);
@@ -200,7 +200,7 @@ public class PartitionUtilTest
     {
         String partitionPatten = "year=${year}/birth_month${month}/";
         // mock
-        when(table.getParameters()).thenReturn(Map.of(PARTITION_PATTERN_KEY, partitionPatten ));
+        when(table.getParameters()).thenReturn(com.google.common.collect.ImmutableMap.of(PARTITION_PATTERN_KEY, partitionPatten ));
         Optional<String> optionalRegEx = PartitionUtil.getRegExExpression(table);
         assertTrue(optionalRegEx.isPresent());
         Map<String, String> partitions = PartitionUtil.getPartitionColumnData(partitionPatten, "year=2000/birth_month09/", optionalRegEx.get(), table.getPartitionKeys());
@@ -217,7 +217,7 @@ public class PartitionUtilTest
     public void testGetHiveNonHivePartitions()
     {
         // mock
-        List<Column> columns = List.of(
+        List<Column> columns = com.google.common.collect.ImmutableList.of(
                 createColumn("year", "bigint"),
                 createColumn("month", "int"),
                 createColumn("day", "int")
@@ -225,7 +225,7 @@ public class PartitionUtilTest
         // mock
         when(table.getPartitionKeys()).thenReturn(columns);
         String partitionPatten = "year=${year}/birth_month${month}/${day}";
-        when(table.getParameters()).thenReturn(Map.of(PARTITION_PATTERN_KEY, partitionPatten + "/"));
+        when(table.getParameters()).thenReturn(com.google.common.collect.ImmutableMap.of(PARTITION_PATTERN_KEY, partitionPatten + "/"));
         Optional<String> optionalRegEx = PartitionUtil.getRegExExpression(table);
         assertTrue(optionalRegEx.isPresent());
         Map<String, String> partitions = PartitionUtil.getPartitionColumnData(partitionPatten, "year=2000/birth_month09/12/",
@@ -246,7 +246,7 @@ public class PartitionUtilTest
     public void testGetPartitionFolders()
     {
         // re-mock
-        List<Column> columns = List.of(
+        List<Column> columns = com.google.common.collect.ImmutableList.of(
                 createColumn("year", "bigint"),
                 createColumn("month", "int"),
                 createColumn("day", "int")
@@ -255,7 +255,7 @@ public class PartitionUtilTest
         String partitionPattern = "year=${year}/birth_month${month}/${day}";
 
         // list of folders in a bucket
-        List<String> bucketFolders = List.of(
+        List<String> bucketFolders = com.google.common.collect.ImmutableList.of(
                 "year=2000/birth_month09/12/",
                 "year=2000/birth_month09/abc",
                 "year=2001/birth_month12/20/",
@@ -282,16 +282,16 @@ public class PartitionUtilTest
     public void testHivePartition()
     {
         // re-mock
-        List<Column> columns = List.of(
+        List<Column> columns = com.google.common.collect.ImmutableList.of(
                 createColumn("statename", "string"),
                 createColumn("zipcode", "varchar")
         );
         when(table.getPartitionKeys()).thenReturn(columns);
         String partitionPattern = "StateName=${statename}/ZipCode=${zipcode}";
         // mock
-        when(table.getParameters()).thenReturn(Map.of(PARTITION_PATTERN_KEY, partitionPattern + "/"));
+        when(table.getParameters()).thenReturn(com.google.common.collect.ImmutableMap.of(PARTITION_PATTERN_KEY, partitionPattern + "/"));
         // list of folders in a bucket
-        List<String> bucketFolders = List.of(
+        List<String> bucketFolders = com.google.common.collect.ImmutableList.of(
                 "StateName=WB/ZipCode=700099/",
                 "year=2000/birth_month09/abc/",
                 "StateName=TN/ZipCode=600001/",
@@ -324,7 +324,7 @@ public class PartitionUtilTest
     public void testNonHivePartition()
     {
         // re-mock
-        List<Column> columns = List.of(
+        List<Column> columns = com.google.common.collect.ImmutableList.of(
                 createColumn("statename", "string"),
                 createColumn("district", "varchar"),
                 createColumn("zipcode", "string")
@@ -332,9 +332,9 @@ public class PartitionUtilTest
         when(table.getPartitionKeys()).thenReturn(columns);
         String partitionPattern = "${statename}/${district}/${zipcode}";
         // mock
-        when(table.getParameters()).thenReturn(Map.of(PARTITION_PATTERN_KEY, partitionPattern + "/"));
+        when(table.getParameters()).thenReturn(com.google.common.collect.ImmutableMap.of(PARTITION_PATTERN_KEY, partitionPattern + "/"));
         // list of folders in a bucket
-        List<String> bucketFolders = List.of(
+        List<String> bucketFolders = com.google.common.collect.ImmutableList.of(
                 "WB/Kolkata/700099/",
                 "year=2000/birth_month09/abc/",
                 "TN/DistrictChennai/600001/",
@@ -364,7 +364,7 @@ public class PartitionUtilTest
     public void testMixedLayoutStringOnlyPartition()
     {
         // re-mock
-        List<Column> columns = List.of(
+        List<Column> columns = com.google.common.collect.ImmutableList.of(
                 createColumn("statename", "string"),
                 createColumn("district", "varchar"),
                 createColumn("zipcode", "string")
@@ -372,9 +372,9 @@ public class PartitionUtilTest
         when(table.getPartitionKeys()).thenReturn(columns);
         String partitionPattern = "StateName=${statename}/District${district}/${zipcode}";
         // mock
-        when(table.getParameters()).thenReturn(Map.of(PARTITION_PATTERN_KEY, partitionPattern + "/"));
+        when(table.getParameters()).thenReturn(com.google.common.collect.ImmutableMap.of(PARTITION_PATTERN_KEY, partitionPattern + "/"));
         // list of folders in a bucket
-        List<String> bucketFolders = List.of(
+        List<String> bucketFolders = com.google.common.collect.ImmutableList.of(
                 "StateName=WB/DistrictKolkata/700099/",
                 "year=2000/birth_month09/abc/",
                 "StateName=TN/DistrictChennai/600001/",

--- a/athena-gcs/src/test/java/com/amazonaws/athena/connectors/gcs/filter/FilterExpressionBuilderTest.java
+++ b/athena-gcs/src/test/java/com/amazonaws/athena/connectors/gcs/filter/FilterExpressionBuilderTest.java
@@ -57,11 +57,11 @@ public class FilterExpressionBuilderTest
     public void testGetExpressions()
     {
         Map<String, java.util.Optional<java.util.Set<String>>> result = FilterExpressionBuilder.getConstraintsForPartitionedColumns(
-            List.of(new Column().withName("year")),
+            com.google.common.collect.ImmutableList.of(new Column().withName("year")),
             new Constraints(createSummaryWithLValueRangeEqual("year", new ArrowType.Utf8(), "1")));
         assertEquals(result.size(), 1);
-        assertEquals(result.get("year").get(), java.util.Set.of("1"));
-        assertEquals(result.get("yeAr").get(), java.util.Set.of("1"));
+        assertEquals(result.get("year").get(), com.google.common.collect.ImmutableSet.of("1"));
+        assertEquals(result.get("yeAr").get(), com.google.common.collect.ImmutableSet.of("1"));
     }
 
     public static Map<String, ValueSet> createSummaryWithLValueRangeEqual(String fieldName, ArrowType fieldType, Object fieldValue)
@@ -72,7 +72,7 @@ public class FilterExpressionBuilderTest
 
         Mockito.when(block.getFieldReader(anyString())).thenReturn(fieldReader);
         Marker low = Marker.exactly(new BlockAllocatorImpl(), new ArrowType.Utf8(), fieldValue);
-        return Map.of(
+        return com.google.common.collect.ImmutableMap.of(
                 fieldName, SortedRangeSet.of(false, new Range(low, low))
         );
     }

--- a/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryMetadataHandler.java
+++ b/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryMetadataHandler.java
@@ -156,7 +156,7 @@ public class BigQueryMetadataHandler
     @Override
     public GetTableResponse doGetTable(BlockAllocator blockAllocator, GetTableRequest getTableRequest) throws java.io.IOException
     {
-        var projectName = BigQueryUtils.getProjectName(getTableRequest.getCatalogName(), configOptions);
+        String projectName = BigQueryUtils.getProjectName(getTableRequest.getCatalogName(), configOptions);
 
         logger.info("doGetTable called with request {}. Resolved projectName: {}", getTableRequest, projectName);
 

--- a/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryUtils.java
+++ b/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryUtils.java
@@ -85,7 +85,7 @@ public class BigQueryUtils
 
     public static String getEnvBigQueryCredsSmId(java.util.Map<String, String> configOptions)
     {
-        var smid = configOptions.getOrDefault(BigQueryConstants.ENV_BIG_QUERY_CREDS_SM_ID, "");
+        String smid = configOptions.getOrDefault(BigQueryConstants.ENV_BIG_QUERY_CREDS_SM_ID, "");
         if (smid.isEmpty()) {
             throw new RuntimeException(String.format("Configuration variable: %s not set", BigQueryConstants.ENV_BIG_QUERY_CREDS_SM_ID));
         }

--- a/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryRecordHandlerTest.java
+++ b/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryRecordHandlerTest.java
@@ -140,7 +140,7 @@ public class BigQueryRecordHandlerTest
                 .build();
 
         schemaForRead = new Schema(BigQueryTestUtils.getTestSchemaFieldsArrow());
-        spillWriter = new S3BlockSpiller(amazonS3, spillConfig, allocator, schemaForRead, ConstraintEvaluator.emptyEvaluator(), java.util.Map.of());
+        spillWriter = new S3BlockSpiller(amazonS3, spillConfig, allocator, schemaForRead, ConstraintEvaluator.emptyEvaluator(), com.google.common.collect.ImmutableMap.of());
         spillReader = new S3BlockSpillReader(amazonS3, allocator);
 
         //Mock the BigQuery Client to return Datasets, and Table Schema information.
@@ -150,7 +150,7 @@ public class BigQueryRecordHandlerTest
         when(bigQuery.listTables(nullable(DatasetId.class))).thenReturn(tables);
 
         //The class we want to test.
-        bigQueryRecordHandler = new BigQueryRecordHandler(amazonS3, awsSecretsManager, athena, java.util.Map.of());
+        bigQueryRecordHandler = new BigQueryRecordHandler(amazonS3, awsSecretsManager, athena, com.google.common.collect.ImmutableMap.of());
 
         logger.info("Completed init.");
     }
@@ -211,7 +211,7 @@ public class BigQueryRecordHandlerTest
 
             //Execute the test
             bigQueryRecordHandler.readWithConstraint(spillWriter, request, queryStatusChecker);
-            logger.info("Project Name: "+BigQueryUtils.getProjectName(request.getCatalogName(), java.util.Map.of("gcp_project_id", "test")));
+            logger.info("Project Name: "+BigQueryUtils.getProjectName(request.getCatalogName(), com.google.common.collect.ImmutableMap.of("gcp_project_id", "test")));
 
             //Ensure that there was a spill so that we can read the spilled block.
             assertTrue(spillWriter.spilled());
@@ -280,7 +280,7 @@ public class BigQueryRecordHandlerTest
 
             //Execute the test
             bigQueryRecordHandler.readWithConstraint(spillWriter, request, queryStatusChecker);
-            logger.info("Project Name: "+BigQueryUtils.getProjectName(request.getCatalogName(), java.util.Map.of("gcp_project_id", "test")));
+            logger.info("Project Name: "+BigQueryUtils.getProjectName(request.getCatalogName(), com.google.common.collect.ImmutableMap.of("gcp_project_id", "test")));
 
         }
     }

--- a/athena-hbase/src/test/java/com/amazonaws/athena/connectors/hbase/HbaseMetadataHandlerTest.java
+++ b/athena-hbase/src/test/java/com/amazonaws/athena/connectors/hbase/HbaseMetadataHandlerTest.java
@@ -119,7 +119,7 @@ public class HbaseMetadataHandlerTest
                 mockConnFactory,
                 "spillBucket",
                 "spillPrefix",
-                java.util.Map.of());
+                com.google.common.collect.ImmutableMap.of());
 
         when(mockConnFactory.getOrCreateConn(nullable(String.class))).thenReturn(mockClient);
 

--- a/athena-hbase/src/test/java/com/amazonaws/athena/connectors/hbase/HbaseRecordHandlerTest.java
+++ b/athena-hbase/src/test/java/com/amazonaws/athena/connectors/hbase/HbaseRecordHandlerTest.java
@@ -169,7 +169,7 @@ public class HbaseRecordHandlerTest
 
         schemaForRead = TestUtils.makeSchema().addStringField(HbaseSchemaUtils.ROW_COLUMN_NAME).build();
 
-        handler = new HbaseRecordHandler(amazonS3, mockSecretsManager, mockAthena, mockConnFactory, java.util.Map.of());
+        handler = new HbaseRecordHandler(amazonS3, mockSecretsManager, mockAthena, mockConnFactory, com.google.common.collect.ImmutableMap.of());
         spillReader = new S3BlockSpillReader(amazonS3, allocator);
     }
 

--- a/athena-hortonworks-hive/src/test/java/com/amazonaws/athena/connectors/hortonworks/HiveMetadataHandlerTest.java
+++ b/athena-hortonworks-hive/src/test/java/com/amazonaws/athena/connectors/hortonworks/HiveMetadataHandlerTest.java
@@ -77,7 +77,7 @@ public class HiveMetadataHandlerTest
         this.secretsManager = Mockito.mock(AWSSecretsManager.class);
         this.athena = Mockito.mock(AmazonAthena.class);
         Mockito.when(this.secretsManager.getSecretValue(Mockito.eq(new GetSecretValueRequest().withSecretId("testSecret")))).thenReturn(new GetSecretValueResult().withSecretString("{\"username\": \"testUser\", \"password\": \"testPassword\"}"));
-        this.hiveMetadataHandler = new HiveMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, this.jdbcConnectionFactory, java.util.Map.of());
+        this.hiveMetadataHandler = new HiveMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, this.jdbcConnectionFactory, com.google.common.collect.ImmutableMap.of());
         this.federatedIdentity = Mockito.mock(FederatedIdentity.class);
 
     }
@@ -194,7 +194,7 @@ public class HiveMetadataHandlerTest
         JdbcConnectionFactory jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         Mockito.when(jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(connection);
         Mockito.when(connection.getMetaData().getSearchStringEscape()).thenThrow(new SQLException());
-        HiveMetadataHandler implalaMetadataHandler = new HiveMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, jdbcConnectionFactory, java.util.Map.of());
+        HiveMetadataHandler implalaMetadataHandler = new HiveMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, jdbcConnectionFactory, com.google.common.collect.ImmutableMap.of());
         implalaMetadataHandler.doGetTableLayout(Mockito.mock(BlockAllocator.class), getTableLayoutRequest);
     }
 

--- a/athena-hortonworks-hive/src/test/java/com/amazonaws/athena/connectors/hortonworks/HiveMuxMetadataHandlerTest.java
+++ b/athena-hortonworks-hive/src/test/java/com/amazonaws/athena/connectors/hortonworks/HiveMuxMetadataHandlerTest.java
@@ -74,7 +74,7 @@ public class HiveMuxMetadataHandlerTest
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", HiveConstants.HIVE_NAME,
                 "hive2://jdbc:hive2://54.89.6.2:10000/authena;AuthMech=3;${testSecret}", "testSecret");
-        this.jdbcMetadataHandler = new HiveMuxMetadataHandler(this.secretsManager, this.athena, this.jdbcConnectionFactory, this.metadataHandlerMap, databaseConnectionConfig, java.util.Map.of());
+        this.jdbcMetadataHandler = new HiveMuxMetadataHandler(this.secretsManager, this.athena, this.jdbcConnectionFactory, this.metadataHandlerMap, databaseConnectionConfig, com.google.common.collect.ImmutableMap.of());
     }
 
     @Test
@@ -116,7 +116,7 @@ public class HiveMuxMetadataHandlerTest
                 "hive2://jdbc:hive2://54.89.6.2:10000/authena;AuthMech=3;${testSecret}", "testSecret");
         try {
             new HiveMuxMetadataHandler(this.secretsManager, this.athena, this.jdbcConnectionFactory,
-                    metadataHandlersMap, databaseConnectionConfig, java.util.Map.of());
+                    metadataHandlersMap, databaseConnectionConfig, com.google.common.collect.ImmutableMap.of());
         } catch (Exception e) {
             e.getMessage();
             Assert.assertTrue(e.getMessage().contains("Max 100 catalogs supported in multiplexer."));

--- a/athena-hortonworks-hive/src/test/java/com/amazonaws/athena/connectors/hortonworks/HiveMuxRecordHandlerTest.java
+++ b/athena-hortonworks-hive/src/test/java/com/amazonaws/athena/connectors/hortonworks/HiveMuxRecordHandlerTest.java
@@ -71,7 +71,7 @@ public class HiveMuxRecordHandlerTest
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", HiveConstants.HIVE_NAME,
         		"hive2://jdbc:hive2://54.89.6.2:10000/authena;AuthMech=3;${testSecret}", "testSecret");
-        this.jdbcRecordHandler = new HiveMuxRecordHandler(this.amazonS3, this.secretsManager, this.athena, this.jdbcConnectionFactory, databaseConnectionConfig, this.recordHandlerMap, java.util.Map.of());
+        this.jdbcRecordHandler = new HiveMuxRecordHandler(this.amazonS3, this.secretsManager, this.athena, this.jdbcConnectionFactory, databaseConnectionConfig, this.recordHandlerMap, com.google.common.collect.ImmutableMap.of());
     }
 
     @Test
@@ -95,7 +95,7 @@ public class HiveMuxRecordHandlerTest
                 "hive2://jdbc:hive2://54.89.6.2:10000/authena;AuthMech=3;${testSecret}", "testSecret");
         try {
             new HiveMuxRecordHandler(this.amazonS3, this.secretsManager, this.athena,
-                    this.jdbcConnectionFactory, databaseConnectionConfig, recorddataHandlersMap, java.util.Map.of());
+                    this.jdbcConnectionFactory, databaseConnectionConfig, recorddataHandlersMap, com.google.common.collect.ImmutableMap.of());
         } catch (Exception e) {
             e.getMessage();
             Assert.assertTrue(e.getMessage().contains("Max 100 catalogs supported in multiplexer."));

--- a/athena-hortonworks-hive/src/test/java/com/amazonaws/athena/connectors/hortonworks/HiveRecordHandlerTest.java
+++ b/athena-hortonworks-hive/src/test/java/com/amazonaws/athena/connectors/hortonworks/HiveRecordHandlerTest.java
@@ -82,7 +82,7 @@ public class HiveRecordHandlerTest
         final DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", HiveConstants.HIVE_NAME,
                 "hive2://jdbc:hive2://54.89.6.2:10000/authena;AuthMech=3;UID=hive;PWD=hive");
 
-        this.hiveRecordHandler = new HiveRecordHandler(databaseConnectionConfig, amazonS3, secretsManager, athena, jdbcConnectionFactory, jdbcSplitQueryBuilder, java.util.Map.of());
+        this.hiveRecordHandler = new HiveRecordHandler(databaseConnectionConfig, amazonS3, secretsManager, athena, jdbcConnectionFactory, jdbcSplitQueryBuilder, com.google.common.collect.ImmutableMap.of());
     }
 
   

--- a/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/MultiplexingJdbcMetadataHandlerTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/MultiplexingJdbcMetadataHandlerTest.java
@@ -68,7 +68,7 @@ public class MultiplexingJdbcMetadataHandlerTest
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", "fakedatabase",
                 "fakedatabase://jdbc:fakedatabase://hostname/${testSecret}", "testSecret");
-        this.jdbcMetadataHandler = new MultiplexingJdbcMetadataHandler(this.secretsManager, this.athena, this.jdbcConnectionFactory, this.metadataHandlerMap, databaseConnectionConfig, java.util.Map.of());
+        this.jdbcMetadataHandler = new MultiplexingJdbcMetadataHandler(this.secretsManager, this.athena, this.jdbcConnectionFactory, this.metadataHandlerMap, databaseConnectionConfig, com.google.common.collect.ImmutableMap.of());
     }
 
     @Test

--- a/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/MultiplexingJdbcRecordHandlerTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/MultiplexingJdbcRecordHandlerTest.java
@@ -64,7 +64,7 @@ public class MultiplexingJdbcRecordHandlerTest
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", "fakedatabase",
                 "fakedatabase://jdbc:fakedatabase://hostname/${testSecret}", "testSecret");
-        this.jdbcRecordHandler = new MultiplexingJdbcRecordHandler(this.amazonS3, this.secretsManager, this.athena, this.jdbcConnectionFactory, databaseConnectionConfig, this.recordHandlerMap, java.util.Map.of());
+        this.jdbcRecordHandler = new MultiplexingJdbcRecordHandler(this.amazonS3, this.secretsManager, this.athena, this.jdbcConnectionFactory, databaseConnectionConfig, this.recordHandlerMap, com.google.common.collect.ImmutableMap.of());
     }
 
     @Test

--- a/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcArrowTypeConverterTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcArrowTypeConverterTest.java
@@ -29,29 +29,29 @@ public class JdbcArrowTypeConverterTest
     @Test
     public void toArrowType()
     {
-        Assert.assertEquals(Types.MinorType.BIT.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.BIT, 0, 0, java.util.Map.of()));
-        Assert.assertEquals(Types.MinorType.BIT.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.BOOLEAN, 0, 0, java.util.Map.of()));
-        Assert.assertEquals(Types.MinorType.TINYINT.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.TINYINT, 0, 0, java.util.Map.of()));
-        Assert.assertEquals(Types.MinorType.SMALLINT.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.SMALLINT, 0, 0, java.util.Map.of()));
-        Assert.assertEquals(Types.MinorType.INT.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.INTEGER, 0, 0, java.util.Map.of()));
-        Assert.assertEquals(Types.MinorType.BIGINT.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.BIGINT, 0, 0, java.util.Map.of()));
-        Assert.assertEquals(Types.MinorType.FLOAT4.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.REAL, 0, 0, java.util.Map.of()));
-        Assert.assertEquals(Types.MinorType.FLOAT4.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.FLOAT, 0, 0, java.util.Map.of()));
-        Assert.assertEquals(Types.MinorType.FLOAT8.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.DOUBLE, 0, 0, java.util.Map.of()));
-        Assert.assertEquals(new ArrowType.Decimal(5, 3), JdbcArrowTypeConverter.toArrowType(java.sql.Types.DECIMAL, 5, 3, java.util.Map.of()));
-        Assert.assertEquals(new ArrowType.Decimal(38, 0), JdbcArrowTypeConverter.toArrowType(java.sql.Types.NUMERIC, 0, 0, java.util.Map.of()));
-        Assert.assertEquals(Types.MinorType.VARCHAR.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.CHAR, 0, 0, java.util.Map.of()));
-        Assert.assertEquals(Types.MinorType.VARCHAR.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.NCHAR, 0, 0, java.util.Map.of()));
-        Assert.assertEquals(Types.MinorType.VARCHAR.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.VARCHAR, 0, 0, java.util.Map.of()));
-        Assert.assertEquals(Types.MinorType.VARCHAR.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.NVARCHAR, 0, 0, java.util.Map.of()));
-        Assert.assertEquals(Types.MinorType.VARCHAR.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.LONGVARCHAR, 0, 0, java.util.Map.of()));
-        Assert.assertEquals(Types.MinorType.VARCHAR.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.LONGNVARCHAR, 0, 0, java.util.Map.of()));
-        Assert.assertEquals(Types.MinorType.VARBINARY.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.BINARY, 0, 0, java.util.Map.of()));
-        Assert.assertEquals(Types.MinorType.VARBINARY.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.VARBINARY, 0, 0, java.util.Map.of()));
-        Assert.assertEquals(Types.MinorType.VARBINARY.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.LONGVARBINARY, 0, 0, java.util.Map.of()));
-        Assert.assertEquals(Types.MinorType.DATEDAY.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.DATE, 0, 0, java.util.Map.of()));
-        Assert.assertEquals(Types.MinorType.TIMEMILLI.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.TIME, 0, 0, java.util.Map.of()));
-        Assert.assertEquals(Types.MinorType.DATEMILLI.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.TIMESTAMP, 0, 0, java.util.Map.of()));
-        Assert.assertEquals(Types.MinorType.LIST.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.ARRAY, 0, 0, java.util.Map.of()));
+        Assert.assertEquals(Types.MinorType.BIT.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.BIT, 0, 0, com.google.common.collect.ImmutableMap.of()));
+        Assert.assertEquals(Types.MinorType.BIT.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.BOOLEAN, 0, 0, com.google.common.collect.ImmutableMap.of()));
+        Assert.assertEquals(Types.MinorType.TINYINT.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.TINYINT, 0, 0, com.google.common.collect.ImmutableMap.of()));
+        Assert.assertEquals(Types.MinorType.SMALLINT.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.SMALLINT, 0, 0, com.google.common.collect.ImmutableMap.of()));
+        Assert.assertEquals(Types.MinorType.INT.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.INTEGER, 0, 0, com.google.common.collect.ImmutableMap.of()));
+        Assert.assertEquals(Types.MinorType.BIGINT.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.BIGINT, 0, 0, com.google.common.collect.ImmutableMap.of()));
+        Assert.assertEquals(Types.MinorType.FLOAT4.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.REAL, 0, 0, com.google.common.collect.ImmutableMap.of()));
+        Assert.assertEquals(Types.MinorType.FLOAT4.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.FLOAT, 0, 0, com.google.common.collect.ImmutableMap.of()));
+        Assert.assertEquals(Types.MinorType.FLOAT8.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.DOUBLE, 0, 0, com.google.common.collect.ImmutableMap.of()));
+        Assert.assertEquals(new ArrowType.Decimal(5, 3), JdbcArrowTypeConverter.toArrowType(java.sql.Types.DECIMAL, 5, 3, com.google.common.collect.ImmutableMap.of()));
+        Assert.assertEquals(new ArrowType.Decimal(38, 0), JdbcArrowTypeConverter.toArrowType(java.sql.Types.NUMERIC, 0, 0, com.google.common.collect.ImmutableMap.of()));
+        Assert.assertEquals(Types.MinorType.VARCHAR.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.CHAR, 0, 0, com.google.common.collect.ImmutableMap.of()));
+        Assert.assertEquals(Types.MinorType.VARCHAR.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.NCHAR, 0, 0, com.google.common.collect.ImmutableMap.of()));
+        Assert.assertEquals(Types.MinorType.VARCHAR.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.VARCHAR, 0, 0, com.google.common.collect.ImmutableMap.of()));
+        Assert.assertEquals(Types.MinorType.VARCHAR.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.NVARCHAR, 0, 0, com.google.common.collect.ImmutableMap.of()));
+        Assert.assertEquals(Types.MinorType.VARCHAR.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.LONGVARCHAR, 0, 0, com.google.common.collect.ImmutableMap.of()));
+        Assert.assertEquals(Types.MinorType.VARCHAR.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.LONGNVARCHAR, 0, 0, com.google.common.collect.ImmutableMap.of()));
+        Assert.assertEquals(Types.MinorType.VARBINARY.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.BINARY, 0, 0, com.google.common.collect.ImmutableMap.of()));
+        Assert.assertEquals(Types.MinorType.VARBINARY.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.VARBINARY, 0, 0, com.google.common.collect.ImmutableMap.of()));
+        Assert.assertEquals(Types.MinorType.VARBINARY.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.LONGVARBINARY, 0, 0, com.google.common.collect.ImmutableMap.of()));
+        Assert.assertEquals(Types.MinorType.DATEDAY.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.DATE, 0, 0, com.google.common.collect.ImmutableMap.of()));
+        Assert.assertEquals(Types.MinorType.TIMEMILLI.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.TIME, 0, 0, com.google.common.collect.ImmutableMap.of()));
+        Assert.assertEquals(Types.MinorType.DATEMILLI.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.TIMESTAMP, 0, 0, com.google.common.collect.ImmutableMap.of()));
+        Assert.assertEquals(Types.MinorType.LIST.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.ARRAY, 0, 0, com.google.common.collect.ImmutableMap.of()));
     }
 }

--- a/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandlerTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandlerTest.java
@@ -85,7 +85,7 @@ public class JdbcMetadataHandlerTest
         Mockito.when(this.secretsManager.getSecretValue(Mockito.eq(new GetSecretValueRequest().withSecretId("testSecret")))).thenReturn(new GetSecretValueResult().withSecretString("{\"username\": \"testUser\", \"password\": \"testPassword\"}"));
         DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", "fakedatabase",
                 "fakedatabase://jdbc:fakedatabase://hostname/${testSecret}", "testSecret");
-        this.jdbcMetadataHandler = new JdbcMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, jdbcConnectionFactory, java.util.Map.of())
+        this.jdbcMetadataHandler = new JdbcMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, jdbcConnectionFactory, com.google.common.collect.ImmutableMap.of())
         {
             @Override
             public Schema getPartitionSchema(final String catalogName)

--- a/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcRecordHandlerTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcRecordHandlerTest.java
@@ -97,7 +97,7 @@ public class JdbcRecordHandlerTest
         Mockito.when(this.connection.prepareStatement("someSql")).thenReturn(this.preparedStatement);
         DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", "fakedatabase",
                 "fakedatabase://jdbc:fakedatabase://hostname/${testSecret}", "testSecret");
-        this.jdbcRecordHandler = new JdbcRecordHandler(this.amazonS3, this.secretsManager, this.athena, databaseConnectionConfig, this.jdbcConnectionFactory, java.util.Map.of())
+        this.jdbcRecordHandler = new JdbcRecordHandler(this.amazonS3, this.secretsManager, this.athena, databaseConnectionConfig, this.jdbcConnectionFactory, com.google.common.collect.ImmutableMap.of())
         {
             @Override
             public PreparedStatement buildSplitSql(Connection jdbcConnection, String catalogName, TableName tableName, Schema schema, Constraints constraints, Split split)
@@ -140,7 +140,7 @@ public class JdbcRecordHandlerTest
 
         SpillConfig spillConfig = Mockito.mock(SpillConfig.class);
         Mockito.when(spillConfig.getSpillLocation()).thenReturn(s3SpillLocation);
-        BlockSpiller s3Spiller = new S3BlockSpiller(this.amazonS3, spillConfig, allocator, fieldSchema, constraintEvaluator, java.util.Map.of());
+        BlockSpiller s3Spiller = new S3BlockSpiller(this.amazonS3, spillConfig, allocator, fieldSchema, constraintEvaluator, com.google.common.collect.ImmutableMap.of());
         ReadRecordsRequest readRecordsRequest = new ReadRecordsRequest(this.federatedIdentity, "testCatalog", "testQueryId", inputTableName, fieldSchema, splitBuilder.build(), constraints, 1024, 1024);
 
         Mockito.when(amazonS3.putObject(any())).thenAnswer((Answer<PutObjectResult>) invocation -> {

--- a/athena-kafka/src/main/java/com/amazonaws/athena/connectors/kafka/KafkaRecordHandler.java
+++ b/athena-kafka/src/main/java/com/amazonaws/athena/connectors/kafka/KafkaRecordHandler.java
@@ -44,7 +44,6 @@ import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 
 public class KafkaRecordHandler
@@ -86,7 +85,7 @@ public class KafkaRecordHandler
         try (Consumer<String, TopicResultSet> kafkaConsumer = KafkaUtils.getKafkaConsumer(recordsRequest.getSchema(), configOptions)) {
             // Set which topic and partition we are going to read.
             TopicPartition partition = new TopicPartition(splitParameters.topic, splitParameters.partition);
-            Collection<TopicPartition> partitions = List.of(partition);
+            Collection<TopicPartition> partitions = com.google.common.collect.ImmutableList.of(partition);
 
             // Assign the topic and partition into this consumer.
             kafkaConsumer.assign(partitions);

--- a/athena-kafka/src/test/java/com/amazonaws/athena/connectors/kafka/KafkaAbstractDeserializerTest.java
+++ b/athena-kafka/src/test/java/com/amazonaws/athena/connectors/kafka/KafkaAbstractDeserializerTest.java
@@ -40,7 +40,7 @@ public abstract class KafkaAbstractDeserializerTest
                     true,
                     KafkaUtils.toArrowType(it.getType()),
                     null,
-                    Map.of(
+                    com.google.common.collect.ImmutableMap.of(
                             "mapping", it.getMapping(),
                             "formatHint", it.getFormatHint(),
                             "type", it.getType()
@@ -62,7 +62,7 @@ public abstract class KafkaAbstractDeserializerTest
                     true,
                     KafkaUtils.toArrowType(it.getType()),
                     null,
-                    Map.of(
+                    com.google.common.collect.ImmutableMap.of(
                             "formatHint", it.getFormatHint(),
                             "type", it.getType()
                     )

--- a/athena-kafka/src/test/java/com/amazonaws/athena/connectors/kafka/KafkaCompositeHandlerTest.java
+++ b/athena-kafka/src/test/java/com/amazonaws/athena/connectors/kafka/KafkaCompositeHandlerTest.java
@@ -47,7 +47,7 @@ public class KafkaCompositeHandlerTest {
         System.setProperty("aws.region", "us-west-2");
     }
 
-    private java.util.Map<String, String> configOptions = java.util.Map.of(
+    private java.util.Map<String, String> configOptions = com.google.common.collect.ImmutableMap.of(
         "glue_registry_arn", "arn:aws:glue:us-west-2:123456789101:registry/Athena-Kafka",
         "bootstrap.servers", "test"
     );

--- a/athena-kafka/src/test/java/com/amazonaws/athena/connectors/kafka/KafkaMetadataHandlerTest.java
+++ b/athena-kafka/src/test/java/com/amazonaws/athena/connectors/kafka/KafkaMetadataHandlerTest.java
@@ -91,7 +91,7 @@ public class KafkaMetadataHandlerTest {
         partitions = Mockito.mock(Block.class);
         partitionCols = Mockito.mock(List.class);
         constraints = Mockito.mock(Constraints.class);
-        var configOptions = java.util.Map.of(
+        java.util.Map configOptions = com.google.common.collect.ImmutableMap.of(
             "aws.region", "us-west-2",
             "glue_registry_arn", "arn:aws:glue:us-west-2:123456789101:registry/Athena-NEW",
             "auth_type", KafkaUtils.AuthType.SSL.toString(),
@@ -101,11 +101,11 @@ public class KafkaMetadataHandlerTest {
             "secrets_manager_secret", "Kafka_afq");
 
         consumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
-        Map<TopicPartition, Long> partitionsStart = Map.of(
+        Map<TopicPartition, Long> partitionsStart = com.google.common.collect.ImmutableMap.of(
                 new TopicPartition("testTopic", 0), 0L,
                 new TopicPartition("testTopic", 1), 0L
         );
-        Map<TopicPartition, Long> partitionsEnd = Map.of(
+        Map<TopicPartition, Long> partitionsEnd = com.google.common.collect.ImmutableMap.of(
                 new TopicPartition("testTopic", 0), 20100L,
                 new TopicPartition("testTopic", 1), 7850L
         );
@@ -136,7 +136,7 @@ public class KafkaMetadataHandlerTest {
         ListSchemasRequest listSchemasRequest = new ListSchemasRequest(federatedIdentity, QUERY_ID, "default");
         ListSchemasResponse listSchemasResponse = kafkaMetadataHandler.doListSchemaNames(blockAllocator, listSchemasRequest);
 
-        assertEquals(new ArrayList(List.of("Asdf")), new ArrayList(listSchemasResponse.getSchemas()));
+        assertEquals(new ArrayList(com.google.common.collect.ImmutableList.of("Asdf")), new ArrayList(listSchemasResponse.getSchemas()));
     }
 
     @Test(expected = RuntimeException.class)

--- a/athena-kafka/src/test/java/com/amazonaws/athena/connectors/kafka/KafkaRecordHandlerTest.java
+++ b/athena-kafka/src/test/java/com/amazonaws/athena/connectors/kafka/KafkaRecordHandlerTest.java
@@ -127,7 +127,7 @@ public class KafkaRecordHandlerTest {
                 .withSpillLocation(s3SpillLocation)
                 .build();
         allocator = new BlockAllocatorImpl();
-        kafkaRecordHandler = new KafkaRecordHandler(amazonS3, awsSecretsManager, athena, java.util.Map.of());
+        kafkaRecordHandler = new KafkaRecordHandler(amazonS3, awsSecretsManager, athena, com.google.common.collect.ImmutableMap.of());
     }
 
     @Test
@@ -145,7 +145,7 @@ public class KafkaRecordHandlerTest {
         Schema schema = createSchema(createCsvTopicSchema());
 
         PowerMockito.mockStatic(KafkaUtils.class);
-        PowerMockito.when(KafkaUtils.getKafkaConsumer(schema, java.util.Map.of())).thenReturn(consumer);
+        PowerMockito.when(KafkaUtils.getKafkaConsumer(schema, com.google.common.collect.ImmutableMap.of())).thenReturn(consumer);
         PowerMockito.when(KafkaUtils.createSplitParam(anyMap())).thenReturn(splitParameters);
 
         ConstraintEvaluator evaluator = mock(ConstraintEvaluator.class);
@@ -159,7 +159,7 @@ public class KafkaRecordHandlerTest {
         when(queryStatusChecker.isQueryRunning()).thenReturn(true);
 
         ReadRecordsRequest request = createReadRecordsRequest(schema);
-        BlockSpiller spiller = new S3BlockSpiller(amazonS3, spillConfig, allocator, schema, ConstraintEvaluator.emptyEvaluator(), java.util.Map.of());
+        BlockSpiller spiller = new S3BlockSpiller(amazonS3, spillConfig, allocator, schema, ConstraintEvaluator.emptyEvaluator(), com.google.common.collect.ImmutableMap.of());
         kafkaRecordHandler.readWithConstraint(spiller, request, queryStatusChecker);
     }
 
@@ -178,7 +178,7 @@ public class KafkaRecordHandlerTest {
         Schema schema = createSchema(createCsvTopicSchema());
 
         PowerMockito.mockStatic(KafkaUtils.class);
-        PowerMockito.when(KafkaUtils.getKafkaConsumer(schema, java.util.Map.of())).thenReturn(consumer);
+        PowerMockito.when(KafkaUtils.getKafkaConsumer(schema, com.google.common.collect.ImmutableMap.of())).thenReturn(consumer);
         PowerMockito.when(KafkaUtils.createSplitParam(anyMap())).thenReturn(splitParameters);
 
         QueryStatusChecker queryStatusChecker = mock(QueryStatusChecker.class);
@@ -206,7 +206,7 @@ public class KafkaRecordHandlerTest {
         Schema schema = createSchema(createCsvTopicSchema());
 
         PowerMockito.mockStatic(KafkaUtils.class);
-        PowerMockito.when(KafkaUtils.getKafkaConsumer(schema, java.util.Map.of())).thenReturn(consumer);
+        PowerMockito.when(KafkaUtils.getKafkaConsumer(schema, com.google.common.collect.ImmutableMap.of())).thenReturn(consumer);
         PowerMockito.when(KafkaUtils.createSplitParam(anyMap())).thenReturn(splitParameters);
 
         ReadRecordsRequest request = createReadRecordsRequest(schema);
@@ -230,7 +230,7 @@ public class KafkaRecordHandlerTest {
         Schema schema = createSchema(createCsvTopicSchema());
 
         PowerMockito.mockStatic(KafkaUtils.class);
-        PowerMockito.when(KafkaUtils.getKafkaConsumer(schema, java.util.Map.of())).thenReturn(consumer);
+        PowerMockito.when(KafkaUtils.getKafkaConsumer(schema, com.google.common.collect.ImmutableMap.of())).thenReturn(consumer);
         PowerMockito.when(KafkaUtils.createSplitParam(anyMap())).thenReturn(splitParameters);
 
         QueryStatusChecker queryStatusChecker = mock(QueryStatusChecker.class);
@@ -282,7 +282,7 @@ public class KafkaRecordHandlerTest {
                     true,
                     KafkaUtils.toArrowType(it.getType()),
                     null,
-                    Map.of(
+                    com.google.common.collect.ImmutableMap.of(
                             "mapping", it.getMapping(),
                             "formatHint", it.getFormatHint(),
                             "type", it.getType()

--- a/athena-kafka/src/test/java/com/amazonaws/athena/connectors/kafka/KafkaUtilsTest.java
+++ b/athena-kafka/src/test/java/com/amazonaws/athena/connectors/kafka/KafkaUtilsTest.java
@@ -111,7 +111,7 @@ public class KafkaUtilsTest {
     @Mock
     AWSGlue awsGlue;
 
-    final java.util.Map<String, String> configOptions = Map.of(
+    final java.util.Map<String, String> configOptions = com.google.common.collect.ImmutableMap.of(
         "glue_registry_arn", "arn:aws:glue:us-west-2:123456789101:registry/Athena-Kafka",
         "secret_manager_kafka_creds_name", "testSecret",
         "kafka_endpoint", "12.207.18.179:9092",
@@ -159,12 +159,12 @@ public class KafkaUtilsTest {
         Mockito.when(amazonS3Client.getObject(any())).thenReturn(s3Obj);
         S3ObjectSummary s3 = new S3ObjectSummary();
         s3.setKey("test/key");
-        Mockito.when(oList.getObjectSummaries()).thenReturn(List.of(s3));
+        Mockito.when(oList.getObjectSummaries()).thenReturn(com.google.common.collect.ImmutableList.of(s3));
     }
 
     @Test
     public void testGetScramAuthKafkaProperties() throws Exception {
-        var testConfigOptions = new java.util.HashMap(configOptions);
+        java.util.HashMap testConfigOptions = new java.util.HashMap(configOptions);
         testConfigOptions.put("auth_type", KafkaUtils.AuthType.SASL_SSL_SCRAM_SHA512.toString());
         String sasljaasconfig = "org.apache.kafka.common.security.scram.ScramLoginModule required username=\"admin\" password=\"test\";";
         Properties properties = getKafkaProperties(testConfigOptions);
@@ -175,7 +175,7 @@ public class KafkaUtilsTest {
 
     @Test
     public void testGetSSLAuthKafkaProperties() throws Exception {
-        var testConfigOptions = new java.util.HashMap(configOptions);
+        java.util.HashMap testConfigOptions = new java.util.HashMap(configOptions);
         testConfigOptions.put("auth_type", KafkaUtils.AuthType.SSL.toString());
         Properties properties = getKafkaProperties(testConfigOptions);
         assertEquals("SSL", properties.get("security.protocol"));
@@ -202,7 +202,7 @@ public class KafkaUtilsTest {
 
     @Test
     public void testGetKafkaConsumerWithSchema() throws Exception {
-        var testConfigOptions = new java.util.HashMap(configOptions);
+        java.util.HashMap testConfigOptions = new java.util.HashMap(configOptions);
         testConfigOptions.put("auth_type", KafkaUtils.AuthType.NO_AUTH.toString());
         Field field = new Field("name", FieldType.nullable(new ArrowType.Utf8()), null);
         Map<String, String> metadataSchema = new HashMap<>();
@@ -214,7 +214,7 @@ public class KafkaUtilsTest {
 
     @Test
     public void testGetKafkaConsumer() throws Exception {
-        var testConfigOptions = new java.util.HashMap(configOptions);
+        java.util.HashMap testConfigOptions = new java.util.HashMap(configOptions);
         testConfigOptions.put("auth_type", KafkaUtils.AuthType.NO_AUTH.toString());
         Consumer<String, String> consumer = KafkaUtils.getKafkaConsumer(testConfigOptions);
         assertNotNull(consumer);
@@ -222,7 +222,7 @@ public class KafkaUtilsTest {
 
     @Test
     public void testCreateSplitParam() {
-        Map<String, String> params = Map.of(
+        Map<String, String> params = com.google.common.collect.ImmutableMap.of(
                 SplitParameters.TOPIC, "testTopic",
                 SplitParameters.PARTITION, "0",
                 SplitParameters.START_OFFSET, "0",
@@ -235,13 +235,13 @@ public class KafkaUtilsTest {
 
     @Test(expected = RuntimeException.class)
     public void testGetKafkaPropertiesForRuntimeException() throws Exception {
-        var testConfigOptions = new java.util.HashMap(configOptions);
+        java.util.HashMap testConfigOptions = new java.util.HashMap(configOptions);
         testConfigOptions.put("auth_type", "UNKNOWN");
         getKafkaProperties(testConfigOptions);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testGetKafkaPropertiesForIllegalArgumentException() throws Exception {
-        getKafkaProperties(java.util.Map.of());
+        getKafkaProperties(com.google.common.collect.ImmutableMap.of());
     }
 }

--- a/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/AmazonMskMetadataHandler.java
+++ b/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/AmazonMskMetadataHandler.java
@@ -39,10 +39,15 @@ import com.amazonaws.athena.connector.lambda.metadata.ListTablesResponse;
 import com.amazonaws.athena.connectors.msk.dto.SplitParameters;
 import com.amazonaws.athena.connectors.msk.dto.TopicPartitionPiece;
 import com.amazonaws.athena.connectors.msk.dto.TopicSchema;
+import com.amazonaws.services.glue.AWSGlue;
 import com.amazonaws.services.glue.AWSGlueClientBuilder;
 import com.amazonaws.services.glue.model.GetRegistryRequest;
+import com.amazonaws.services.glue.model.GetRegistryResult;
 import com.amazonaws.services.glue.model.ListRegistriesRequest;
+import com.amazonaws.services.glue.model.ListRegistriesResult;
+import com.amazonaws.services.glue.model.ListSchemasResult;
 import com.amazonaws.services.glue.model.RegistryId;
+import com.amazonaws.services.glue.model.RegistryListItem;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
@@ -83,6 +88,13 @@ public class AmazonMskMetadataHandler extends MetadataHandler
         this.kafkaConsumer = kafkaConsumer;
     }
 
+    private Stream<String> filteredRegistriesStream(Stream<RegistryListItem> registries)
+    {
+        return registries
+            .filter(r -> r.getDescription() != null && r.getDescription().contains(REGISTRY_MARKER))
+            .map(r -> r.getRegistryName());
+    }
+
     /**
      * It will list the schema name which is set to default.
      *
@@ -94,18 +106,17 @@ public class AmazonMskMetadataHandler extends MetadataHandler
     public ListSchemasResponse doListSchemaNames(BlockAllocator blockAllocator, ListSchemasRequest listSchemasRequest)
     {
         LOGGER.info("doListSchemaNames called with Catalog: {}", listSchemasRequest.getCatalogName());
-        var glue = AWSGlueClientBuilder.defaultClient();
-        var listRequest = new ListRegistriesRequest().withMaxResults(100);
-        var start = glue.listRegistries(listRequest);
-        List<String> registries = Stream.iterate(
-            start,
-            r -> r != null,
-            r -> (r.getNextToken() == null) ? null : glue.listRegistries(listRequest.withNextToken(r.getNextToken())))
-                .flatMap(r -> r.getRegistries().stream())
-                .filter(r -> r.getDescription() != null && r.getDescription().contains(REGISTRY_MARKER))
-                .map(r -> r.getRegistryName())
-                .collect(Collectors.toList());
-        var result = new ListSchemasResponse(listSchemasRequest.getCatalogName(), registries);
+        AWSGlue glue = AWSGlueClientBuilder.defaultClient();
+        Stream<String> allFilteredRegistries = Stream.empty();
+        for (ListRegistriesRequest listRequest = new ListRegistriesRequest().withMaxResults(100); listRequest != null; ) {
+            ListRegistriesResult currentResult = glue.listRegistries(listRequest);
+            // Setup the next request
+            String nextToken = currentResult.getNextToken();
+            listRequest = (nextToken == null) ? null : listRequest.withNextToken(nextToken);
+            // Concat the results from the current page
+            allFilteredRegistries = Stream.concat(allFilteredRegistries, filteredRegistriesStream(currentResult.getRegistries().stream()));
+        }
+        ListSchemasResponse result = new ListSchemasResponse(listSchemasRequest.getCatalogName(), allFilteredRegistries.collect(Collectors.toList()));
         LOGGER.debug("doListSchemaNames result: {}", result);
         return result;
     }
@@ -113,8 +124,8 @@ public class AmazonMskMetadataHandler extends MetadataHandler
     private String resolveGlueRegistryName(String glueRegistryName)
     {
         try {
-            var glue = AWSGlueClientBuilder.defaultClient();
-            var getRegistryResult = glue.getRegistry(new GetRegistryRequest().withRegistryId(new RegistryId().withRegistryName(glueRegistryName)));
+            AWSGlue glue = AWSGlueClientBuilder.defaultClient();
+            GetRegistryResult getRegistryResult = glue.getRegistry(new GetRegistryRequest().withRegistryId(new RegistryId().withRegistryName(glueRegistryName)));
             if (!(getRegistryResult.getDescription() != null && getRegistryResult.getDescription().contains(REGISTRY_MARKER))) {
                 throw new Exception(String.format("Found a registry with a matching name [%s] but not marked for AthenaFederationMSK", glueRegistryName));
             }
@@ -139,44 +150,50 @@ public class AmazonMskMetadataHandler extends MetadataHandler
         LOGGER.info("doListTables: {}", listTablesRequest);
         String glueRegistryNameResolved = resolveGlueRegistryName(listTablesRequest.getSchemaName());
         LOGGER.info("Resolved Glue registry name to: {}", glueRegistryNameResolved);
-        var glue = AWSGlueClientBuilder.defaultClient();
+        AWSGlue glue = AWSGlueClientBuilder.defaultClient();
         // In this situation we want to loop through all the pages to return up to the MAX_RESULTS size
         if (listTablesRequest.getPageSize() == UNLIMITED_PAGE_SIZE_VALUE) {
             LOGGER.info("Request page size is UNLIMITED_PAGE_SIZE_VALUE");
-            var listRequest = new com.amazonaws.services.glue.model.ListSchemasRequest()
-                .withRegistryId(new RegistryId().withRegistryName(glueRegistryNameResolved))
-                .withMaxResults(100);
-            var start = glue.listSchemas(listRequest);
-            List<TableName> tableNames = Stream.iterate(
-                start,
-                r -> r != null,
-                r -> (r.getNextToken() == null) ? null : glue.listSchemas(listRequest.withNextToken(r.getNextToken())))
-                    .flatMap(r -> r.getSchemas().stream())
-                    .limit(MAX_RESULTS + 1)
-                    .map(schemaListItem -> schemaListItem.getSchemaName())
-                    .map(glueSchemaName -> new TableName(glueRegistryNameResolved, glueSchemaName))
-                    .collect(Collectors.toList());
-            if (tableNames.size() > MAX_RESULTS) {
-                throw new RuntimeException(
-                    String.format("Exceeded maximum result size. Current doListTables result size: %d", tableNames.size()));
+            List<TableName> allTableNames = new ArrayList();
+            for (
+                com.amazonaws.services.glue.model.ListSchemasRequest listRequest = new com.amazonaws.services.glue.model.ListSchemasRequest()
+                    .withRegistryId(new RegistryId().withRegistryName(glueRegistryNameResolved))
+                    .withMaxResults(100);
+                listRequest != null;
+            ) {
+                ListSchemasResult currentResult = glue.listSchemas(listRequest);
+                // Setup the next request
+                String nextToken = currentResult.getNextToken();
+                listRequest = (nextToken == null) ? null : listRequest.withNextToken(nextToken);
+                // Append the results from the current page
+                allTableNames.addAll(
+                    currentResult.getSchemas().stream()
+                        .map(schemaListItem -> schemaListItem.getSchemaName())
+                        .map(glueSchemaName -> new TableName(glueRegistryNameResolved, glueSchemaName))
+                        .collect(Collectors.toList())
+                );
+                if (allTableNames.size() > MAX_RESULTS) {
+                    throw new RuntimeException(
+                        String.format("Exceeded maximum result size. Current doListTables result size: %d", allTableNames.size()));
+                }
             }
-            var result = new ListTablesResponse(listTablesRequest.getCatalogName(), tableNames, null);
+            ListTablesResponse result = new ListTablesResponse(listTablesRequest.getCatalogName(), allTableNames, null);
             LOGGER.debug("doListTables result: {}", result);
             return result;
         }
 
         // Otherwise don't retrieve all pages, just pass through the page token.
-        var pageSize = Math.min(listTablesRequest.getPageSize(), 100); // 100 is the maximum Glue allows
-        var listRequest = new com.amazonaws.services.glue.model.ListSchemasRequest()
+        int pageSize = Math.min(listTablesRequest.getPageSize(), 100); // 100 is the maximum Glue allows
+        com.amazonaws.services.glue.model.ListSchemasRequest listRequest = new com.amazonaws.services.glue.model.ListSchemasRequest()
             .withRegistryId(new RegistryId().withRegistryName(glueRegistryNameResolved))
             .withMaxResults(pageSize);
-        var listSchemasResult = glue.listSchemas(listRequest);
-        var tableNames = listSchemasResult.getSchemas()
+        ListSchemasResult listSchemasResult = glue.listSchemas(listRequest);
+        List<TableName> tableNames = listSchemasResult.getSchemas()
             .stream()
             .map(schemaListItem -> schemaListItem.getSchemaName())
             .map(glueSchemaName -> new TableName(glueRegistryNameResolved, glueSchemaName))
             .collect(Collectors.toList());
-        var result = new ListTablesResponse(listTablesRequest.getCatalogName(), tableNames, listSchemasResult.getNextToken());
+        ListTablesResponse result = new ListTablesResponse(listTablesRequest.getCatalogName(), tableNames, listSchemasResult.getNextToken());
         LOGGER.debug("doListTables [paginated] result: {}", result);
         return result;
     }
@@ -184,20 +201,24 @@ public class AmazonMskMetadataHandler extends MetadataHandler
     private String findGlueRegistryNameIgnoringCasing(String glueRegistryNameIn)
     {
         LOGGER.debug("findGlueRegistryNameIgnoringCasing {}", glueRegistryNameIn);
-        var glue = AWSGlueClientBuilder.defaultClient();
-        var listRequest = new ListRegistriesRequest().withMaxResults(100);
-        var start = glue.listRegistries(listRequest);
-        var result = Stream.iterate(
-            start,
-            r -> r != null,
-            r -> (r.getNextToken() == null) ? null : glue.listRegistries(listRequest.withNextToken(r.getNextToken())))
-                .flatMap(r -> r.getRegistries().stream())
-                .filter(r -> r.getDescription() != null && r.getDescription().contains(REGISTRY_MARKER))
-                .map(r -> r.getRegistryName())
-                .filter(r ->  r.equalsIgnoreCase(glueRegistryNameIn))
-                .findAny().get();
-        LOGGER.debug("findGlueRegistryNameIgnoringCasing result: {}", result);
-        return result;
+        AWSGlue glue = AWSGlueClientBuilder.defaultClient();
+        for (ListRegistriesRequest listRequest = new ListRegistriesRequest().withMaxResults(100); listRequest != null; ) {
+            ListRegistriesResult currentResult = glue.listRegistries(listRequest);
+            // Setup the next request
+            String nextToken = currentResult.getNextToken();
+            listRequest = (nextToken == null) ? null : listRequest.withNextToken(nextToken);
+            // Try to find the registry ignoring the case
+            java.util.Optional<String> result = filteredRegistriesStream(currentResult.getRegistries().stream())
+                .filter(r -> r.equalsIgnoreCase(glueRegistryNameIn))
+                .findAny();
+            // Continue searching through the other pages if we haven't found the registry yet
+            if (!result.isPresent()) {
+                continue;
+            }
+            LOGGER.debug("findGlueRegistryNameIgnoringCasing result: {}", result.get());
+            return result.get();
+        }
+        throw new RuntimeException(String.format("Could not find Glue Registry: %s", glueRegistryNameIn));
     }
 
     // Assumes that glueRegistryNameIn is already resolved to the right name
@@ -205,21 +226,31 @@ public class AmazonMskMetadataHandler extends MetadataHandler
     {
         LOGGER.debug("findGlueSchemaNameIgnoringCasing {} {}", glueRegistryNameIn, glueSchemaNameIn);
         // List all schemas under the input registry
-        var glue = AWSGlueClientBuilder.defaultClient();
-        var listSchemasRequest = new com.amazonaws.services.glue.model.ListSchemasRequest()
-            .withRegistryId(new RegistryId().withRegistryName(glueRegistryNameIn))
-            .withMaxResults(100);
-        var start = glue.listSchemas(listSchemasRequest);
-        var result = Stream.iterate(
-            start,
-            r -> r != null,
-            r -> (r.getNextToken() == null) ? null : glue.listSchemas(listSchemasRequest.withNextToken(r.getNextToken())))
-                .flatMap(r -> r.getSchemas().stream())
+        AWSGlue glue = AWSGlueClientBuilder.defaultClient();
+        for (
+            com.amazonaws.services.glue.model.ListSchemasRequest listRequest = new com.amazonaws.services.glue.model.ListSchemasRequest()
+                .withRegistryId(new RegistryId().withRegistryName(glueRegistryNameIn))
+                .withMaxResults(100);
+            listRequest != null;
+        ) {
+            ListSchemasResult currentResult = glue.listSchemas(listRequest);
+            // Setup the next request
+            String nextToken = currentResult.getNextToken();
+            listRequest = (nextToken == null) ? null : listRequest.withNextToken(nextToken);
+            // Find the schema name ignoring the case in this page
+            java.util.Optional<String> foundSchema = currentResult.getSchemas().stream()
                 .map(schemaListItem -> schemaListItem.getSchemaName())
                 .filter(glueSchemaName -> glueSchemaName.equalsIgnoreCase(glueSchemaNameIn))
-                .findAny().get();
-        LOGGER.debug("findGlueSchemaNameIgnoringCasing result: {}", result);
-        return result;
+                .findAny();
+            // Continue looking at the next page if not found
+            if (!foundSchema.isPresent()) {
+                continue;
+            }
+            // Return the found schema
+            LOGGER.debug("findGlueSchemaNameIgnoringCasing result: {}", foundSchema.get());
+            return foundSchema.get();
+        }
+        throw new RuntimeException(String.format("Could not find Glue Schema: %s", glueSchemaNameIn));
     }
 
     /**
@@ -244,7 +275,7 @@ public class AmazonMskMetadataHandler extends MetadataHandler
             String glueSchemaNameResolved = findGlueSchemaNameIgnoringCasing(glueRegistryNameResolved, getTableRequest.getTableName().getTableName());
             tableSchema = getSchema(glueRegistryNameResolved, glueSchemaNameResolved);
         }
-        var result = new GetTableResponse(
+        GetTableResponse result = new GetTableResponse(
             getTableRequest.getCatalogName(),
             new TableName(
                 tableSchema.getCustomMetadata().get("glueRegistryName"),
@@ -394,7 +425,7 @@ public class AmazonMskMetadataHandler extends MetadataHandler
                     true,
                     AmazonMskUtils.toArrowType(it.getType()),
                     null,
-                    Map.of(
+                    com.google.common.collect.ImmutableMap.of(
                             "mapping", it.getMapping(),
                             "formatHint", it.getFormatHint(),
                             "type", it.getType()

--- a/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/AmazonMskMetadataHandler.java
+++ b/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/AmazonMskMetadataHandler.java
@@ -71,6 +71,7 @@ import static com.amazonaws.athena.connectors.msk.AmazonMskConstants.MAX_RECORDS
 
 public class AmazonMskMetadataHandler extends MetadataHandler
 {
+    private static final int maxGluePageSize = 100;
     private static final long MAX_RESULTS = 100_000;
     private static final String REGISTRY_MARKER = "{AthenaFederationMSK}";
     private static final Logger LOGGER = LoggerFactory.getLogger(AmazonMskMetadataHandler.class);
@@ -95,6 +96,28 @@ public class AmazonMskMetadataHandler extends MetadataHandler
             .map(r -> r.getRegistryName());
     }
 
+    private ListRegistriesResult listRegistriesFromGlue(AWSGlue glue, String nextToken, boolean start)
+    {
+        if (!start && nextToken == null) {
+            return null;
+        }
+        ListRegistriesRequest listRequest = new ListRegistriesRequest().withMaxResults(maxGluePageSize);
+        listRequest = (nextToken == null) ? listRequest : listRequest.withNextToken(nextToken);
+        return glue.listRegistries(listRequest);
+    }
+
+    private ListSchemasResult listSchemasFromGlue(AWSGlue glue, String glueRegistryName, int pageSize, String nextToken, boolean start)
+    {
+        if (!start && nextToken == null) {
+            return null;
+        }
+        com.amazonaws.services.glue.model.ListSchemasRequest listRequest = new com.amazonaws.services.glue.model.ListSchemasRequest()
+            .withRegistryId(new RegistryId().withRegistryName(glueRegistryName))
+            .withMaxResults(Math.min(pageSize, maxGluePageSize));
+        listRequest = (nextToken == null) ? listRequest : listRequest.withNextToken(nextToken);
+        return glue.listSchemas(listRequest);
+    }
+
     /**
      * It will list the schema name which is set to default.
      *
@@ -108,11 +131,11 @@ public class AmazonMskMetadataHandler extends MetadataHandler
         LOGGER.info("doListSchemaNames called with Catalog: {}", listSchemasRequest.getCatalogName());
         AWSGlue glue = AWSGlueClientBuilder.defaultClient();
         Stream<String> allFilteredRegistries = Stream.empty();
-        for (ListRegistriesRequest listRequest = new ListRegistriesRequest().withMaxResults(100); listRequest != null; ) {
-            ListRegistriesResult currentResult = glue.listRegistries(listRequest);
-            // Setup the next request
-            String nextToken = currentResult.getNextToken();
-            listRequest = (nextToken == null) ? null : listRequest.withNextToken(nextToken);
+        for (
+            ListRegistriesResult currentResult = listRegistriesFromGlue(glue, null, true);
+            currentResult != null;
+            currentResult = listRegistriesFromGlue(glue, currentResult.getNextToken(), false)
+        ) {
             // Concat the results from the current page
             allFilteredRegistries = Stream.concat(allFilteredRegistries, filteredRegistriesStream(currentResult.getRegistries().stream()));
         }
@@ -141,30 +164,28 @@ public class AmazonMskMetadataHandler extends MetadataHandler
      * List all the tables. It pulls all the schema names from a Glue registry.
      *
      * @param blockAllocator - instance of {@link BlockAllocator}
-     * @param listTablesRequest - instance of {@link ListTablesRequest}
+     * @param federationListTablesRequest - instance of {@link ListTablesRequest}
      * @return {@link ListTablesResponse}
      */
     @Override
-    public ListTablesResponse doListTables(BlockAllocator blockAllocator, ListTablesRequest listTablesRequest)
+    public ListTablesResponse doListTables(BlockAllocator blockAllocator, ListTablesRequest federationListTablesRequest)
     {
-        LOGGER.info("doListTables: {}", listTablesRequest);
-        String glueRegistryNameResolved = resolveGlueRegistryName(listTablesRequest.getSchemaName());
+        LOGGER.info("doListTables: {}", federationListTablesRequest);
+        String glueRegistryNameResolved = resolveGlueRegistryName(federationListTablesRequest.getSchemaName());
         LOGGER.info("Resolved Glue registry name to: {}", glueRegistryNameResolved);
         AWSGlue glue = AWSGlueClientBuilder.defaultClient();
         // In this situation we want to loop through all the pages to return up to the MAX_RESULTS size
-        if (listTablesRequest.getPageSize() == UNLIMITED_PAGE_SIZE_VALUE) {
+        // And only do this if we don't have a token passed in, otherwise if we have a token that takes precedence
+        // over the fact that the page size was set to unlimited.
+        if (federationListTablesRequest.getPageSize() == UNLIMITED_PAGE_SIZE_VALUE &&
+                federationListTablesRequest.getNextToken() == null) {
             LOGGER.info("Request page size is UNLIMITED_PAGE_SIZE_VALUE");
             List<TableName> allTableNames = new ArrayList();
             for (
-                com.amazonaws.services.glue.model.ListSchemasRequest listRequest = new com.amazonaws.services.glue.model.ListSchemasRequest()
-                    .withRegistryId(new RegistryId().withRegistryName(glueRegistryNameResolved))
-                    .withMaxResults(100);
-                listRequest != null;
+                ListSchemasResult currentResult = listSchemasFromGlue(glue, glueRegistryNameResolved, maxGluePageSize, null, true);
+                currentResult != null;
+                currentResult = listSchemasFromGlue(glue, glueRegistryNameResolved, maxGluePageSize, currentResult.getNextToken(), false)
             ) {
-                ListSchemasResult currentResult = glue.listSchemas(listRequest);
-                // Setup the next request
-                String nextToken = currentResult.getNextToken();
-                listRequest = (nextToken == null) ? null : listRequest.withNextToken(nextToken);
                 // Append the results from the current page
                 allTableNames.addAll(
                     currentResult.getSchemas().stream()
@@ -177,23 +198,30 @@ public class AmazonMskMetadataHandler extends MetadataHandler
                         String.format("Exceeded maximum result size. Current doListTables result size: %d", allTableNames.size()));
                 }
             }
-            ListTablesResponse result = new ListTablesResponse(listTablesRequest.getCatalogName(), allTableNames, null);
+            ListTablesResponse result = new ListTablesResponse(federationListTablesRequest.getCatalogName(), allTableNames, null);
             LOGGER.debug("doListTables result: {}", result);
             return result;
         }
 
         // Otherwise don't retrieve all pages, just pass through the page token.
-        int pageSize = Math.min(listTablesRequest.getPageSize(), 100); // 100 is the maximum Glue allows
-        com.amazonaws.services.glue.model.ListSchemasRequest listRequest = new com.amazonaws.services.glue.model.ListSchemasRequest()
-            .withRegistryId(new RegistryId().withRegistryName(glueRegistryNameResolved))
-            .withMaxResults(pageSize);
-        ListSchemasResult listSchemasResult = glue.listSchemas(listRequest);
-        List<TableName> tableNames = listSchemasResult.getSchemas()
+        ListSchemasResult listSchemasResultFromGlue = listSchemasFromGlue(
+            glue,
+            glueRegistryNameResolved,
+            federationListTablesRequest.getPageSize(),
+            federationListTablesRequest.getNextToken(),
+            // always consider this as a starting rqeuest if the token is null
+            federationListTablesRequest.getNextToken() == null);
+        // Convert the glue response into our own federation response
+        List<TableName> tableNames = listSchemasResultFromGlue.getSchemas()
             .stream()
             .map(schemaListItem -> schemaListItem.getSchemaName())
             .map(glueSchemaName -> new TableName(glueRegistryNameResolved, glueSchemaName))
             .collect(Collectors.toList());
-        ListTablesResponse result = new ListTablesResponse(listTablesRequest.getCatalogName(), tableNames, listSchemasResult.getNextToken());
+        // Pass through whatever token we got from Glue to the user
+        ListTablesResponse result = new ListTablesResponse(
+            federationListTablesRequest.getCatalogName(),
+            tableNames,
+            listSchemasResultFromGlue.getNextToken());
         LOGGER.debug("doListTables [paginated] result: {}", result);
         return result;
     }
@@ -202,11 +230,11 @@ public class AmazonMskMetadataHandler extends MetadataHandler
     {
         LOGGER.debug("findGlueRegistryNameIgnoringCasing {}", glueRegistryNameIn);
         AWSGlue glue = AWSGlueClientBuilder.defaultClient();
-        for (ListRegistriesRequest listRequest = new ListRegistriesRequest().withMaxResults(100); listRequest != null; ) {
-            ListRegistriesResult currentResult = glue.listRegistries(listRequest);
-            // Setup the next request
-            String nextToken = currentResult.getNextToken();
-            listRequest = (nextToken == null) ? null : listRequest.withNextToken(nextToken);
+        for (
+            ListRegistriesResult currentResult = listRegistriesFromGlue(glue, null, true);
+            currentResult != null;
+            currentResult = listRegistriesFromGlue(glue, currentResult.getNextToken(), false)
+        ) {
             // Try to find the registry ignoring the case
             java.util.Optional<String> result = filteredRegistriesStream(currentResult.getRegistries().stream())
                 .filter(r -> r.equalsIgnoreCase(glueRegistryNameIn))
@@ -228,15 +256,10 @@ public class AmazonMskMetadataHandler extends MetadataHandler
         // List all schemas under the input registry
         AWSGlue glue = AWSGlueClientBuilder.defaultClient();
         for (
-            com.amazonaws.services.glue.model.ListSchemasRequest listRequest = new com.amazonaws.services.glue.model.ListSchemasRequest()
-                .withRegistryId(new RegistryId().withRegistryName(glueRegistryNameIn))
-                .withMaxResults(100);
-            listRequest != null;
+            ListSchemasResult currentResult = listSchemasFromGlue(glue, glueRegistryNameIn, maxGluePageSize, null, true);
+            currentResult != null;
+            currentResult = listSchemasFromGlue(glue, glueRegistryNameIn, maxGluePageSize, currentResult.getNextToken(), false)
         ) {
-            ListSchemasResult currentResult = glue.listSchemas(listRequest);
-            // Setup the next request
-            String nextToken = currentResult.getNextToken();
-            listRequest = (nextToken == null) ? null : listRequest.withNextToken(nextToken);
             // Find the schema name ignoring the case in this page
             java.util.Optional<String> foundSchema = currentResult.getSchemas().stream()
                 .map(schemaListItem -> schemaListItem.getSchemaName())

--- a/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/AmazonMskRecordHandler.java
+++ b/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/AmazonMskRecordHandler.java
@@ -44,7 +44,6 @@ import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 
 public class AmazonMskRecordHandler
@@ -86,7 +85,7 @@ public class AmazonMskRecordHandler
         try (Consumer<String, TopicResultSet> kafkaConsumer = AmazonMskUtils.getKafkaConsumer(recordsRequest.getSchema(), configOptions)) {
             // Set which topic and partition we are going to read.
             TopicPartition partition = new TopicPartition(splitParameters.topic, splitParameters.partition);
-            Collection<TopicPartition> partitions = List.of(partition);
+            Collection<TopicPartition> partitions = com.google.common.collect.ImmutableList.of(partition);
 
             // Assign the topic and partition into this consumer.
             kafkaConsumer.assign(partitions);

--- a/athena-msk/src/test/java/com/amazonaws/athena/connectors/msk/AmazonMskCompositeHandlerTest.java
+++ b/athena-msk/src/test/java/com/amazonaws/athena/connectors/msk/AmazonMskCompositeHandlerTest.java
@@ -47,7 +47,7 @@ public class AmazonMskCompositeHandlerTest {
         System.setProperty("aws.region", "us-west-2");
     }
 
-    private java.util.Map<String, String> configOptions = java.util.Map.of(
+    private java.util.Map<String, String> configOptions = com.google.common.collect.ImmutableMap.of(
         "glue_registry_arn", "arn:aws:glue:us-west-2:123456789101:registry/Athena-Kafka",
         "bootstrap.servers", "test"
     );

--- a/athena-msk/src/test/java/com/amazonaws/athena/connectors/msk/AmazonMskMetadataHandlerTest.java
+++ b/athena-msk/src/test/java/com/amazonaws/athena/connectors/msk/AmazonMskMetadataHandlerTest.java
@@ -91,7 +91,7 @@ public class AmazonMskMetadataHandlerTest {
         partitions = Mockito.mock(Block.class);
         partitionCols = Mockito.mock(List.class);
         constraints = Mockito.mock(Constraints.class);
-        var configOptions = java.util.Map.of(
+        java.util.Map configOptions = com.google.common.collect.ImmutableMap.of(
             "aws.region", "us-west-2",
             "glue_registry_arn", "arn:aws:glue:us-west-2:123456789101:registry/Athena-NEW",
             "auth_type", AmazonMskUtils.AuthType.SSL.toString(),
@@ -101,11 +101,11 @@ public class AmazonMskMetadataHandlerTest {
             "secrets_manager_secret", "AmazonMSK_afq");
 
         consumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
-        Map<TopicPartition, Long> partitionsStart = Map.of(
+        Map<TopicPartition, Long> partitionsStart = com.google.common.collect.ImmutableMap.of(
                 new TopicPartition("testTopic", 0), 0L,
                 new TopicPartition("testTopic", 1), 0L
         );
-        Map<TopicPartition, Long> partitionsEnd = Map.of(
+        Map<TopicPartition, Long> partitionsEnd = com.google.common.collect.ImmutableMap.of(
                 new TopicPartition("testTopic", 0), 20100L,
                 new TopicPartition("testTopic", 1), 7850L
         );
@@ -136,7 +136,7 @@ public class AmazonMskMetadataHandlerTest {
         ListSchemasRequest listSchemasRequest = new ListSchemasRequest(federatedIdentity, QUERY_ID, "default");
         ListSchemasResponse listSchemasResponse = amazonMskMetadataHandler.doListSchemaNames(blockAllocator, listSchemasRequest);
 
-        assertEquals(new ArrayList(List.of("Asdf")), new ArrayList(listSchemasResponse.getSchemas()));
+        assertEquals(new ArrayList(com.google.common.collect.ImmutableList.of("Asdf")), new ArrayList(listSchemasResponse.getSchemas()));
     }
 
     @Test(expected = RuntimeException.class)

--- a/athena-msk/src/test/java/com/amazonaws/athena/connectors/msk/AmazonMskRecordHandlerTest.java
+++ b/athena-msk/src/test/java/com/amazonaws/athena/connectors/msk/AmazonMskRecordHandlerTest.java
@@ -127,7 +127,7 @@ public class AmazonMskRecordHandlerTest {
                 .withSpillLocation(s3SpillLocation)
                 .build();
         allocator = new BlockAllocatorImpl();
-        amazonMskRecordHandler = new AmazonMskRecordHandler(amazonS3, awsSecretsManager, athena, java.util.Map.of());
+        amazonMskRecordHandler = new AmazonMskRecordHandler(amazonS3, awsSecretsManager, athena, com.google.common.collect.ImmutableMap.of());
     }
 
     @Test
@@ -145,7 +145,7 @@ public class AmazonMskRecordHandlerTest {
         Schema schema = createSchema(createCsvTopicSchema());
 
         PowerMockito.mockStatic(AmazonMskUtils.class);
-        PowerMockito.when(AmazonMskUtils.getKafkaConsumer(schema, java.util.Map.of())).thenReturn(consumer);
+        PowerMockito.when(AmazonMskUtils.getKafkaConsumer(schema, com.google.common.collect.ImmutableMap.of())).thenReturn(consumer);
         PowerMockito.when(AmazonMskUtils.createSplitParam(anyMap())).thenReturn(splitParameters);
 
         ConstraintEvaluator evaluator = mock(ConstraintEvaluator.class);
@@ -159,7 +159,7 @@ public class AmazonMskRecordHandlerTest {
         when(queryStatusChecker.isQueryRunning()).thenReturn(true);
 
         ReadRecordsRequest request = createReadRecordsRequest(schema);
-        BlockSpiller spiller = new S3BlockSpiller(amazonS3, spillConfig, allocator, schema, ConstraintEvaluator.emptyEvaluator(), java.util.Map.of());
+        BlockSpiller spiller = new S3BlockSpiller(amazonS3, spillConfig, allocator, schema, ConstraintEvaluator.emptyEvaluator(), com.google.common.collect.ImmutableMap.of());
         amazonMskRecordHandler.readWithConstraint(spiller, request, queryStatusChecker);
     }
 
@@ -178,7 +178,7 @@ public class AmazonMskRecordHandlerTest {
         Schema schema = createSchema(createCsvTopicSchema());
 
         PowerMockito.mockStatic(AmazonMskUtils.class);
-        PowerMockito.when(AmazonMskUtils.getKafkaConsumer(schema, java.util.Map.of())).thenReturn(consumer);
+        PowerMockito.when(AmazonMskUtils.getKafkaConsumer(schema, com.google.common.collect.ImmutableMap.of())).thenReturn(consumer);
         PowerMockito.when(AmazonMskUtils.createSplitParam(anyMap())).thenReturn(splitParameters);
 
         QueryStatusChecker queryStatusChecker = mock(QueryStatusChecker.class);
@@ -206,7 +206,7 @@ public class AmazonMskRecordHandlerTest {
         Schema schema = createSchema(createCsvTopicSchema());
 
         PowerMockito.mockStatic(AmazonMskUtils.class);
-        PowerMockito.when(AmazonMskUtils.getKafkaConsumer(schema, java.util.Map.of())).thenReturn(consumer);
+        PowerMockito.when(AmazonMskUtils.getKafkaConsumer(schema, com.google.common.collect.ImmutableMap.of())).thenReturn(consumer);
         PowerMockito.when(AmazonMskUtils.createSplitParam(anyMap())).thenReturn(splitParameters);
 
         ReadRecordsRequest request = createReadRecordsRequest(schema);
@@ -230,7 +230,7 @@ public class AmazonMskRecordHandlerTest {
         Schema schema = createSchema(createCsvTopicSchema());
 
         PowerMockito.mockStatic(AmazonMskUtils.class);
-        PowerMockito.when(AmazonMskUtils.getKafkaConsumer(schema, java.util.Map.of())).thenReturn(consumer);
+        PowerMockito.when(AmazonMskUtils.getKafkaConsumer(schema, com.google.common.collect.ImmutableMap.of())).thenReturn(consumer);
         PowerMockito.when(AmazonMskUtils.createSplitParam(anyMap())).thenReturn(splitParameters);
 
         QueryStatusChecker queryStatusChecker = mock(QueryStatusChecker.class);
@@ -282,7 +282,7 @@ public class AmazonMskRecordHandlerTest {
                     true,
                     AmazonMskUtils.toArrowType(it.getType()),
                     null,
-                    Map.of(
+                    com.google.common.collect.ImmutableMap.of(
                             "mapping", it.getMapping(),
                             "formatHint", it.getFormatHint(),
                             "type", it.getType()

--- a/athena-msk/src/test/java/com/amazonaws/athena/connectors/msk/AmazonMskUtilsTest.java
+++ b/athena-msk/src/test/java/com/amazonaws/athena/connectors/msk/AmazonMskUtilsTest.java
@@ -111,7 +111,7 @@ public class AmazonMskUtilsTest {
     @Mock
     AWSGlue awsGlue;
 
-    final java.util.Map<String, String> configOptions = Map.of(
+    final java.util.Map<String, String> configOptions = com.google.common.collect.ImmutableMap.of(
         "glue_registry_arn", "arn:aws:glue:us-west-2:123456789101:registry/Athena-Kafka",
         "secret_manager_kafka_creds_name", "testSecret",
         "kafka_endpoint", "12.207.18.179:9092",
@@ -158,12 +158,12 @@ public class AmazonMskUtilsTest {
         Mockito.when(amazonS3Client.getObject(any())).thenReturn(s3Obj);
         S3ObjectSummary s3 = new S3ObjectSummary();
         s3.setKey("test/key");
-        Mockito.when(oList.getObjectSummaries()).thenReturn(List.of(s3));
+        Mockito.when(oList.getObjectSummaries()).thenReturn(com.google.common.collect.ImmutableList.of(s3));
     }
 
     @Test
     public void testGetScramAuthKafkaProperties() throws Exception {
-        var testConfigOptions = new java.util.HashMap(configOptions);
+        java.util.HashMap testConfigOptions = new java.util.HashMap(configOptions);
         testConfigOptions.put("auth_type", AmazonMskUtils.AuthType.SASL_SSL_SCRAM_SHA512.toString());
         String sasljaasconfig = "org.apache.kafka.common.security.scram.ScramLoginModule required username=\"admin\" password=\"test\";";
         Properties properties = getKafkaProperties(testConfigOptions);
@@ -174,7 +174,7 @@ public class AmazonMskUtilsTest {
 
     @Test
     public void testGetIAMAuthKafkaProperties() throws Exception {
-        var testConfigOptions = new java.util.HashMap(configOptions);
+        java.util.HashMap testConfigOptions = new java.util.HashMap(configOptions);
         testConfigOptions.put("auth_type", AmazonMskUtils.AuthType.SASL_SSL_AWS_MSK_IAM.toString());
         Properties properties = getKafkaProperties(testConfigOptions);
         assertEquals("SASL_SSL", properties.get("security.protocol"));
@@ -185,7 +185,7 @@ public class AmazonMskUtilsTest {
 
     @Test
     public void testGetSSLAuthKafkaProperties() throws Exception {
-        var testConfigOptions = new java.util.HashMap(configOptions);
+        java.util.HashMap testConfigOptions = new java.util.HashMap(configOptions);
         testConfigOptions.put("auth_type", AmazonMskUtils.AuthType.SSL.toString());
         Properties properties = getKafkaProperties(testConfigOptions);
         assertEquals("SSL", properties.get("security.protocol"));
@@ -212,7 +212,7 @@ public class AmazonMskUtilsTest {
 
     @Test
     public void testGetKafkaConsumerWithSchema() throws Exception {
-        var testConfigOptions = new java.util.HashMap(configOptions);
+        java.util.HashMap testConfigOptions = new java.util.HashMap(configOptions);
         testConfigOptions.put("auth_type", AmazonMskUtils.AuthType.NO_AUTH.toString());
         Field field = new Field("name", FieldType.nullable(new ArrowType.Utf8()), null);
         Map<String, String> metadataSchema = new HashMap<>();
@@ -224,7 +224,7 @@ public class AmazonMskUtilsTest {
 
     @Test
     public void testGetKafkaConsumer() throws Exception {
-        var testConfigOptions = new java.util.HashMap(configOptions);
+        java.util.HashMap testConfigOptions = new java.util.HashMap(configOptions);
         testConfigOptions.put("auth_type", AmazonMskUtils.AuthType.NO_AUTH.toString());
         Consumer<String, String> consumer = AmazonMskUtils.getKafkaConsumer(testConfigOptions);
         assertNotNull(consumer);
@@ -232,7 +232,7 @@ public class AmazonMskUtilsTest {
 
     @Test
     public void testCreateSplitParam() {
-        Map<String, String> params = Map.of(
+        Map<String, String> params = com.google.common.collect.ImmutableMap.of(
                 SplitParameters.TOPIC, "testTopic",
                 SplitParameters.PARTITION, "0",
                 SplitParameters.START_OFFSET, "0",
@@ -245,13 +245,13 @@ public class AmazonMskUtilsTest {
 
     @Test(expected = RuntimeException.class)
     public void testGetKafkaPropertiesForRuntimeException() throws Exception {
-        var testConfigOptions = new java.util.HashMap(configOptions);
+        java.util.HashMap testConfigOptions = new java.util.HashMap(configOptions);
         testConfigOptions.put("auth_type", "UNKNOWN");
         getKafkaProperties(testConfigOptions);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testGetKafkaPropertiesForIllegalArgumentException() throws Exception {
-        getKafkaProperties(java.util.Map.of());
+        getKafkaProperties(com.google.common.collect.ImmutableMap.of());
     }
 }

--- a/athena-msk/src/test/java/com/amazonaws/athena/connectors/msk/MskAbstractDeserializerTest.java
+++ b/athena-msk/src/test/java/com/amazonaws/athena/connectors/msk/MskAbstractDeserializerTest.java
@@ -40,7 +40,7 @@ public abstract class MskAbstractDeserializerTest
                     true,
                     AmazonMskUtils.toArrowType(it.getType()),
                     null,
-                    Map.of(
+                    com.google.common.collect.ImmutableMap.of(
                             "mapping", it.getMapping(),
                             "formatHint", it.getFormatHint(),
                             "type", it.getType()
@@ -62,7 +62,7 @@ public abstract class MskAbstractDeserializerTest
                     true,
                     AmazonMskUtils.toArrowType(it.getType()),
                     null,
-                    Map.of(
+                    com.google.common.collect.ImmutableMap.of(
                             "formatHint", it.getFormatHint(),
                             "type", it.getType()
                     )

--- a/athena-mysql/src/test/java/com/amazonaws/athena/connectors/mysql/MySqlMetadataHandlerTest.java
+++ b/athena-mysql/src/test/java/com/amazonaws/athena/connectors/mysql/MySqlMetadataHandlerTest.java
@@ -87,7 +87,7 @@ public class MySqlMetadataHandlerTest
         this.secretsManager = Mockito.mock(AWSSecretsManager.class);
         this.athena = Mockito.mock(AmazonAthena.class);
         Mockito.when(this.secretsManager.getSecretValue(Mockito.eq(new GetSecretValueRequest().withSecretId("testSecret")))).thenReturn(new GetSecretValueResult().withSecretString("{\"username\": \"testUser\", \"password\": \"testPassword\"}"));
-        this.mySqlMetadataHandler = new MySqlMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, this.jdbcConnectionFactory, java.util.Map.of());
+        this.mySqlMetadataHandler = new MySqlMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, this.jdbcConnectionFactory, com.google.common.collect.ImmutableMap.of());
         this.federatedIdentity = Mockito.mock(FederatedIdentity.class);
     }
 
@@ -197,7 +197,7 @@ public class MySqlMetadataHandlerTest
         JdbcConnectionFactory jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         Mockito.when(jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(connection);
         Mockito.when(connection.getMetaData().getSearchStringEscape()).thenThrow(new SQLException());
-        MySqlMetadataHandler mySqlMetadataHandler = new MySqlMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, jdbcConnectionFactory, java.util.Map.of());
+        MySqlMetadataHandler mySqlMetadataHandler = new MySqlMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, jdbcConnectionFactory, com.google.common.collect.ImmutableMap.of());
 
         mySqlMetadataHandler.doGetTableLayout(Mockito.mock(BlockAllocator.class), getTableLayoutRequest);
     }

--- a/athena-mysql/src/test/java/com/amazonaws/athena/connectors/mysql/MySqlMuxJdbcMetadataHandlerTest.java
+++ b/athena-mysql/src/test/java/com/amazonaws/athena/connectors/mysql/MySqlMuxJdbcMetadataHandlerTest.java
@@ -68,7 +68,7 @@ public class MySqlMuxJdbcMetadataHandlerTest
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", "fakedatabase",
                 "fakedatabase://jdbc:fakedatabase://hostname/${testSecret}", "testSecret");
-        this.jdbcMetadataHandler = new MySqlMuxMetadataHandler(this.secretsManager, this.athena, this.jdbcConnectionFactory, this.metadataHandlerMap, databaseConnectionConfig, java.util.Map.of());
+        this.jdbcMetadataHandler = new MySqlMuxMetadataHandler(this.secretsManager, this.athena, this.jdbcConnectionFactory, this.metadataHandlerMap, databaseConnectionConfig, com.google.common.collect.ImmutableMap.of());
     }
 
     @Test

--- a/athena-mysql/src/test/java/com/amazonaws/athena/connectors/mysql/MySqlMuxJdbcRecordHandlerTest.java
+++ b/athena-mysql/src/test/java/com/amazonaws/athena/connectors/mysql/MySqlMuxJdbcRecordHandlerTest.java
@@ -64,7 +64,7 @@ public class MySqlMuxJdbcRecordHandlerTest
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", "mysql",
                 "mysql://jdbc:mysql://hostname/${testSecret}", "testSecret");
-        this.jdbcRecordHandler = new MySqlMuxRecordHandler(this.amazonS3, this.secretsManager, this.athena, this.jdbcConnectionFactory, databaseConnectionConfig, this.recordHandlerMap, java.util.Map.of());
+        this.jdbcRecordHandler = new MySqlMuxRecordHandler(this.amazonS3, this.secretsManager, this.athena, this.jdbcConnectionFactory, databaseConnectionConfig, this.recordHandlerMap, com.google.common.collect.ImmutableMap.of());
     }
 
     @Test

--- a/athena-mysql/src/test/java/com/amazonaws/athena/connectors/mysql/MySqlRecordHandlerTest.java
+++ b/athena-mysql/src/test/java/com/amazonaws/athena/connectors/mysql/MySqlRecordHandlerTest.java
@@ -76,7 +76,7 @@ public class MySqlRecordHandlerTest
         final DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", MYSQL_NAME,
                 "mysql://jdbc:mysql://hostname/user=A&password=B");
 
-        this.mySqlRecordHandler = new MySqlRecordHandler(databaseConnectionConfig, amazonS3, secretsManager, athena, jdbcConnectionFactory, jdbcSplitQueryBuilder, java.util.Map.of());
+        this.mySqlRecordHandler = new MySqlRecordHandler(databaseConnectionConfig, amazonS3, secretsManager, athena, jdbcConnectionFactory, jdbcSplitQueryBuilder, com.google.common.collect.ImmutableMap.of());
     }
 
     @Test

--- a/athena-neptune/src/test/java/com/amazonaws/athena/connectors/neptune/NeptuneMetadataHandlerTest.java
+++ b/athena-neptune/src/test/java/com/amazonaws/athena/connectors/neptune/NeptuneMetadataHandlerTest.java
@@ -86,7 +86,7 @@ public class NeptuneMetadataHandlerTest extends TestBase {
         allocator = new BlockAllocatorImpl();
         handler = new NeptuneMetadataHandler(glue,neptuneConnection,
                 new LocalKeyFactory(), mock(AWSSecretsManager.class), mock(AmazonAthena.class), "spill-bucket",
-                "spill-prefix", java.util.Map.of());
+                "spill-prefix", com.google.common.collect.ImmutableMap.of());
         logger.info("setUpBefore - exit");
     }
 

--- a/athena-neptune/src/test/java/com/amazonaws/athena/connectors/neptune/NeptuneRecordHandlerTest.java
+++ b/athena-neptune/src/test/java/com/amazonaws/athena/connectors/neptune/NeptuneRecordHandlerTest.java
@@ -173,7 +173,7 @@ public class NeptuneRecordHandlerTest extends TestBase {
                         return mockObject;
                 });
 
-                handler = new NeptuneRecordHandler(amazonS3, awsSecretsManager, athena, neptuneConnection, java.util.Map.of());
+                handler = new NeptuneRecordHandler(amazonS3, awsSecretsManager, athena, neptuneConnection, com.google.common.collect.ImmutableMap.of());
                 spillReader = new S3BlockSpillReader(amazonS3, allocator);
         }
 

--- a/athena-oracle/src/test/java/com/amazonaws/athena/connectors/oracle/OracleMetadataHandlerTest.java
+++ b/athena-oracle/src/test/java/com/amazonaws/athena/connectors/oracle/OracleMetadataHandlerTest.java
@@ -86,7 +86,7 @@ public class OracleMetadataHandlerTest
         this.secretsManager = Mockito.mock(AWSSecretsManager.class);
         this.athena = Mockito.mock(AmazonAthena.class);
         Mockito.when(this.secretsManager.getSecretValue(Mockito.eq(new GetSecretValueRequest().withSecretId("testSecret")))).thenReturn(new GetSecretValueResult().withSecretString("{\"username\": \"testUser\", \"password\": \"testPassword\"}"));
-        this.oracleMetadataHandler = new OracleMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, this.jdbcConnectionFactory, java.util.Map.of());
+        this.oracleMetadataHandler = new OracleMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, this.jdbcConnectionFactory, com.google.common.collect.ImmutableMap.of());
         this.federatedIdentity = Mockito.mock(FederatedIdentity.class);
     }
 
@@ -194,7 +194,7 @@ public class OracleMetadataHandlerTest
         JdbcConnectionFactory jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         Mockito.when(jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(connection);
         Mockito.when(connection.getMetaData().getSearchStringEscape()).thenThrow(new SQLException());
-        OracleMetadataHandler oracleMetadataHandler = new OracleMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, jdbcConnectionFactory, java.util.Map.of());
+        OracleMetadataHandler oracleMetadataHandler = new OracleMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, jdbcConnectionFactory, com.google.common.collect.ImmutableMap.of());
 
         oracleMetadataHandler.doGetTableLayout(Mockito.mock(BlockAllocator.class), getTableLayoutRequest);
     }

--- a/athena-oracle/src/test/java/com/amazonaws/athena/connectors/oracle/OracleMuxJdbcMetadataHandlerTest.java
+++ b/athena-oracle/src/test/java/com/amazonaws/athena/connectors/oracle/OracleMuxJdbcMetadataHandlerTest.java
@@ -70,7 +70,7 @@ public class OracleMuxJdbcMetadataHandlerTest
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", "fakedatabase",
                 "fakedatabase://jdbc:fakedatabase://hostname/${testSecret}", "testSecret");
-        this.jdbcMetadataHandler = new OracleMuxMetadataHandler(this.secretsManager, this.athena, this.jdbcConnectionFactory, this.metadataHandlerMap, databaseConnectionConfig, java.util.Map.of());
+        this.jdbcMetadataHandler = new OracleMuxMetadataHandler(this.secretsManager, this.athena, this.jdbcConnectionFactory, this.metadataHandlerMap, databaseConnectionConfig, com.google.common.collect.ImmutableMap.of());
     }
 
     @Test

--- a/athena-oracle/src/test/java/com/amazonaws/athena/connectors/oracle/OracleMuxJdbcRecordHandlerTest.java
+++ b/athena-oracle/src/test/java/com/amazonaws/athena/connectors/oracle/OracleMuxJdbcRecordHandlerTest.java
@@ -66,7 +66,7 @@ public class OracleMuxJdbcRecordHandlerTest
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", "oracle",
                 "oracle://jdbc:oracle:thin:${testSecret}@//127.0.0.1:1521/orcl", "testSecret");
-        this.jdbcRecordHandler = new OracleMuxRecordHandler(this.amazonS3, this.secretsManager, this.athena, this.jdbcConnectionFactory, databaseConnectionConfig, this.recordHandlerMap, java.util.Map.of());
+        this.jdbcRecordHandler = new OracleMuxRecordHandler(this.amazonS3, this.secretsManager, this.athena, this.jdbcConnectionFactory, databaseConnectionConfig, this.recordHandlerMap, com.google.common.collect.ImmutableMap.of());
     }
 
     @Test

--- a/athena-oracle/src/test/java/com/amazonaws/athena/connectors/oracle/OracleRecordHandlerTest.java
+++ b/athena-oracle/src/test/java/com/amazonaws/athena/connectors/oracle/OracleRecordHandlerTest.java
@@ -77,7 +77,7 @@ public class OracleRecordHandlerTest
         final DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", ORACLE_NAME,
                 "oracle://jdbc:oracle:thin:username/password@//127.0.0.1:1521/orcl");
 
-        this.oracleRecordHandler = new OracleRecordHandler(databaseConnectionConfig, amazonS3, secretsManager, athena, jdbcConnectionFactory, jdbcSplitQueryBuilder, java.util.Map.of());
+        this.oracleRecordHandler = new OracleRecordHandler(databaseConnectionConfig, amazonS3, secretsManager, athena, jdbcConnectionFactory, jdbcSplitQueryBuilder, com.google.common.collect.ImmutableMap.of());
     }
 
     @Test

--- a/athena-postgresql/src/test/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlMetadataHandlerTest.java
+++ b/athena-postgresql/src/test/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlMetadataHandlerTest.java
@@ -95,7 +95,7 @@ public class PostGreSqlMetadataHandlerTest
         Mockito.when(this.jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(this.connection);
         this.secretsManager = Mockito.mock(AWSSecretsManager.class);
         Mockito.when(this.secretsManager.getSecretValue(Mockito.eq(new GetSecretValueRequest().withSecretId("testSecret")))).thenReturn(new GetSecretValueResult().withSecretString("{\"username\": \"testUser\", \"password\": \"testPassword\"}"));
-        this.postGreSqlMetadataHandler = new PostGreSqlMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, this.jdbcConnectionFactory, java.util.Map.of());
+        this.postGreSqlMetadataHandler = new PostGreSqlMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, this.jdbcConnectionFactory, com.google.common.collect.ImmutableMap.of());
         this.federatedIdentity = Mockito.mock(FederatedIdentity.class);
     }
 
@@ -208,7 +208,7 @@ public class PostGreSqlMetadataHandlerTest
         JdbcConnectionFactory jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         Mockito.when(jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(connection);
         Mockito.when(connection.getMetaData().getSearchStringEscape()).thenThrow(new SQLException());
-        PostGreSqlMetadataHandler postGreSqlMetadataHandler = new PostGreSqlMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, jdbcConnectionFactory, java.util.Map.of());
+        PostGreSqlMetadataHandler postGreSqlMetadataHandler = new PostGreSqlMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, jdbcConnectionFactory, com.google.common.collect.ImmutableMap.of());
 
         postGreSqlMetadataHandler.doGetTableLayout(Mockito.mock(BlockAllocator.class), getTableLayoutRequest);
     }

--- a/athena-postgresql/src/test/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlMuxJdbcMetadataHandlerTest.java
+++ b/athena-postgresql/src/test/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlMuxJdbcMetadataHandlerTest.java
@@ -68,7 +68,7 @@ public class PostGreSqlMuxJdbcMetadataHandlerTest
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", "postgres",
                 "postgres://jdbc:postgresql://hostname/${testSecret}", "testSecret");
-        this.jdbcMetadataHandler = new PostGreSqlMuxMetadataHandler(this.secretsManager, this.athena, this.jdbcConnectionFactory, this.metadataHandlerMap, databaseConnectionConfig, java.util.Map.of());
+        this.jdbcMetadataHandler = new PostGreSqlMuxMetadataHandler(this.secretsManager, this.athena, this.jdbcConnectionFactory, this.metadataHandlerMap, databaseConnectionConfig, com.google.common.collect.ImmutableMap.of());
     }
 
     @Test

--- a/athena-postgresql/src/test/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlMuxJdbcRecordHandlerTest.java
+++ b/athena-postgresql/src/test/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlMuxJdbcRecordHandlerTest.java
@@ -64,7 +64,7 @@ public class PostGreSqlMuxJdbcRecordHandlerTest
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", "postgres",
                 "postgres://jdbc:postgresql://hostname/${testSecret}", "testSecret");
-        this.jdbcRecordHandler = new PostGreSqlMuxRecordHandler(this.amazonS3, this.secretsManager, this.athena, this.jdbcConnectionFactory, databaseConnectionConfig, this.recordHandlerMap, java.util.Map.of());
+        this.jdbcRecordHandler = new PostGreSqlMuxRecordHandler(this.amazonS3, this.secretsManager, this.athena, this.jdbcConnectionFactory, databaseConnectionConfig, this.recordHandlerMap, com.google.common.collect.ImmutableMap.of());
     }
 
     @Test

--- a/athena-postgresql/src/test/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlRecordHandlerTest.java
+++ b/athena-postgresql/src/test/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlRecordHandlerTest.java
@@ -86,7 +86,7 @@ public class PostGreSqlRecordHandlerTest extends TestBase
         final DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", POSTGRES_NAME,
                 "postgres://jdbc:postgresql://hostname/user=A&password=B");
 
-        this.postGreSqlRecordHandler = new PostGreSqlRecordHandler(databaseConnectionConfig, amazonS3, secretsManager, athena, jdbcConnectionFactory, jdbcSplitQueryBuilder, java.util.Map.of());
+        this.postGreSqlRecordHandler = new PostGreSqlRecordHandler(databaseConnectionConfig, amazonS3, secretsManager, athena, jdbcConnectionFactory, jdbcSplitQueryBuilder, com.google.common.collect.ImmutableMap.of());
     }
 
     @Test

--- a/athena-redis/src/test/java/com/amazonaws/athena/connectors/redis/RedisMetadataHandlerTest.java
+++ b/athena-redis/src/test/java/com/amazonaws/athena/connectors/redis/RedisMetadataHandlerTest.java
@@ -121,7 +121,7 @@ public class RedisMetadataHandlerTest
         when(mockFactory.getOrCreateConn(eq(decodedEndpoint), anyBoolean(), anyBoolean(), nullable(String.class))).thenReturn(mockConnection);
         when(mockConnection.sync()).thenReturn(mockSyncCommands);
 
-        handler = new RedisMetadataHandler(mockGlue, new LocalKeyFactory(), mockSecretsManager, mockAthena, mockFactory, "bucket", "prefix", java.util.Map.of());
+        handler = new RedisMetadataHandler(mockGlue, new LocalKeyFactory(), mockSecretsManager, mockAthena, mockFactory, "bucket", "prefix", com.google.common.collect.ImmutableMap.of());
         allocator = new BlockAllocatorImpl();
 
         when(mockSecretsManager.getSecretValue(nullable(GetSecretValueRequest.class)))

--- a/athena-redis/src/test/java/com/amazonaws/athena/connectors/redis/RedisRecordHandlerTest.java
+++ b/athena-redis/src/test/java/com/amazonaws/athena/connectors/redis/RedisRecordHandlerTest.java
@@ -173,7 +173,7 @@ public class RedisRecordHandlerTest
                     throw new RuntimeException("Unknown secret " + request.getSecretId());
                 });
 
-        handler = new RedisRecordHandler(amazonS3, mockSecretsManager, mockAthena, mockFactory, java.util.Map.of());
+        handler = new RedisRecordHandler(amazonS3, mockSecretsManager, mockAthena, mockFactory, com.google.common.collect.ImmutableMap.of());
         spillReader = new S3BlockSpillReader(amazonS3, allocator);
 
         logger.info("setUpBefore - exit");

--- a/athena-redshift/src/test/java/com/amazonaws/athena/connectors/redshift/RedshiftMetadataHandlerTest.java
+++ b/athena-redshift/src/test/java/com/amazonaws/athena/connectors/redshift/RedshiftMetadataHandlerTest.java
@@ -96,7 +96,7 @@ public class RedshiftMetadataHandlerTest
         Mockito.when(this.jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(this.connection);
         this.secretsManager = Mockito.mock(AWSSecretsManager.class);
         Mockito.when(this.secretsManager.getSecretValue(Mockito.eq(new GetSecretValueRequest().withSecretId("testSecret")))).thenReturn(new GetSecretValueResult().withSecretString("{\"username\": \"testUser\", \"password\": \"testPassword\"}"));
-        this.redshiftMetadataHandler = new RedshiftMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, this.jdbcConnectionFactory, java.util.Map.of());
+        this.redshiftMetadataHandler = new RedshiftMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, this.jdbcConnectionFactory, com.google.common.collect.ImmutableMap.of());
         this.federatedIdentity = Mockito.mock(FederatedIdentity.class);
     }
 
@@ -209,7 +209,7 @@ public class RedshiftMetadataHandlerTest
         JdbcConnectionFactory jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         Mockito.when(jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(connection);
         Mockito.when(connection.getMetaData().getSearchStringEscape()).thenThrow(new SQLException());
-        RedshiftMetadataHandler redshiftMetadataHandler = new RedshiftMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, jdbcConnectionFactory, java.util.Map.of());
+        RedshiftMetadataHandler redshiftMetadataHandler = new RedshiftMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, jdbcConnectionFactory, com.google.common.collect.ImmutableMap.of());
 
         redshiftMetadataHandler.doGetTableLayout(Mockito.mock(BlockAllocator.class), getTableLayoutRequest);
     }

--- a/athena-redshift/src/test/java/com/amazonaws/athena/connectors/redshift/RedshiftMuxJdbcMetadataHandlerTest.java
+++ b/athena-redshift/src/test/java/com/amazonaws/athena/connectors/redshift/RedshiftMuxJdbcMetadataHandlerTest.java
@@ -68,7 +68,7 @@ public class RedshiftMuxJdbcMetadataHandlerTest
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", "redshift",
                 "redshift://jdbc:redshift://hostname/${testSecret}", "testSecret");
-        this.jdbcMetadataHandler = new RedshiftMuxMetadataHandler(this.secretsManager, this.athena, this.jdbcConnectionFactory, this.metadataHandlerMap, databaseConnectionConfig, java.util.Map.of());
+        this.jdbcMetadataHandler = new RedshiftMuxMetadataHandler(this.secretsManager, this.athena, this.jdbcConnectionFactory, this.metadataHandlerMap, databaseConnectionConfig, com.google.common.collect.ImmutableMap.of());
     }
 
     @Test

--- a/athena-redshift/src/test/java/com/amazonaws/athena/connectors/redshift/RedshiftMuxJdbcRecordHandlerTest.java
+++ b/athena-redshift/src/test/java/com/amazonaws/athena/connectors/redshift/RedshiftMuxJdbcRecordHandlerTest.java
@@ -64,7 +64,7 @@ public class RedshiftMuxJdbcRecordHandlerTest
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", "redshift",
                 "redshift://jdbc:redshift://hostname/${testSecret}", "testSecret");
-        this.jdbcRecordHandler = new RedshiftMuxRecordHandler(this.amazonS3, this.secretsManager, this.athena, this.jdbcConnectionFactory, databaseConnectionConfig, this.recordHandlerMap, java.util.Map.of());
+        this.jdbcRecordHandler = new RedshiftMuxRecordHandler(this.amazonS3, this.secretsManager, this.athena, this.jdbcConnectionFactory, databaseConnectionConfig, this.recordHandlerMap, com.google.common.collect.ImmutableMap.of());
     }
 
     @Test

--- a/athena-redshift/src/test/java/com/amazonaws/athena/connectors/redshift/RedshiftRecordHandlerTest.java
+++ b/athena-redshift/src/test/java/com/amazonaws/athena/connectors/redshift/RedshiftRecordHandlerTest.java
@@ -88,7 +88,7 @@ public class RedshiftRecordHandlerTest
         final DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", REDSHIFT_NAME,
                 "redshift://jdbc:redshift://hostname/user=A&password=B");
 
-        this.redshiftRecordHandler = new RedshiftRecordHandler(databaseConnectionConfig, amazonS3, secretsManager, athena, jdbcConnectionFactory, jdbcSplitQueryBuilder, java.util.Map.of());
+        this.redshiftRecordHandler = new RedshiftRecordHandler(databaseConnectionConfig, amazonS3, secretsManager, athena, jdbcConnectionFactory, jdbcSplitQueryBuilder, com.google.common.collect.ImmutableMap.of());
     }
 
     @Test

--- a/athena-saphana/src/main/java/com/amazonaws/athena/connectors/saphana/SaphanaMetadataHandler.java
+++ b/athena-saphana/src/main/java/com/amazonaws/athena/connectors/saphana/SaphanaMetadataHandler.java
@@ -310,7 +310,7 @@ public class SaphanaMetadataHandler extends JdbcMetadataHandler
                     if (isSpatialDataType) {
                         schemaBuilder.addField(FieldBuilder.newBuilder(columnName, columnType)
                                 .addField(new Field(quoteColumnName(columnName) + TO_WELL_KNOWN_TEXT_FUNCTION,
-                                        new FieldType(true, columnType, null), List.of()))
+                                        new FieldType(true, columnType, null), com.google.common.collect.ImmutableList.of()))
                                 .build());
                     }
                     else {

--- a/athena-saphana/src/test/java/com/amazonaws/athena/connectors/saphana/SaphanaMetadataHandlerTest.java
+++ b/athena-saphana/src/test/java/com/amazonaws/athena/connectors/saphana/SaphanaMetadataHandlerTest.java
@@ -82,7 +82,7 @@ public class SaphanaMetadataHandlerTest
         this.secretsManager = Mockito.mock(AWSSecretsManager.class);
         this.athena = Mockito.mock(AmazonAthena.class);
         Mockito.when(this.secretsManager.getSecretValue(Mockito.eq(new GetSecretValueRequest().withSecretId("testSecret")))).thenReturn(new GetSecretValueResult().withSecretString("{\"username\": \"testUser\", \"password\": \"testPassword\"}"));
-        this.saphanaMetadataHandler = new SaphanaMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, this.jdbcConnectionFactory, java.util.Map.of());
+        this.saphanaMetadataHandler = new SaphanaMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, this.jdbcConnectionFactory, com.google.common.collect.ImmutableMap.of());
         this.federatedIdentity = Mockito.mock(FederatedIdentity.class);
         this.blockAllocator = Mockito.mock(BlockAllocator.class);
     }
@@ -189,7 +189,7 @@ public class SaphanaMetadataHandlerTest
         JdbcConnectionFactory jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         Mockito.when(jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(connection);
         Mockito.when(connection.getMetaData().getSearchStringEscape()).thenThrow(new SQLException());
-        SaphanaMetadataHandler saphanaMetadataHandler = new SaphanaMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, jdbcConnectionFactory, java.util.Map.of());
+        SaphanaMetadataHandler saphanaMetadataHandler = new SaphanaMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, jdbcConnectionFactory, com.google.common.collect.ImmutableMap.of());
 
         saphanaMetadataHandler.doGetTableLayout(Mockito.mock(BlockAllocator.class), getTableLayoutRequest);
     }

--- a/athena-saphana/src/test/java/com/amazonaws/athena/connectors/saphana/SaphanaMuxJdbcMetadataHandlerTest.java
+++ b/athena-saphana/src/test/java/com/amazonaws/athena/connectors/saphana/SaphanaMuxJdbcMetadataHandlerTest.java
@@ -64,7 +64,7 @@ public class SaphanaMuxJdbcMetadataHandlerTest {
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", "fakedatabase",
                 "fakedatabase://jdbc:fakedatabase://hostname/${testSecret}", "testSecret");
-        this.jdbcMetadataHandler = new SaphanaMuxMetadataHandler(this.secretsManager, this.athena, this.jdbcConnectionFactory, this.metadataHandlerMap, databaseConnectionConfig, java.util.Map.of());
+        this.jdbcMetadataHandler = new SaphanaMuxMetadataHandler(this.secretsManager, this.athena, this.jdbcConnectionFactory, this.metadataHandlerMap, databaseConnectionConfig, com.google.common.collect.ImmutableMap.of());
     }
     @Test
     public void doListSchemaNames()

--- a/athena-saphana/src/test/java/com/amazonaws/athena/connectors/saphana/SaphanaMuxJdbcRecordHandlerTest.java
+++ b/athena-saphana/src/test/java/com/amazonaws/athena/connectors/saphana/SaphanaMuxJdbcRecordHandlerTest.java
@@ -64,7 +64,7 @@ public class SaphanaMuxJdbcRecordHandlerTest
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", "saphana",
                 "fakedatabase://jdbc:fakedatabase://hostname/${testSecret}", "testSecret");
-        this.jdbcRecordHandler = new SaphanaMuxRecordHandler(this.amazonS3, this.secretsManager, this.athena, this.jdbcConnectionFactory, databaseConnectionConfig, this.recordHandlerMap, java.util.Map.of());
+        this.jdbcRecordHandler = new SaphanaMuxRecordHandler(this.amazonS3, this.secretsManager, this.athena, this.jdbcConnectionFactory, databaseConnectionConfig, this.recordHandlerMap, com.google.common.collect.ImmutableMap.of());
     }
 
     @Test

--- a/athena-saphana/src/test/java/com/amazonaws/athena/connectors/saphana/SaphanaRecordHandlerTest.java
+++ b/athena-saphana/src/test/java/com/amazonaws/athena/connectors/saphana/SaphanaRecordHandlerTest.java
@@ -72,7 +72,7 @@ public class SaphanaRecordHandlerTest
         final DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", SaphanaConstants.SAPHANA_NAME,
                 "saphana://jdbc:saphana://115.113.87.100/TMODE=ANSI,CHARSET=UTF8,DATABASE=TEST,USER=DBC,PASSWORD=DBC");
 
-        this.saphanaRecordHandler = new SaphanaRecordHandler(databaseConnectionConfig, amazonS3, secretsManager, athena, jdbcConnectionFactory, jdbcSplitQueryBuilder, java.util.Map.of());
+        this.saphanaRecordHandler = new SaphanaRecordHandler(databaseConnectionConfig, amazonS3, secretsManager, athena, jdbcConnectionFactory, jdbcSplitQueryBuilder, com.google.common.collect.ImmutableMap.of());
     }
 
     private ValueSet getSingleValueSet(Object value) {

--- a/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMetadataHandler.java
+++ b/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMetadataHandler.java
@@ -74,7 +74,6 @@ import java.util.stream.Collectors;
 
 import static com.amazonaws.athena.connectors.snowflake.SnowflakeConstants.MAX_PARTITION_COUNT;
 import static com.amazonaws.athena.connectors.snowflake.SnowflakeConstants.PARTITION_RECORD_COUNT;
-import static java.util.Map.entry;
 
 /**
  * Handles metadata for Snowflake. User must have access to `schemata`, `tables`, `columns` in
@@ -356,13 +355,13 @@ public class SnowflakeMetadataHandler extends JdbcMetadataHandler
                 String dataType = hashMap.get(columnName);
                 LOGGER.debug("columnName: " + columnName);
                 LOGGER.debug("dataType: " + dataType);
-                final Map<String, ArrowType> stringArrowTypeMap = Map.ofEntries(
-                        entry("INTEGER", Types.MinorType.INT.getType()),
-                        entry("DATE", Types.MinorType.DATEDAY.getType()),
-                        entry("TIMESTAMP", Types.MinorType.DATEMILLI.getType()),
-                        entry("TIMESTAMP_LTZ", Types.MinorType.DATEMILLI.getType()),
-                        entry("TIMESTAMP_NTZ", Types.MinorType.DATEMILLI.getType()),
-                        entry("TIMESTAMP_TZ", Types.MinorType.DATEMILLI.getType())
+                final Map<String, ArrowType> stringArrowTypeMap = com.google.common.collect.ImmutableMap.of(
+                    "INTEGER", (ArrowType) Types.MinorType.INT.getType(),
+                    "DATE", (ArrowType) Types.MinorType.DATEDAY.getType(),
+                    "TIMESTAMP", (ArrowType) Types.MinorType.DATEMILLI.getType(),
+                    "TIMESTAMP_LTZ", (ArrowType) Types.MinorType.DATEMILLI.getType(),
+                    "TIMESTAMP_NTZ", (ArrowType) Types.MinorType.DATEMILLI.getType(),
+                    "TIMESTAMP_TZ", (ArrowType) Types.MinorType.DATEMILLI.getType()
                 );
                 if (dataType != null && stringArrowTypeMap.containsKey(dataType.toUpperCase())) {
                     columnType = stringArrowTypeMap.get(dataType.toUpperCase());

--- a/athena-snowflake/src/test/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMetadataHandlerTest.java
+++ b/athena-snowflake/src/test/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMetadataHandlerTest.java
@@ -77,7 +77,7 @@ public class SnowflakeMetadataHandlerTest
         this.secretsManager = Mockito.mock(AWSSecretsManager.class);
         this.athena = Mockito.mock(AmazonAthena.class);
         Mockito.when(this.secretsManager.getSecretValue(Mockito.eq(new GetSecretValueRequest().withSecretId("testSecret")))).thenReturn(new GetSecretValueResult().withSecretString("{\"username\": \"testUser\", \"password\": \"testPassword\"}"));
-        this.snowflakeMetadataHandler = new SnowflakeMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, this.jdbcConnectionFactory, java.util.Map.of());
+        this.snowflakeMetadataHandler = new SnowflakeMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, this.jdbcConnectionFactory, com.google.common.collect.ImmutableMap.of());
         this.federatedIdentity = Mockito.mock(FederatedIdentity.class);
         this.blockAllocator = Mockito.mock(BlockAllocator.class);
     }
@@ -245,7 +245,7 @@ public class SnowflakeMetadataHandlerTest
         JdbcConnectionFactory jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         Mockito.when(jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(connection);
         Mockito.when(connection.getMetaData().getSearchStringEscape()).thenThrow(new SQLException());
-        SnowflakeMetadataHandler snowflakeMetadataHandler = new SnowflakeMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, jdbcConnectionFactory, java.util.Map.of());
+        SnowflakeMetadataHandler snowflakeMetadataHandler = new SnowflakeMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, jdbcConnectionFactory, com.google.common.collect.ImmutableMap.of());
 
         snowflakeMetadataHandler.doGetTableLayout(Mockito.mock(BlockAllocator.class), getTableLayoutRequest);
     }

--- a/athena-snowflake/src/test/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMuxJdbcMetadataHandlerTest.java
+++ b/athena-snowflake/src/test/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMuxJdbcMetadataHandlerTest.java
@@ -62,7 +62,7 @@ public class SnowflakeMuxJdbcMetadataHandlerTest
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", "fakedatabase",
                 "fakedatabase://jdbc:fakedatabase://hostname/${testSecret}", "testSecret");
-        this.jdbcMetadataHandler = new SnowflakeMuxMetadataHandler(this.secretsManager, this.athena, this.jdbcConnectionFactory, this.metadataHandlerMap, databaseConnectionConfig, java.util.Map.of());
+        this.jdbcMetadataHandler = new SnowflakeMuxMetadataHandler(this.secretsManager, this.athena, this.jdbcConnectionFactory, this.metadataHandlerMap, databaseConnectionConfig, com.google.common.collect.ImmutableMap.of());
     }
 
     @Test

--- a/athena-snowflake/src/test/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMuxJdbcRecordHandlerTest.java
+++ b/athena-snowflake/src/test/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMuxJdbcRecordHandlerTest.java
@@ -68,7 +68,7 @@ public class SnowflakeMuxJdbcRecordHandlerTest
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", "snowflake",
                 "snowflake://jdbc:snowflake://hostname/?warehouse=warehousename&db=dbname&schema=schemaname&user=xxx&password=xxx");
-        this.jdbcRecordHandler = new SnowflakeMuxRecordHandler(this.amazonS3, this.secretsManager, this.athena, this.jdbcConnectionFactory, databaseConnectionConfig, this.recordHandlerMap, java.util.Map.of());
+        this.jdbcRecordHandler = new SnowflakeMuxRecordHandler(this.amazonS3, this.secretsManager, this.athena, this.jdbcConnectionFactory, databaseConnectionConfig, this.recordHandlerMap, com.google.common.collect.ImmutableMap.of());
     }
 
     @Test

--- a/athena-snowflake/src/test/java/com/amazonaws/athena/connectors/snowflake/SnowflakeRecordHandlerTest.java
+++ b/athena-snowflake/src/test/java/com/amazonaws/athena/connectors/snowflake/SnowflakeRecordHandlerTest.java
@@ -77,7 +77,7 @@ public class SnowflakeRecordHandlerTest
         final DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", SnowflakeConstants.SNOWFLAKE_NAME,
                 "snowflake://jdbc:snowflake://hostname/?warehouse=warehousename&db=dbname&schema=schemaname&user=xxx&password=xxx");
 
-        this.snowflakeRecordHandler = new SnowflakeRecordHandler(databaseConnectionConfig, amazonS3, secretsManager, athena, jdbcConnectionFactory, jdbcSplitQueryBuilder, java.util.Map.of());
+        this.snowflakeRecordHandler = new SnowflakeRecordHandler(databaseConnectionConfig, amazonS3, secretsManager, athena, jdbcConnectionFactory, jdbcSplitQueryBuilder, com.google.common.collect.ImmutableMap.of());
     }
 
     @Test

--- a/athena-sqlserver/src/test/java/com/amazonaws/athena/connectors/sqlserver/SqlServerMetadataHandlerTest.java
+++ b/athena-sqlserver/src/test/java/com/amazonaws/athena/connectors/sqlserver/SqlServerMetadataHandlerTest.java
@@ -98,7 +98,7 @@ public class SqlServerMetadataHandlerTest
         this.secretsManager = Mockito.mock(AWSSecretsManager.class);
         this.athena = Mockito.mock(AmazonAthena.class);
         Mockito.when(this.secretsManager.getSecretValue(Mockito.eq(new GetSecretValueRequest().withSecretId("testSecret")))).thenReturn(new GetSecretValueResult().withSecretString("{\"user\": \"testUser\", \"password\": \"testPassword\"}"));
-        this.sqlServerMetadataHandler = new SqlServerMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, this.jdbcConnectionFactory, java.util.Map.of());
+        this.sqlServerMetadataHandler = new SqlServerMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, this.jdbcConnectionFactory, com.google.common.collect.ImmutableMap.of());
         this.federatedIdentity = Mockito.mock(FederatedIdentity.class);
         this.allocator = new BlockAllocatorImpl();
     }
@@ -220,7 +220,7 @@ public class SqlServerMetadataHandlerTest
         JdbcConnectionFactory jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         Mockito.when(jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(connection);
         Mockito.when(connection.getMetaData().getSearchStringEscape()).thenThrow(new SQLException());
-        SqlServerMetadataHandler sqlServerMetadataHandler = new SqlServerMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, jdbcConnectionFactory, java.util.Map.of());
+        SqlServerMetadataHandler sqlServerMetadataHandler = new SqlServerMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, jdbcConnectionFactory, com.google.common.collect.ImmutableMap.of());
 
         sqlServerMetadataHandler.doGetTableLayout(Mockito.mock(BlockAllocator.class), getTableLayoutRequest);
     }
@@ -269,19 +269,19 @@ public class SqlServerMetadataHandlerTest
         GetSplitsRequest getSplitsRequest = new GetSplitsRequest(this.federatedIdentity, "testQueryId", "testCatalogName", tableName, getTableLayoutResponse.getPartitions(), new ArrayList<>(partitionCols), constraints, null);
         GetSplitsResponse getSplitsResponse = this.sqlServerMetadataHandler.doGetSplits(splitBlockAllocator, getSplitsRequest);
 
-        Set<Map<String, String>> expectedSplits = new HashSet<>();
-        expectedSplits.add(Map.ofEntries(
-                Map.entry(sqlServerMetadataHandler.PARTITION_NUMBER, "1"),
-                Map.entry("PARTITIONING_COLUMN", "pc"),
-                Map.entry("PARTITION_FUNCTION", "pf")));
-        expectedSplits.add(Map.ofEntries(
-                Map.entry(sqlServerMetadataHandler.PARTITION_NUMBER, "2"),
-                Map.entry("PARTITIONING_COLUMN", "pc"),
-                Map.entry("PARTITION_FUNCTION", "pf")));
-        expectedSplits.add(Map.ofEntries(
-                Map.entry(sqlServerMetadataHandler.PARTITION_NUMBER, "3"),
-                Map.entry("PARTITIONING_COLUMN", "pc"),
-                Map.entry("PARTITION_FUNCTION", "pf")));
+        Set<Map<String, String>> expectedSplits = com.google.common.collect.ImmutableSet.of(
+            com.google.common.collect.ImmutableMap.of(
+                sqlServerMetadataHandler.PARTITION_NUMBER, "1",
+                "PARTITIONING_COLUMN", "pc",
+                "PARTITION_FUNCTION", "pf"),
+            com.google.common.collect.ImmutableMap.of(
+                sqlServerMetadataHandler.PARTITION_NUMBER, "2",
+                "PARTITIONING_COLUMN", "pc",
+                "PARTITION_FUNCTION", "pf"),
+            com.google.common.collect.ImmutableMap.of(
+                sqlServerMetadataHandler.PARTITION_NUMBER, "3",
+                "PARTITIONING_COLUMN", "pc",
+                "PARTITION_FUNCTION", "pf"));
         Assert.assertEquals(expectedSplits.size(), getSplitsResponse.getSplits().size());
         Set<Map<String, String>> actualSplits = getSplitsResponse.getSplits().stream().map(Split::getProperties).collect(Collectors.toSet());
         Assert.assertEquals(expectedSplits, actualSplits);
@@ -371,11 +371,11 @@ public class SqlServerMetadataHandlerTest
         GetSplitsRequest getSplitsRequest = new GetSplitsRequest(this.federatedIdentity, "testQueryId", "testCatalogName", tableName, getTableLayoutResponse.getPartitions(), new ArrayList<>(partitionCols), constraints, "2");
         GetSplitsResponse getSplitsResponse = this.sqlServerMetadataHandler.doGetSplits(splitBlockAllocator, getSplitsRequest);
 
-        Set<Map<String, String>> expectedSplits = new HashSet<>();
-        expectedSplits.add(Map.ofEntries(
-                Map.entry(sqlServerMetadataHandler.PARTITION_NUMBER, "3"),
-                Map.entry("PARTITIONING_COLUMN", "pc"),
-                Map.entry("PARTITION_FUNCTION", "pf")));
+        Set<Map<String, String>> expectedSplits = com.google.common.collect.ImmutableSet.of(
+            com.google.common.collect.ImmutableMap.of(
+                sqlServerMetadataHandler.PARTITION_NUMBER, "3",
+                "PARTITIONING_COLUMN", "pc",
+                "PARTITION_FUNCTION", "pf"));
         Set<Map<String, String>> actualSplits = getSplitsResponse.getSplits().stream().map(Split::getProperties).collect(Collectors.toSet());
         Assert.assertEquals(expectedSplits, actualSplits);
     }

--- a/athena-sqlserver/src/test/java/com/amazonaws/athena/connectors/sqlserver/SqlServerMuxMetadataHandlerTest.java
+++ b/athena-sqlserver/src/test/java/com/amazonaws/athena/connectors/sqlserver/SqlServerMuxMetadataHandlerTest.java
@@ -66,7 +66,7 @@ public class SqlServerMuxMetadataHandlerTest
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", "fakedatabase",
                 "fakedatabase://jdbc:fakedatabase://hostname/${testSecret}", "testSecret");
-        this.jdbcMetadataHandler = new SqlServerMuxMetadataHandler(this.secretsManager, this.athena, this.jdbcConnectionFactory, this.metadataHandlerMap, databaseConnectionConfig, java.util.Map.of());
+        this.jdbcMetadataHandler = new SqlServerMuxMetadataHandler(this.secretsManager, this.athena, this.jdbcConnectionFactory, this.metadataHandlerMap, databaseConnectionConfig, com.google.common.collect.ImmutableMap.of());
     }
 
     @Test

--- a/athena-sqlserver/src/test/java/com/amazonaws/athena/connectors/sqlserver/SqlServerMuxRecordHandlerTest.java
+++ b/athena-sqlserver/src/test/java/com/amazonaws/athena/connectors/sqlserver/SqlServerMuxRecordHandlerTest.java
@@ -64,7 +64,7 @@ public class SqlServerMuxRecordHandlerTest
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", SqlServerConstants.NAME,
                 "sqlserver://jdbc:sqlserver://hostname;${testSecret}", "testSecret");
-        this.jdbcRecordHandler = new SqlServerMuxRecordHandler(this.amazonS3, this.secretsManager, this.athena, this.jdbcConnectionFactory, databaseConnectionConfig, this.recordHandlerMap, java.util.Map.of());
+        this.jdbcRecordHandler = new SqlServerMuxRecordHandler(this.amazonS3, this.secretsManager, this.athena, this.jdbcConnectionFactory, databaseConnectionConfig, this.recordHandlerMap, com.google.common.collect.ImmutableMap.of());
     }
 
     @Test

--- a/athena-sqlserver/src/test/java/com/amazonaws/athena/connectors/sqlserver/SqlServerRecordHandlerTest.java
+++ b/athena-sqlserver/src/test/java/com/amazonaws/athena/connectors/sqlserver/SqlServerRecordHandlerTest.java
@@ -75,7 +75,7 @@ public class SqlServerRecordHandlerTest
         final DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", SqlServerConstants.NAME,
                 "sqlserver://jdbc:sqlserver://hostname;databaseName=fakedatabase");
 
-        this.sqlServerRecordHandler = new SqlServerRecordHandler(databaseConnectionConfig, amazonS3, secretsManager, athena, jdbcConnectionFactory, jdbcSplitQueryBuilder, java.util.Map.of());
+        this.sqlServerRecordHandler = new SqlServerRecordHandler(databaseConnectionConfig, amazonS3, secretsManager, athena, jdbcConnectionFactory, jdbcSplitQueryBuilder, com.google.common.collect.ImmutableMap.of());
     }
 
     private ValueSet getSingleValueSet(Object value) {

--- a/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseMetadataHandler.java
+++ b/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseMetadataHandler.java
@@ -314,7 +314,7 @@ public class SynapseMetadataHandler extends JdbcMetadataHandler
             stmt.setString(1, tableName.getSchemaName() + "." + tableName.getTableName());
             try (ResultSet dataTypeResultSet = stmt.executeQuery()) {
                 while (dataTypeResultSet.next()) {
-                    List<String> columnDetails = List.of(
+                    List<String> columnDetails = com.google.common.collect.ImmutableList.of(
                             dataTypeResultSet.getString("DATA_TYPE").trim(),
                             dataTypeResultSet.getString("PRECISION").trim(),
                             dataTypeResultSet.getString("SCALE").trim());

--- a/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/SynapseMuxMetadataHandlerTest.java
+++ b/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/SynapseMuxMetadataHandlerTest.java
@@ -66,7 +66,7 @@ public class SynapseMuxMetadataHandlerTest
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", "fakedatabase",
                 "fakedatabase://jdbc:fakedatabase://hostname/${testSecret}", "testSecret");
-        this.jdbcMetadataHandler = new SynapseMuxMetadataHandler(this.secretsManager, this.athena, this.jdbcConnectionFactory, this.metadataHandlerMap, databaseConnectionConfig, java.util.Map.of());
+        this.jdbcMetadataHandler = new SynapseMuxMetadataHandler(this.secretsManager, this.athena, this.jdbcConnectionFactory, this.metadataHandlerMap, databaseConnectionConfig, com.google.common.collect.ImmutableMap.of());
     }
 
     @Test

--- a/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/SynapseMuxRecordHandlerTest.java
+++ b/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/SynapseMuxRecordHandlerTest.java
@@ -64,7 +64,7 @@ public class SynapseMuxRecordHandlerTest
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", SynapseConstants.NAME,
                 "synapse://jdbc:sqlserver://hostname;${testSecret}", "testSecret");
-        this.jdbcRecordHandler = new SynapseMuxRecordHandler(this.amazonS3, this.secretsManager, this.athena, this.jdbcConnectionFactory, databaseConnectionConfig, this.recordHandlerMap, java.util.Map.of());
+        this.jdbcRecordHandler = new SynapseMuxRecordHandler(this.amazonS3, this.secretsManager, this.athena, this.jdbcConnectionFactory, databaseConnectionConfig, this.recordHandlerMap, com.google.common.collect.ImmutableMap.of());
     }
 
     @Test

--- a/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/SynapseRecordHandlerTest.java
+++ b/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/SynapseRecordHandlerTest.java
@@ -75,7 +75,7 @@ public class SynapseRecordHandlerTest
         final DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", SynapseConstants.NAME,
                 "synapse://jdbc:sqlserver://hostname;databaseName=fakedatabase");
 
-        this.synapseRecordHandler = new SynapseRecordHandler(databaseConnectionConfig, amazonS3, secretsManager, athena, jdbcConnectionFactory, jdbcSplitQueryBuilder, java.util.Map.of());
+        this.synapseRecordHandler = new SynapseRecordHandler(databaseConnectionConfig, amazonS3, secretsManager, athena, jdbcConnectionFactory, jdbcSplitQueryBuilder, com.google.common.collect.ImmutableMap.of());
     }
 
     private ValueSet getSingleValueSet(Object value) {
@@ -135,7 +135,7 @@ public class SynapseRecordHandlerTest
         Schema schema = schemaBuilder.build();
 
         Split split = Mockito.mock(Split.class);
-        Mockito.when(split.getProperties()).thenReturn(Map.of("PARTITION_BOUNDARY_FROM", "0", "PARTITION_NUMBER", "1", "PARTITION_COLUMN", "testCol1", "PARTITION_BOUNDARY_TO", "100000"));
+        Mockito.when(split.getProperties()).thenReturn(com.google.common.collect.ImmutableMap.of("PARTITION_BOUNDARY_FROM", "0", "PARTITION_NUMBER", "1", "PARTITION_COLUMN", "testCol1", "PARTITION_BOUNDARY_TO", "100000"));
         Mockito.when(split.getProperty(Mockito.eq("PARTITION_BOUNDARY_FROM"))).thenReturn("0");
         Mockito.when(split.getProperty(Mockito.eq("PARTITION_NUMBER"))).thenReturn("1");
         Mockito.when(split.getProperty(Mockito.eq("PARTITION_COLUMN"))).thenReturn("testCol1");
@@ -146,21 +146,21 @@ public class SynapseRecordHandlerTest
         Mockito.when(this.connection.prepareStatement(nullable(String.class))).thenReturn(expectedPreparedStatement);
         this.synapseRecordHandler.buildSplitSql(this.connection, "testCatalogName", tableName, schema, constraints, split);
 
-        Mockito.when(split.getProperties()).thenReturn(Map.of("PARTITION_BOUNDARY_FROM", " ", "PARTITION_NUMBER", "1", "PARTITION_COLUMN", "testCol1", "PARTITION_BOUNDARY_TO", "100000"));
+        Mockito.when(split.getProperties()).thenReturn(com.google.common.collect.ImmutableMap.of("PARTITION_BOUNDARY_FROM", " ", "PARTITION_NUMBER", "1", "PARTITION_COLUMN", "testCol1", "PARTITION_BOUNDARY_TO", "100000"));
         Mockito.when(split.getProperty(Mockito.eq("PARTITION_BOUNDARY_FROM"))).thenReturn(" ");
         Mockito.when(split.getProperty(Mockito.eq("PARTITION_NUMBER"))).thenReturn("1");
         Mockito.when(split.getProperty(Mockito.eq("PARTITION_COLUMN"))).thenReturn("testCol1");
         Mockito.when(split.getProperty(Mockito.eq("PARTITION_BOUNDARY_TO"))).thenReturn("100000");
         this.synapseRecordHandler.buildSplitSql(this.connection, "testCatalogName", tableName, schema, constraints, split);
 
-        Mockito.when(split.getProperties()).thenReturn(Map.of("PARTITION_BOUNDARY_FROM", "300000", "PARTITION_NUMBER", "2", "PARTITION_COLUMN", "testCol1", "PARTITION_BOUNDARY_TO", " "));
+        Mockito.when(split.getProperties()).thenReturn(com.google.common.collect.ImmutableMap.of("PARTITION_BOUNDARY_FROM", "300000", "PARTITION_NUMBER", "2", "PARTITION_COLUMN", "testCol1", "PARTITION_BOUNDARY_TO", " "));
         Mockito.when(split.getProperty(Mockito.eq("PARTITION_BOUNDARY_FROM"))).thenReturn("300000");
         Mockito.when(split.getProperty(Mockito.eq("PARTITION_NUMBER"))).thenReturn("1");
         Mockito.when(split.getProperty(Mockito.eq("PARTITION_COLUMN"))).thenReturn("testCol1");
         Mockito.when(split.getProperty(Mockito.eq("PARTITION_BOUNDARY_TO"))).thenReturn(" ");
         this.synapseRecordHandler.buildSplitSql(this.connection, "testCatalogName", tableName, schema, constraints, split);
 
-        Mockito.when(split.getProperties()).thenReturn(Map.of("PARTITION_BOUNDARY_FROM", " ", "PARTITION_NUMBER", "2", "PARTITION_COLUMN", "testCol1", "PARTITION_BOUNDARY_TO", " "));
+        Mockito.when(split.getProperties()).thenReturn(com.google.common.collect.ImmutableMap.of("PARTITION_BOUNDARY_FROM", " ", "PARTITION_NUMBER", "2", "PARTITION_COLUMN", "testCol1", "PARTITION_BOUNDARY_TO", " "));
         Mockito.when(split.getProperty(Mockito.eq("PARTITION_BOUNDARY_FROM"))).thenReturn(" ");
         Mockito.when(split.getProperty(Mockito.eq("PARTITION_NUMBER"))).thenReturn("1");
         Mockito.when(split.getProperty(Mockito.eq("PARTITION_COLUMN"))).thenReturn("testCol1");

--- a/athena-teradata/src/test/java/com/amazonaws/athena/connectors/teradata/TeradataMetadataHandlerTest.java
+++ b/athena-teradata/src/test/java/com/amazonaws/athena/connectors/teradata/TeradataMetadataHandlerTest.java
@@ -71,7 +71,7 @@ public class TeradataMetadataHandlerTest
         this.secretsManager = Mockito.mock(AWSSecretsManager.class);
         this.athena = Mockito.mock(AmazonAthena.class);
         Mockito.when(this.secretsManager.getSecretValue(Mockito.eq(new GetSecretValueRequest().withSecretId("testSecret")))).thenReturn(new GetSecretValueResult().withSecretString("{\"username\": \"testUser\", \"password\": \"testPassword\"}"));
-        this.teradataMetadataHandler = new TeradataMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, this.jdbcConnectionFactory, java.util.Map.of("partitioncount", "1000"));
+        this.teradataMetadataHandler = new TeradataMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, this.jdbcConnectionFactory, com.google.common.collect.ImmutableMap.of("partitioncount", "1000"));
         this.federatedIdentity = Mockito.mock(FederatedIdentity.class);
         this.blockAllocator = Mockito.mock(BlockAllocator.class);
     }
@@ -179,7 +179,7 @@ public class TeradataMetadataHandlerTest
         JdbcConnectionFactory jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         Mockito.when(jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(connection);
         Mockito.when(connection.getMetaData().getSearchStringEscape()).thenThrow(new SQLException());
-        TeradataMetadataHandler teradataMetadataHandler = new TeradataMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, jdbcConnectionFactory, java.util.Map.of());
+        TeradataMetadataHandler teradataMetadataHandler = new TeradataMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, jdbcConnectionFactory, com.google.common.collect.ImmutableMap.of());
 
         teradataMetadataHandler.doGetTableLayout(Mockito.mock(BlockAllocator.class), getTableLayoutRequest);
     }

--- a/athena-teradata/src/test/java/com/amazonaws/athena/connectors/teradata/TeradataMuxJdbcMetadataHandlerTest.java
+++ b/athena-teradata/src/test/java/com/amazonaws/athena/connectors/teradata/TeradataMuxJdbcMetadataHandlerTest.java
@@ -62,7 +62,7 @@ public class TeradataMuxJdbcMetadataHandlerTest {
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", "fakedatabase",
                 "fakedatabase://jdbc:fakedatabase://hostname/${testSecret}", "testSecret");
-        this.jdbcMetadataHandler = new TeradataMuxMetadataHandler(this.secretsManager, this.athena, this.jdbcConnectionFactory, this.metadataHandlerMap, databaseConnectionConfig, java.util.Map.of());
+        this.jdbcMetadataHandler = new TeradataMuxMetadataHandler(this.secretsManager, this.athena, this.jdbcConnectionFactory, this.metadataHandlerMap, databaseConnectionConfig, com.google.common.collect.ImmutableMap.of());
     }
     @Test
     public void doListSchemaNames()

--- a/athena-teradata/src/test/java/com/amazonaws/athena/connectors/teradata/TeradataMuxJdbcRecordHandlerTest.java
+++ b/athena-teradata/src/test/java/com/amazonaws/athena/connectors/teradata/TeradataMuxJdbcRecordHandlerTest.java
@@ -64,7 +64,7 @@ public class TeradataMuxJdbcRecordHandlerTest
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", "teradata",
                 "teradata://jdbc:teradata://hostname/${testSecret}", "testSecret");
-        this.jdbcRecordHandler = new TeradataMuxRecordHandler(this.amazonS3, this.secretsManager, this.athena, this.jdbcConnectionFactory, databaseConnectionConfig, this.recordHandlerMap, java.util.Map.of());
+        this.jdbcRecordHandler = new TeradataMuxRecordHandler(this.amazonS3, this.secretsManager, this.athena, this.jdbcConnectionFactory, databaseConnectionConfig, this.recordHandlerMap, com.google.common.collect.ImmutableMap.of());
     }
 
     @Test

--- a/athena-teradata/src/test/java/com/amazonaws/athena/connectors/teradata/TeradataRecordHandlerTest.java
+++ b/athena-teradata/src/test/java/com/amazonaws/athena/connectors/teradata/TeradataRecordHandlerTest.java
@@ -72,7 +72,7 @@ public class TeradataRecordHandlerTest
         final DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", TeradataConstants.TERADATA_NAME,
                 "teradata://jdbc:teradata://115.113.87.100/TMODE=ANSI,CHARSET=UTF8,DATABASE=TEST,USER=DBC,PASSWORD=DBC");
 
-        this.teradataRecordHandler = new TeradataRecordHandler(databaseConnectionConfig, amazonS3, secretsManager, athena, jdbcConnectionFactory, jdbcSplitQueryBuilder, java.util.Map.of());
+        this.teradataRecordHandler = new TeradataRecordHandler(databaseConnectionConfig, amazonS3, secretsManager, athena, jdbcConnectionFactory, jdbcSplitQueryBuilder, com.google.common.collect.ImmutableMap.of());
     }
 
     private ValueSet getSingleValueSet(Object value) {

--- a/athena-timestream/src/test/java/com/amazonaws/athena/connectors/timestream/TimestreamMetadataHandlerTest.java
+++ b/athena-timestream/src/test/java/com/amazonaws/athena/connectors/timestream/TimestreamMetadataHandlerTest.java
@@ -119,7 +119,7 @@ public class TimestreamMetadataHandlerTest
                 mockAthena,
                 "spillBucket",
                 "spillPrefix",
-                java.util.Map.of());
+                com.google.common.collect.ImmutableMap.of());
 
         allocator = new BlockAllocatorImpl();
     }

--- a/athena-timestream/src/test/java/com/amazonaws/athena/connectors/timestream/TimestreamRecordHandlerTest.java
+++ b/athena-timestream/src/test/java/com/amazonaws/athena/connectors/timestream/TimestreamRecordHandlerTest.java
@@ -179,7 +179,7 @@ public class TimestreamRecordHandlerTest
                 .addField("region", Types.MinorType.VARCHAR.getType())
                 .build();
 
-        handler = new TimestreamRecordHandler(amazonS3, mockSecretsManager, mockAthena, mockClient, java.util.Map.of());
+        handler = new TimestreamRecordHandler(amazonS3, mockSecretsManager, mockAthena, mockClient, com.google.common.collect.ImmutableMap.of());
         spillReader = new S3BlockSpillReader(amazonS3, allocator);
     }
 

--- a/athena-tpcds/src/test/java/com/amazonaws/athena/connectors/tpcds/TPCDSMetadataHandlerTest.java
+++ b/athena-tpcds/src/test/java/com/amazonaws/athena/connectors/tpcds/TPCDSMetadataHandlerTest.java
@@ -84,7 +84,7 @@ public class TPCDSMetadataHandlerTest
     public void setUp()
             throws Exception
     {
-        handler = new TPCDSMetadataHandler(new LocalKeyFactory(), mockSecretsManager, mockAthena, "spillBucket", "spillPrefix", java.util.Map.of());
+        handler = new TPCDSMetadataHandler(new LocalKeyFactory(), mockSecretsManager, mockAthena, "spillBucket", "spillPrefix", com.google.common.collect.ImmutableMap.of());
         allocator = new BlockAllocatorImpl();
     }
 

--- a/athena-tpcds/src/test/java/com/amazonaws/athena/connectors/tpcds/TPCDSRecordHandlerTest.java
+++ b/athena-tpcds/src/test/java/com/amazonaws/athena/connectors/tpcds/TPCDSRecordHandlerTest.java
@@ -123,7 +123,7 @@ public class TPCDSRecordHandlerTest
 
         mockS3Storage = new ArrayList<>();
         allocator = new BlockAllocatorImpl();
-        handler = new TPCDSRecordHandler(mockS3, mockSecretsManager, mockAthena, java.util.Map.of());
+        handler = new TPCDSRecordHandler(mockS3, mockSecretsManager, mockAthena, com.google.common.collect.ImmutableMap.of());
         spillReader = new S3BlockSpillReader(mockS3, allocator);
 
         when(mockS3.putObject(any()))

--- a/athena-vertica/src/test/java/com/amazonaws/athena/connectors/vertica/VerticaMetadataHandlerTest.java
+++ b/athena-vertica/src/test/java/com/amazonaws/athena/connectors/vertica/VerticaMetadataHandlerTest.java
@@ -133,7 +133,7 @@ public class VerticaMetadataHandlerTest extends TestBase
                 "spill-prefix",
                 verticaSchemaUtils,
                 amazonS3,
-                java.util.Map.of());
+                com.google.common.collect.ImmutableMap.of());
         this.allocator =  new BlockAllocatorImpl();
         this.databaseMetaData = this.connection.getMetaData();
         verticaMetadataHandlerMocked = Mockito.spy(this.verticaMetadataHandler);

--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,9 @@
     <description>The Amazon Athena Query Federation SDK allows you to customize Amazon Athena with your own code.</description>
     <url>https://github.com/awslabs/aws-athena-query-federation</url>
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <!-- Uncomment to target java 8 -->
+        <!--<maven.compiler.release>8</maven.compiler.release>-->
+        <maven.compiler.release>11</maven.compiler.release>
         <maven.compiler.plugin.version>3.11.0</maven.compiler.plugin.version>
         <aws-sdk.version>1.12.420</aws-sdk.version>
         <aws.lambda-java-core.version>1.2.2</aws.lambda-java-core.version>


### PR DESCRIPTION
There are some future projects that will require building on Java 8, so just make these minor mechanical changes to enable us to target Java 8 easily in the future.

Development environments don't need to change since the Java compiler and maven allow us to target an older Java version even though we are on a newer compiler.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
