### PR TITLE
workflows/cut_release: Use ubuntu-latest instead of self-hosted

### DIFF
--- a/.github/workflows/cut_release.yml
+++ b/.github/workflows/cut_release.yml
@@ -6,12 +6,11 @@ on:
 jobs:
   cut_release:
     name: Cut a release
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: Setup dependencies
         run: |
-          sudo yum -y update
-          sudo yum -y install python3 python3-pip libxml2
+          sudo apt-get install -y libxml2-utils python3
           pip3 install lxml beautifulsoup4
 
       - name: Set up JDK 11


### PR DESCRIPTION
workflows/cut_release: Use ubuntu-latest instead of self-hosted

Our self-hosted runners are missing `gh cli`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
