### PR TITLE
athena-dynamodb: Improve ddb sort key pushdown handling

### DIFF
--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBMetadataHandler.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBMetadataHandler.java
@@ -300,7 +300,7 @@ public class DynamoDBMetadataHandler
             if (rangeKey.isPresent()) {
                 String rangeKeyName = rangeKey.get();
                 if (summary.containsKey(rangeKeyName)) {
-                    String rangeKeyFilter = DDBPredicateUtils.generateSingleColumnFilter(rangeKeyName, summary.get(rangeKeyName), valueAccumulator, valueNameProducer, recordMetadata);
+                    String rangeKeyFilter = DDBPredicateUtils.generateSingleColumnFilter(rangeKeyName, summary.get(rangeKeyName), valueAccumulator, valueNameProducer, recordMetadata, true);
                     partitionSchemaBuilder.addMetadata(RANGE_KEY_NAME_METADATA, rangeKeyName);
                     partitionSchemaBuilder.addMetadata(RANGE_KEY_FILTER_METADATA, rangeKeyFilter);
                     columnsToIgnore.add(rangeKeyName);


### PR DESCRIPTION
In Athena v3, we are pushing down more predicates than we were in v2, which exposed an issue with how the athena-dynamodb connector was handling push downs for sort keys.

DDB does not allow sort keys to have more than one condition associated with them, so when we get SortedRangeSet push downs with upper and lower bounds from Athena, we were applying both bounds and then getting an error upon querying DDB.

In order to resolve this issue, we can simply just apply only one of the bounds when we are dealing with sort keys. In this implementation, upper bounds were chosen as the one that takes priority when both upper and lower bounds are present since upper bounds should theoretically filter more than a lower bound.

Issue #1089



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
