### PR TITLE
Adding support for TIMESTAMPMICROTZ including various refactoring and bug fixes for existing TIMESTAMPMILLITZ support.

### DIFF
--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/util/DDBRecordMetadata.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/util/DDBRecordMetadata.java
@@ -123,8 +123,9 @@ public class DDBRecordMetadata
     public static boolean isDateTimeFieldType(Types.MinorType fieldType)
     {
         return fieldType.equals(Types.MinorType.DATEMILLI)
-                || fieldType.equals(Types.MinorType.DATEDAY)
-                || fieldType.equals(Types.MinorType.TIMESTAMPMILLITZ);
+            || fieldType.equals(Types.MinorType.DATEDAY)
+            || fieldType.equals(Types.MinorType.TIMESTAMPMILLITZ)
+            || fieldType.equals(Types.MinorType.TIMESTAMPMICROTZ);
     }
 
     /**

--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/util/DDBTypeUtils.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/util/DDBTypeUtils.java
@@ -308,6 +308,7 @@ public final class DDBTypeUtils
                 switch (fieldType) {
                     case DATEMILLI:
                         return DateTimeFormatterUtil.stringToDateTime((String) value, customerConfiguredFormat, defaultTimeZone);
+                    case TIMESTAMPMICROTZ:
                     case TIMESTAMPMILLITZ:
                         return DateTimeFormatterUtil.stringToZonedDateTime((String) value, customerConfiguredFormat, defaultTimeZone);
                     case DATEDAY:

--- a/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBRecordHandlerTest.java
+++ b/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBRecordHandlerTest.java
@@ -772,6 +772,6 @@ public class DynamoDBRecordHandlerTest
     private long getPackedDateTimeWithZone(String s)
     {
         ZonedDateTime zdt = ZonedDateTime.parse(s);
-        return DateTimeFormatterUtil.packDateTimeWithZone(zdt);
+        return DateTimeFormatterUtil.timestampMilliTzHolderFromObject(zdt).value;
     }
 }

--- a/athena-federation-sdk/README.md
+++ b/athena-federation-sdk/README.md
@@ -34,7 +34,8 @@ The below table lists the supported Apache Arrow types as well as the correspond
 |-------------|-----------------|
 |BIT|int, boolean|
 |DATEMILLI|Date, long|
-|TIMESTAMPMILLITZ|Date, long|
+|TIMESTAMPMILLITZ|LocalDateTime, ZonedDateTime, Date, long|
+|TIMESTAMPMICROTZ|LocalDateTime, ZonedDateTime, Date, long|
 |DATEDAY|Date, long, int|
 |FLOAT8|double|
 |FLOAT4|float|

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/ArrowSchemaUtils.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/ArrowSchemaUtils.java
@@ -1,0 +1,50 @@
+/*-
+ * #%L
+ * Amazon Athena Query Federation SDK
+ * %%
+ * Copyright (C) 2023 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connector.lambda.data;
+
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Utility class for dealing with Arrow Schemas
+ */
+public class ArrowSchemaUtils
+{
+    public static Field remapArrowTypesWithinField(Field inputField, Function<ArrowType, ArrowType> arrowTypeMapper)
+    {
+        // Recursively transform any FieldTypes in the children Fields
+        List<Field> updatedChildren = inputField.getChildren().stream()
+            .map(f -> remapArrowTypesWithinField(f, arrowTypeMapper))
+            .collect(Collectors.toList());
+        ArrowType newArrowType = arrowTypeMapper.apply(inputField.getType());
+        FieldType oldFieldType = inputField.getFieldType();
+        FieldType newFieldType = new FieldType(oldFieldType.isNullable(), newArrowType, oldFieldType.getDictionary(), oldFieldType.getMetadata());
+        return new Field(inputField.getName(), newFieldType, updatedChildren);
+    }
+
+    private ArrowSchemaUtils()
+    {
+    }
+}

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/ArrowTypeComparator.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/ArrowTypeComparator.java
@@ -88,6 +88,7 @@ public class ArrowTypeComparator
                 return ((java.time.LocalDateTime) lhs).compareTo((java.time.LocalDateTime) rhs);
             case DATEDAY:
                 return ((Integer) lhs).compareTo((Integer) rhs);
