### PR TITLE
add data stream support for elasticsearch

### DIFF
--- a/athena-elasticsearch/src/main/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchRecordHandler.java
+++ b/athena-elasticsearch/src/main/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchRecordHandler.java
@@ -139,8 +139,8 @@ public class ElasticsearchRecordHandler
 
         String domain = recordsRequest.getTableName().getSchemaName();
         String endpoint = recordsRequest.getSplit().getProperty(domain);
-        String index = recordsRequest.getTableName().getTableName();
         String shard = recordsRequest.getSplit().getProperty(ElasticsearchMetadataHandler.SHARD_KEY);
+        String index = recordsRequest.getSplit().getProperty(ElasticsearchMetadataHandler.INDEX_KEY);
         long numRows = 0;
 
         if (queryStatusChecker.isQueryRunning()) {

--- a/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchRecordHandlerTest.java
+++ b/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchRecordHandlerTest.java
@@ -307,6 +307,8 @@ public class ElasticsearchRecordHandlerTest
 
         split = Split.newBuilder(makeSpillLocation(), null)
                 .add("movies", "https://search-movies-ne3fcqzfipy6jcrew2wca6kyqu.us-east-1.es.amazonaws.com")
+                .add(ElasticsearchMetadataHandler.SHARD_KEY, "_shards:5")
+                .add(ElasticsearchMetadataHandler.INDEX_KEY, "index1")
                 .build();
 
         when(clientFactory.getOrCreateClient(nullable(String.class))).thenReturn(mockClient);


### PR DESCRIPTION
Add support for Data Stream for elastic search.

Data Stream contains multiple indices, see following notes for more information.

https://opensearch.org/docs/1.1/opensearch/data-streams/

https://opster.com/guides/opensearch/opensearch-machine-learning/opensearch-data-streams/#How-to-create-data-streams-in-OpenSearch

*Issue #, if available:*
https://github.com/awslabs/aws-athena-query-federation/issues/511


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
