### PR TITLE
athena-gcs: Fix StorageMetadata::getCompatibleFieldType

### DIFF
--- a/athena-gcs/src/main/java/com/amazonaws/athena/connectors/gcs/storage/StorageMetadata.java
+++ b/athena-gcs/src/main/java/com/amazonaws/athena/connectors/gcs/storage/StorageMetadata.java
@@ -248,19 +248,25 @@ public class StorageMetadata
 
     private static ArrowType getCompatibleFieldType(ArrowType arrowType)
     {
-        switch (arrowType.getTypeID()) {
-            case Time: {
+        Types.MinorType fieldType = Types.getMinorTypeForArrowType(arrowType);
+        switch (fieldType) {
+            case TIMESTAMPNANO:
+            case TIMESTAMPSEC:
+            case TIMESTAMPMILLI:
+            case TIMEMICRO:
+            case TIMESTAMPMICRO:
+            case TIMENANO:
                 return Types.MinorType.DATEMILLI.getType();
-            }
-            case Timestamp: {
+            case TIMESTAMPMILLITZ:
+            case TIMESTAMPMICROTZ: {
                 return new ArrowType.Timestamp(
                     org.apache.arrow.vector.types.TimeUnit.MILLISECOND,
                     ((ArrowType.Timestamp) arrowType).getTimezone());
             }
             // NOTE: Not sure that both of these should go to Utf8,
             // but just keeping it in-line with how it was before.
-            case FixedSizeBinary:
-            case LargeBinary:
+            case FIXEDSIZEBINARY:
+            case LARGEVARBINARY:
                 return ArrowType.Utf8.INSTANCE;
         }
         return arrowType;

--- a/athena-teradata/src/main/java/com/amazonaws/athena/connectors/teradata/TeradataMetadataHandler.java
+++ b/athena-teradata/src/main/java/com/amazonaws/athena/connectors/teradata/TeradataMetadataHandler.java
@@ -374,8 +374,7 @@ public class TeradataMetadataHandler extends JdbcMetadataHandler
                                 resultSet.getInt("DECIMAL_DIGITS")));
                     }
                     else {
-                        LOGGER.info("getSchema:columnType is not instance of ArrowType column[" + columnName +
-                                "] to a supported type, attempted " + columnType + " - defaulting type to VARCHAR.");
+                        LOGGER.info("getSchema:columnType is a supported ArrowType. Column: {} ArrowType: {}", columnName, columnType);
                         schemaBuilder.addField(FieldBuilder.newBuilder(columnName, columnType).build());
                     }
                 }


### PR DESCRIPTION
    athena-gcs: Fix StorageMetadata::getCompatibleFieldType

    - The previous version of this code was converting all
      ArrowType.Timestamp without timezones into ArrowType.Date.
      This patch returns us to that past behavior in
      the athena-gcs connector to avoid issues with the Athena Console.
      ** Note that it doesn't look like we ever hit the
         TIMESTAMPMILLITZ case in the past, because that case immediately
         would throw an exception in the connector itself before any
         response is returned to the Athena Console.

    - Fix an incorrect logging message in TeradataMetadataHandler
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