+            case TIMESTAMPMICROTZ:
             case TIMESTAMPMILLITZ:
                 ArrowType.Timestamp actualArrowType = (ArrowType.Timestamp) arrowType;
                 if (lhs instanceof Long) {

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/ArrowTypeComparator.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/ArrowTypeComparator.java
@@ -24,7 +24,6 @@ import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.bouncycastle.util.Arrays;
-import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -90,14 +89,10 @@ public class ArrowTypeComparator
             case DATEDAY:
                 return ((Integer) lhs).compareTo((Integer) rhs);
             case TIMESTAMPMILLITZ:
+                ArrowType.Timestamp actualArrowType = (ArrowType.Timestamp) arrowType;
                 if (lhs instanceof Long) {
-                    ZonedDateTime lhsZdt = DateTimeFormatterUtil.constructZonedDateTime(((Long) lhs).longValue());
-                    ZonedDateTime rhsZdt = DateTimeFormatterUtil.constructZonedDateTime(((Long) rhs).longValue());
-                    return lhsZdt.compareTo(rhsZdt);
-                }
-                else if (lhs instanceof org.joda.time.LocalDateTime) {
-                    ZonedDateTime lhsZdt = getZonedDateTime((org.joda.time.LocalDateTime) lhs);
-                    ZonedDateTime rhsZdt = getZonedDateTime((org.joda.time.LocalDateTime) rhs);
+                    ZonedDateTime lhsZdt = DateTimeFormatterUtil.constructZonedDateTime(((Long) lhs).longValue(), actualArrowType);
+                    ZonedDateTime rhsZdt = DateTimeFormatterUtil.constructZonedDateTime(((Long) rhs).longValue(), actualArrowType);
                     return lhsZdt.compareTo(rhsZdt);
                 }
                 else {
@@ -121,20 +116,5 @@ public class ArrowTypeComparator
                 logger.warn("compare: Unknown type " + type + " object: " + lhs.getClass());
                 throw new IllegalArgumentException("Unknown type " + type + " object: " + lhs.getClass());
         }
-    }
-
-    /**
-     * convert LocalDateTime representing timestamp and timezone packed long
-     * by unpacking the two values and constructing a zoned date time from it.
-     * this is used only if the type is TIMESTAMPMILLITZ.
-     *
-     * @param ldt LocalDateTime representing timestamp and timezone packed long
-     * @return ZonedDateTime with the timestamp and timezone extracted from ldt
-     */
-    private static ZonedDateTime getZonedDateTime(org.joda.time.LocalDateTime ldt)
-    {
-        DateTimeZone dtz = ldt.getChronology().getZone();
-        long dateTimeWithTimeZone = ldt.toDateTime(dtz).getMillis();
-        return DateTimeFormatterUtil.constructZonedDateTime(dateTimeWithTimeZone);
     }
 }

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/DateTimeFormatterUtil.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/DateTimeFormatterUtil.java
@@ -20,14 +20,16 @@
 package com.amazonaws.athena.connector.lambda.data;
 
 import com.amazonaws.util.StringUtils;
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.commons.lang3.time.DateFormatUtils;
 import org.apache.commons.lang3.time.DateUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.math.BigDecimal;
-import java.sql.Timestamp;
 import java.text.ParseException;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -60,6 +62,27 @@ public class DateTimeFormatterUtil
     // This encoding is from Presto's DateTimeEncoding.
     private static final int TIME_ZONE_MASK = 0xFFF;
     private static final int MILLIS_SHIFT = 12;
+
+    // By default this is enabled because this is the historical behavior
+    private static boolean packTimezone = true;
+
+    public static void disableTimezonePacking()
+    {
+        logger.info("Timezone packing disabled");
+        packTimezone = false;
+    }
+
+    // Enabling is only available in tests.
+    // In production, once an application calls disable we don't allow it to be
+    // re-enable it during the lifetime of the application since there is no
+    // use case for toggling this and this makes reasoning about what happpens
+    // when we investigate issues easier.
+    @VisibleForTesting
+    static void enableTimezonePacking()
+    {
+        logger.info("Timezone packing enabled");
+        packTimezone = true;
+    }
 
     private DateTimeFormatterUtil()
     {}
@@ -239,7 +262,7 @@ public class DateTimeFormatterUtil
      * @param zdt ZonedDateTime to extract timezone and time millis in UTC from
      * @return long value representing ZonedDateTime
      */
