### PR TITLE
publish_to_maven_central: use -am flag

### DIFF
--- a/.github/workflows/publish_to_maven_central.yml
+++ b/.github/workflows/publish_to_maven_central.yml
@@ -26,7 +26,7 @@ jobs:
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
       - name: Publish to Apache Maven Central
-        run: mvn clean deploy --batch-mode -Dmaven.compiler.release=8 -P release -pl ".,athena-federation-sdk,athena-federation-integ-test,athena-dynamodb,athena-cloudwatch,athena-cloudwatch-metrics,athena-aws-cmdb"
+        run: mvn clean deploy --batch-mode -Dmaven.compiler.release=8 -am -P release -pl ".,athena-federation-sdk,athena-dynamodb,athena-cloudwatch,athena-cloudwatch-metrics,athena-aws-cmdb"
         env:
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}


### PR DESCRIPTION
-am flag will make sure that we build all the dependencies


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
