### PR TITLE
domain.predicate.Constraints: Fix close() method signature

### DIFF
--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/domain/predicate/Constraints.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/domain/predicate/Constraints.java
@@ -89,7 +89,6 @@ public class Constraints
 
     @Override
     public void close()
-            throws Exception
     {
         for (ValueSet next : summary.values()) {
             try {


### PR DESCRIPTION
Constraints.close() does not actually throw Exception, so there's no need to declare it.

Declaring it unnecessarily causes users of this class to be forced to catch or forced to declare that it throws Exception.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