-    public static long packDateTimeWithZone(ZonedDateTime zdt)
+    private static long packDateTimeWithZone(ZonedDateTime zdt)
     {
         String zoneId = zdt.getZone().getId();
         LocalDateTime zdtInUtc = zdt.withZoneSameInstant(UTC_ZONE_ID).toLocalDateTime();
@@ -257,7 +280,7 @@ public class DateTimeFormatterUtil
      * @param zoneId string value of the timezone (ex: UTC)
      * @return long value representing ZonedDateTime
      */
-    public static long packDateTimeWithZone(long millisUtc, String zoneId)
+    private static long packDateTimeWithZone(long millisUtc, String zoneId)
     {
         TimeZoneKey timeZoneKey = TimeZoneKey.getTimeZoneKey(zoneId);
         requireNonNull(timeZoneKey, "timeZoneKey is null");
@@ -296,19 +319,75 @@ public class DateTimeFormatterUtil
     }
 
     /**
-     * Reconstruct ZonedDateTime type from datetime and timezone packed long
-     * @param dateTimeWithTimeZone datetime and timezone packed long
-     * @return ZonedDateTime representing values from dateTimeWithTimeZone
+     * Reconstruct a ZonedDateTime given an epoch timestamp and its arrow type
+     * @param epochTimestamp this is the timestamp in epoch time. Possibly in packed form, where it contains the timezone.
+     * @param arrowType this is the arrowType that the value being passed in came from. The arrow type contains information about the units and timezone.
+     * @return ZonedDateTime the converted ZonedDateTime from the epochUtc timestamp and timezone either from the packed value or arrowType.
      */
-    public static ZonedDateTime constructZonedDateTime(long dateTimeWithTimeZone)
+    public static ZonedDateTime constructZonedDateTime(long epochTimestamp, ArrowType.Timestamp arrowType)
     {
-        TimeZoneKey timeZoneKey = unpackZoneKey(dateTimeWithTimeZone);
-        long millisUtc = unpackMillisUtc(dateTimeWithTimeZone);
-        LocalDateTime zdtInUtc = new Timestamp(millisUtc).toLocalDateTime();
-        ZoneId timeZone = ZoneId.of(timeZoneKey.getId());
-        LocalDateTime localDateTime = zdtInUtc.atZone(UTC_ZONE_ID)
-                .withZoneSameInstant(timeZone)
-                .toLocalDateTime();
-        return ZonedDateTime.of(localDateTime, timeZone);
+        org.apache.arrow.vector.types.TimeUnit timeunit = arrowType.getUnit();
+        ZoneId timeZone = ZoneId.of(arrowType.getTimezone());
+        if (packTimezone) {
+            if (!org.apache.arrow.vector.types.TimeUnit.MILLISECOND.equals(timeunit)) {
+                throw new UnsupportedOperationException("Unpacking is only supported for milliseconds");
+            }
+            // arrowType's timezone is ignored in this case since the timezone is packed into the long
+            TimeZoneKey timeZoneKey = unpackZoneKey(epochTimestamp);
+            epochTimestamp = unpackMillisUtc(epochTimestamp);
+            timeZone = ZoneId.of(timeZoneKey.getId());
+        }
+        return Instant.EPOCH
+            .plus(epochTimestamp, DateTimeFormatterUtil.arrowTimeUnitToChronoUnit(timeunit))
+            .atZone(timeZone);
+    }
+
+    public static java.time.temporal.ChronoUnit arrowTimeUnitToChronoUnit(org.apache.arrow.vector.types.TimeUnit timeunit)
+    {
+        switch (timeunit) {
+            case MICROSECOND:
+                return java.time.temporal.ChronoUnit.MICROS;
+            case MILLISECOND:
+                return java.time.temporal.ChronoUnit.MILLIS;
+            case NANOSECOND:
+                return java.time.temporal.ChronoUnit.NANOS;
+            case SECOND:
+                return java.time.temporal.ChronoUnit.SECONDS;
+        }
+
+        throw new UnsupportedOperationException(String.format("Unsupported timeunit: %s", timeunit));
+    }
+
+    public static ZonedDateTime zonedDateTimeFromObject(Object value)
+    {
+        if (value instanceof ZonedDateTime) {
+            return (ZonedDateTime) value;
+        }
+        else if (value instanceof LocalDateTime) {
+            return ((LocalDateTime) value).atZone(ZoneId.of("UTC"));
+        }
+        else if (value instanceof Date) {
+            return ((Date) value).toInstant().atZone(ZoneId.of("UTC"));
+        }
+
+        throw new UnsupportedOperationException(String.format("Type: %s not supported", value.getClass()));
+    }
+
+    public static org.apache.arrow.vector.holders.TimeStampMilliTZHolder timestampMilliTzHolderFromObject(Object value)
+    {
+        ZonedDateTime zdt = zonedDateTimeFromObject(value);
+        org.apache.arrow.vector.holders.TimeStampMilliTZHolder holder = new org.apache.arrow.vector.holders.TimeStampMilliTZHolder();
+        holder.timezone = zdt.getZone().getId();
+        holder.value = zdt.toInstant().toEpochMilli();
+
+        // Pack the timezone if packing is enabled.
+        // Note that it doesn't matter if we already also have the timezone
+        // set in the holder, since engines that expect packing will not be
+        // looking at that field.
+        if (packTimezone) {
+            holder.value = packDateTimeWithZone(holder.value, holder.timezone);
+        }
+
+        return holder;
     }
 }

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/DateTimeFormatterUtil.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/DateTimeFormatterUtil.java
@@ -390,4 +390,24 @@ public class DateTimeFormatterUtil
 
         return holder;
     }
