### PR TITLE
[DynamoDB] Add Cross-Account Functionality

### DIFF
--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBMetadataHandler.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBMetadataHandler.java
@@ -19,6 +19,7 @@
  */
 package com.amazonaws.athena.connectors.dynamodb;
 
+import com.amazonaws.athena.connector.credentials.CrossAccountCredentialsProvider;
 import com.amazonaws.athena.connector.lambda.QueryStatusChecker;
 import com.amazonaws.athena.connector.lambda.ThrottlingInvoker;
 import com.amazonaws.athena.connector.lambda.data.Block;
@@ -135,7 +136,9 @@ public class DynamoDBMetadataHandler
     public DynamoDBMetadataHandler(java.util.Map<String, String> configOptions)
     {
         super(SOURCE_TYPE, configOptions);
-        this.ddbClient = AmazonDynamoDBClientBuilder.standard().build();
+        this.ddbClient = AmazonDynamoDBClientBuilder.standard()
+            .withCredentials(CrossAccountCredentialsProvider.getCrossAccountCredentialsIfPresent(configOptions, "DynamoDBMetadataHandler_CrossAccountRoleSession"))
+            .build();
         this.glueClient = getAwsGlue();
         this.invoker = ThrottlingInvoker.newDefaultBuilder(EXCEPTION_FILTER, configOptions).build();
         this.tableResolver = new DynamoDBTableResolver(invoker, ddbClient);

--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBRecordHandler.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBRecordHandler.java
@@ -20,6 +20,7 @@
 package com.amazonaws.athena.connectors.dynamodb;
 
 import com.amazonaws.AmazonWebServiceRequest;
+import com.amazonaws.athena.connector.credentials.CrossAccountCredentialsProvider;
 import com.amazonaws.athena.connector.lambda.QueryStatusChecker;
 import com.amazonaws.athena.connector.lambda.ThrottlingInvoker;
 import com.amazonaws.athena.connector.lambda.data.Block;
@@ -104,7 +105,9 @@ public class DynamoDBRecordHandler
     public DynamoDBRecordHandler(java.util.Map<String, String> configOptions)
     {
         super(sourceType, configOptions);
-        this.ddbClient = AmazonDynamoDBClientBuilder.standard().build();
+        this.ddbClient = AmazonDynamoDBClientBuilder.standard()
+            .withCredentials(CrossAccountCredentialsProvider.getCrossAccountCredentialsIfPresent(configOptions, "DynamoDBRecordHandler_CrossAccountRoleSession"))
+            .build();
         this.invokerCache = CacheBuilder.newBuilder().build(
             new CacheLoader<String, ThrottlingInvoker>() {
                 @Override

--- a/athena-federation-sdk/pom.xml
+++ b/athena-federation-sdk/pom.xml
@@ -121,6 +121,33 @@
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-sts</artifactId>
+            <version>${aws-sdk.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.datatype</groupId>
+                    <artifactId>jackson-datatype-jsr310</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.dataformat</groupId>
+                    <artifactId>jackson-dataformat-cbor</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-glue</artifactId>
             <version>${aws-sdk.version}</version>
         </dependency>

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/credentials/CrossAccountCredentialsProvider.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/credentials/CrossAccountCredentialsProvider.java
@@ -1,0 +1,58 @@
+/*-
+ * #%L
+ * Amazon Athena Query Federation SDK
+ * %%
+ * Copyright (C) 2019 - 2023 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connector.credentials;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicSessionCredentials;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceAsyncClientBuilder;
+import com.amazonaws.services.securitytoken.model.AssumeRoleRequest;
+import com.amazonaws.services.securitytoken.model.AssumeRoleResult;
+import com.amazonaws.services.securitytoken.model.Credentials;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+public class CrossAccountCredentialsProvider
+{
+    private static final String CROSS_ACCOUNT_ROLE_ARN_CONFIG = "cross_account_role_arn";
+    private static final Logger logger = LoggerFactory.getLogger(CrossAccountCredentialsProvider.class);
+
+    private CrossAccountCredentialsProvider() {}
+
+    public static AWSCredentialsProvider getCrossAccountCredentialsIfPresent(Map<String, String> configOptions, String roleSessionName)
+    {
+        if (configOptions.containsKey(CROSS_ACCOUNT_ROLE_ARN_CONFIG)) {
+            logger.debug("Found cross-account role arn to assume.");
+            AWSSecurityTokenService stsClient = AWSSecurityTokenServiceAsyncClientBuilder.standard().build();
+            AssumeRoleRequest assumeRoleRequest = new AssumeRoleRequest()
+                .withRoleArn(configOptions.get(CROSS_ACCOUNT_ROLE_ARN_CONFIG))
+                .withRoleSessionName(roleSessionName);
+            AssumeRoleResult assumeRoleResult = stsClient.assumeRole(assumeRoleRequest);
+            Credentials credentials = assumeRoleResult.getCredentials();
+            BasicSessionCredentials basicSessionCredentials = new BasicSessionCredentials(credentials.getAccessKeyId(), credentials.getSecretAccessKey(), credentials.getSessionToken());
+            return new AWSStaticCredentialsProvider(basicSessionCredentials);
+        }
+        return DefaultAWSCredentialsProviderChain.getInstance();
+    }
+}


### PR DESCRIPTION
Prior to this change, we supported using cross-account Glue data catalogs to fetch metadata for DynamoDB tables. However, we did not have any support for allowing customers to query a cross-account DynamoDB table, so this provided very little value.

With this change, customers can now query DynamoDB tables across accounts, both with and without the use of a cross account Glue data catalog. To do so, the customer adds an environment variable to their connector, `cross_account_role_arn`. They also have to perform standard IAM configurations for cross-account resource access. Specifically, the account containing the DynamoDB table (account A) adds a role which the calling account (account B) with the connector has permissions to assume, containing a policy against the table and its indices to Scan, Query, and DescribeTable. An additional ListTables permission against the account is needed as well. Account B then adds a policy to the function execution role to assume the role in account A and their queries will now work. I provide the sample setup below which will be easier to digest.

*Issue #, if available:* https://github.com/awslabs/aws-athena-query-federation/issues/292

*Description of changes:*

[Testing]
- Tested with two AWS accounts. I am providing the relevant IAM policies below with obscured table names and account ids for the DynamoDB changes. I am not providing the policies for the cross data catalog because that functionality already exists today.

### IAM policies:
For each of the policies below, "Account A" will refer to the account containing the DynamoDB table, and "Account B" will refer to the account containing the Athena DynamoDB Connector.

#### Account A - new IAM policy and role

Policy:
```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Action": [
                "dynamodb:Scan",
                "dynamodb:Query",
                "dynamodb:DescribeTable"
            ],
            "Resource": [
                "arn:aws:dynamodb:*:<ACCOUNT_A_ID>:table/<TABLE_NAME>/index/*",
                "arn:aws:dynamodb:*:<ACCOUNT_A_ID>:table/<TABLE_NAME>"
            ]
        },
        {
            "Effect": "Allow",
            "Action": [
                "dynamodb:ListTables"
            ],
            "Resource": [
                "arn:aws:dynamodb:*:<ACCOUNT_A_ID>:table/*"
            ]
        }
    ]
}
```
Role `CrossAccountQueryAndScanDdbRole` has above policy. Here is the trusted entities for the role - note that we can use the AWS account ID even though this will be called from a lambda in account B.
```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Principal": {
                "AWS": "arn:aws:iam::<ACCOUNT_B_ID>:root"
            },
            "Action": "sts:AssumeRole",
            "Condition": {}
        }
    ]
}
```


#### Account B - new policy attached to lambda function role
```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Action": "sts:AssumeRole",
            "Resource": "arn:aws:iam::<ACCOUNT_A_ID>:role/CrossAccountQueryAndScanDdbRole"
        }
    ]
}
```


### Queries ran:

```
// List schemas if cross-account glue is or is not configured
show schemas in lambda:ddb

// List tables if cross-account glue is configured
show tables in lambda:ddb.databaseforcrossaccountddb

// Describe table if cross-account glue is configured
describe `lambda:ddb`.`databaseforcrossaccountddb`.`<OBSCURED>`

// Describe table if cross-account glue is not configured
describe `lambda:ddb`.`default`.`<OBSCURED>`

// Select - if cross-account glue is configured
select * from "lambda:ddb"."databaseforcrossaccountddb"."<OBSCURED>" limit 1;

// Select - if cross-account glue is not configured
select * from "lambda:ddb"."default"."<OBSCURED>" limit 1;

```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
