### PR TITLE
.github/workflows/maven_push.yml enhancements

### DIFF
--- a/.github/workflows/maven_push.yml
+++ b/.github/workflows/maven_push.yml
@@ -1,18 +1,31 @@
 name: Java CI Push
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
-  build:
-
-    runs-on: self-hosted
-
+  # This is from: https://github.com/fkirc/skip-duplicate-actions#example-1-skip-entire-jobs
+  pre_job:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up JDK 11
-      uses: actions/setup-java@v3
-      with:
-        distribution: 'corretto'
-        java-version: '11'
-    - name: Build with Maven
-      run: mvn -B package -T8 --file pom.xml
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v5.3.0
+        with:
+          cancel_others: 'true'
+          concurrent_skipping: 'same_content'
+          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
+
+  build:
+    needs: pre_job
+    if: needs.pre_job.outputs.should_skip != 'true'
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'corretto'
+          java-version: '11'
+      - name: Build with Maven
+        run: mvn -B package -T 2C --file pom.xml


### PR DESCRIPTION
- First, we need to add back pull_request, since outside contributors won't hit the push trigger when they open a pull request, since they do it from their own forks.

- Second, in order to avoid duplicate workflows running, we leverage this skip-duplicate-actions from the Github Action marketplace to avoid running duplicate workflows in multiple different situations.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