+
+    public static org.apache.arrow.vector.holders.TimeStampMicroTZHolder timestampMicroTzHolderFromObject(Object value)
+    {
+        if (packTimezone) {
+            throw new UnsupportedOperationException("Packing for TimeStampMicroTZ is not currently supported");
+        }
+
+        ZonedDateTime zdt = zonedDateTimeFromObject(value);
+        String zone = zdt.getZone().getId();
+        Instant instant = zdt.toInstant();
+
+        // From: https://stackoverflow.com/a/47869726
+        long epochMicros = java.util.concurrent.TimeUnit.SECONDS.toMicros(instant.getEpochSecond()) +
+            instant.getLong(java.time.temporal.ChronoField.MICRO_OF_SECOND);
+
+        org.apache.arrow.vector.holders.TimeStampMicroTZHolder holder = new org.apache.arrow.vector.holders.TimeStampMicroTZHolder();
+        holder.timezone = zone;
+        holder.value = epochMicros;
+        return holder;
+    }
 }

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/SupportedTypes.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/SupportedTypes.java
@@ -37,6 +37,7 @@ public enum SupportedTypes
     DATEMILLI(Types.MinorType.DATEMILLI),
     DATEDAY(Types.MinorType.DATEDAY),
     TIMESTAMPMILLITZ(Types.MinorType.TIMESTAMPMILLITZ),
