### PR TITLE
bump redshift to preferred driver version

### DIFF
--- a/athena-redshift/pom.xml
+++ b/athena-redshift/pom.xml
@@ -22,8 +22,8 @@
         </dependency>
         <dependency>
             <groupId>com.amazon.redshift</groupId>
-            <artifactId>redshift-jdbc42-no-awssdk</artifactId>
-            <version>1.2.55.1083</version>
+            <artifactId>redshift-jdbc42</artifactId>
+            <version>2.1.0.13</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>


### PR DESCRIPTION
addresses #1156 and an internal ticket to add support for redshift serverless

This change bumps the redshift jdbc driver to the latest supported driver. Checked with former redshift jdbc driver team member that the driver is backwards compatible and more efficient. 
