### PR TITLE
Don't depend on Google Guava toImmutableList

### DIFF
--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/resolver/DynamoDBTableResolver.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/resolver/DynamoDBTableResolver.java
@@ -39,9 +39,9 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
 
 import static com.amazonaws.athena.connectors.dynamodb.constants.DynamoDBConstants.DEFAULT_SCHEMA;
-import static com.google.common.collect.ImmutableList.toImmutableList;
 
 /**
  * This class helps with resolving the differences in casing between DynamoDB and Presto. Presto expects all
@@ -77,7 +77,7 @@ public class DynamoDBTableResolver
         return listTablesInternal().stream()
                 .map(table -> table.toLowerCase(Locale.ENGLISH)) // lowercase for compatibility
                 .map(table -> new TableName(DEFAULT_SCHEMA, table))
-                .collect(toImmutableList());
+                .collect(Collectors.toList());
     }
 
     private List<String> listTablesInternal()

--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/util/DDBPredicateUtils.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/util/DDBPredicateUtils.java
@@ -41,7 +41,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.google.common.base.Preconditions.checkState;
-import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.getOnlyElement;
 
 /**
@@ -296,7 +295,7 @@ public class DDBPredicateUtils
             for (Object value : singleValues) {
                 bindValue(originalColumnName, value, accumulator, recordMetadata);
             }
-            String values = COMMA_JOINER.join(Stream.generate(valueNameProducer::getNext).limit(singleValues.size()).collect(toImmutableList()));
+            String values = COMMA_JOINER.join(Stream.generate(valueNameProducer::getNext).limit(singleValues.size()).collect(Collectors.toList()));
             disjuncts.add((isWhitelist ? "" : "NOT ") + columnName + " IN (" + values + ")");
         }
 


### PR DESCRIPTION
Collectors.toList() will already provide an immutable List and this avoids issues with certain Spark distributions having a different version of Google Guava.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