+    TIMESTAMPMICROTZ(Types.MinorType.TIMESTAMPMICROTZ),
     FLOAT8(Types.MinorType.FLOAT8),
     FLOAT4(Types.MinorType.FLOAT4),
     INT(Types.MinorType.INT),

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/data/ArrowSchemaUtilsTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/data/ArrowSchemaUtilsTest.java
@@ -1,0 +1,112 @@
+/*-
+ * #%L
+ * Amazon Athena Query Federation SDK
+ * %%
+ * Copyright (C) 2023 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connector.lambda.data;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.DictionaryEncoding;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.junit.Test;
+
+import java.util.function.Function;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class ArrowSchemaUtilsTest {
+
+    @Test
+    public void testRemapTypeInStruct() {
+        // Verify that this type is changed later
+        DictionaryEncoding bsdfDictionaryEncoding = new DictionaryEncoding(1111, false, new ArrowType.Int(32, false));
+        Map<String, String> bsdfMeta = ImmutableMap.of("11111111", "2222222222");
+        FieldType bsdfType = new FieldType(true, new ArrowType.Utf8(), bsdfDictionaryEncoding, bsdfMeta);
+        Field bsdf = new Field("bsdf", bsdfType, null);
+
+        // Verify that this type is unchanged later
+        DictionaryEncoding csdfDictionaryEncoding = new DictionaryEncoding(2222, true, new ArrowType.Int(32, true));
+        Map<String, String> csdfMeta = ImmutableMap.of("3333333333", "4444444444");
+        FieldType csdfType = new FieldType(true, new ArrowType.Decimal(12, 3, 32), csdfDictionaryEncoding, csdfMeta);
+        Field csdf = new Field("csdf", csdfType, null);
+
+        // Inner struct
+        DictionaryEncoding asdfDictionaryEncoding = new DictionaryEncoding(33333, false, new ArrowType.Int(64, false));
+        Map<String, String> asdfMeta = ImmutableMap.of("55555555", "66666666");
+        FieldType asdfFieldType = new FieldType(true, new ArrowType.Struct(), asdfDictionaryEncoding, asdfMeta);
+        Field asdf = new Field("asdf", asdfFieldType, ImmutableList.of(bsdf, csdf));
+
+        // Outer struct that also repeats bsdf and csdf on the outside
+        DictionaryEncoding aasdfDictionaryEncoding = new DictionaryEncoding(44444, true, new ArrowType.Int(64, true));
+        Map<String, String> aasdfMeta = ImmutableMap.of("7777", "88888");
+        FieldType aasdfFieldType = new FieldType(true, new ArrowType.Struct(), aasdfDictionaryEncoding, aasdfMeta);
+        Field aasdf = new Field("aasdf", aasdfFieldType, ImmutableList.of(asdf, bsdf, csdf));
+
+        Function<ArrowType, ArrowType> arrowTypeMapper = arrowType -> {
+            if (arrowType instanceof ArrowType.Utf8) {
+                return new ArrowType.Decimal(24, 6, 32);
+            } else {
+                return arrowType;
+            }
+        };
+
+        // Run remapArrowTypesWithinField
+        Field outputField = ArrowSchemaUtils.remapArrowTypesWithinField(aasdf, arrowTypeMapper);
+
+        // This verifies most of the fields
+        assertEquals(
+            "aasdf: Struct[dictionary: 44444]<" +
+                "asdf: Struct[dictionary: 33333]<" +
+                    "bsdf: Decimal(24, 6, 32)[dictionary: 1111], " +
+                    "csdf: Decimal(12, 3, 32)[dictionary: 2222]" +
+                ">, " +
+                "bsdf: Decimal(24, 6, 32)[dictionary: 1111], " +
+                "csdf: Decimal(12, 3, 32)[dictionary: 2222]" +
+            ">",
+            outputField.toString());
+
+        // Now verify the fields that aren't covered by toString()
+        assertTrue(outputField.getFieldType().isNullable());
+        assertEquals(aasdfMeta, outputField.getFieldType().getMetadata());
+
+        Field outputAsdf = outputField.getChildren().get(0);
+        assertTrue(outputAsdf.getFieldType().isNullable());
+        assertEquals(asdfMeta, outputAsdf.getFieldType().getMetadata());
+
+        Field innerOutputBsdf = outputField.getChildren().get(0).getChildren().get(0);
+        assertTrue(innerOutputBsdf.getFieldType().isNullable());
+        assertEquals(bsdfMeta, innerOutputBsdf.getFieldType().getMetadata());
+
+        Field innerOutputCsdf = outputField.getChildren().get(0).getChildren().get(1);
+        assertTrue(innerOutputCsdf.getFieldType().isNullable());
+        assertEquals(csdfMeta, innerOutputCsdf.getFieldType().getMetadata());
+
+        Field outputBsdf = outputField.getChildren().get(1);
+        assertTrue(outputBsdf.getFieldType().isNullable());
+        assertEquals(bsdfMeta, outputBsdf.getFieldType().getMetadata());
+
+        Field outputCsdf = outputField.getChildren().get(2);
+        assertTrue(outputCsdf.getFieldType().isNullable());
+        assertEquals(csdfMeta, outputCsdf.getFieldType().getMetadata());
+    }
+}
+

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/data/BlockUtilsTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/data/BlockUtilsTest.java
@@ -20,7 +20,9 @@ package com.amazonaws.athena.connector.lambda.data;
  * #L%
  */
 
+import com.google.common.collect.ImmutableList;
 import org.apache.arrow.vector.types.DateUnit;
+import org.apache.arrow.vector.types.TimeUnit;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Schema;
@@ -55,6 +57,9 @@ public class BlockUtilsTest
     public void setup()
     {
         logger.info("{}: enter", testName.getMethodName());
+        // This is the default behavior of DateTimeFormatterUtil but some tests
+        // will selectively disable it.
+        DateTimeFormatterUtil.enableTimezonePacking();
         TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
         allocator = new BlockAllocatorImpl();
     }
