### PR TITLE
[Bug Fix] [athena-cloudwatch] Stop lowercasing all schemas and tables, fix data integrity issue

### DIFF
--- a/athena-cloudwatch/src/main/java/com/amazonaws/athena/connectors/cloudwatch/CloudwatchMetadataHandler.java
+++ b/athena-cloudwatch/src/main/java/com/amazonaws/athena/connectors/cloudwatch/CloudwatchMetadataHandler.java
@@ -159,7 +159,7 @@ public class CloudwatchMetadataHandler
                 throw new RuntimeException("Too many log groups, exceeded max metadata results for schema count.");
             }
             result = invoker.invoke(() -> awsLogs.describeLogGroups(request));
-            result.getLogGroups().forEach(next -> schemas.add(next.getLogGroupName().toLowerCase()));
+            result.getLogGroups().forEach(next -> schemas.add(next.getLogGroupName()));
             request.setNextToken(result.getNextToken());
             logger.info("doListSchemaNames: Listing log groups {} {}", result.getNextToken(), schemas.size());
         }
@@ -224,9 +224,9 @@ public class CloudwatchMetadataHandler
     public GetTableResponse doGetTable(BlockAllocator blockAllocator, GetTableRequest getTableRequest)
     {
         TableName tableName = getTableRequest.getTableName();
-        tableResolver.validateTable(tableName);
+        CloudwatchTableName cwTableName = tableResolver.validateTable(tableName);
         return new GetTableResponse(getTableRequest.getCatalogName(),
-                getTableRequest.getTableName(),
+                cwTableName.toTableName(),
                 CLOUDWATCH_SCHEMA,
                 Collections.singleton(LOG_STREAM_FIELD));
     }
@@ -360,6 +360,6 @@ public class CloudwatchMetadataHandler
      */
     private TableName toTableName(ListTablesRequest request, LogStream logStream)
     {
-        return new TableName(request.getSchemaName(), logStream.getLogStreamName().toLowerCase());
+        return new TableName(request.getSchemaName(), logStream.getLogStreamName());
     }
 }

--- a/athena-cloudwatch/src/main/java/com/amazonaws/athena/connectors/cloudwatch/CloudwatchTableName.java
+++ b/athena-cloudwatch/src/main/java/com/amazonaws/athena/connectors/cloudwatch/CloudwatchTableName.java
@@ -46,7 +46,7 @@ public class CloudwatchTableName
 
     public TableName toTableName()
     {
-        return new TableName(logGroupName.toLowerCase(), logStreamName.toLowerCase());
+        return new TableName(logGroupName, logStreamName);
     }
 
     @Override


### PR DESCRIPTION
There are two bugs that this fixes. First, any list tables or list schemas calls would automatically lowercase the resulting log groups and log streams. Second, the existing logic which tried to allow for case insensitive lookups for matching log streams wrongly compared two strings and would always return the first log stream it found, instead of the actual matching log stream.

Correctness tested against miscellaneous mixed case log streams and log groups. Queries are all correct for listing schemas, listing tables, describing tables, and selecting from tables.

Note that queries will return indeterminate results if there are two log groups or log streams with case insensitive name matches. If log stream "asdf" and "ASDF" both exist, "asdf" will be picked. If log stream "asDF" and "ASdf" both exist, it is indeterminate which will be returned.

*Issue #, if available:*
https://github.com/awslabs/aws-athena-query-federation/issues/652

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
