### PR TITLE
maven_push.yml: use same_content_newer instead

### DIFF
--- a/.github/workflows/maven_push.yml
+++ b/.github/workflows/maven_push.yml
@@ -13,8 +13,7 @@ jobs:
         uses: fkirc/skip-duplicate-actions@v5.3.0
         with:
           cancel_others: 'true'
-          concurrent_skipping: 'same_content'
-          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
+          concurrent_skipping: 'same_content_newer'
 
   build:
     needs: pre_job


### PR DESCRIPTION
maven_push.yml: use same_content_newer instead

same_content is deprecated and the recommendation is to use
same_content.

See: https://github.com/marketplace/actions/skip-duplicate-actions#skip-concurrent-workflow-runs


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