@@ -69,94 +74,113 @@ public class BlockUtilsTest
     @Test
     public void copyRows()
     {
-        Schema schema = SchemaBuilder.newBuilder()
-                .addField("col1", new ArrowType.Int(32, true))
+        for (TimeUnit timeUnit : ImmutableList.of(TimeUnit.MILLISECOND, TimeUnit.MICROSECOND)) {
+            if (timeUnit.equals(TimeUnit.MICROSECOND)) {
+                DateTimeFormatterUtil.disableTimezonePacking();
+            }
+            Schema schema = SchemaBuilder.newBuilder()
+                    .addField("col1", new ArrowType.Int(32, true))
 
-                .addField("col2", new ArrowType.Decimal(38, 9))
-                .addField("col3", new ArrowType.Timestamp(org.apache.arrow.vector.types.TimeUnit.MILLISECOND, "UTC"))
-                .build();
+                    .addField("col2", new ArrowType.Decimal(38, 9))
+                    .addField("col3", new ArrowType.Timestamp(timeUnit, "UTC"))
+                    .build();
 
-        LocalDateTime ldt = LocalDateTime.of(2020, 03, 18, 12,54,29);
-        Date date = Date.from(ldt.atZone(ZoneId.systemDefault()).toInstant());
+            LocalDateTime ldt = LocalDateTime.of(2020, 03, 18, 12,54,29);
+            Date date = Date.from(ldt.atZone(ZoneId.systemDefault()).toInstant());
 
-        //Make a block with 3 rows
-        Block src = allocator.createBlock(schema);
-        BlockUtils.setValue(src.getFieldVector("col1"), 0, 10);
-        BlockUtils.setValue(src.getFieldVector("col2"), 0, new BigDecimal(20));
-        BlockUtils.setValue(src.getFieldVector("col3"), 0, ldt);
+            //Make a block with 3 rows
+            Block src = allocator.createBlock(schema);
+            BlockUtils.setValue(src.getFieldVector("col1"), 0, 10);
+            BlockUtils.setValue(src.getFieldVector("col2"), 0, new BigDecimal(20));
+            BlockUtils.setValue(src.getFieldVector("col3"), 0, ldt);
 
-        BlockUtils.setValue(src.getFieldVector("col1"), 1, 11);
-        BlockUtils.setValue(src.getFieldVector("col2"), 1, new BigDecimal(21));
-        BlockUtils.setValue(src.getFieldVector("col3"), 1, ZonedDateTime.of(ldt, ZoneId.of("-05:00")));
+            BlockUtils.setValue(src.getFieldVector("col1"), 1, 11);
+            BlockUtils.setValue(src.getFieldVector("col2"), 1, new BigDecimal(21));
+            BlockUtils.setValue(src.getFieldVector("col3"), 1, ZonedDateTime.of(ldt, ZoneId.of("-05:00")));
 
-        BlockUtils.setValue(src.getFieldVector("col1"), 2, 12);
-        BlockUtils.setValue(src.getFieldVector("col2"), 2, new BigDecimal(22));
-        BlockUtils.setValue(src.getFieldVector("col3"), 2, date);
-        src.setRowCount(3);
+            BlockUtils.setValue(src.getFieldVector("col1"), 2, 12);
+            BlockUtils.setValue(src.getFieldVector("col2"), 2, new BigDecimal(22));
+            BlockUtils.setValue(src.getFieldVector("col3"), 2, date);
+            src.setRowCount(3);
 
-        //Make the destination block
-        Block dst = allocator.createBlock(schema);
+            //Make the destination block
+            Block dst = allocator.createBlock(schema);
 
-        assertEquals(3, BlockUtils.copyRows(src, dst, 0, 2));
+            assertEquals(3, BlockUtils.copyRows(src, dst, 0, 2));
 
-        assertEquals(src, dst);
+            assertEquals(src, dst);
+        }
     }
 
     @Test
     public void isNullRow()
     {
-        Schema schema = SchemaBuilder.newBuilder()
-                .addField("col1", new ArrowType.Int(32, true))
-                .addField("col2", new ArrowType.Int(32, true))
-                .addField("col3", new ArrowType.Timestamp(org.apache.arrow.vector.types.TimeUnit.MILLISECOND, "UTC"))
-                .build();
+        for (TimeUnit timeUnit : ImmutableList.of(TimeUnit.MILLISECOND, TimeUnit.MICROSECOND)) {
+            if (timeUnit.equals(TimeUnit.MICROSECOND)) {
+                DateTimeFormatterUtil.disableTimezonePacking();
+            }
+            Schema schema = SchemaBuilder.newBuilder()
+                    .addField("col1", new ArrowType.Int(32, true))
+                    .addField("col2", new ArrowType.Int(32, true))
+                    .addField("col3", new ArrowType.Timestamp(timeUnit, "UTC"))
+                    .build();
 
-        LocalDateTime ldt = LocalDateTime.now();
+            LocalDateTime ldt = LocalDateTime.now();
 
-        //Make a block with 2 rows and no null rows
-        Block block = allocator.createBlock(schema);
-        BlockUtils.setValue(block.getFieldVector("col1"), 0, 10);
-        BlockUtils.setValue(block.getFieldVector("col2"), 0, 20);
-        BlockUtils.setValue(block.getFieldVector("col3"), 0, ldt);
+            //Make a block with 2 rows and no null rows
+            Block block = allocator.createBlock(schema);
+            BlockUtils.setValue(block.getFieldVector("col1"), 0, 10);
+            BlockUtils.setValue(block.getFieldVector("col2"), 0, 20);
+            BlockUtils.setValue(block.getFieldVector("col3"), 0, ldt);
 
-        BlockUtils.setValue(block.getFieldVector("col1"), 1, 11);
-        BlockUtils.setValue(block.getFieldVector("col2"), 1, 21);
-        BlockUtils.setValue(block.getFieldVector("col3"), 1, ZonedDateTime.of(ldt, ZoneId.of("-05:00")));
-        block.setRowCount(2);
+            BlockUtils.setValue(block.getFieldVector("col1"), 1, 11);
+            BlockUtils.setValue(block.getFieldVector("col2"), 1, 21);
+            BlockUtils.setValue(block.getFieldVector("col3"), 1, ZonedDateTime.of(ldt, ZoneId.of("-05:00")));
+            block.setRowCount(2);
 
-        assertFalse(BlockUtils.isNullRow(block, 1));
+            assertFalse(BlockUtils.isNullRow(block, 1));
 
-        //now set a row to null
-        BlockUtils.unsetRow(1, block);
-        assertTrue(BlockUtils.isNullRow(block, 1));
+            //now set a row to null
+            BlockUtils.unsetRow(1, block);
+            assertTrue(BlockUtils.isNullRow(block, 1));
+        }
     }
 
     @Test
     public void fieldToString() throws java.text.ParseException
     {
-        Schema schema = SchemaBuilder.newBuilder()
-                .addField("col1", new ArrowType.Int(32, true))
-                .addField("col2", new ArrowType.Timestamp(org.apache.arrow.vector.types.TimeUnit.MILLISECOND, "UTC"))
-                .addField("col3", new ArrowType.Date(org.apache.arrow.vector.types.DateUnit.DAY))
-                .build();
+        for (TimeUnit timeUnit : ImmutableList.of(TimeUnit.MILLISECOND, TimeUnit.MICROSECOND)) {
+            String expectedString = "Block{rows=2, col1=[10, 11], col2=[2020-03-18T12:54:29Z[UTC], 2020-03-18T12:54:29-05:00], col3=[18339, 18259]}";
+            if (timeUnit.equals(TimeUnit.MICROSECOND)) {
+                DateTimeFormatterUtil.disableTimezonePacking();
+                // The difference here is because TimeUnit.MILLISECOND with packing is using the packed
+                // timezone value rather than using the timezone from the ArrowType
+                expectedString = "Block{rows=2, col1=[10, 11], col2=[2020-03-18T12:54:29Z[UTC], 2020-03-18T17:54:29Z[UTC]], col3=[18339, 18259]}";
+            }
 
-        LocalDateTime ldt = LocalDateTime.of(2020, 03, 18, 12,54,29);
+            Schema schema = SchemaBuilder.newBuilder()
+                    .addField("col1", new ArrowType.Int(32, true))
+                    .addField("col2", new ArrowType.Timestamp(timeUnit, "UTC"))
+                    .addField("col3", new ArrowType.Date(org.apache.arrow.vector.types.DateUnit.DAY))
+                    .build();
 
-        //Make a block with 2 rows and no null rows
-        Block block = allocator.createBlock(schema);
-        BlockUtils.setValue(block.getFieldVector("col1"), 0, 10);
-        BlockUtils.setValue(block.getFieldVector("col2"), 0, ldt);
-        BlockUtils.setValue(block.getFieldVector("col3"), 0, java.sql.Timestamp.valueOf(ldt));
+            LocalDateTime ldt = LocalDateTime.of(2020, 03, 18, 12,54,29);
 
-        BlockUtils.setValue(block.getFieldVector("col1"), 1, 11);
-        BlockUtils.setValue(block.getFieldVector("col2"), 1, ZonedDateTime.of(ldt, ZoneId.of("-05:00")));
-        BlockUtils.setValue(block.getFieldVector("col3"), 1, new java.text.SimpleDateFormat("yyyy-MM-dd").parse("2019-12-29"));
-        block.setRowCount(2);
+            //Make a block with 2 rows and no null rows
+            Block block = allocator.createBlock(schema);
+            BlockUtils.setValue(block.getFieldVector("col1"), 0, 10);
+            BlockUtils.setValue(block.getFieldVector("col2"), 0, ldt);
+            BlockUtils.setValue(block.getFieldVector("col3"), 0, java.sql.Timestamp.valueOf(ldt));
 
-        String actual = block.toString();
-        assertEquals(
-            "Block{rows=2, col1=[10, 11], col2=[2020-03-18T12:54:29Z[UTC], 2020-03-18T12:54:29-05:00], col3=[18339, 18259]}",
-            actual);
+            BlockUtils.setValue(block.getFieldVector("col1"), 1, 11);
+            BlockUtils.setValue(block.getFieldVector("col2"), 1, ZonedDateTime.of(ldt, ZoneId.of("-05:00")));
+            BlockUtils.setValue(block.getFieldVector("col3"), 1, new java.text.SimpleDateFormat("yyyy-MM-dd").parse("2019-12-29"));
+            block.setRowCount(2);
+
+            String actual = block.toString();
+
+            assertEquals(expectedString, actual);
+        }
     }
 
     @Test

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/serde/v2/ArrowSerDeTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/serde/v2/ArrowSerDeTest.java
@@ -38,7 +38,9 @@ public class ArrowSerDeTest
     // MinorType.DECIMAL which is a similar case of no default mapping to ArrowType does not need this as
     // MinorType name and ArrowType name are the same so simple fall back of enum name works.
     private static final ImmutableMap<SupportedTypes, String> FALL_BACK_ARROW_TYPE_CLASS = ImmutableMap.of(
-            SupportedTypes.TIMESTAMPMILLITZ, ArrowType.Timestamp.class.getSimpleName());
+        SupportedTypes.TIMESTAMPMILLITZ, ArrowType.Timestamp.class.getSimpleName(),
+        SupportedTypes.TIMESTAMPMICROTZ, ArrowType.Timestamp.class.getSimpleName()
+    );
 
     @Test
     public void testSupportedTypesHaveSerializers()


### PR DESCRIPTION
Adding support for TIMESTAMPMICROTZ including various refactoring and bug fixes for existing TIMESTAMPMILLITZ support.


commit 526400f3b7266c09a0624b90c476529340484aaa

    Add support for TIMESTAMPMICROTZ

commit 32e0bccf7b80c7e8b2ccc452cfb141ee78a761b8

    Add support unpacked timestamps with timezones

    - Refactor how we write timestamps to not expose packing publicly.

    - Added a switch to disable packing in DateTimeFormatterUtil.

    - Updates DateTimeFormatterUtil.constructZonedDateTime to deal with both
      packed and unpacked timestamps.

    - Fixes and refactoring of the GCS connector code when
    handling schema conversions for Time and Timestamp types.
      - [...]StorageMetadata.java was not preserving timezones for
         Timestamp types previously.

    - Gets rid of joda time usage since it looks like the only reason it was
      there was because of Arrow using in the past. However its been gone
      since ARROW-2015.

commit 2481d140d5ac2fcbf3f584cf8bfd0e84f69e7d09

    Add ArrowSchemaUtils.remapArrowTypesWithinField

    Utility method to recursively remap ArrowTypes given a mapping
    function.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
