### PR TITLE
feat(athena-redshift): Support spill buckets using KMS CMK keys, passing role arn for lambda

### DIFF
--- a/athena-redshift/athena-redshift.yaml
+++ b/athena-redshift/athena-redshift.yaml
@@ -48,11 +48,24 @@ Parameters:
   SubnetIds:
     Description: 'One or more Subnet IDs corresponding to the Subnet that the Lambda function can use to access you data source. (e.g. subnet1,subnet2)'
     Type: 'List<AWS::EC2::Subnet::Id>'
+  KMSKeyId:
+    Description: "(Optional) By default any data that is spilled to S3 is encrypted using AES-GCM and a randomly generated key. Setting a KMS Key ID allows your Lambda function to use KMS for key generation for a stronger source of encryption keys."
+    Type: String
+    Default: ""
+  LambdaRole:
+    Description: "(Optional) A custom IAM role ARN to be used by the Connector lambda"
+    Type: String
+    Default: ""
   PermissionsBoundaryARN:
     Description: "(Optional) An IAM policy ARN to use as the PermissionsBoundary for the created Lambda function's execution role"
     Default: ''
     Type: String
 Conditions:
+  HasKMSKeyId: !Not [!Equals [!Ref KMSKeyId, ""]]
+  NotHasLambdaRole: !Equals [!Ref LambdaRole, ""]
+  NotHasLambdaRoleAndHasKMSKeyId: !And
+    - !Condition NotHasLambdaRole
+    - !Condition HasKMSKeyId
   HasPermissionsBoundary: !Not [ !Equals [ !Ref PermissionsBoundaryARN, "" ] ]
 Resources:
   JdbcConnectorConfig:
@@ -64,6 +77,7 @@ Resources:
           spill_bucket: !Ref SpillBucket
           spill_prefix: !Ref SpillPrefix
           default: !Ref DefaultConnectionString
+          kms_key_id: !If [HasKMSKeyId, !Ref KMSKeyId, !Ref "AWS::NoValue"]
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.redshift.RedshiftMuxCompositeHandler"
       CodeUri: "./target/athena-redshift-2022.47.1.jar"
@@ -71,40 +85,84 @@ Resources:
       Runtime: java11
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
-      PermissionsBoundary: !If [ HasPermissionsBoundary, !Ref PermissionsBoundaryARN, !Ref "AWS::NoValue" ]
-      Policies:
-        - Statement:
-            - Action:
-                - secretsmanager:GetSecretValue
-              Effect: Allow
-              Resource: !Sub 'arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:${SecretNamePrefix}*'
-          Version: '2012-10-17'
-        - Statement:
-            - Action:
-                - logs:CreateLogGroup
-              Effect: Allow
-              Resource: !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*'
-          Version: '2012-10-17'
-        - Statement:
-          - Action:
-              - logs:CreateLogStream
-              - logs:PutLogEvents
-            Effect: Allow
-            Resource: !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${LambdaFunctionName}:*'
-          Version: '2012-10-17'
-        - Statement:
-          - Action:
-              - athena:GetQueryExecution
-              - s3:ListAllMyBuckets
-            Effect: Allow
-            Resource: '*'
-          Version: '2012-10-17'
-        #S3CrudPolicy allows our connector to spill large responses to S3. You can optionally replace this pre-made policy
-        #with one that is more restrictive and can only 'put' but not read,delete, or overwrite files.
-        - S3CrudPolicy:
-            BucketName: !Ref SpillBucket
-        #VPCAccessPolicy allows our connector to run in a VPC so that it can access your data source.
-        - VPCAccessPolicy: {}
+      Role: !If [NotHasLambdaRole, !GetAtt FunctionRole.Arn, !Ref LambdaRole]
       VpcConfig:
         SecurityGroupIds: !Ref SecurityGroupIds
         SubnetIds: !Ref SubnetIds
+
+  FunctionRole:
+    Condition: NotHasLambdaRole
+    Type: AWS::IAM::Role
+    Properties:
+      PermissionsBoundary: !If [ HasPermissionsBoundary, !Ref PermissionsBoundaryARN, !Ref "AWS::NoValue" ]
+      ManagedPolicyArns:
+        - "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - "sts:AssumeRole"
+
+
+  FunctionExecutionPolicy:
+    Condition: NotHasLambdaRole
+    Type: "AWS::IAM::Policy"
+    Properties:
+      PolicyName: FunctionExecutionPolicy
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - secretsmanager:GetSecretValue
+            Resource: !Sub 'arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:${SecretNamePrefix}*'
+          - Effect: Allow
+            Action:
+              - athena:GetQueryExecution
+              - s3:ListAllMyBuckets
+            Resource: '*'
+          - Effect: Allow
+            Action:
+              - s3:GetObject
+              - s3:ListBucket
+              - s3:GetBucketLocation
+              - s3:GetObjectVersion
+              - s3:PutObject
+              - s3:PutObjectAcl
+              - s3:GetLifecycleConfiguration
+              - s3:PutLifecycleConfiguration
+              - s3:DeleteObject
+            Resource:
+              - Fn::Sub:
+                - arn:${AWS::Partition}:s3:::${bucketName}
+                - bucketName:
+                    Ref: SpillBucket
+              - Fn::Sub:
+                - arn:${AWS::Partition}:s3:::${bucketName}/*
+                - bucketName:
+                    Ref: SpillBucket
+      Roles:
+        - !Ref FunctionRole
+
+  FunctionKMSPolicy:
+    Condition: NotHasLambdaRoleAndHasKMSKeyId
+    Type: "AWS::IAM::Policy"
+    Properties:
+      PolicyName: FunctionKMSPolicy
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+             - kms:GenerateRandom
+            Resource: '*'
+          - Effect: Allow
+            Action:
+              - kms:GenerateDataKey
+            Resource: !Sub "arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${KMSKeyId}"
+      Roles:
+        - !Ref FunctionRole


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* This PR allows the `athena-redshift` connector to be passed a Role ARN for the lambda to use, and allows the role it creates when a role is not passed to write to a spill bucket that uses KMS CMK encryption.

I've tested this in a live environment with the following configurations, asserting that Athena is able to successfully list the schema and execute queries:
* Without using either new parameter - works as expected, no breaking changes, spill bucket uses the `KMS_MANAGED` CDK bucket encryption type
* Passing just a `LambdaRole` parameter - works as expected, correctly skips creating the role in the application manifest, lambda assumes the role arn passed in via the parameter, and is able to spill correctly
* Passing just a `KMSKeyId` parameter - works as expected, creates the role it created prior, role has an additional inline policy granting access to the KMS Key ID passed

The parameter names/descriptions, conditions, and role/policy resources were inspired/copied from the `athena-cloudwatch` connector which already supported both of these features. I added the condition `NotHasLambdaRoleAndHasKMSKeyId` because if for some reason someone passes both a role arn and a kms key id, the cloudwatch connector template will fail to render currently because it will skip role creation, but will still try to attach a KMS policy. I havent come up with a valid reason to pass both parameters, but the added conditional prevents errors in the event someone does.

The `AWSLambdaVPCAccessExecutionRole` managed policy replaces the permissions added via the SAM `VPCAccessPolicy` and includes the permissions from `AWSLambdaBasicExecutionRole` which were previously individually included in this template. It may look like some permissions were removed, but all permissions are still granted to the generated role via the managed policy.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
