### PR TITLE
[MSK + Kafka] Add pagination support on doGetSplits()

### DIFF
--- a/athena-kafka/src/main/java/com/amazonaws/athena/connectors/kafka/KafkaMetadataHandler.java
+++ b/athena-kafka/src/main/java/com/amazonaws/athena/connectors/kafka/KafkaMetadataHandler.java
@@ -58,7 +58,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -73,6 +73,7 @@ public class KafkaMetadataHandler extends MetadataHandler
 {
     private static final int maxGluePageSize = 100;
     private static final long MAX_RESULTS = 100_000;
+    static final long MAX_SPLITS_PER_REQUEST = 1000; // around 45k splits will exceed the 6mb response
     private static final String REGISTRY_MARKER = "{AthenaFederationKafka}";
     private static final Logger LOGGER = LoggerFactory.getLogger(KafkaMetadataHandler.class);
     private final Consumer<String, String> kafkaConsumer;
@@ -362,10 +363,12 @@ public class KafkaMetadataHandler extends MetadataHandler
         LOGGER.info("Retrieved topicName: {}", topic);
 
         // Get the available partitions of the topic from kafka server.
-        Collection<TopicPartition> topicPartitions = kafkaConsumer.partitionsFor(topic)
-                .stream()
+        List<TopicPartition> topicPartitions = kafkaConsumer.partitionsFor(topic).stream()
                 .map(it -> new TopicPartition(it.topic(), it.partition()))
                 .collect(Collectors.toList());
+        // consumer does not always return the same order for the partitions. We need to sort it so the continuation token
+        // has meaning.
+        Collections.sort(topicPartitions, (tp1, tp2) -> tp1.partition() - tp2.partition());
 
         LOGGER.debug("[KafkaPartition] total partitions {} found for topic: {}", topicPartitions.size(), topic);
 
@@ -391,7 +394,12 @@ public class KafkaMetadataHandler extends MetadataHandler
 
         Set<Split> splits = new HashSet<>();
         SpillLocation spillLocation = makeSpillLocation(request);
-        for (TopicPartition partition : topicPartitions) {
+        int continuationToken = request.getContinuationToken() == null ? 0 : Integer.parseInt(request.getContinuationToken());
+        for (
+            int partitionIndex = continuationToken;
+            partitionIndex < topicPartitions.size();
+            partitionIndex++) {
+            TopicPartition partition = topicPartitions.get(partitionIndex);
             // Calculate how many pieces we can divide a topic partition.
             List<TopicPartitionPiece>  topicPartitionPieces = pieceTopicPartition(startOffsets.get(partition), endOffsets.get(partition));
             LOGGER.info("[TopicPartitionPiece] Total pieces created {} for partition {} in topic {}",
@@ -417,8 +425,14 @@ public class KafkaMetadataHandler extends MetadataHandler
                         .add(SplitParameters.END_OFFSET, Long.toString(topicPartitionPiece.endOffset));
                 splits.add(splitBuilder.build());
             }
-        }
 
+            // if this isn't the last partition, and we've read more than our max splits per request, paginate the request.
+            if (splits.size() >= MAX_SPLITS_PER_REQUEST && partitionIndex < topicPartitions.size() - 1) { 
+                LOGGER.debug("[kafka] Total split created {} exceeded MAX_SPLITS_PER_REQUEST, sending paginated response", splits.size());
+                String encodedContinuationToken = String.valueOf(partitionIndex + 1);
+                return new GetSplitsResponse(request.getCatalogName(), splits, encodedContinuationToken);
+            }
+        }
         LOGGER.debug("[kafka] Total split created {} ", splits.size());
         return new GetSplitsResponse(request.getCatalogName(), splits);
     }

--- a/athena-kafka/src/test/java/com/amazonaws/athena/connectors/kafka/KafkaMetadataHandlerTest.java
+++ b/athena-kafka/src/test/java/com/amazonaws/athena/connectors/kafka/KafkaMetadataHandlerTest.java
@@ -53,6 +53,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -101,14 +102,15 @@ public class KafkaMetadataHandlerTest {
             "secrets_manager_secret", "Kafka_afq");
 
         consumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
-        Map<TopicPartition, Long> partitionsStart = com.google.common.collect.ImmutableMap.of(
-                new TopicPartition("testTopic", 0), 0L,
-                new TopicPartition("testTopic", 1), 0L
-        );
-        Map<TopicPartition, Long> partitionsEnd = com.google.common.collect.ImmutableMap.of(
-                new TopicPartition("testTopic", 0), 20100L,
-                new TopicPartition("testTopic", 1), 7850L
-        );
+        Map<TopicPartition, Long> partitionsStart = new HashMap<>();
+        Map<TopicPartition, Long> partitionsEnd = new HashMap<>();
+
+        // max splits per request is 1000. Here we will make 1500 partitions that each have the max records
+        // for a single split. we expect 1500 splits to generate, over two requests.
+        for (int i = 0; i < 1500; i++) {
+            partitionsStart.put(new TopicPartition("testTopic", i), 0L);
+            partitionsEnd.put(new TopicPartition("testTopic",  i), com.amazonaws.athena.connectors.kafka.KafkaConstants.MAX_RECORDS_IN_SPLIT - 1L); // keep simple and don't have multiple pieces
+        }
         List<PartitionInfo> partitionInfoList = new ArrayList<>(partitionsStart.keySet())
                 .stream()
                 .map(it -> new PartitionInfo(it.topic(), it.partition(), null, null, null))
@@ -215,10 +217,24 @@ public class KafkaMetadataHandlerTest {
                 Mockito.mock(Block.class),
                 new ArrayList<>(),
                 Mockito.mock(Constraints.class),
-                "continuationToken"
+                null 
         );
 
         GetSplitsResponse response = kafkaMetadataHandler.doGetSplits(blockAllocator, request);
-        assertEquals(4, response.getSplits().size());
+        assertEquals(1000, response.getSplits().size());
+        assertEquals("1000", response.getContinuationToken());
+        request = new GetSplitsRequest(
+                federatedIdentity,
+                QUERY_ID,
+                "kafka",
+                new TableName("default", "testTopic"),
+                Mockito.mock(Block.class),
+                new ArrayList<>(),
+                Mockito.mock(Constraints.class),
+                response.getContinuationToken()
+        );
+        response = kafkaMetadataHandler.doGetSplits(blockAllocator, request);
+        assertEquals(500, response.getSplits().size());
+        assertNull(response.getContinuationToken());
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

    Add pagination for MSK doGetSplits

    - Around 40-50k splits will cause the response for doGetSplits to exceed
      the 6mb limit set by lambda
    - Here I set the max splits per request to 1000.
    - This patch adds pagination support for doGetSplits to avoid exceeding
      the max response size and updates tests
    - We then also have to sort the partitions by id as they come in,
      because the consumer can fetch them in different orders sometimes.
      Without sorting, the continuation token loses meaning


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
