### PR TITLE
[Timestream] Add case-insensitive lookup to allow queries against cased dbs/tables to succeed

### DIFF
--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/util/PaginatedRequestIterator.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/util/PaginatedRequestIterator.java
@@ -1,0 +1,73 @@
+/*-
+ * #%L
+ * Amazon Athena Query Federation SDK
+ * %%
+ * Copyright (C) 2019 - 2023 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connector.util;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+public class PaginatedRequestIterator<T> implements Iterator<T>
+{
+    final Function<String, T> fetchPage;
+    final Function<T, String> getToken;
+
+    boolean notStarted = true;
+    String nextPageToken = null;
+
+    // This is a static to avoid the possibility of users retaining a reference to the iterator
+    // and trying to use it after converting it to a Stream.
+    public static <X> Stream<X> stream(Function<String, X> fetchPage, Function<X, String> getToken)
+    {
+        return StreamSupport.stream(
+             Spliterators.spliteratorUnknownSize(
+                new PaginatedRequestIterator<X>(fetchPage, getToken),
+                Spliterator.IMMUTABLE | Spliterator.ORDERED),
+            false);
+    }
+
+    public PaginatedRequestIterator(Function<String, T> fetchPage, Function<T, String> getToken)
+    {
+        this.fetchPage = fetchPage;
+        this.getToken = getToken;
+    }
+
+    @Override
+    public boolean hasNext()
+    {
+        return notStarted || nextPageToken != null;
+    }
+
+    @Override
+    public T next()
+    {
+        if (!hasNext()) {
+            throw new NoSuchElementException("No more pages left");
+        }
+
+        T current = fetchPage.apply(nextPageToken);
+        notStarted = false;
+        nextPageToken = getToken.apply(current);
+        return current;
+    }
+}

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/util/PaginatedRequestIteratorTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/util/PaginatedRequestIteratorTest.java
@@ -1,0 +1,109 @@
+/*-
+ * #%L
+ * Amazon Athena Query Federation SDK
+ * %%
+ * Copyright (C) 2019 - 2023 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connector.util;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.*;
+
+public class PaginatedRequestIteratorTest
+{
+    Function<String, Map<String, String>> fakePageRequest = (pageToken) -> {
+        if (pageToken == null) {
+            return ImmutableMap.of(
+                "data", "aaa",
+                "nextPage", "2"
+            );
+        }
+        else if (pageToken.equals("2")) {
+            return ImmutableMap.of(
+                "data", "bbb",
+                "nextPage", "3"
+            );
+        }
+        else if (pageToken.equals("3")) {
+            return ImmutableMap.of(
+                "data", "ccc"
+            );
+        }
+        return null;
+    };
+
+    Function<Map<String, String>, String> getPageToken = (in) -> in.get("nextPage");
+
+    @Test
+    public void testIteratesOverAllPages()
+    {
+        List<String> result = PaginatedRequestIterator.stream(fakePageRequest, getPageToken)
+            .map(r -> r.get("data"))
+            .collect(Collectors.toList());
+
+        assertEquals(ImmutableList.of("aaa", "bbb", "ccc"), result);
+    }
+
+    @Test
+    public void testBehavior()
+    {
+        PaginatedRequestIterator<Map<String, String>> iterator = new PaginatedRequestIterator<Map<String, String>>(fakePageRequest, getPageToken);
+        assertTrue(iterator.hasNext());
+
+        // Call hasNext() multiple times to make sure it keeps returning true until we've actually moved ahead
+        for (int i = 0; i < 10; i++) {
+            assertTrue(iterator.hasNext());
+        }
+
+        assertEquals(ImmutableMap.of("data", "aaa", "nextPage", "2"), iterator.next());
+
+        // Call hasNext() multiple times to make sure it keeps returning true until we've actually moved ahead
+        for (int i = 0; i < 10; i++) {
+            assertTrue(iterator.hasNext());
+        }
+
+        assertEquals(ImmutableMap.of("data", "bbb", "nextPage", "3"), iterator.next());
+        assertTrue(iterator.hasNext());
+
+        // Call hasNext() multiple times to make sure it keeps returning true until we've actually moved ahead
+        for (int i = 0; i < 10; i++) {
+            assertTrue(iterator.hasNext());
+        }
+
+        assertEquals(ImmutableMap.of("data", "ccc"), iterator.next());
+        assertFalse(iterator.hasNext()); // Should not have anything else
+
+        // Should throw
+        try {
+            iterator.next();
+            fail("Expected NoSuchElementException but did not get one");
+        } catch (NoSuchElementException ex) {
+            // Expected
+        }
+
+        // Validate hasNext() is false again
+        assertFalse(iterator.hasNext());
+    }
+}

--- a/athena-kafka/src/main/java/com/amazonaws/athena/connectors/kafka/KafkaMetadataHandler.java
+++ b/athena-kafka/src/main/java/com/amazonaws/athena/connectors/kafka/KafkaMetadataHandler.java
@@ -36,6 +36,7 @@ import com.amazonaws.athena.connector.lambda.metadata.ListSchemasRequest;
 import com.amazonaws.athena.connector.lambda.metadata.ListSchemasResponse;
 import com.amazonaws.athena.connector.lambda.metadata.ListTablesRequest;
 import com.amazonaws.athena.connector.lambda.metadata.ListTablesResponse;
+import com.amazonaws.athena.connector.util.PaginatedRequestIterator;
 import com.amazonaws.athena.connectors.kafka.dto.SplitParameters;
 import com.amazonaws.athena.connectors.kafka.dto.TopicPartitionPiece;
 import com.amazonaws.athena.connectors.kafka.dto.TopicSchema;
@@ -97,21 +98,15 @@ public class KafkaMetadataHandler extends MetadataHandler
             .map(r -> r.getRegistryName());
     }
 
-    private ListRegistriesResult listRegistriesFromGlue(AWSGlue glue, String nextToken, boolean start)
+    private ListRegistriesResult listRegistriesFromGlue(AWSGlue glue, String nextToken)
     {
-        if (!start && nextToken == null) {
-            return null;
-        }
         ListRegistriesRequest listRequest = new ListRegistriesRequest().withMaxResults(maxGluePageSize);
         listRequest = (nextToken == null) ? listRequest : listRequest.withNextToken(nextToken);
         return glue.listRegistries(listRequest);
     }
 
-    private ListSchemasResult listSchemasFromGlue(AWSGlue glue, String glueRegistryName, int pageSize, String nextToken, boolean start)
+    private ListSchemasResult listSchemasFromGlue(AWSGlue glue, String glueRegistryName, int pageSize, String nextToken)
     {
-        if (!start && nextToken == null) {
-            return null;
-        }
         com.amazonaws.services.glue.model.ListSchemasRequest listRequest = new com.amazonaws.services.glue.model.ListSchemasRequest()
             .withRegistryId(new RegistryId().withRegistryName(glueRegistryName))
             .withMaxResults(Math.min(pageSize, maxGluePageSize));
@@ -131,15 +126,9 @@ public class KafkaMetadataHandler extends MetadataHandler
     {
         LOGGER.info("doListSchemaNames called with Catalog: {}", listSchemasRequest.getCatalogName());
         AWSGlue glue = AWSGlueClientBuilder.defaultClient();
-        Stream<String> allFilteredRegistries = Stream.empty();
-        for (
-            ListRegistriesResult currentResult = listRegistriesFromGlue(glue, null, true);
-            currentResult != null;
-            currentResult = listRegistriesFromGlue(glue, currentResult.getNextToken(), false)
-        ) {
-            // Concat the results from the current page
-            allFilteredRegistries = Stream.concat(allFilteredRegistries, filteredRegistriesStream(currentResult.getRegistries().stream()));
-        }
+
+        Stream<String> allFilteredRegistries = PaginatedRequestIterator.stream((pageToken) -> listRegistriesFromGlue(glue, pageToken), ListRegistriesResult::getNextToken)
+            .flatMap(result -> filteredRegistriesStream(result.getRegistries().stream()));
         ListSchemasResponse result = new ListSchemasResponse(listSchemasRequest.getCatalogName(), allFilteredRegistries.collect(Collectors.toList()));
         LOGGER.debug("doListSchemaNames result: {}", result);
         return result;
@@ -181,23 +170,19 @@ public class KafkaMetadataHandler extends MetadataHandler
         if (federationListTablesRequest.getPageSize() == UNLIMITED_PAGE_SIZE_VALUE &&
                 federationListTablesRequest.getNextToken() == null) {
             LOGGER.info("Request page size is UNLIMITED_PAGE_SIZE_VALUE");
-            List<TableName> allTableNames = new ArrayList();
-            for (
-                ListSchemasResult currentResult = listSchemasFromGlue(glue, glueRegistryNameResolved, maxGluePageSize, null, true);
-                currentResult != null;
-                currentResult = listSchemasFromGlue(glue, glueRegistryNameResolved, maxGluePageSize, currentResult.getNextToken(), false)
-            ) {
-                // Append the results from the current page
-                allTableNames.addAll(
+
+            List<TableName> allTableNames = PaginatedRequestIterator.stream((pageToken) -> listSchemasFromGlue(glue, glueRegistryNameResolved, maxGluePageSize, pageToken), ListSchemasResult::getNextToken)
+                .flatMap(currentResult ->
                     currentResult.getSchemas().stream()
                         .map(schemaListItem -> schemaListItem.getSchemaName())
                         .map(glueSchemaName -> new TableName(glueRegistryNameResolved, glueSchemaName))
-                        .collect(Collectors.toList())
-                );
-                if (allTableNames.size() > MAX_RESULTS) {
-                    throw new RuntimeException(
-                        String.format("Exceeded maximum result size. Current doListTables result size: %d", allTableNames.size()));
-                }
+                )
+                .limit(MAX_RESULTS + 1)
+                .collect(Collectors.toList());
+
+            if (allTableNames.size() > MAX_RESULTS) {
+                throw new RuntimeException(
+                    String.format("Exceeded maximum result size. Current doListTables result size: %d", allTableNames.size()));
             }
             ListTablesResponse result = new ListTablesResponse(federationListTablesRequest.getCatalogName(), allTableNames, null);
             LOGGER.debug("doListTables result: {}", result);
@@ -209,9 +194,7 @@ public class KafkaMetadataHandler extends MetadataHandler
             glue,
             glueRegistryNameResolved,
             federationListTablesRequest.getPageSize(),
-            federationListTablesRequest.getNextToken(),
-            // always consider this as a starting rqeuest if the token is null
-            federationListTablesRequest.getNextToken() == null);
+            federationListTablesRequest.getNextToken());
         // Convert the glue response into our own federation response
         List<TableName> tableNames = listSchemasResultFromGlue.getSchemas()
             .stream()
@@ -231,50 +214,34 @@ public class KafkaMetadataHandler extends MetadataHandler
     {
         LOGGER.debug("findGlueRegistryNameIgnoringCasing {}", glueRegistryNameIn);
         AWSGlue glue = AWSGlueClientBuilder.defaultClient();
-        for (
-            ListRegistriesResult currentResult = listRegistriesFromGlue(glue, null, true);
-            currentResult != null;
-            currentResult = listRegistriesFromGlue(glue, currentResult.getNextToken(), false)
-        ) {
-            // Try to find the registry ignoring the case
-            java.util.Optional<String> result = filteredRegistriesStream(currentResult.getRegistries().stream())
-                .filter(r -> r.equalsIgnoreCase(glueRegistryNameIn))
-                .findAny();
-            // Continue searching through the other pages if we haven't found the registry yet
-            if (!result.isPresent()) {
-                continue;
-            }
-            LOGGER.debug("findGlueRegistryNameIgnoringCasing result: {}", result.get());
-            return result.get();
-        }
-        throw new RuntimeException(String.format("Could not find Glue Registry: %s", glueRegistryNameIn));
+
+        // Try to find the registry ignoring the case
+        String result = PaginatedRequestIterator.stream((pageToken) -> listRegistriesFromGlue(glue, pageToken), ListRegistriesResult::getNextToken)
+            .flatMap(currentResult -> filteredRegistriesStream(currentResult.getRegistries().stream()))
+            .filter(r -> r.equalsIgnoreCase(glueRegistryNameIn))
+            .findAny()
+            .orElseThrow(() -> new RuntimeException(String.format("Could not find Glue Registry: %s", glueRegistryNameIn)));
+        LOGGER.debug("findGlueRegistryNameIgnoringCasing result: {}", result);
+        return result;
     }
 
     // Assumes that glueRegistryNameIn is already resolved to the right name
     private String findGlueSchemaNameIgnoringCasing(String glueRegistryNameIn, String glueSchemaNameIn)
     {
         LOGGER.debug("findGlueSchemaNameIgnoringCasing {} {}", glueRegistryNameIn, glueSchemaNameIn);
-        // List all schemas under the input registry
         AWSGlue glue = AWSGlueClientBuilder.defaultClient();
-        for (
-            ListSchemasResult currentResult = listSchemasFromGlue(glue, glueRegistryNameIn, maxGluePageSize, null, true);
-            currentResult != null;
-            currentResult = listSchemasFromGlue(glue, glueRegistryNameIn, maxGluePageSize, currentResult.getNextToken(), false)
-        ) {
-            // Find the schema name ignoring the case in this page
-            java.util.Optional<String> foundSchema = currentResult.getSchemas().stream()
-                .map(schemaListItem -> schemaListItem.getSchemaName())
-                .filter(glueSchemaName -> glueSchemaName.equalsIgnoreCase(glueSchemaNameIn))
-                .findAny();
-            // Continue looking at the next page if not found
-            if (!foundSchema.isPresent()) {
-                continue;
-            }
-            // Return the found schema
-            LOGGER.debug("findGlueSchemaNameIgnoringCasing result: {}", foundSchema.get());
-            return foundSchema.get();
-        }
-        throw new RuntimeException(String.format("Could not find Glue Schema: %s", glueSchemaNameIn));
+        // List all schemas under the input registry
+        // Find the schema name ignoring the case in this page
+        String result = PaginatedRequestIterator.stream((pageToken) -> listSchemasFromGlue(glue, glueRegistryNameIn, maxGluePageSize, pageToken), ListSchemasResult::getNextToken)
+            .flatMap(currentResult -> currentResult.getSchemas().stream())
+            .map(schemaListItem -> schemaListItem.getSchemaName())
+            .filter(glueSchemaName -> glueSchemaName.equalsIgnoreCase(glueSchemaNameIn))
+            .findAny()
+            .orElseThrow(() -> new RuntimeException(String.format("Could not find Glue Schema: %s", glueSchemaNameIn)));
+
+        // Return the found schema
+        LOGGER.debug("findGlueSchemaNameIgnoringCasing result: {}", result);
+        return result;
     }
 
     /**

--- a/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/AmazonMskRecordHandler.java
+++ b/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/AmazonMskRecordHandler.java
@@ -210,7 +210,7 @@ public class AmazonMskRecordHandler
             for (MSKField field : record.value().getFields()) {
                 boolean isMatched = block.offerValue(field.getName(), rowNum, field.getValue());
                 if (!isMatched) {
-                    LOGGER.debug("[FailedToSpill] {} Failed to split record, offset: {}", splitParameters, record.offset());
+                    LOGGER.debug("[FailedToSpill] {} Failed to splil record, offset: {}", splitParameters, record.offset());
                     return 0;
                 }
             }


### PR DESCRIPTION
*Issue #, if available:* [#792](https://github.com/awslabs/aws-athena-query-federation/issues/792)

*Description of changes:*

Because Trino follows Hive naming conventions, where schema names and table names are lower-cased and are case-insensitive, DML queries against our connectors will receive lower-cased versions of schema and table names. This will lead to query failures if the Timestream schema/table are not both in lowercase format.

Example: Database name is "MixedCaseDb" and table name is "tableWithMixedCase".

`SELECT * FROM "lambda:timestream"."MixedCaseDb"."tableWithMixedCase"` will be sent down to Timestream with the schema name `mixedcasedb` and table name `tablewithmixedcase`, which will then fail to resolve because Timestream is case-sensitive.

This PR adds logic to do a lookup of a case-insensitive match for the schema and table name against the Timestream datasource if the initial attempt to fetch the table definition fails.

We also pull out the functionality to make the actual Timestream API calls so that we can parse the results one page at a time instead of after reading all pages.

Testing was done against databases with mixed cases, tables with mixed cases, and db/table combos that were all lowercase.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
