### PR TITLE
big query return athena catalog name instead of project name from gcp

### DIFF
--- a/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryMetadataHandler.java
+++ b/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryMetadataHandler.java
@@ -163,7 +163,7 @@ public class BigQueryMetadataHandler
         final Schema tableSchema = getSchema(projectName, getTableRequest.getTableName().getSchemaName(),
                 getTableRequest.getTableName().getTableName());
         // TODO: Do we actually need to lowercase here?
-        return new GetTableResponse(projectName.toLowerCase(), getTableRequest.getTableName(), tableSchema);
+        return new GetTableResponse(getTableRequest.getCatalogName().toLowerCase(), getTableRequest.getTableName(), tableSchema);
     }
 
     /**


### PR DESCRIPTION
big query return athena catalog name instead of project name from big query for GetTableResponse.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
