### PR TITLE
[JDBC Fix] IN predicate with variable expression formed malformed SQL

### DIFF
--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/FederationExpressionParser.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/FederationExpressionParser.java
@@ -73,11 +73,6 @@ public abstract class FederationExpressionParser
      */
     public String parseFunctionCallExpression(FunctionCallExpression functionCallExpression)
     {
-        return parseFunctionCallExpressionHelper(functionCallExpression);
-    }
-
-    protected String parseFunctionCallExpressionHelper(FunctionCallExpression functionCallExpression)
-    {
         FunctionName functionName = functionCallExpression.getFunctionName();
         List<FederationExpression> functionArguments = functionCallExpression.getArguments();
 
@@ -89,10 +84,10 @@ public abstract class FederationExpressionParser
                 }
                 else if (argument instanceof VariableExpression) {
                     return parseVariableExpression((VariableExpression) argument);
-                // recursive case
                 }
+                // recursive case
                 else if (argument instanceof FunctionCallExpression) {
-                    return parseFunctionCallExpressionHelper((FunctionCallExpression) argument);
+                    return parseFunctionCallExpression((FunctionCallExpression) argument);
                 }
                 throw new RuntimeException("Should not reach this case - a new subclass was introduced and is not handled.");
             }).collect(Collectors.toList());

--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcFederationExpressionParser.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcFederationExpressionParser.java
@@ -105,7 +105,7 @@ public abstract class JdbcFederationExpressionParser extends FederationExpressio
                 clause = Joiner.on(" >= ").join(arguments);
                 break;
             case IN_PREDICATE_FUNCTION_NAME:
-                clause = arguments.get(0) + " IN (" + arguments.get(1) + ")";
+                clause = arguments.get(0) + " IN " + arguments.get(1);
                 break;
             case IS_DISTINCT_FROM_OPERATOR_FUNCTION_NAME:
                 String argZero = arguments.get(0);


### PR DESCRIPTION
Previous logic would append a predicate of arg0 IN (arg1) However, arg1 is always of type array, so it's already surrounded by parentheses. So, just append the predicate as arg0 IN arg1.

I also removed the unnecessary helper method for the recursive jdbc expression parser.

Tested this by running Trino locally and performing miscellaneous queries against a TPCDS table. Initial query which failed:
```
select * from lambda.test.store_sales where ss_item_sk in (ss_store_sk, 2, 3) limit 10;
```
Error:
```
java.sql.sqlexception: Operand should contain 1 column(s): java.lang.RuntimeExceptionjava.lang.RuntimeException: java.sql.SQLException: Operand should contain 1 column(s)at com.amazonaws.athena.connector.lambda.handlers.CompositeHandler.handleRequest(CompositeHandler.java:117)Caused by: java.sql.SQLException: Operand should contain 1 column(s)at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:130)at com.mysql.cj.jdbc.exceptions.SQLExceptionsMapping.translateException(SQLExceptionsMapping.java:122)at com.mysql.cj.jdbc.ClientPreparedStatement.executeInternal(ClientPreparedStatement.java:916)at com.mysql.cj.jdbc.ClientPreparedStatement.executeQuery(ClientPreparedStatement.java:972)at com.amazonaws.athena.connectors.jdbc.manager.JdbcRecordHandler.readWithConstraint(JdbcRecordHandler.java:148)at com.amazonaws.athena.connector.lambda.handlers.RecordHandler.doReadRecords(RecordHandler.java:197)at com.amazonaws.athena.connector.lambda.handlers.RecordHandler.doHandleRequest(RecordHandler.java:163)at com.amazonaws.athena.connector.lambda.handlers.CompositeHandler.handleRequest(CompositeHandler.java:147)at com.amazonaws.athena.connector.lambda.handlers.CompositeHandler.handleRequest(CompositeHandler.java:112)
```

The error was because the generated SQL added this predicate string:
```
(`ss_item_sk` IN ((`ss_store_sk`, 2, 3)))
```

now it appends:

```
(`ss_item_sk` IN (`ss_store_sk`, 2, 3))
```

This query now succeeds after the changes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
