### PR TITLE
predicate pushdown changes

### DIFF
--- a/athena-cloudera-hive/src/main/java/com/amazonaws/athena/connectors/cloudera/HiveFederationExpressionParser.java
+++ b/athena-cloudera-hive/src/main/java/com/amazonaws/athena/connectors/cloudera/HiveFederationExpressionParser.java
@@ -1,6 +1,6 @@
 /*-
  * #%L
- * athena-datalakegen2
+ * athena-cloudera-hive
  * %%
  * Copyright (C) 2019 - 2022 Amazon Web Services
  * %%
@@ -17,14 +17,24 @@
  * limitations under the License.
  * #L%
  */
-package com.amazonaws.athena.connectors.datalakegen2;
+package com.amazonaws.athena.connectors.cloudera;
 
-public class DataLakeGen2Constants
+import com.amazonaws.athena.connectors.jdbc.manager.JdbcFederationExpressionParser;
+import com.google.common.base.Joiner;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+
+import java.util.List;
+
+public class HiveFederationExpressionParser extends JdbcFederationExpressionParser
 {
-    public static final String NAME = "datalakegentwo";
-    public static final String DRIVER_CLASS = "com.microsoft.sqlserver.jdbc.SQLServerDriver";
-    public static final int DEFAULT_PORT = 1433;
-    public static final String QUOTE_CHARACTER = "\"";
+    public HiveFederationExpressionParser(String quoteChar)
+    {
+        super(quoteChar);
+    }
 
-    private DataLakeGen2Constants() {}
+    @Override
+    public String writeArrayConstructorClause(ArrowType type, List<String> arguments)
+    {
+        return Joiner.on(", ").join(arguments);
+    }    
 }

--- a/athena-cloudera-hive/src/main/java/com/amazonaws/athena/connectors/cloudera/HiveMetadataHandler.java
+++ b/athena-cloudera-hive/src/main/java/com/amazonaws/athena/connectors/cloudera/HiveMetadataHandler.java
@@ -18,6 +18,7 @@
  * #L%
  */
 package com.amazonaws.athena.connectors.cloudera;
+
 import com.amazonaws.athena.connector.lambda.QueryStatusChecker;
 import com.amazonaws.athena.connector.lambda.data.Block;
 import com.amazonaws.athena.connector.lambda.data.BlockAllocator;
@@ -27,12 +28,21 @@ import com.amazonaws.athena.connector.lambda.data.SchemaBuilder;
 import com.amazonaws.athena.connector.lambda.data.SupportedTypes;
 import com.amazonaws.athena.connector.lambda.domain.Split;
 import com.amazonaws.athena.connector.lambda.domain.TableName;
+import com.amazonaws.athena.connector.lambda.domain.predicate.functions.StandardFunctions;
 import com.amazonaws.athena.connector.lambda.domain.spill.SpillLocation;
+import com.amazonaws.athena.connector.lambda.metadata.GetDataSourceCapabilitiesRequest;
+import com.amazonaws.athena.connector.lambda.metadata.GetDataSourceCapabilitiesResponse;
 import com.amazonaws.athena.connector.lambda.metadata.GetSplitsRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetSplitsResponse;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableLayoutRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableResponse;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.DataSourceOptimizations;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.OptimizationSubType;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.pushdown.ComplexExpressionPushdownSubType;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.pushdown.FilterPushdownSubType;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.pushdown.LimitPushdownSubType;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.pushdown.TopNPushdownSubType;
 import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionConfig;
 import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionInfo;
 import com.amazonaws.athena.connectors.jdbc.connection.JdbcConnectionFactory;
@@ -42,6 +52,8 @@ import com.amazonaws.athena.connectors.jdbc.manager.JdbcMetadataHandler;
 import com.amazonaws.services.athena.AmazonAthena;
 import com.amazonaws.services.secretsmanager.AWSSecretsManager;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.ArrowType;
@@ -56,12 +68,17 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import static com.amazonaws.athena.connector.lambda.domain.predicate.functions.StandardFunctions.IS_DISTINCT_FROM_OPERATOR_FUNCTION_NAME;
+import static com.amazonaws.athena.connector.lambda.domain.predicate.functions.StandardFunctions.NULLIF_FUNCTION_NAME;
 
 public class HiveMetadataHandler extends JdbcMetadataHandler
 {
@@ -225,6 +242,38 @@ public class HiveMetadataHandler extends JdbcMetadataHandler
         }
         return new GetSplitsResponse(getSplitsRequest.getCatalogName(), splits, null);
     }
+
+    /**
+     * Overridden this method to describe the types of capabilities supported by a data source
+     * @param allocator Tool for creating and managing Apache Arrow Blocks.
+     * @param request Provides details about the catalog being used.
+     * @return A GetDataSourceCapabilitiesResponse object which returns a map of supported capabilities
+     */
+    @Override
+    public GetDataSourceCapabilitiesResponse doGetDataSourceCapabilities(BlockAllocator allocator, GetDataSourceCapabilitiesRequest request)
+    {
+        Set<StandardFunctions> unsupportedFunctions = ImmutableSet.of(NULLIF_FUNCTION_NAME, IS_DISTINCT_FROM_OPERATOR_FUNCTION_NAME);
+        ImmutableMap.Builder<String, List<OptimizationSubType>> capabilities = ImmutableMap.builder();
+        capabilities.put(DataSourceOptimizations.SUPPORTS_FILTER_PUSHDOWN.withSupportedSubTypes(
+                FilterPushdownSubType.SORTED_RANGE_SET, FilterPushdownSubType.NULLABLE_COMPARISON
+        ));
+        capabilities.put(DataSourceOptimizations.SUPPORTS_COMPLEX_EXPRESSION_PUSHDOWN.withSupportedSubTypes(
+                ComplexExpressionPushdownSubType.SUPPORTED_FUNCTION_EXPRESSION_TYPES
+                        .withSubTypeProperties(Arrays.stream(StandardFunctions.values())
+                                .filter(values -> !unsupportedFunctions.contains(values))
+                                .map(standardFunctions -> standardFunctions.getFunctionName().getFunctionName())
+                                .toArray(String[]::new))
+        ));
+        capabilities.put(DataSourceOptimizations.SUPPORTS_TOP_N_PUSHDOWN.withSupportedSubTypes(
+                TopNPushdownSubType.SUPPORTS_ORDER_BY
+        ));
+        capabilities.put(DataSourceOptimizations.SUPPORTS_LIMIT_PUSHDOWN.withSupportedSubTypes(
+                LimitPushdownSubType.INTEGER_CONSTANT
+        ));
+
+        return new GetDataSourceCapabilitiesResponse(request.getCatalogName(), capabilities.build());
+    }
+
     private int decodeContinuationToken(GetSplitsRequest request)
     {
         if (request.hasContinuationToken()) {

--- a/athena-cloudera-hive/src/main/java/com/amazonaws/athena/connectors/cloudera/HiveQueryStringBuilder.java
+++ b/athena-cloudera-hive/src/main/java/com/amazonaws/athena/connectors/cloudera/HiveQueryStringBuilder.java
@@ -20,6 +20,7 @@
 package com.amazonaws.athena.connectors.cloudera;
 
 import com.amazonaws.athena.connector.lambda.domain.Split;
+import com.amazonaws.athena.connectors.jdbc.manager.FederationExpressionParser;
 import com.amazonaws.athena.connectors.jdbc.manager.JdbcSplitQueryBuilder;
 import com.google.common.base.Strings;
 
@@ -28,9 +29,9 @@ import java.util.List;
 
 public class HiveQueryStringBuilder extends JdbcSplitQueryBuilder
 {
-    public HiveQueryStringBuilder(String quoteCharacters)
+    public HiveQueryStringBuilder(final String quoteCharacters, final FederationExpressionParser federationExpressionParser)
     {
-        super(quoteCharacters);
+        super(quoteCharacters, federationExpressionParser);
     }
 
     @Override

--- a/athena-cloudera-hive/src/main/java/com/amazonaws/athena/connectors/cloudera/HiveRecordHandler.java
+++ b/athena-cloudera-hive/src/main/java/com/amazonaws/athena/connectors/cloudera/HiveRecordHandler.java
@@ -63,7 +63,7 @@ public class HiveRecordHandler extends JdbcRecordHandler
     public HiveRecordHandler(DatabaseConnectionConfig databaseConnectionConfig, JdbcConnectionFactory jdbcConnectionFactory, java.util.Map<String, String> configOptions)
     {
         this(databaseConnectionConfig, AmazonS3ClientBuilder.defaultClient(), AWSSecretsManagerClientBuilder.defaultClient(), AmazonAthenaClientBuilder.defaultClient(),
-                jdbcConnectionFactory, new HiveQueryStringBuilder(HIVE_QUOTE_CHARACTER), configOptions);
+                jdbcConnectionFactory, new HiveQueryStringBuilder(HIVE_QUOTE_CHARACTER, new HiveFederationExpressionParser(HIVE_QUOTE_CHARACTER)), configOptions);
     }
     @VisibleForTesting
     HiveRecordHandler(DatabaseConnectionConfig databaseConnectionConfig, AmazonS3 amazonS3, AWSSecretsManager secretsManager, AmazonAthena athena, JdbcConnectionFactory jdbcConnectionFactory, JdbcSplitQueryBuilder jdbcSplitQueryBuilder, java.util.Map<String, String> configOptions)

--- a/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveQueryStringBuilderTest.java
+++ b/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveQueryStringBuilderTest.java
@@ -26,6 +26,8 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import static com.amazonaws.athena.connectors.cloudera.HiveConstants.HIVE_QUOTE_CHARACTER;
+
 @SuppressWarnings("deprecation")
 @RunWith(MockitoJUnitRunner.class)
 public class HiveQueryStringBuilderTest
@@ -39,7 +41,7 @@ public class HiveQueryStringBuilderTest
 	{
 	    String expectedFrom1 = " FROM default.schema.table ";
 	    String expectedFrom2 = " FROM default.table ";
-		HiveQueryStringBuilder builder = new HiveQueryStringBuilder("");
+		HiveQueryStringBuilder builder = new HiveQueryStringBuilder(HIVE_QUOTE_CHARACTER, new HiveFederationExpressionParser(HIVE_QUOTE_CHARACTER));
 		String fromResult1 = builder.getFromClauseWithSplit("default", "schema", "table", split);
 		String fromResult2 = builder.getFromClauseWithSplit("default", "", "table", split);
 		Assert.assertEquals(expectedFrom1, fromResult1);

--- a/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveRecordHandlerTest.java
+++ b/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveRecordHandlerTest.java
@@ -20,24 +20,6 @@
 
 package com.amazonaws.athena.connectors.cloudera;
 
-import java.sql.Connection;
-import java.sql.Date;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
-import java.util.Collections;
-import java.util.concurrent.TimeUnit;
-
-import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionConfig;
-import com.amazonaws.athena.connectors.jdbc.connection.JdbcConnectionFactory;
-import com.amazonaws.athena.connectors.jdbc.connection.JdbcCredentialProvider;
-import com.amazonaws.athena.connectors.jdbc.manager.JdbcSplitQueryBuilder;
-import org.apache.arrow.vector.types.Types;
-import org.apache.arrow.vector.types.pojo.Schema;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mockito;
-
 import com.amazonaws.athena.connector.lambda.data.FieldBuilder;
 import com.amazonaws.athena.connector.lambda.data.SchemaBuilder;
 import com.amazonaws.athena.connector.lambda.domain.Split;
@@ -46,6 +28,10 @@ import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
 import com.amazonaws.athena.connector.lambda.domain.predicate.Range;
 import com.amazonaws.athena.connector.lambda.domain.predicate.SortedRangeSet;
 import com.amazonaws.athena.connector.lambda.domain.predicate.ValueSet;
+import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionConfig;
+import com.amazonaws.athena.connectors.jdbc.connection.JdbcConnectionFactory;
+import com.amazonaws.athena.connectors.jdbc.connection.JdbcCredentialProvider;
+import com.amazonaws.athena.connectors.jdbc.manager.JdbcSplitQueryBuilder;
 import com.amazonaws.services.athena.AmazonAthena;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.secretsmanager.AWSSecretsManager;
@@ -53,8 +39,21 @@ import com.amazonaws.services.secretsmanager.model.GetSecretValueRequest;
 import com.amazonaws.services.secretsmanager.model.GetSecretValueResult;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
 
-import static org.mockito.ArgumentMatchers.any;
+import java.sql.Connection;
+import java.sql.Date;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import static com.amazonaws.athena.connectors.cloudera.HiveConstants.HIVE_QUOTE_CHARACTER;
 import static org.mockito.ArgumentMatchers.nullable;
 
 public class HiveRecordHandlerTest
@@ -78,7 +77,7 @@ public class HiveRecordHandlerTest
         this.connection = Mockito.mock(Connection.class);
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         Mockito.when(this.jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(this.connection);
-        jdbcSplitQueryBuilder = new HiveQueryStringBuilder("`");
+        jdbcSplitQueryBuilder = new HiveQueryStringBuilder(HIVE_QUOTE_CHARACTER, new HiveFederationExpressionParser(HIVE_QUOTE_CHARACTER));
         final DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", HiveConstants.HIVE_NAME,
                 "hive2://jdbc:hive2://54.89.6.2:10000/authena;AuthMech=3;UID=hive;PWD=hive");
 

--- a/athena-cloudera-impala/src/main/java/com/amazonaws/athena/connectors/cloudera/ImpalaFederationExpressionParser.java
+++ b/athena-cloudera-impala/src/main/java/com/amazonaws/athena/connectors/cloudera/ImpalaFederationExpressionParser.java
@@ -1,6 +1,6 @@
 /*-
  * #%L
- * athena-datalakegen2
+ * athena-cloudera-impala
  * %%
  * Copyright (C) 2019 - 2022 Amazon Web Services
  * %%
@@ -17,14 +17,24 @@
  * limitations under the License.
  * #L%
  */
-package com.amazonaws.athena.connectors.datalakegen2;
+package com.amazonaws.athena.connectors.hortonworks;
 
-public class DataLakeGen2Constants
+import com.amazonaws.athena.connectors.jdbc.manager.JdbcFederationExpressionParser;
+import com.google.common.base.Joiner;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+
+import java.util.List;
+
+public class ImpalaFederationExpressionParser extends JdbcFederationExpressionParser
 {
-    public static final String NAME = "datalakegentwo";
-    public static final String DRIVER_CLASS = "com.microsoft.sqlserver.jdbc.SQLServerDriver";
-    public static final int DEFAULT_PORT = 1433;
-    public static final String QUOTE_CHARACTER = "\"";
+    public ImpalaFederationExpressionParser(String quoteChar)
+    {
+        super(quoteChar);
+    }
 
-    private DataLakeGen2Constants() {}
+    @Override
+    public String writeArrayConstructorClause(ArrowType type, List<String> arguments)
+    {
+        return Joiner.on(", ").join(arguments);
+    }
 }

--- a/athena-cloudera-impala/src/main/java/com/amazonaws/athena/connectors/cloudera/ImpalaMetadataHandler.java
+++ b/athena-cloudera-impala/src/main/java/com/amazonaws/athena/connectors/cloudera/ImpalaMetadataHandler.java
@@ -27,12 +27,21 @@ import com.amazonaws.athena.connector.lambda.data.SchemaBuilder;
 import com.amazonaws.athena.connector.lambda.data.SupportedTypes;
 import com.amazonaws.athena.connector.lambda.domain.Split;
 import com.amazonaws.athena.connector.lambda.domain.TableName;
+import com.amazonaws.athena.connector.lambda.domain.predicate.functions.StandardFunctions;
 import com.amazonaws.athena.connector.lambda.domain.spill.SpillLocation;
+import com.amazonaws.athena.connector.lambda.metadata.GetDataSourceCapabilitiesRequest;
+import com.amazonaws.athena.connector.lambda.metadata.GetDataSourceCapabilitiesResponse;
 import com.amazonaws.athena.connector.lambda.metadata.GetSplitsRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetSplitsResponse;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableLayoutRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableResponse;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.DataSourceOptimizations;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.OptimizationSubType;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.pushdown.ComplexExpressionPushdownSubType;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.pushdown.FilterPushdownSubType;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.pushdown.LimitPushdownSubType;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.pushdown.TopNPushdownSubType;
 import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionConfig;
 import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionInfo;
 import com.amazonaws.athena.connectors.jdbc.connection.JdbcConnectionFactory;
@@ -42,6 +51,7 @@ import com.amazonaws.athena.connectors.jdbc.manager.JdbcMetadataHandler;
 import com.amazonaws.services.athena.AmazonAthena;
 import com.amazonaws.services.secretsmanager.AWSSecretsManager;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.ArrowType;
@@ -56,9 +66,11 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -86,6 +98,30 @@ public class ImpalaMetadataHandler extends JdbcMetadataHandler
     {
         super(databaseConnectionConfiguration, secretManager, athena, jdbcConnectionFactory, configOptions);
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public GetDataSourceCapabilitiesResponse doGetDataSourceCapabilities(BlockAllocator allocator, GetDataSourceCapabilitiesRequest request)
+    {
+        ImmutableMap.Builder<String, List<OptimizationSubType>> capabilities = ImmutableMap.builder();
+        capabilities.put(DataSourceOptimizations.SUPPORTS_FILTER_PUSHDOWN.withSupportedSubTypes(
+                FilterPushdownSubType.SORTED_RANGE_SET, FilterPushdownSubType.NULLABLE_COMPARISON
+        ));
+        capabilities.put(DataSourceOptimizations.SUPPORTS_LIMIT_PUSHDOWN.withSupportedSubTypes(
+                LimitPushdownSubType.INTEGER_CONSTANT
+        ));
+        capabilities.put(DataSourceOptimizations.SUPPORTS_COMPLEX_EXPRESSION_PUSHDOWN.withSupportedSubTypes(
+                ComplexExpressionPushdownSubType.SUPPORTED_FUNCTION_EXPRESSION_TYPES
+                        .withSubTypeProperties(Arrays.stream(StandardFunctions.values())
+                                .map(standardFunctions -> standardFunctions.getFunctionName().getFunctionName())
+                                .toArray(String[]::new))
+        ));
+        capabilities.put(DataSourceOptimizations.SUPPORTS_TOP_N_PUSHDOWN.withSupportedSubTypes(TopNPushdownSubType.SUPPORTS_ORDER_BY));
+
+        return new GetDataSourceCapabilitiesResponse(request.getCatalogName(), capabilities.build());
+    }
+
     /**
      * Delegates creation of partition schema to database type implementation.
      *

--- a/athena-cloudera-impala/src/main/java/com/amazonaws/athena/connectors/cloudera/ImpalaQueryStringBuilder.java
+++ b/athena-cloudera-impala/src/main/java/com/amazonaws/athena/connectors/cloudera/ImpalaQueryStringBuilder.java
@@ -20,6 +20,7 @@
 package com.amazonaws.athena.connectors.cloudera;
 
 import com.amazonaws.athena.connector.lambda.domain.Split;
+import com.amazonaws.athena.connectors.jdbc.manager.FederationExpressionParser;
 import com.amazonaws.athena.connectors.jdbc.manager.JdbcSplitQueryBuilder;
 import com.google.common.base.Strings;
 
@@ -28,9 +29,9 @@ import java.util.List;
 
 public class ImpalaQueryStringBuilder extends JdbcSplitQueryBuilder
 {
-    public ImpalaQueryStringBuilder(String quoteCharacters)
+    public ImpalaQueryStringBuilder(String quoteCharacters, final FederationExpressionParser federationExpressionParser)
     {
-        super(quoteCharacters);
+        super(quoteCharacters, federationExpressionParser);
     }
 
     @Override

--- a/athena-cloudera-impala/src/main/java/com/amazonaws/athena/connectors/cloudera/ImpalaRecordHandler.java
+++ b/athena-cloudera-impala/src/main/java/com/amazonaws/athena/connectors/cloudera/ImpalaRecordHandler.java
@@ -22,6 +22,7 @@ package com.amazonaws.athena.connectors.cloudera;
 import com.amazonaws.athena.connector.lambda.domain.Split;
 import com.amazonaws.athena.connector.lambda.domain.TableName;
 import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
+import com.amazonaws.athena.connectors.hortonworks.ImpalaFederationExpressionParser;
 import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionConfig;
 import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionInfo;
 import com.amazonaws.athena.connectors.jdbc.connection.JdbcConnectionFactory;
@@ -63,7 +64,7 @@ public class ImpalaRecordHandler extends JdbcRecordHandler
     public ImpalaRecordHandler(DatabaseConnectionConfig databaseConnectionConfig, JdbcConnectionFactory jdbcConnectionFactory, java.util.Map<String, String> configOptions)
     {
         this(databaseConnectionConfig, AmazonS3ClientBuilder.defaultClient(), AWSSecretsManagerClientBuilder.defaultClient(), AmazonAthenaClientBuilder.defaultClient(),
-                jdbcConnectionFactory, new ImpalaQueryStringBuilder(IMPALA_QUOTE_CHARACTER), configOptions);
+                jdbcConnectionFactory, new ImpalaQueryStringBuilder(IMPALA_QUOTE_CHARACTER, new ImpalaFederationExpressionParser(IMPALA_QUOTE_CHARACTER)), configOptions);
     }
     @VisibleForTesting
     ImpalaRecordHandler(DatabaseConnectionConfig databaseConnectionConfig, AmazonS3 amazonS3, AWSSecretsManager secretsManager, AmazonAthena athena, JdbcConnectionFactory jdbcConnectionFactory, JdbcSplitQueryBuilder jdbcSplitQueryBuilder, java.util.Map<String, String> configOptions)

--- a/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaQueryStringBuilderTest.java
+++ b/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaQueryStringBuilderTest.java
@@ -20,11 +20,14 @@
 package com.amazonaws.athena.connectors.cloudera;
 
 import com.amazonaws.athena.connector.lambda.domain.Split;
+import com.amazonaws.athena.connectors.hortonworks.ImpalaFederationExpressionParser;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+
+import static com.amazonaws.athena.connectors.cloudera.ImpalaConstants.IMPALA_QUOTE_CHARACTER;
 
 @SuppressWarnings("deprecation")
 @RunWith(MockitoJUnitRunner.class)
@@ -39,7 +42,7 @@ public class ImpalaQueryStringBuilderTest
 	{
 	    String expectedFrom1 = " FROM default.schema.table ";
 	    String expectedFrom2 = " FROM default.table ";
-		ImpalaQueryStringBuilder builder = new ImpalaQueryStringBuilder("");
+		ImpalaQueryStringBuilder builder = new ImpalaQueryStringBuilder(IMPALA_QUOTE_CHARACTER, new ImpalaFederationExpressionParser(IMPALA_QUOTE_CHARACTER));
 		String fromResult1 = builder.getFromClauseWithSplit("default", "schema", "table", split);
 		String fromResult2 = builder.getFromClauseWithSplit("default", "", "table", split);
 		Assert.assertEquals(expectedFrom1, fromResult1);

--- a/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaRecordHandlerTest.java
+++ b/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaRecordHandlerTest.java
@@ -20,24 +20,6 @@
 
 package com.amazonaws.athena.connectors.cloudera;
 
-import java.sql.Connection;
-import java.sql.Date;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
-import java.util.Collections;
-import java.util.concurrent.TimeUnit;
-
-import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionConfig;
-import com.amazonaws.athena.connectors.jdbc.connection.JdbcConnectionFactory;
-import com.amazonaws.athena.connectors.jdbc.connection.JdbcCredentialProvider;
-import com.amazonaws.athena.connectors.jdbc.manager.JdbcSplitQueryBuilder;
-import org.apache.arrow.vector.types.Types;
-import org.apache.arrow.vector.types.pojo.Schema;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mockito;
-
 import com.amazonaws.athena.connector.lambda.data.FieldBuilder;
 import com.amazonaws.athena.connector.lambda.data.SchemaBuilder;
 import com.amazonaws.athena.connector.lambda.domain.Split;
@@ -46,6 +28,11 @@ import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
 import com.amazonaws.athena.connector.lambda.domain.predicate.Range;
 import com.amazonaws.athena.connector.lambda.domain.predicate.SortedRangeSet;
 import com.amazonaws.athena.connector.lambda.domain.predicate.ValueSet;
+import com.amazonaws.athena.connectors.hortonworks.ImpalaFederationExpressionParser;
+import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionConfig;
+import com.amazonaws.athena.connectors.jdbc.connection.JdbcConnectionFactory;
+import com.amazonaws.athena.connectors.jdbc.connection.JdbcCredentialProvider;
+import com.amazonaws.athena.connectors.jdbc.manager.JdbcSplitQueryBuilder;
 import com.amazonaws.services.athena.AmazonAthena;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.secretsmanager.AWSSecretsManager;
@@ -53,8 +40,21 @@ import com.amazonaws.services.secretsmanager.model.GetSecretValueRequest;
 import com.amazonaws.services.secretsmanager.model.GetSecretValueResult;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
 
-import static org.mockito.ArgumentMatchers.any;
+import java.sql.Connection;
+import java.sql.Date;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import static com.amazonaws.athena.connectors.cloudera.ImpalaConstants.IMPALA_QUOTE_CHARACTER;
 import static org.mockito.ArgumentMatchers.nullable;
 
 
@@ -79,7 +79,7 @@ public class ImpalaRecordHandlerTest
         this.connection = Mockito.mock(Connection.class);
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         Mockito.when(this.jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(this.connection);
-        jdbcSplitQueryBuilder = new ImpalaQueryStringBuilder("`");
+        jdbcSplitQueryBuilder = new ImpalaQueryStringBuilder(IMPALA_QUOTE_CHARACTER, new ImpalaFederationExpressionParser(IMPALA_QUOTE_CHARACTER));
 
         final DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", ImpalaConstants.IMPALA_NAME,
                 "impala://jdbc:impala://54.89.6.2:10000/authena;{testSecret}","testSecret");

--- a/athena-datalakegen2/src/main/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2FederationExpressionParser.java
+++ b/athena-datalakegen2/src/main/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2FederationExpressionParser.java
@@ -1,6 +1,6 @@
 /*-
  * #%L
- * athena-datalakegen2
+ * athena-DataLakeGen2
  * %%
  * Copyright (C) 2019 - 2022 Amazon Web Services
  * %%
@@ -19,12 +19,22 @@
  */
 package com.amazonaws.athena.connectors.datalakegen2;
 
-public class DataLakeGen2Constants
-{
-    public static final String NAME = "datalakegentwo";
-    public static final String DRIVER_CLASS = "com.microsoft.sqlserver.jdbc.SQLServerDriver";
-    public static final int DEFAULT_PORT = 1433;
-    public static final String QUOTE_CHARACTER = "\"";
+import com.amazonaws.athena.connectors.jdbc.manager.JdbcFederationExpressionParser;
+import com.google.common.base.Joiner;
+import org.apache.arrow.vector.types.pojo.ArrowType;
 
-    private DataLakeGen2Constants() {}
+import java.util.List;
+
+public class DataLakeGen2FederationExpressionParser extends JdbcFederationExpressionParser
+{
+    public DataLakeGen2FederationExpressionParser(String quoteChar)
+    {
+        super(quoteChar);
+    }
+
+    @Override
+    public String writeArrayConstructorClause(ArrowType type, List<String> arguments)
+    {
+        return Joiner.on(", ").join(arguments);
+    }    
 }

--- a/athena-datalakegen2/src/main/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2MetadataHandler.java
+++ b/athena-datalakegen2/src/main/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2MetadataHandler.java
@@ -28,11 +28,19 @@ import com.amazonaws.athena.connector.lambda.data.SchemaBuilder;
 import com.amazonaws.athena.connector.lambda.data.SupportedTypes;
 import com.amazonaws.athena.connector.lambda.domain.Split;
 import com.amazonaws.athena.connector.lambda.domain.TableName;
+import com.amazonaws.athena.connector.lambda.domain.predicate.functions.StandardFunctions;
+import com.amazonaws.athena.connector.lambda.metadata.GetDataSourceCapabilitiesRequest;
+import com.amazonaws.athena.connector.lambda.metadata.GetDataSourceCapabilitiesResponse;
 import com.amazonaws.athena.connector.lambda.metadata.GetSplitsRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetSplitsResponse;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableLayoutRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableResponse;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.DataSourceOptimizations;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.OptimizationSubType;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.pushdown.ComplexExpressionPushdownSubType;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.pushdown.FilterPushdownSubType;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.pushdown.TopNPushdownSubType;
 import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionConfig;
 import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionInfo;
 import com.amazonaws.athena.connectors.jdbc.connection.JdbcConnectionFactory;
@@ -43,6 +51,7 @@ import com.amazonaws.services.athena.AmazonAthena;
 import com.amazonaws.services.secretsmanager.AWSSecretsManager;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
@@ -55,11 +64,15 @@ import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import static com.amazonaws.athena.connector.lambda.domain.predicate.functions.StandardFunctions.IS_DISTINCT_FROM_OPERATOR_FUNCTION_NAME;
 
 public class DataLakeGen2MetadataHandler extends JdbcMetadataHandler
 {
@@ -103,6 +116,29 @@ public class DataLakeGen2MetadataHandler extends JdbcMetadataHandler
         java.util.Map<String, String> configOptions)
     {
         super(databaseConnectionConfig, secretsManager, athena, jdbcConnectionFactory, configOptions);
+    }
+
+    @Override
+    public GetDataSourceCapabilitiesResponse doGetDataSourceCapabilities(BlockAllocator allocator, GetDataSourceCapabilitiesRequest request)
+    {
+        Set<StandardFunctions> unSupportedFunctions = ImmutableSet.of(IS_DISTINCT_FROM_OPERATOR_FUNCTION_NAME);
+        ImmutableMap.Builder<String, List<OptimizationSubType>> capabilities = ImmutableMap.builder();
+
+        capabilities.put(DataSourceOptimizations.SUPPORTS_FILTER_PUSHDOWN.withSupportedSubTypes(
+                FilterPushdownSubType.SORTED_RANGE_SET, FilterPushdownSubType.NULLABLE_COMPARISON
+        ));
+        capabilities.put(DataSourceOptimizations.SUPPORTS_COMPLEX_EXPRESSION_PUSHDOWN.withSupportedSubTypes(
+                ComplexExpressionPushdownSubType.SUPPORTED_FUNCTION_EXPRESSION_TYPES
+                        .withSubTypeProperties(Arrays.stream(StandardFunctions.values())
+                                .filter(values -> !unSupportedFunctions.contains(values))
+                                .map(standardFunctions -> standardFunctions.getFunctionName().getFunctionName())
+                                .toArray(String[]::new))
+        ));
+        capabilities.put(DataSourceOptimizations.SUPPORTS_TOP_N_PUSHDOWN.withSupportedSubTypes(
+                TopNPushdownSubType.SUPPORTS_ORDER_BY
+        ));
+
+        return new GetDataSourceCapabilitiesResponse(request.getCatalogName(), capabilities.build());
     }
 
     @Override

--- a/athena-datalakegen2/src/main/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2QueryStringBuilder.java
+++ b/athena-datalakegen2/src/main/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2QueryStringBuilder.java
@@ -20,6 +20,7 @@
 package com.amazonaws.athena.connectors.datalakegen2;
 
 import com.amazonaws.athena.connector.lambda.domain.Split;
+import com.amazonaws.athena.connectors.jdbc.manager.FederationExpressionParser;
 import com.amazonaws.athena.connectors.jdbc.manager.JdbcSplitQueryBuilder;
 import com.google.common.base.Strings;
 import org.slf4j.Logger;
@@ -31,9 +32,9 @@ import java.util.List;
 public class DataLakeGen2QueryStringBuilder extends JdbcSplitQueryBuilder
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(DataLakeGen2QueryStringBuilder.class);
-    public DataLakeGen2QueryStringBuilder(String quoteCharacters)
+    public DataLakeGen2QueryStringBuilder(String quoteCharacters, final FederationExpressionParser federationExpressionParser)
     {
-        super(quoteCharacters);
+        super(quoteCharacters, federationExpressionParser);
     }
 
     @Override

--- a/athena-datalakegen2/src/main/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2RecordHandler.java
+++ b/athena-datalakegen2/src/main/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2RecordHandler.java
@@ -41,9 +41,11 @@ import org.apache.commons.lang3.Validate;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+
+import static com.amazonaws.athena.connectors.datalakegen2.DataLakeGen2Constants.QUOTE_CHARACTER;
+
 public class DataLakeGen2RecordHandler extends JdbcRecordHandler
 {
-    private static final String QUOTE_CHARACTER = "\"";
     private static final int FETCH_SIZE = 1000;
     private final JdbcSplitQueryBuilder jdbcSplitQueryBuilder;
     public DataLakeGen2RecordHandler(java.util.Map<String, String> configOptions)
@@ -54,7 +56,7 @@ public class DataLakeGen2RecordHandler extends JdbcRecordHandler
     {
         this(databaseConnectionConfig, AmazonS3ClientBuilder.defaultClient(), AWSSecretsManagerClientBuilder.defaultClient(), AmazonAthenaClientBuilder.defaultClient(),
                 new GenericJdbcConnectionFactory(databaseConnectionConfig, DataLakeGen2MetadataHandler.JDBC_PROPERTIES,
-                        new DatabaseConnectionInfo(DataLakeGen2Constants.DRIVER_CLASS, DataLakeGen2Constants.DEFAULT_PORT)), new DataLakeGen2QueryStringBuilder(QUOTE_CHARACTER), configOptions);
+                        new DatabaseConnectionInfo(DataLakeGen2Constants.DRIVER_CLASS, DataLakeGen2Constants.DEFAULT_PORT)), new DataLakeGen2QueryStringBuilder(QUOTE_CHARACTER, new DataLakeGen2FederationExpressionParser(QUOTE_CHARACTER)), configOptions);
     }
     @VisibleForTesting
     DataLakeGen2RecordHandler(DatabaseConnectionConfig databaseConnectionConfig, AmazonS3 amazonS3, AWSSecretsManager secretsManager, AmazonAthena athena, JdbcConnectionFactory jdbcConnectionFactory, JdbcSplitQueryBuilder jdbcSplitQueryBuilder, java.util.Map<String, String> configOptions)

--- a/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeQueryStringBuilderTest.java
+++ b/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeQueryStringBuilderTest.java
@@ -27,6 +27,8 @@ import org.testng.Assert;
 import java.util.ArrayList;
 import java.util.Collections;
 
+import static com.amazonaws.athena.connectors.datalakegen2.DataLakeGen2Constants.QUOTE_CHARACTER;
+
 public class DataLakeQueryStringBuilderTest
 {
     static {
@@ -39,15 +41,15 @@ public class DataLakeQueryStringBuilderTest
         Split split = Mockito.mock(Split.class);
         Mockito.when(split.getProperties()).thenReturn(Collections.singletonMap("partition", "p0"));
         Mockito.when(split.getProperty(Mockito.eq("partition"))).thenReturn("p0");
-        DataLakeGen2QueryStringBuilder builder = new DataLakeGen2QueryStringBuilder("'");
-        Assert.assertEquals(" FROM 'default'.'table' ", builder.getFromClauseWithSplit("default", "", "table", split));
-        Assert.assertEquals(" FROM 'default'.'schema'.'table' ", builder.getFromClauseWithSplit("default", "schema", "table", split));
+        DataLakeGen2QueryStringBuilder builder = new DataLakeGen2QueryStringBuilder(QUOTE_CHARACTER, new DataLakeGen2FederationExpressionParser(QUOTE_CHARACTER));
+        Assert.assertEquals(" FROM \"default\".\"table\" ", builder.getFromClauseWithSplit("default", "", "table", split));
+        Assert.assertEquals(" FROM \"default\".\"schema\".\"table\" ", builder.getFromClauseWithSplit("default", "schema", "table", split));
     }
 
     @Test
     public void testGetPartitionWhereClauses()
     {
-        DataLakeGen2QueryStringBuilder builder = new DataLakeGen2QueryStringBuilder("'");
+        DataLakeGen2QueryStringBuilder builder = new DataLakeGen2QueryStringBuilder(QUOTE_CHARACTER, new DataLakeGen2FederationExpressionParser(QUOTE_CHARACTER));
 
         Split split = Mockito.mock(Split.class);
         Mockito.when(split.getProperties()).thenReturn(Collections.singletonMap("partition", "p0"));

--- a/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeRecordHandlerTest.java
+++ b/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeRecordHandlerTest.java
@@ -47,6 +47,7 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.Collections;
 
+import static com.amazonaws.athena.connectors.datalakegen2.DataLakeGen2Constants.QUOTE_CHARACTER;
 import static org.mockito.ArgumentMatchers.nullable;
 
 public class DataLakeRecordHandlerTest
@@ -70,7 +71,7 @@ public class DataLakeRecordHandlerTest
         this.connection = Mockito.mock(Connection.class);
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         Mockito.when(this.jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(this.connection);
-        jdbcSplitQueryBuilder = new DataLakeGen2QueryStringBuilder("`");
+        jdbcSplitQueryBuilder = new DataLakeGen2QueryStringBuilder(QUOTE_CHARACTER, new DataLakeGen2FederationExpressionParser(QUOTE_CHARACTER));
         final DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", DataLakeGen2Constants.NAME,
                 "datalakegentwo://jdbc:sqlserver://hostname;databaseName=fakedatabase");
 
@@ -108,7 +109,7 @@ public class DataLakeRecordHandlerTest
                 .put("testCol4", valueSet)
                 .build());
 
-        String expectedSql = "SELECT `testCol1`, `testCol2`, `testCol3`, `testCol4` FROM `testSchema`.`testTable`  WHERE (`testCol4` = ?)";
+        String expectedSql = "SELECT \"testCol1\", \"testCol2\", \"testCol3\", \"testCol4\" FROM \"testSchema\".\"testTable\"  WHERE (\"testCol4\" = ?)";
         PreparedStatement expectedPreparedStatement = Mockito.mock(PreparedStatement.class);
         Mockito.when(this.connection.prepareStatement(Mockito.eq(expectedSql))).thenReturn(expectedPreparedStatement);
         PreparedStatement preparedStatement = this.dataLakeGen2RecordHandler.buildSplitSql(this.connection, "testCatalogName", tableName, schema, constraints, split);

--- a/athena-db2/src/main/java/com/amazonaws/athena/connectors/db2/Db2Constants.java
+++ b/athena-db2/src/main/java/com/amazonaws/athena/connectors/db2/Db2Constants.java
@@ -24,6 +24,7 @@ public class Db2Constants
     public static final String NAME = "dbtwo";
     public static final String DRIVER_CLASS = "com.ibm.db2.jcc.DB2Driver";
     public static final int DEFAULT_PORT = 50001;
+    public static final String QUOTE_CHARACTER = "\"";
 
     public static final String QRY_TO_LIST_SCHEMAS = "select schemaname as name " +
             "from syscat.schemata " +

--- a/athena-db2/src/main/java/com/amazonaws/athena/connectors/db2/Db2FederationExpressionParser.java
+++ b/athena-db2/src/main/java/com/amazonaws/athena/connectors/db2/Db2FederationExpressionParser.java
@@ -1,6 +1,6 @@
 /*-
  * #%L
- * athena-datalakegen2
+ * athena-db2
  * %%
  * Copyright (C) 2019 - 2022 Amazon Web Services
  * %%
@@ -17,14 +17,24 @@
  * limitations under the License.
  * #L%
  */
-package com.amazonaws.athena.connectors.datalakegen2;
+package com.amazonaws.athena.connectors.db2;
 
-public class DataLakeGen2Constants
+import com.amazonaws.athena.connectors.jdbc.manager.JdbcFederationExpressionParser;
+import com.google.common.base.Joiner;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+
+import java.util.List;
+
+public class Db2FederationExpressionParser extends JdbcFederationExpressionParser
 {
-    public static final String NAME = "datalakegentwo";
-    public static final String DRIVER_CLASS = "com.microsoft.sqlserver.jdbc.SQLServerDriver";
-    public static final int DEFAULT_PORT = 1433;
-    public static final String QUOTE_CHARACTER = "\"";
+    public Db2FederationExpressionParser(String quoteChar)
+    {
+        super(quoteChar);
+    }
 
-    private DataLakeGen2Constants() {}
+    @Override
+    public String writeArrayConstructorClause(ArrowType type, List<String> arguments)
+    {
+        return Joiner.on(", ").join(arguments);
+    }    
 }

--- a/athena-db2/src/main/java/com/amazonaws/athena/connectors/db2/Db2MetadataHandler.java
+++ b/athena-db2/src/main/java/com/amazonaws/athena/connectors/db2/Db2MetadataHandler.java
@@ -28,7 +28,10 @@ import com.amazonaws.athena.connector.lambda.data.SchemaBuilder;
 import com.amazonaws.athena.connector.lambda.data.SupportedTypes;
 import com.amazonaws.athena.connector.lambda.domain.Split;
 import com.amazonaws.athena.connector.lambda.domain.TableName;
+import com.amazonaws.athena.connector.lambda.domain.predicate.functions.StandardFunctions;
 import com.amazonaws.athena.connector.lambda.domain.spill.SpillLocation;
+import com.amazonaws.athena.connector.lambda.metadata.GetDataSourceCapabilitiesRequest;
+import com.amazonaws.athena.connector.lambda.metadata.GetDataSourceCapabilitiesResponse;
 import com.amazonaws.athena.connector.lambda.metadata.GetSplitsRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetSplitsResponse;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableLayoutRequest;
@@ -38,6 +41,12 @@ import com.amazonaws.athena.connector.lambda.metadata.ListSchemasRequest;
 import com.amazonaws.athena.connector.lambda.metadata.ListSchemasResponse;
 import com.amazonaws.athena.connector.lambda.metadata.ListTablesRequest;
 import com.amazonaws.athena.connector.lambda.metadata.ListTablesResponse;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.DataSourceOptimizations;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.OptimizationSubType;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.pushdown.ComplexExpressionPushdownSubType;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.pushdown.FilterPushdownSubType;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.pushdown.LimitPushdownSubType;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.pushdown.TopNPushdownSubType;
 import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionConfig;
 import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionInfo;
 import com.amazonaws.athena.connectors.jdbc.connection.GenericJdbcConnectionFactory;
@@ -49,6 +58,8 @@ import com.amazonaws.athena.connectors.jdbc.manager.PreparedStatementBuilder;
 import com.amazonaws.services.athena.AmazonAthena;
 import com.amazonaws.services.secretsmanager.AWSSecretsManager;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.ArrowType;
@@ -69,6 +80,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import static com.amazonaws.athena.connector.lambda.domain.predicate.functions.StandardFunctions.NULLIF_FUNCTION_NAME;
 
 public class Db2MetadataHandler extends JdbcMetadataHandler
 {
@@ -296,6 +309,36 @@ public class Db2MetadataHandler extends JdbcMetadataHandler
             }
         }
         return new GetSplitsResponse(getSplitsRequest.getCatalogName(), splits, null);
+    }
+
+    /**
+     * Overridden this method to describe the types of capabilities supported by a data source
+     * @param allocator Tool for creating and managing Apache Arrow Blocks.
+     * @param request Provides details about the catalog being used.
+     * @return A GetDataSourceCapabilitiesResponse object which returns a map of supported capabilities
+     */
+    @Override
+    public GetDataSourceCapabilitiesResponse doGetDataSourceCapabilities(BlockAllocator allocator, GetDataSourceCapabilitiesRequest request)
+    {
+        Set<StandardFunctions> unsupportedFunctions = ImmutableSet.of(NULLIF_FUNCTION_NAME);
+        ImmutableMap.Builder<String, List<OptimizationSubType>> capabilities = ImmutableMap.builder();
+        capabilities.put(DataSourceOptimizations.SUPPORTS_FILTER_PUSHDOWN.withSupportedSubTypes(
+                FilterPushdownSubType.SORTED_RANGE_SET, FilterPushdownSubType.NULLABLE_COMPARISON
+        ));
+        capabilities.put(DataSourceOptimizations.SUPPORTS_COMPLEX_EXPRESSION_PUSHDOWN.withSupportedSubTypes(
+                ComplexExpressionPushdownSubType.SUPPORTED_FUNCTION_EXPRESSION_TYPES
+                        .withSubTypeProperties(Arrays.stream(StandardFunctions.values())
+                                .filter(values -> !unsupportedFunctions.contains(values))
+                                .map(standardFunctions -> standardFunctions.getFunctionName().getFunctionName())
+                                .toArray(String[]::new))
+        ));
+        capabilities.put(DataSourceOptimizations.SUPPORTS_TOP_N_PUSHDOWN.withSupportedSubTypes(
+                TopNPushdownSubType.SUPPORTS_ORDER_BY
+        ));
+        capabilities.put(DataSourceOptimizations.SUPPORTS_LIMIT_PUSHDOWN.withSupportedSubTypes(
+                LimitPushdownSubType.INTEGER_CONSTANT
+        ));
+        return new GetDataSourceCapabilitiesResponse(request.getCatalogName(), capabilities.build());
     }
 
     /**

--- a/athena-db2/src/main/java/com/amazonaws/athena/connectors/db2/Db2QueryStringBuilder.java
+++ b/athena-db2/src/main/java/com/amazonaws/athena/connectors/db2/Db2QueryStringBuilder.java
@@ -20,6 +20,7 @@
 package com.amazonaws.athena.connectors.db2;
 
 import com.amazonaws.athena.connector.lambda.domain.Split;
+import com.amazonaws.athena.connectors.jdbc.manager.FederationExpressionParser;
 import com.amazonaws.athena.connectors.jdbc.manager.JdbcSplitQueryBuilder;
 import com.google.common.base.Strings;
 import org.slf4j.Logger;
@@ -31,9 +32,9 @@ import java.util.List;
 public class Db2QueryStringBuilder extends JdbcSplitQueryBuilder
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(Db2QueryStringBuilder.class);
-    public Db2QueryStringBuilder(String quoteCharacters)
+    public Db2QueryStringBuilder(final String quoteCharacters, final FederationExpressionParser federationExpressionParser)
     {
-        super(quoteCharacters);
+        super(quoteCharacters, federationExpressionParser);
     }
 
     /**

--- a/athena-db2/src/main/java/com/amazonaws/athena/connectors/db2/Db2RecordHandler.java
+++ b/athena-db2/src/main/java/com/amazonaws/athena/connectors/db2/Db2RecordHandler.java
@@ -43,9 +43,10 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
+import static com.amazonaws.athena.connectors.db2.Db2Constants.QUOTE_CHARACTER;
+
 public class Db2RecordHandler extends JdbcRecordHandler
 {
-    private static final String QUOTE_CHARACTER = "\"";
     private static final int FETCH_SIZE = 1000;
     private final JdbcSplitQueryBuilder jdbcSplitQueryBuilder;
     public Db2RecordHandler(java.util.Map<String, String> configOptions)
@@ -62,7 +63,7 @@ public class Db2RecordHandler extends JdbcRecordHandler
     {
         this(databaseConnectionConfig, AmazonS3ClientBuilder.defaultClient(), AWSSecretsManagerClientBuilder.defaultClient(), AmazonAthenaClientBuilder.defaultClient(),
                 new GenericJdbcConnectionFactory(databaseConnectionConfig, null,
-                        new DatabaseConnectionInfo(Db2Constants.DRIVER_CLASS, Db2Constants.DEFAULT_PORT)), new Db2QueryStringBuilder(QUOTE_CHARACTER), configOptions);
+                        new DatabaseConnectionInfo(Db2Constants.DRIVER_CLASS, Db2Constants.DEFAULT_PORT)), new Db2QueryStringBuilder(QUOTE_CHARACTER, new Db2FederationExpressionParser(QUOTE_CHARACTER)), configOptions);
     }
 
     @VisibleForTesting

--- a/athena-db2/src/test/java/com/amazonaws/athena/connectors/db2/Db2QueryStringBuilderTest.java
+++ b/athena-db2/src/test/java/com/amazonaws/athena/connectors/db2/Db2QueryStringBuilderTest.java
@@ -27,6 +27,8 @@ import org.testng.Assert;
 
 import java.util.Arrays;
 
+import static com.amazonaws.athena.connectors.db2.Db2Constants.QUOTE_CHARACTER;
+
 public class Db2QueryStringBuilderTest {
     @Mock
     Split split;
@@ -35,15 +37,15 @@ public class Db2QueryStringBuilderTest {
     public void testQueryBuilder()
     {
         Split split = Mockito.mock(Split.class);
-        Db2QueryStringBuilder builder = new Db2QueryStringBuilder("'");
-        Assert.assertEquals(" FROM 'default'.'table' ", builder.getFromClauseWithSplit("default", "", "table", split));
-        Assert.assertEquals(" FROM 'default'.'schema'.'table' ", builder.getFromClauseWithSplit("default", "schema", "table", split));
+        Db2QueryStringBuilder builder = new Db2QueryStringBuilder(QUOTE_CHARACTER, new Db2FederationExpressionParser(QUOTE_CHARACTER));
+        Assert.assertEquals(" FROM \"default\".\"table\" ", builder.getFromClauseWithSplit("default", "", "table", split));
+        Assert.assertEquals(" FROM \"default\".\"schema\".\"table\" ", builder.getFromClauseWithSplit("default", "schema", "table", split));
     }
 
     @Test
     public void testGetPartitionWhereClauses()
     {
-        Db2QueryStringBuilder builder = new Db2QueryStringBuilder("'");
+        Db2QueryStringBuilder builder =  new Db2QueryStringBuilder(QUOTE_CHARACTER, new Db2FederationExpressionParser(QUOTE_CHARACTER));
         Split split = Mockito.mock(Split.class);
         Mockito.when(split.getProperty(Mockito.eq("PARTITION_NUMBER"))).thenReturn("0");
         Mockito.when(split.getProperty(Mockito.eq("PARTITIONING_COLUMN"))).thenReturn("PC");

--- a/athena-db2/src/test/java/com/amazonaws/athena/connectors/db2/Db2RecordHandlerTest.java
+++ b/athena-db2/src/test/java/com/amazonaws/athena/connectors/db2/Db2RecordHandlerTest.java
@@ -47,6 +47,7 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.Collections;
 
+import static com.amazonaws.athena.connectors.db2.Db2Constants.QUOTE_CHARACTER;
 import static org.mockito.ArgumentMatchers.nullable;
 
 public class Db2RecordHandlerTest {
@@ -67,7 +68,7 @@ public class Db2RecordHandlerTest {
         this.connection = Mockito.mock(Connection.class);
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         Mockito.when(this.jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(this.connection);
-        jdbcSplitQueryBuilder = new Db2QueryStringBuilder("`");
+        jdbcSplitQueryBuilder = new Db2QueryStringBuilder(QUOTE_CHARACTER, new Db2FederationExpressionParser(QUOTE_CHARACTER));
         final DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", Db2Constants.NAME,
                 "dbtwo://jdbc:db2://hostname/fakedatabase:${testsecret}");
         this.db2RecordHandler = new Db2RecordHandler(databaseConnectionConfig, amazonS3, secretsManager, athena, jdbcConnectionFactory, jdbcSplitQueryBuilder, com.google.common.collect.ImmutableMap.of());
@@ -104,7 +105,7 @@ public class Db2RecordHandlerTest {
                 .put("testCol4", valueSet)
                 .build());
 
-        String expectedSql = "SELECT `testCol1`, `testCol2`, `testCol3`, `testCol4` FROM `testSchema`.`testTable`  WHERE (`testCol4` = ?)";
+        String expectedSql = "SELECT \"testCol1\", \"testCol2\", \"testCol3\", \"testCol4\" FROM \"testSchema\".\"testTable\"  WHERE (\"testCol4\" = ?)";
         PreparedStatement expectedPreparedStatement = Mockito.mock(PreparedStatement.class);
         Mockito.when(this.connection.prepareStatement(Mockito.eq(expectedSql))).thenReturn(expectedPreparedStatement);
         PreparedStatement preparedStatement = this.db2RecordHandler.buildSplitSql(this.connection, "testCatalogName", tableName, schema, constraints, split);

--- a/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryFederationExpressionParser.java
+++ b/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryFederationExpressionParser.java
@@ -1,0 +1,143 @@
+/*-
+ * #%L
+ * athena-bigquery
+ * %%
+ * Copyright (C) 2019 - 2022 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.google.bigquery;
+
+import com.amazonaws.athena.connector.lambda.domain.predicate.functions.FunctionName;
+import com.amazonaws.athena.connector.lambda.domain.predicate.functions.OperatorType;
+import com.amazonaws.athena.connector.lambda.domain.predicate.functions.StandardFunctions;
+import com.amazonaws.athena.connectors.jdbc.manager.FederationExpressionParser;
+import com.google.common.base.Joiner;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.commons.lang3.NotImplementedException;
+
+import java.util.List;
+
+/**
+ * Based on com.amazonaws.athena.connectors.jdbc.manager.JdbcFederationExpressionParser class
+ */
+public class BigQueryFederationExpressionParser extends FederationExpressionParser
+{
+    public String writeArrayConstructorClause(ArrowType type, List<String> arguments)
+    {
+        return Joiner.on(", ").join(arguments);
+    }
+
+    @Override
+    public String mapFunctionToDataSourceSyntax(FunctionName functionName, ArrowType type, List<String> arguments)
+    {
+        StandardFunctions functionEnum = StandardFunctions.fromFunctionName(functionName);
+        OperatorType operatorType = functionEnum.getOperatorType();
+
+        if (arguments == null || arguments.size() == 0) {
+            throw new IllegalArgumentException("Arguments cannot be null or empty.");
+        }
+        switch (operatorType) {
+            case UNARY:
+                if (arguments.size() != 1) {
+                    throw new IllegalArgumentException("Unary function type " + functionName.getFunctionName() + " was provided with " + arguments.size() + " arguments.");
+                }
+                break;
+            case BINARY:
+                if (arguments.size() != 2) {
+                    throw new IllegalArgumentException("Binary function type " + functionName.getFunctionName() + " was provided with " + arguments.size() + " arguments.");
+                }
+                break;
+            case VARARG:
+                break;
+            default:
+                throw new RuntimeException("A new operator type was introduced without adding support for it.");
+        }
+
+        String clause = "";
+        switch (functionEnum) {
+            case ADD_FUNCTION_NAME:
+                clause = Joiner.on(" + ").join(arguments);
+                break;
+            case AND_FUNCTION_NAME:
+                clause = Joiner.on(" AND ").join(arguments);
+                break;
+            case ARRAY_CONSTRUCTOR_FUNCTION_NAME: // up to subclass
+                clause = writeArrayConstructorClause(type, arguments);
+                break;
+            case DIVIDE_FUNCTION_NAME:
+                clause = Joiner.on(" / ").join(arguments);
+                break;
+            case EQUAL_OPERATOR_FUNCTION_NAME:
+                clause = Joiner.on(" = ").join(arguments);
+                break;
+            case GREATER_THAN_OPERATOR_FUNCTION_NAME:
+                clause = Joiner.on(" > ").join(arguments);
+                break;
+            case GREATER_THAN_OR_EQUAL_OPERATOR_FUNCTION_NAME:
+                clause = Joiner.on(" >= ").join(arguments);
+                break;
+            case IN_PREDICATE_FUNCTION_NAME:
+                clause = arguments.get(0) + " IN " + arguments.get(1);
+                break;
+            case IS_DISTINCT_FROM_OPERATOR_FUNCTION_NAME:
+                String argZero = arguments.get(0);
+                String argOne = arguments.get(1);
+                clause = argZero + " IS DISTINCT FROM " + argOne;
+                break;
+            case IS_NULL_FUNCTION_NAME:
+                clause = arguments.get(0) + " IS NULL";
+                break;
+            case LESS_THAN_OPERATOR_FUNCTION_NAME:
+                clause = Joiner.on(" < ").join(arguments);
+                break;
+            case LESS_THAN_OR_EQUAL_OPERATOR_FUNCTION_NAME:
+                clause = Joiner.on(" <= ").join(arguments);
+                break;
+            case LIKE_PATTERN_FUNCTION_NAME:
+                clause = arguments.get(0) + " LIKE " + arguments.get(1);
+                break;
+            case MODULUS_FUNCTION_NAME:
+                clause = " MOD(" + arguments.get(0) + "," + arguments.get(1) + ")";
+                break;
+            case MULTIPLY_FUNCTION_NAME:
+                clause = Joiner.on(" * ").join(arguments);
+                break;
+            case NEGATE_FUNCTION_NAME:
+                clause = "-" + arguments.get(0);
+                break;
+            case NOT_EQUAL_OPERATOR_FUNCTION_NAME:
+                clause = Joiner.on(" <> ").join(arguments);
+                break;
+            case NOT_FUNCTION_NAME:
+                clause = " NOT " + arguments.get(0);
+                break;
+            case NULLIF_FUNCTION_NAME:
+                clause = "NULLIF(" + arguments.get(0) + ", " + arguments.get(1) + ")";
+                break;
+            case OR_FUNCTION_NAME:
+                clause = Joiner.on(" OR ").join(arguments);
+                break;
+            case SUBTRACT_FUNCTION_NAME:
+                clause = Joiner.on(" - ").join(arguments);
+                break;
+            default:
+                throw new NotImplementedException("The function " + functionName.getFunctionName() + " does not have an implementation");
+        }
+        if (clause == null) {
+            return "";
+        }
+        return "(" + clause + ")";
+    }
+}

--- a/athena-hortonworks-hive/src/main/java/com/amazonaws/athena/connectors/hortonworks/HiveFederationExpressionParser.java
+++ b/athena-hortonworks-hive/src/main/java/com/amazonaws/athena/connectors/hortonworks/HiveFederationExpressionParser.java
@@ -1,6 +1,6 @@
 /*-
  * #%L
- * athena-datalakegen2
+ * athena-hortonworks-hive
  * %%
  * Copyright (C) 2019 - 2022 Amazon Web Services
  * %%
@@ -17,14 +17,24 @@
  * limitations under the License.
  * #L%
  */
-package com.amazonaws.athena.connectors.datalakegen2;
+package com.amazonaws.athena.connectors.hortonworks;
 
-public class DataLakeGen2Constants
+import com.amazonaws.athena.connectors.jdbc.manager.JdbcFederationExpressionParser;
+import com.google.common.base.Joiner;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+
+import java.util.List;
+
+public class HiveFederationExpressionParser extends JdbcFederationExpressionParser
 {
-    public static final String NAME = "datalakegentwo";
-    public static final String DRIVER_CLASS = "com.microsoft.sqlserver.jdbc.SQLServerDriver";
-    public static final int DEFAULT_PORT = 1433;
-    public static final String QUOTE_CHARACTER = "\"";
+    public HiveFederationExpressionParser(String quoteChar)
+    {
+        super(quoteChar);
+    }
 
-    private DataLakeGen2Constants() {}
+    @Override
+    public String writeArrayConstructorClause(ArrowType type, List<String> arguments)
+    {
+        return Joiner.on(", ").join(arguments);
+    }
 }

--- a/athena-hortonworks-hive/src/main/java/com/amazonaws/athena/connectors/hortonworks/HiveQueryStringBuilder.java
+++ b/athena-hortonworks-hive/src/main/java/com/amazonaws/athena/connectors/hortonworks/HiveQueryStringBuilder.java
@@ -20,6 +20,7 @@
 package com.amazonaws.athena.connectors.hortonworks;
 
 import com.amazonaws.athena.connector.lambda.domain.Split;
+import com.amazonaws.athena.connectors.jdbc.manager.FederationExpressionParser;
 import com.amazonaws.athena.connectors.jdbc.manager.JdbcSplitQueryBuilder;
 import com.google.common.base.Strings;
 
@@ -28,9 +29,9 @@ import java.util.List;
 
 public class HiveQueryStringBuilder extends JdbcSplitQueryBuilder
 {
-    public HiveQueryStringBuilder(String quoteCharacters)
+    public HiveQueryStringBuilder(String quoteCharacters, final FederationExpressionParser federationExpressionParser)
     {
-        super(quoteCharacters);
+        super(quoteCharacters, federationExpressionParser);
     }
 
     @Override

--- a/athena-hortonworks-hive/src/main/java/com/amazonaws/athena/connectors/hortonworks/HiveRecordHandler.java
+++ b/athena-hortonworks-hive/src/main/java/com/amazonaws/athena/connectors/hortonworks/HiveRecordHandler.java
@@ -63,7 +63,7 @@ public class HiveRecordHandler extends JdbcRecordHandler
     public HiveRecordHandler(DatabaseConnectionConfig databaseConnectionConfig, JdbcConnectionFactory jdbcConnectionFactory, java.util.Map<String, String> configOptions)
     {
         this(databaseConnectionConfig, AmazonS3ClientBuilder.defaultClient(), AWSSecretsManagerClientBuilder.defaultClient(), AmazonAthenaClientBuilder.defaultClient(),
-                jdbcConnectionFactory, new HiveQueryStringBuilder(HIVE_QUOTE_CHARACTER), configOptions);
+                jdbcConnectionFactory, new HiveQueryStringBuilder(HIVE_QUOTE_CHARACTER, new HiveFederationExpressionParser(HIVE_QUOTE_CHARACTER)), configOptions);
     }
     @VisibleForTesting
     HiveRecordHandler(DatabaseConnectionConfig databaseConnectionConfig, AmazonS3 amazonS3, AWSSecretsManager secretsManager, AmazonAthena athena, JdbcConnectionFactory jdbcConnectionFactory, JdbcSplitQueryBuilder jdbcSplitQueryBuilder, java.util.Map<String, String> configOptions)

--- a/athena-hortonworks-hive/src/test/java/com/amazonaws/athena/connectors/hortonworks/HiveQueryStringBuilderTest.java
+++ b/athena-hortonworks-hive/src/test/java/com/amazonaws/athena/connectors/hortonworks/HiveQueryStringBuilderTest.java
@@ -26,6 +26,8 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import static com.amazonaws.athena.connectors.hortonworks.HiveConstants.HIVE_QUOTE_CHARACTER;
+
 @SuppressWarnings("deprecation")
 @RunWith(MockitoJUnitRunner.class)
 public class HiveQueryStringBuilderTest
@@ -39,7 +41,7 @@ public class HiveQueryStringBuilderTest
 	{
 	    String expectedFrom1 = " FROM default.schema.table ";
 	    String expectedFrom2 = " FROM default.table ";
-		HiveQueryStringBuilder builder = new HiveQueryStringBuilder("");
+		HiveQueryStringBuilder builder = new HiveQueryStringBuilder(HIVE_QUOTE_CHARACTER, new HiveFederationExpressionParser(HIVE_QUOTE_CHARACTER));
 		String fromResult1 = builder.getFromClauseWithSplit("default", "schema", "table", split);
 		String fromResult2 = builder.getFromClauseWithSplit("default", "", "table", split);
 		Assert.assertEquals(expectedFrom1, fromResult1);

--- a/athena-hortonworks-hive/src/test/java/com/amazonaws/athena/connectors/hortonworks/HiveRecordHandlerTest.java
+++ b/athena-hortonworks-hive/src/test/java/com/amazonaws/athena/connectors/hortonworks/HiveRecordHandlerTest.java
@@ -54,6 +54,7 @@ import com.amazonaws.services.secretsmanager.model.GetSecretValueResult;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
+import static com.amazonaws.athena.connectors.hortonworks.HiveConstants.HIVE_QUOTE_CHARACTER;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.nullable;
 
@@ -78,7 +79,7 @@ public class HiveRecordHandlerTest
         this.connection = Mockito.mock(Connection.class);
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         Mockito.when(this.jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(this.connection);
-        jdbcSplitQueryBuilder = new HiveQueryStringBuilder("`");
+        jdbcSplitQueryBuilder = new HiveQueryStringBuilder(HIVE_QUOTE_CHARACTER, new HiveFederationExpressionParser(HIVE_QUOTE_CHARACTER));
         final DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", HiveConstants.HIVE_NAME,
                 "hive2://jdbc:hive2://54.89.6.2:10000/authena;AuthMech=3;UID=hive;PWD=hive");
 

--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcSplitQueryBuilder.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcSplitQueryBuilder.java
@@ -200,7 +200,7 @@ public abstract class JdbcSplitQueryBuilder
         return statement;
     }
 
-    private String extractOrderByClause(Constraints constraints)
+    protected String extractOrderByClause(Constraints constraints)
     {
         List<OrderByField> orderByClause = constraints.getOrderByClause();
         if (orderByClause == null || orderByClause.size() == 0) {

--- a/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleFederationExpressionParser.java
+++ b/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleFederationExpressionParser.java
@@ -1,6 +1,6 @@
 /*-
  * #%L
- * athena-datalakegen2
+ * athena-oracle
  * %%
  * Copyright (C) 2019 - 2022 Amazon Web Services
  * %%
@@ -17,14 +17,24 @@
  * limitations under the License.
  * #L%
  */
-package com.amazonaws.athena.connectors.datalakegen2;
+package com.amazonaws.athena.connectors.oracle;
 
-public class DataLakeGen2Constants
+import com.amazonaws.athena.connectors.jdbc.manager.JdbcFederationExpressionParser;
+import com.google.common.base.Joiner;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+
+import java.util.List;
+
+public class OracleFederationExpressionParser extends JdbcFederationExpressionParser
 {
-    public static final String NAME = "datalakegentwo";
-    public static final String DRIVER_CLASS = "com.microsoft.sqlserver.jdbc.SQLServerDriver";
-    public static final int DEFAULT_PORT = 1433;
-    public static final String QUOTE_CHARACTER = "\"";
+    public OracleFederationExpressionParser(String quoteChar)
+    {
+        super(quoteChar);
+    }
 
-    private DataLakeGen2Constants() {}
+    @Override
+    public String writeArrayConstructorClause(ArrowType type, List<String> arguments)
+    {
+        return Joiner.on(", ").join(arguments);
+    }    
 }

--- a/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleMetadataHandler.java
+++ b/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleMetadataHandler.java
@@ -29,12 +29,20 @@ import com.amazonaws.athena.connector.lambda.data.SchemaBuilder;
 import com.amazonaws.athena.connector.lambda.data.SupportedTypes;
 import com.amazonaws.athena.connector.lambda.domain.Split;
 import com.amazonaws.athena.connector.lambda.domain.TableName;
+import com.amazonaws.athena.connector.lambda.domain.predicate.functions.StandardFunctions;
 import com.amazonaws.athena.connector.lambda.domain.spill.SpillLocation;
+import com.amazonaws.athena.connector.lambda.metadata.GetDataSourceCapabilitiesRequest;
+import com.amazonaws.athena.connector.lambda.metadata.GetDataSourceCapabilitiesResponse;
 import com.amazonaws.athena.connector.lambda.metadata.GetSplitsRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetSplitsResponse;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableLayoutRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableResponse;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.DataSourceOptimizations;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.OptimizationSubType;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.pushdown.ComplexExpressionPushdownSubType;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.pushdown.FilterPushdownSubType;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.pushdown.TopNPushdownSubType;
 import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionConfig;
 import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionInfo;
 import com.amazonaws.athena.connectors.jdbc.connection.JdbcConnectionFactory;
@@ -46,6 +54,8 @@ import com.amazonaws.services.athena.AmazonAthena;
 import com.amazonaws.services.secretsmanager.AWSSecretsManager;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.ArrowType;
@@ -65,6 +75,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import static com.amazonaws.athena.connector.lambda.domain.predicate.functions.StandardFunctions.IS_DISTINCT_FROM_OPERATOR_FUNCTION_NAME;
+import static com.amazonaws.athena.connector.lambda.domain.predicate.functions.StandardFunctions.MODULUS_FUNCTION_NAME;
+import static com.amazonaws.athena.connector.lambda.domain.predicate.functions.StandardFunctions.NULLIF_FUNCTION_NAME;
+
 /**
  * Handles metadata for ORACLE. User must have access to `schemata`, `tables`, `columns`, `partitions` tables in
  * information_schema.
@@ -205,6 +220,34 @@ public class OracleMetadataHandler
         }
 
         return new GetSplitsResponse(getSplitsRequest.getCatalogName(), splits, null);
+    }
+
+    /**
+     * Overridden this method to describe the types of capabilities supported by a data source
+     * @param allocator Tool for creating and managing Apache Arrow Blocks.
+     * @param request Provides details about the catalog being used.
+     * @return A GetDataSourceCapabilitiesResponse object which returns a map of supported capabilities
+     */
+    @Override
+    public GetDataSourceCapabilitiesResponse doGetDataSourceCapabilities(BlockAllocator allocator, GetDataSourceCapabilitiesRequest request)
+    {
+        Set<StandardFunctions> unsupportedFunctions = ImmutableSet.of(NULLIF_FUNCTION_NAME, IS_DISTINCT_FROM_OPERATOR_FUNCTION_NAME, MODULUS_FUNCTION_NAME);
+        ImmutableMap.Builder<String, List<OptimizationSubType>> capabilities = ImmutableMap.builder();
+        capabilities.put(DataSourceOptimizations.SUPPORTS_FILTER_PUSHDOWN.withSupportedSubTypes(
+                FilterPushdownSubType.SORTED_RANGE_SET, FilterPushdownSubType.NULLABLE_COMPARISON
+        ));
+        capabilities.put(DataSourceOptimizations.SUPPORTS_COMPLEX_EXPRESSION_PUSHDOWN.withSupportedSubTypes(
+                ComplexExpressionPushdownSubType.SUPPORTED_FUNCTION_EXPRESSION_TYPES
+                        .withSubTypeProperties(Arrays.stream(StandardFunctions.values())
+                                .filter(values -> !unsupportedFunctions.contains(values))
+                                .map(standardFunctions -> standardFunctions.getFunctionName().getFunctionName())
+                                .toArray(String[]::new))
+        ));
+        capabilities.put(DataSourceOptimizations.SUPPORTS_TOP_N_PUSHDOWN.withSupportedSubTypes(
+                TopNPushdownSubType.SUPPORTS_ORDER_BY
+        ));
+
+        return new GetDataSourceCapabilitiesResponse(request.getCatalogName(), capabilities.build());
     }
 
     private int decodeContinuationToken(GetSplitsRequest request)

--- a/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleQueryStringBuilder.java
+++ b/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleQueryStringBuilder.java
@@ -20,6 +20,7 @@
 package com.amazonaws.athena.connectors.oracle;
 
 import com.amazonaws.athena.connector.lambda.domain.Split;
+import com.amazonaws.athena.connectors.jdbc.manager.FederationExpressionParser;
 import com.amazonaws.athena.connectors.jdbc.manager.JdbcSplitQueryBuilder;
 import com.google.common.base.Strings;
 
@@ -35,9 +36,9 @@ import java.util.Set;
 public class OracleQueryStringBuilder
         extends JdbcSplitQueryBuilder
 {
-    public OracleQueryStringBuilder(final String quoteCharacters)
+    public OracleQueryStringBuilder(final String quoteCharacter, final FederationExpressionParser federationExpressionParser)
     {
-        super(quoteCharacters);
+        super(quoteCharacter, federationExpressionParser);
     }
 
     @Override

--- a/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleRecordHandler.java
+++ b/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleRecordHandler.java
@@ -78,7 +78,7 @@ public class OracleRecordHandler
     public OracleRecordHandler(DatabaseConnectionConfig databaseConnectionConfig, JdbcConnectionFactory jdbcConnectionFactory, java.util.Map<String, String> configOptions)
     {
         this(databaseConnectionConfig, AmazonS3ClientBuilder.defaultClient(), AWSSecretsManagerClientBuilder.defaultClient(), AmazonAthenaClientBuilder.defaultClient(),
-                jdbcConnectionFactory, new OracleQueryStringBuilder(ORACLE_QUOTE_CHARACTER), configOptions);
+                jdbcConnectionFactory, new OracleQueryStringBuilder(ORACLE_QUOTE_CHARACTER, new OracleFederationExpressionParser(ORACLE_QUOTE_CHARACTER)), configOptions);
     }
 
     @VisibleForTesting

--- a/athena-oracle/src/test/java/com/amazonaws/athena/connectors/oracle/OracleRecordHandlerTest.java
+++ b/athena-oracle/src/test/java/com/amazonaws/athena/connectors/oracle/OracleRecordHandlerTest.java
@@ -73,7 +73,7 @@ public class OracleRecordHandlerTest
         this.connection = Mockito.mock(Connection.class);
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         Mockito.when(this.jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(this.connection);
-        jdbcSplitQueryBuilder = new OracleQueryStringBuilder(ORACLE_QUOTE_CHARACTER);
+        jdbcSplitQueryBuilder = new OracleQueryStringBuilder(ORACLE_QUOTE_CHARACTER, new OracleFederationExpressionParser(ORACLE_QUOTE_CHARACTER));
         final DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", ORACLE_NAME,
                 "oracle://jdbc:oracle:thin:username/password@//127.0.0.1:1521/orcl");
 

--- a/athena-saphana/src/main/java/com/amazonaws/athena/connectors/saphana/SaphanaFederationExpressionParser.java
+++ b/athena-saphana/src/main/java/com/amazonaws/athena/connectors/saphana/SaphanaFederationExpressionParser.java
@@ -1,0 +1,40 @@
+/*-
+ * #%L
+ * athena-saphana
+ * %%
+ * Copyright (C) 2019 - 2023 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.saphana;
+
+import com.amazonaws.athena.connectors.jdbc.manager.JdbcFederationExpressionParser;
+import com.google.common.base.Joiner;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+
+import java.util.List;
+
+public class SaphanaFederationExpressionParser extends JdbcFederationExpressionParser
+{
+    public SaphanaFederationExpressionParser(String quoteChar)
+    {
+        super(quoteChar);
+    }
+
+    @Override
+    public String writeArrayConstructorClause(ArrowType type, List<String> arguments)
+    {
+        return Joiner.on(", ").join(arguments);
+    }
+}

--- a/athena-saphana/src/main/java/com/amazonaws/athena/connectors/saphana/SaphanaMetadataHandler.java
+++ b/athena-saphana/src/main/java/com/amazonaws/athena/connectors/saphana/SaphanaMetadataHandler.java
@@ -28,12 +28,21 @@ import com.amazonaws.athena.connector.lambda.data.SchemaBuilder;
 import com.amazonaws.athena.connector.lambda.data.SupportedTypes;
 import com.amazonaws.athena.connector.lambda.domain.Split;
 import com.amazonaws.athena.connector.lambda.domain.TableName;
+import com.amazonaws.athena.connector.lambda.domain.predicate.functions.StandardFunctions;
 import com.amazonaws.athena.connector.lambda.domain.spill.SpillLocation;
+import com.amazonaws.athena.connector.lambda.metadata.GetDataSourceCapabilitiesRequest;
+import com.amazonaws.athena.connector.lambda.metadata.GetDataSourceCapabilitiesResponse;
 import com.amazonaws.athena.connector.lambda.metadata.GetSplitsRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetSplitsResponse;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableLayoutRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableResponse;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.DataSourceOptimizations;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.OptimizationSubType;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.pushdown.ComplexExpressionPushdownSubType;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.pushdown.FilterPushdownSubType;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.pushdown.LimitPushdownSubType;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.pushdown.TopNPushdownSubType;
 import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionConfig;
 import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionInfo;
 import com.amazonaws.athena.connectors.jdbc.connection.GenericJdbcConnectionFactory;
@@ -45,6 +54,7 @@ import com.amazonaws.athena.connectors.jdbc.manager.PreparedStatementBuilder;
 import com.amazonaws.services.athena.AmazonAthena;
 import com.amazonaws.services.secretsmanager.AWSSecretsManager;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.ArrowType;
@@ -102,6 +112,30 @@ public class SaphanaMetadataHandler extends JdbcMetadataHandler
     public SaphanaMetadataHandler(DatabaseConnectionConfig databaseConnectionConfig, GenericJdbcConnectionFactory jdbcConnectionFactory, java.util.Map<String, String> configOptions)
     {
             super(databaseConnectionConfig, jdbcConnectionFactory, configOptions);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public GetDataSourceCapabilitiesResponse doGetDataSourceCapabilities(BlockAllocator allocator, GetDataSourceCapabilitiesRequest request)
+    {
+        ImmutableMap.Builder<String, List<OptimizationSubType>> capabilities = ImmutableMap.builder();
+        capabilities.put(DataSourceOptimizations.SUPPORTS_FILTER_PUSHDOWN.withSupportedSubTypes(
+                FilterPushdownSubType.SORTED_RANGE_SET, FilterPushdownSubType.NULLABLE_COMPARISON
+        ));
+        capabilities.put(DataSourceOptimizations.SUPPORTS_LIMIT_PUSHDOWN.withSupportedSubTypes(
+                LimitPushdownSubType.INTEGER_CONSTANT
+        ));
+        capabilities.put(DataSourceOptimizations.SUPPORTS_COMPLEX_EXPRESSION_PUSHDOWN.withSupportedSubTypes(
+                ComplexExpressionPushdownSubType.SUPPORTED_FUNCTION_EXPRESSION_TYPES
+                        .withSubTypeProperties(Arrays.stream(StandardFunctions.values())
+                                .map(standardFunctions -> standardFunctions.getFunctionName().getFunctionName())
+                                .toArray(String[]::new))
+        ));
+
+        capabilities.put(DataSourceOptimizations.SUPPORTS_TOP_N_PUSHDOWN.withSupportedSubTypes(TopNPushdownSubType.SUPPORTS_ORDER_BY));
+
+        return new GetDataSourceCapabilitiesResponse(request.getCatalogName(), capabilities.build());
     }
 
     @Override

--- a/athena-saphana/src/main/java/com/amazonaws/athena/connectors/saphana/SaphanaQueryStringBuilder.java
+++ b/athena-saphana/src/main/java/com/amazonaws/athena/connectors/saphana/SaphanaQueryStringBuilder.java
@@ -25,6 +25,7 @@ import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
 import com.amazonaws.athena.connector.lambda.domain.predicate.Range;
 import com.amazonaws.athena.connector.lambda.domain.predicate.SortedRangeSet;
 import com.amazonaws.athena.connector.lambda.domain.predicate.ValueSet;
+import com.amazonaws.athena.connectors.jdbc.manager.FederationExpressionParser;
 import com.amazonaws.athena.connectors.jdbc.manager.JdbcSplitQueryBuilder;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
@@ -63,12 +64,15 @@ public class SaphanaQueryStringBuilder extends JdbcSplitQueryBuilder
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(SaphanaQueryStringBuilder.class);
 
+    private final FederationExpressionParser federationExpressionParser;
+
     private static final String SPATIAL_CONVERSION_FUNCTION_REGEX = "ST_([a-zA-Z]+)\\(\\)";
     private static final Pattern SPATIAL_CONVERSION_FUNCTION_PATTERN = Pattern.compile(SPATIAL_CONVERSION_FUNCTION_REGEX);
 
-    public SaphanaQueryStringBuilder(String quoteCharacters)
+    public SaphanaQueryStringBuilder(String quoteCharacters, final FederationExpressionParser federationExpressionParser)
     {
-        super(quoteCharacters);
+        super(quoteCharacters, federationExpressionParser);
+        this.federationExpressionParser = federationExpressionParser;
     }
 
     @Override
@@ -152,7 +156,17 @@ public class SaphanaQueryStringBuilder extends JdbcSplitQueryBuilder
             sql.append(" WHERE ")
                     .append(Joiner.on(" AND ").join(clauses));
         }
-        sql.append(appendLimitOffset(split));
+
+        String orderByClause = extractOrderByClause(constraints);
+
+        if (!Strings.isNullOrEmpty(orderByClause)) {
+            sql.append(" ").append(orderByClause);
+        }
+
+        if (constraints.getLimit() > 0) {
+            sql.append(appendLimitOffset(split, constraints));
+        }
+
         LOGGER.debug("Generated SQL : {}", sql);
         PreparedStatement statement = jdbcConnection.prepareStatement(sql.toString());
 
@@ -205,7 +219,6 @@ public class SaphanaQueryStringBuilder extends JdbcSplitQueryBuilder
                     throw new UnsupportedOperationException(String.format("Can't handle type: %s, %s", typeAndValue.getType(), minorTypeForArrowType));
             }
         }
-
         return statement;
     }
 
@@ -270,7 +283,7 @@ public class SaphanaQueryStringBuilder extends JdbcSplitQueryBuilder
     }
 
     private List<String> toConjuncts(List<Field> columns, Constraints constraints,
-                                     List<SaphanaQueryStringBuilder.TypeAndValue> accumulator,
+                                     List<TypeAndValue> accumulator,
                                      Map<String, String> partitionSplit)
     {
         List<String> conjuncts = new ArrayList<>();
@@ -286,11 +299,12 @@ public class SaphanaQueryStringBuilder extends JdbcSplitQueryBuilder
                 }
             }
         }
+        conjuncts.addAll(federationExpressionParser.parseComplexExpressions(columns, constraints));
         return conjuncts;
     }
 
     private String toPredicate(String columnName, ValueSet valueSet, ArrowType type,
-                               List<SaphanaQueryStringBuilder.TypeAndValue> accumulator)
+                               List<TypeAndValue> accumulator)
     {
         List<String> disjuncts = new ArrayList<>();
         List<Object> singleValues = new ArrayList<>();
@@ -357,7 +371,7 @@ public class SaphanaQueryStringBuilder extends JdbcSplitQueryBuilder
             }
             else if (singleValues.size() > 1) {
                 for (Object value : singleValues) {
-                    accumulator.add(new SaphanaQueryStringBuilder.TypeAndValue(type, value));
+                    accumulator.add(new TypeAndValue(type, value));
                 }
                 String values = Joiner.on(",").join(Collections.nCopies(singleValues.size(), "?"));
                 disjuncts.add(quote(columnName) + " IN (" + values + ")");
@@ -368,9 +382,9 @@ public class SaphanaQueryStringBuilder extends JdbcSplitQueryBuilder
     }
 
     private String toPredicate(String columnName, String operator, Object value, ArrowType type,
-                               List<SaphanaQueryStringBuilder.TypeAndValue> accumulator)
+                               List<TypeAndValue> accumulator)
     {
-        accumulator.add(new SaphanaQueryStringBuilder.TypeAndValue(type, value));
+        accumulator.add(new TypeAndValue(type, value));
         return quote(columnName) + " " + operator + " ?";
     }
 }

--- a/athena-saphana/src/main/java/com/amazonaws/athena/connectors/saphana/SaphanaRecordHandler.java
+++ b/athena-saphana/src/main/java/com/amazonaws/athena/connectors/saphana/SaphanaRecordHandler.java
@@ -77,7 +77,7 @@ public class SaphanaRecordHandler extends JdbcRecordHandler
     public SaphanaRecordHandler(DatabaseConnectionConfig databaseConnectionConfig, GenericJdbcConnectionFactory jdbcConnectionFactory, java.util.Map<String, String> configOptions)
     {
         this(databaseConnectionConfig, AmazonS3ClientBuilder.defaultClient(), AWSSecretsManagerClientBuilder.defaultClient(),
-                AmazonAthenaClientBuilder.defaultClient(), jdbcConnectionFactory, new SaphanaQueryStringBuilder(SAPHANA_QUOTE_CHARACTER), configOptions);
+                AmazonAthenaClientBuilder.defaultClient(), jdbcConnectionFactory, new SaphanaQueryStringBuilder(SAPHANA_QUOTE_CHARACTER, new SaphanaFederationExpressionParser(SAPHANA_QUOTE_CHARACTER)), configOptions);
     }
 
     @Override

--- a/athena-saphana/src/test/java/com/amazonaws/athena/connectors/saphana/SaphanaQueryStringBuilderTest.java
+++ b/athena-saphana/src/test/java/com/amazonaws/athena/connectors/saphana/SaphanaQueryStringBuilderTest.java
@@ -31,6 +31,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static com.amazonaws.athena.connectors.saphana.SaphanaConstants.BLOCK_PARTITION_COLUMN_NAME;
+import static com.amazonaws.athena.connectors.saphana.SaphanaConstants.SAPHANA_QUOTE_CHARACTER;
 
 public class SaphanaQueryStringBuilderTest
 {
@@ -42,7 +43,7 @@ public class SaphanaQueryStringBuilderTest
         String expectedString2 = " FROM \"default\".\"schema\".\"table\" PARTITION (p0) ";
         Mockito.when(split.getProperties()).thenReturn(Collections.singletonMap(BLOCK_PARTITION_COLUMN_NAME, "p0"));
         Mockito.when(split.getProperty(Mockito.eq(BLOCK_PARTITION_COLUMN_NAME))).thenReturn("p0");
-        SaphanaQueryStringBuilder builder = new SaphanaQueryStringBuilder("'");
+        SaphanaQueryStringBuilder builder = new SaphanaQueryStringBuilder(SAPHANA_QUOTE_CHARACTER, new SaphanaFederationExpressionParser(SAPHANA_QUOTE_CHARACTER));
         String fromClauseWithSplit1 = builder.getFromClauseWithSplit("default", "", "table", split);
         String fromClauseWithSplit2 = builder.getFromClauseWithSplit("default", "schema", "table", split);
         Assert.assertEquals(expectedString1, fromClauseWithSplit1);
@@ -56,7 +57,7 @@ public class SaphanaQueryStringBuilderTest
         Mockito.when(split.getProperties()).thenReturn(Collections.singletonMap(BLOCK_PARTITION_COLUMN_NAME, "p0"));
         Mockito.when(split.getProperty(Mockito.eq(BLOCK_PARTITION_COLUMN_NAME))).thenReturn("p0");
 
-        SaphanaQueryStringBuilder builder = new SaphanaQueryStringBuilder("'");
+        SaphanaQueryStringBuilder builder = new SaphanaQueryStringBuilder(SAPHANA_QUOTE_CHARACTER, new SaphanaFederationExpressionParser(SAPHANA_QUOTE_CHARACTER));
         List<String> partitionWhereClauseList1 = builder.getPartitionWhereClauses(split);
         Assert.assertEquals(expectedPartitionWhereClauseList1, partitionWhereClauseList1);
     }

--- a/athena-saphana/src/test/java/com/amazonaws/athena/connectors/saphana/SaphanaRecordHandlerTest.java
+++ b/athena-saphana/src/test/java/com/amazonaws/athena/connectors/saphana/SaphanaRecordHandlerTest.java
@@ -23,7 +23,11 @@ import com.amazonaws.athena.connector.lambda.data.FieldBuilder;
 import com.amazonaws.athena.connector.lambda.data.SchemaBuilder;
 import com.amazonaws.athena.connector.lambda.domain.Split;
 import com.amazonaws.athena.connector.lambda.domain.TableName;
-import com.amazonaws.athena.connector.lambda.domain.predicate.*;
+import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
+import com.amazonaws.athena.connector.lambda.domain.predicate.Marker;
+import com.amazonaws.athena.connector.lambda.domain.predicate.Range;
+import com.amazonaws.athena.connector.lambda.domain.predicate.SortedRangeSet;
+import com.amazonaws.athena.connector.lambda.domain.predicate.ValueSet;
 import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionConfig;
 import com.amazonaws.athena.connectors.jdbc.connection.JdbcConnectionFactory;
 import com.amazonaws.athena.connectors.jdbc.connection.JdbcCredentialProvider;
@@ -45,7 +49,7 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.Collections;
 
-import static org.mockito.ArgumentMatchers.any;
+import static com.amazonaws.athena.connectors.saphana.SaphanaConstants.SAPHANA_QUOTE_CHARACTER;
 import static org.mockito.ArgumentMatchers.nullable;
 
 public class SaphanaRecordHandlerTest
@@ -68,7 +72,7 @@ public class SaphanaRecordHandlerTest
         this.connection = Mockito.mock(Connection.class);
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         Mockito.when(this.jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(this.connection);
-        jdbcSplitQueryBuilder = new SaphanaQueryStringBuilder("`");
+        jdbcSplitQueryBuilder = new SaphanaQueryStringBuilder(SAPHANA_QUOTE_CHARACTER, new SaphanaFederationExpressionParser(SAPHANA_QUOTE_CHARACTER));
         final DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", SaphanaConstants.SAPHANA_NAME,
                 "saphana://jdbc:saphana://115.113.87.100/TMODE=ANSI,CHARSET=UTF8,DATABASE=TEST,USER=DBC,PASSWORD=DBC");
 

--- a/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeConstants.java
+++ b/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeConstants.java
@@ -34,6 +34,7 @@ public final class SnowflakeConstants
      * This constant limits the number of records to be returned in a single split.
      */
     public static final int SINGLE_SPLIT_LIMIT_COUNT = 10000;
+    public static final String SNOWFLAKE_QUOTE_CHARACTER = "\"";
 
     private SnowflakeConstants() {}
 }

--- a/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeFederationExpressionParser.java
+++ b/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeFederationExpressionParser.java
@@ -1,6 +1,6 @@
 /*-
  * #%L
- * athena-datalakegen2
+ * athena-snowflake
  * %%
  * Copyright (C) 2019 - 2022 Amazon Web Services
  * %%
@@ -17,14 +17,24 @@
  * limitations under the License.
  * #L%
  */
-package com.amazonaws.athena.connectors.datalakegen2;
+package com.amazonaws.athena.connectors.snowflake;
 
-public class DataLakeGen2Constants
+import com.amazonaws.athena.connectors.jdbc.manager.JdbcFederationExpressionParser;
+import com.google.common.base.Joiner;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+
+import java.util.List;
+
+public class SnowflakeFederationExpressionParser extends JdbcFederationExpressionParser
 {
-    public static final String NAME = "datalakegentwo";
-    public static final String DRIVER_CLASS = "com.microsoft.sqlserver.jdbc.SQLServerDriver";
-    public static final int DEFAULT_PORT = 1433;
-    public static final String QUOTE_CHARACTER = "\"";
+    public SnowflakeFederationExpressionParser(String quoteChar)
+    {
+        super(quoteChar);
+    }
 
-    private DataLakeGen2Constants() {}
+    @Override
+    public String writeArrayConstructorClause(ArrowType type, List<String> arguments)
+    {
+        return Joiner.on(", ").join(arguments);
+    }    
 }

--- a/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMetadataHandler.java
+++ b/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMetadataHandler.java
@@ -30,7 +30,10 @@ import com.amazonaws.athena.connector.lambda.data.SchemaBuilder;
 import com.amazonaws.athena.connector.lambda.data.SupportedTypes;
 import com.amazonaws.athena.connector.lambda.domain.Split;
 import com.amazonaws.athena.connector.lambda.domain.TableName;
+import com.amazonaws.athena.connector.lambda.domain.predicate.functions.StandardFunctions;
 import com.amazonaws.athena.connector.lambda.domain.spill.SpillLocation;
+import com.amazonaws.athena.connector.lambda.metadata.GetDataSourceCapabilitiesRequest;
+import com.amazonaws.athena.connector.lambda.metadata.GetDataSourceCapabilitiesResponse;
 import com.amazonaws.athena.connector.lambda.metadata.GetSplitsRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetSplitsResponse;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableLayoutRequest;
@@ -38,6 +41,12 @@ import com.amazonaws.athena.connector.lambda.metadata.GetTableRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableResponse;
 import com.amazonaws.athena.connector.lambda.metadata.ListSchemasRequest;
 import com.amazonaws.athena.connector.lambda.metadata.ListSchemasResponse;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.DataSourceOptimizations;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.OptimizationSubType;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.pushdown.ComplexExpressionPushdownSubType;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.pushdown.FilterPushdownSubType;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.pushdown.LimitPushdownSubType;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.pushdown.TopNPushdownSubType;
 import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionConfig;
 import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionInfo;
 import com.amazonaws.athena.connectors.jdbc.connection.GenericJdbcConnectionFactory;
@@ -130,6 +139,30 @@ public class SnowflakeMetadataHandler extends JdbcMetadataHandler
         java.util.Map<String, String> configOptions)
     {
         super(databaseConnectionConfig, secretsManager, athena, jdbcConnectionFactory, configOptions);
+    }
+
+    @Override
+    public GetDataSourceCapabilitiesResponse doGetDataSourceCapabilities(BlockAllocator allocator, GetDataSourceCapabilitiesRequest request)
+    {
+        ImmutableMap.Builder<String, List<OptimizationSubType>> capabilities = ImmutableMap.builder();
+
+        capabilities.put(DataSourceOptimizations.SUPPORTS_FILTER_PUSHDOWN.withSupportedSubTypes(
+                FilterPushdownSubType.SORTED_RANGE_SET, FilterPushdownSubType.NULLABLE_COMPARISON
+        ));
+        capabilities.put(DataSourceOptimizations.SUPPORTS_LIMIT_PUSHDOWN.withSupportedSubTypes(
+                LimitPushdownSubType.INTEGER_CONSTANT
+        ));
+        capabilities.put(DataSourceOptimizations.SUPPORTS_COMPLEX_EXPRESSION_PUSHDOWN.withSupportedSubTypes(
+                ComplexExpressionPushdownSubType.SUPPORTED_FUNCTION_EXPRESSION_TYPES
+                        .withSubTypeProperties(Arrays.stream(StandardFunctions.values())
+                                .map(standardFunctions -> standardFunctions.getFunctionName().getFunctionName())
+                                .toArray(String[]::new))
+        ));
+        capabilities.put(DataSourceOptimizations.SUPPORTS_TOP_N_PUSHDOWN.withSupportedSubTypes(
+                TopNPushdownSubType.SUPPORTS_ORDER_BY
+        ));
+
+        return new GetDataSourceCapabilitiesResponse(request.getCatalogName(), capabilities.build());
     }
 
     public SnowflakeMetadataHandler(DatabaseConnectionConfig databaseConnectionConfig, JdbcConnectionFactory jdbcConnectionFactory, java.util.Map<String, String> configOptions)

--- a/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeQueryStringBuilder.java
+++ b/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeQueryStringBuilder.java
@@ -21,6 +21,7 @@
 package com.amazonaws.athena.connectors.snowflake;
 
 import com.amazonaws.athena.connector.lambda.domain.Split;
+import com.amazonaws.athena.connectors.jdbc.manager.FederationExpressionParser;
 import com.amazonaws.athena.connectors.jdbc.manager.JdbcSplitQueryBuilder;
 import com.google.common.base.Strings;
 
@@ -37,9 +38,9 @@ public class SnowflakeQueryStringBuilder
 {
     private static final String EMPTY_STRING = "";
 
-    public SnowflakeQueryStringBuilder(final String quoteCharacters)
+    public SnowflakeQueryStringBuilder(final String quoteCharacters, final FederationExpressionParser federationExpressionParser)
     {
-        super(quoteCharacters);
+        super(quoteCharacters, federationExpressionParser);
     }
 
     @Override

--- a/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeRecordHandler.java
+++ b/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeRecordHandler.java
@@ -44,9 +44,10 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
+import static com.amazonaws.athena.connectors.snowflake.SnowflakeConstants.SNOWFLAKE_QUOTE_CHARACTER;
+
 public class SnowflakeRecordHandler extends JdbcRecordHandler
 {
-    private static final String SNOWFLAKE_QUOTE_CHARACTER = "\"";
     private static final int FETCH_SIZE = 1000;
     private final JdbcSplitQueryBuilder jdbcSplitQueryBuilder;
     /**
@@ -68,7 +69,7 @@ public class SnowflakeRecordHandler extends JdbcRecordHandler
     public SnowflakeRecordHandler(DatabaseConnectionConfig databaseConnectionConfig, GenericJdbcConnectionFactory jdbcConnectionFactory, java.util.Map<String, String> configOptions)
     {
         this(databaseConnectionConfig, AmazonS3ClientBuilder.defaultClient(), AWSSecretsManagerClientBuilder.defaultClient(), AmazonAthenaClientBuilder.defaultClient(),
-                jdbcConnectionFactory, new SnowflakeQueryStringBuilder(SNOWFLAKE_QUOTE_CHARACTER), configOptions);
+                jdbcConnectionFactory, new SnowflakeQueryStringBuilder(SNOWFLAKE_QUOTE_CHARACTER, new SnowflakeFederationExpressionParser(SNOWFLAKE_QUOTE_CHARACTER)), configOptions);
     }
     @VisibleForTesting
     SnowflakeRecordHandler(DatabaseConnectionConfig databaseConnectionConfig, final AmazonS3 amazonS3, final AWSSecretsManager secretsManager,

--- a/athena-snowflake/src/test/java/com/amazonaws/athena/connectors/snowflake/SnowflakeQueryStringBuilderTest.java
+++ b/athena-snowflake/src/test/java/com/amazonaws/athena/connectors/snowflake/SnowflakeQueryStringBuilderTest.java
@@ -28,6 +28,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static com.amazonaws.athena.connectors.snowflake.SnowflakeConstants.SNOWFLAKE_QUOTE_CHARACTER;
+
 public class SnowflakeQueryStringBuilderTest
 {
     @Mock
@@ -37,7 +39,7 @@ public class SnowflakeQueryStringBuilderTest
     public void testQueryBuilderNew()
     {
         Split split = Mockito.mock(Split.class);
-        SnowflakeQueryStringBuilder builder = new SnowflakeQueryStringBuilder("'");
+        SnowflakeQueryStringBuilder builder = new SnowflakeQueryStringBuilder(SNOWFLAKE_QUOTE_CHARACTER, new SnowflakeFederationExpressionParser(SNOWFLAKE_QUOTE_CHARACTER));
         Mockito.when(split.getProperties()).thenReturn(Collections.singletonMap("partition", "p0"));
         Mockito.when(split.getProperty(Mockito.eq("partition"))).thenReturn("p1-p2-p3-p4-p5");
         builder.getFromClauseWithSplit("default", "", "table", split);
@@ -47,7 +49,7 @@ public class SnowflakeQueryStringBuilderTest
     @Test
     public void testGetPartitionWhereClauses()
     {
-        SnowflakeQueryStringBuilder builder = new SnowflakeQueryStringBuilder("'");
+        SnowflakeQueryStringBuilder builder = new SnowflakeQueryStringBuilder(SNOWFLAKE_QUOTE_CHARACTER, new SnowflakeFederationExpressionParser(SNOWFLAKE_QUOTE_CHARACTER));
         List<String> fromClauseWithSplit = builder.getPartitionWhereClauses(split);
         List<String> expected = new ArrayList<>();
         Assert.assertEquals(expected, fromClauseWithSplit);

--- a/athena-snowflake/src/test/java/com/amazonaws/athena/connectors/snowflake/SnowflakeRecordHandlerTest.java
+++ b/athena-snowflake/src/test/java/com/amazonaws/athena/connectors/snowflake/SnowflakeRecordHandlerTest.java
@@ -19,23 +19,23 @@
  * #L%
  */
 package com.amazonaws.athena.connectors.snowflake;
+
 import com.amazonaws.athena.connector.lambda.data.FieldBuilder;
 import com.amazonaws.athena.connector.lambda.data.SchemaBuilder;
 import com.amazonaws.athena.connector.lambda.domain.Split;
 import com.amazonaws.athena.connector.lambda.domain.TableName;
-import com.amazonaws.athena.connector.lambda.domain.predicate.*;
+import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
+import com.amazonaws.athena.connector.lambda.domain.predicate.Marker;
+import com.amazonaws.athena.connector.lambda.domain.predicate.Range;
+import com.amazonaws.athena.connector.lambda.domain.predicate.SortedRangeSet;
+import com.amazonaws.athena.connector.lambda.domain.predicate.ValueSet;
 import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionConfig;
 import com.amazonaws.athena.connectors.jdbc.connection.JdbcConnectionFactory;
 import com.amazonaws.athena.connectors.jdbc.connection.JdbcCredentialProvider;
 import com.amazonaws.athena.connectors.jdbc.manager.JdbcSplitQueryBuilder;
-import com.amazonaws.athena.connectors.snowflake.SnowflakeConstants;
-import com.amazonaws.athena.connectors.snowflake.SnowflakeQueryStringBuilder;
-import com.amazonaws.athena.connectors.snowflake.SnowflakeRecordHandler;
 import com.amazonaws.services.athena.AmazonAthena;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.secretsmanager.AWSSecretsManager;
-import com.amazonaws.services.secretsmanager.model.GetSecretValueRequest;
-import com.amazonaws.services.secretsmanager.model.GetSecretValueResult;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.arrow.vector.types.Types;
@@ -50,7 +50,7 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.Collections;
 
-import static org.mockito.ArgumentMatchers.any;
+import static com.amazonaws.athena.connectors.snowflake.SnowflakeConstants.SNOWFLAKE_QUOTE_CHARACTER;
 import static org.mockito.ArgumentMatchers.nullable;
 
 public class SnowflakeRecordHandlerTest
@@ -73,7 +73,7 @@ public class SnowflakeRecordHandlerTest
         this.connection = Mockito.mock(Connection.class);
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         Mockito.when(this.jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(this.connection);
-        jdbcSplitQueryBuilder = new SnowflakeQueryStringBuilder("`");
+        jdbcSplitQueryBuilder = new SnowflakeQueryStringBuilder(SNOWFLAKE_QUOTE_CHARACTER, new SnowflakeFederationExpressionParser(SNOWFLAKE_QUOTE_CHARACTER));
         final DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", SnowflakeConstants.SNOWFLAKE_NAME,
                 "snowflake://jdbc:snowflake://hostname/?warehouse=warehousename&db=dbname&schema=schemaname&user=xxx&password=xxx");
 

--- a/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerConstants.java
+++ b/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerConstants.java
@@ -24,6 +24,6 @@ public final class SqlServerConstants
     public static final String NAME = "sqlserver";
     public static final String DRIVER_CLASS = "com.microsoft.sqlserver.jdbc.SQLServerDriver";
     public static final int DEFAULT_PORT = 1433;
-
+    public static final String SQLSERVER_QUOTE_CHARACTER = "\"";
     private SqlServerConstants() {}
 }

--- a/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerFederationExpressionParser.java
+++ b/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerFederationExpressionParser.java
@@ -1,6 +1,6 @@
 /*-
  * #%L
- * athena-datalakegen2
+ * athena-sqlserver
  * %%
  * Copyright (C) 2019 - 2022 Amazon Web Services
  * %%
@@ -17,14 +17,24 @@
  * limitations under the License.
  * #L%
  */
-package com.amazonaws.athena.connectors.datalakegen2;
+package com.amazonaws.athena.connectors.sqlserver;
 
-public class DataLakeGen2Constants
+import com.amazonaws.athena.connectors.jdbc.manager.JdbcFederationExpressionParser;
+import com.google.common.base.Joiner;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+
+import java.util.List;
+
+public class SqlServerFederationExpressionParser extends JdbcFederationExpressionParser
 {
-    public static final String NAME = "datalakegentwo";
-    public static final String DRIVER_CLASS = "com.microsoft.sqlserver.jdbc.SQLServerDriver";
-    public static final int DEFAULT_PORT = 1433;
-    public static final String QUOTE_CHARACTER = "\"";
+    public SqlServerFederationExpressionParser(String quoteChar)
+    {
+        super(quoteChar);
+    }
 
-    private DataLakeGen2Constants() {}
+    @Override
+    public String writeArrayConstructorClause(ArrowType type, List<String> arguments)
+    {
+        return Joiner.on(", ").join(arguments);
+    }    
 }

--- a/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerMetadataHandler.java
+++ b/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerMetadataHandler.java
@@ -29,7 +29,10 @@ import com.amazonaws.athena.connector.lambda.data.SchemaBuilder;
 import com.amazonaws.athena.connector.lambda.data.SupportedTypes;
 import com.amazonaws.athena.connector.lambda.domain.Split;
 import com.amazonaws.athena.connector.lambda.domain.TableName;
+import com.amazonaws.athena.connector.lambda.domain.predicate.functions.StandardFunctions;
 import com.amazonaws.athena.connector.lambda.domain.spill.SpillLocation;
+import com.amazonaws.athena.connector.lambda.metadata.GetDataSourceCapabilitiesRequest;
+import com.amazonaws.athena.connector.lambda.metadata.GetDataSourceCapabilitiesResponse;
 import com.amazonaws.athena.connector.lambda.metadata.GetSplitsRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetSplitsResponse;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableLayoutRequest;
@@ -37,6 +40,11 @@ import com.amazonaws.athena.connector.lambda.metadata.GetTableRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableResponse;
 import com.amazonaws.athena.connector.lambda.metadata.ListSchemasRequest;
 import com.amazonaws.athena.connector.lambda.metadata.ListSchemasResponse;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.DataSourceOptimizations;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.OptimizationSubType;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.pushdown.ComplexExpressionPushdownSubType;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.pushdown.FilterPushdownSubType;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.pushdown.TopNPushdownSubType;
 import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionConfig;
 import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionInfo;
 import com.amazonaws.athena.connectors.jdbc.connection.JdbcConnectionFactory;
@@ -150,6 +158,26 @@ public class SqlServerMetadataHandler extends JdbcMetadataHandler
         SchemaBuilder schemaBuilder = SchemaBuilder.newBuilder()
                 .addField(PARTITION_NUMBER, Types.MinorType.VARCHAR.getType());
         return schemaBuilder.build();
+    }
+    @Override
+    public GetDataSourceCapabilitiesResponse doGetDataSourceCapabilities(BlockAllocator allocator, GetDataSourceCapabilitiesRequest request)
+    {
+        ImmutableMap.Builder<String, List<OptimizationSubType>> capabilities = ImmutableMap.builder();
+
+        capabilities.put(DataSourceOptimizations.SUPPORTS_FILTER_PUSHDOWN.withSupportedSubTypes(
+                FilterPushdownSubType.SORTED_RANGE_SET, FilterPushdownSubType.NULLABLE_COMPARISON
+        ));
+        capabilities.put(DataSourceOptimizations.SUPPORTS_COMPLEX_EXPRESSION_PUSHDOWN.withSupportedSubTypes(
+                ComplexExpressionPushdownSubType.SUPPORTED_FUNCTION_EXPRESSION_TYPES
+                        .withSubTypeProperties(Arrays.stream(StandardFunctions.values())
+                                .map(standardFunctions -> standardFunctions.getFunctionName().getFunctionName())
+                                .toArray(String[]::new))
+        ));
+        capabilities.put(DataSourceOptimizations.SUPPORTS_TOP_N_PUSHDOWN.withSupportedSubTypes(
+                TopNPushdownSubType.SUPPORTS_ORDER_BY
+        ));
+
+        return new GetDataSourceCapabilitiesResponse(request.getCatalogName(), capabilities.build());
     }
 
     /**

--- a/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerQueryStringBuilder.java
+++ b/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerQueryStringBuilder.java
@@ -20,6 +20,7 @@
 package com.amazonaws.athena.connectors.sqlserver;
 
 import com.amazonaws.athena.connector.lambda.domain.Split;
+import com.amazonaws.athena.connectors.jdbc.manager.FederationExpressionParser;
 import com.amazonaws.athena.connectors.jdbc.manager.JdbcSplitQueryBuilder;
 import com.google.common.base.Strings;
 import org.slf4j.Logger;
@@ -31,9 +32,9 @@ import java.util.List;
 public class SqlServerQueryStringBuilder extends JdbcSplitQueryBuilder
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(SqlServerQueryStringBuilder.class);
-    public SqlServerQueryStringBuilder(String quoteCharacters)
+    public SqlServerQueryStringBuilder(final String quoteCharacters, final FederationExpressionParser federationExpressionParser)
     {
-        super(quoteCharacters);
+        super(quoteCharacters, federationExpressionParser);
     }
 
     @Override

--- a/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerRecordHandler.java
+++ b/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerRecordHandler.java
@@ -43,9 +43,10 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
+import static com.amazonaws.athena.connectors.sqlserver.SqlServerConstants.SQLSERVER_QUOTE_CHARACTER;
+
 public class SqlServerRecordHandler extends JdbcRecordHandler
 {
-    private static final String SQLSERVER_QUOTE_CHARACTER = "\"";
     private static final int FETCH_SIZE = 1000;
     private final JdbcSplitQueryBuilder jdbcSplitQueryBuilder;
 
@@ -63,7 +64,7 @@ public class SqlServerRecordHandler extends JdbcRecordHandler
     public SqlServerRecordHandler(DatabaseConnectionConfig databaseConnectionConfig, JdbcConnectionFactory jdbcConnectionFactory, java.util.Map<String, String> configOptions)
     {
         this(databaseConnectionConfig, AmazonS3ClientBuilder.defaultClient(), AWSSecretsManagerClientBuilder.defaultClient(),
-                AmazonAthenaClientBuilder.defaultClient(), jdbcConnectionFactory, new SqlServerQueryStringBuilder(SQLSERVER_QUOTE_CHARACTER), configOptions);
+                AmazonAthenaClientBuilder.defaultClient(), jdbcConnectionFactory, new SqlServerQueryStringBuilder(SQLSERVER_QUOTE_CHARACTER, new SqlServerFederationExpressionParser(SQLSERVER_QUOTE_CHARACTER)), configOptions);
     }
 
     @VisibleForTesting

--- a/athena-sqlserver/src/test/java/com/amazonaws/athena/connectors/sqlserver/SqlServerQueryStringBuilderTest.java
+++ b/athena-sqlserver/src/test/java/com/amazonaws/athena/connectors/sqlserver/SqlServerQueryStringBuilderTest.java
@@ -27,6 +27,8 @@ import org.testng.Assert;
 import java.util.ArrayList;
 import java.util.Collections;
 
+import static com.amazonaws.athena.connectors.sqlserver.SqlServerConstants.SQLSERVER_QUOTE_CHARACTER;
+
 public class SqlServerQueryStringBuilderTest
 {
     static {
@@ -39,15 +41,15 @@ public class SqlServerQueryStringBuilderTest
         Split split = Mockito.mock(Split.class);
         Mockito.when(split.getProperties()).thenReturn(Collections.singletonMap("partition", "p0"));
         Mockito.when(split.getProperty(Mockito.eq("partition"))).thenReturn("p0");
-        SqlServerQueryStringBuilder builder = new SqlServerQueryStringBuilder("'");
-        Assert.assertEquals(" FROM 'default'.'table' ", builder.getFromClauseWithSplit("default", "", "table", split));
-        Assert.assertEquals(" FROM 'default'.'schema'.'table' ", builder.getFromClauseWithSplit("default", "schema", "table", split));
+        SqlServerQueryStringBuilder builder = new SqlServerQueryStringBuilder(SQLSERVER_QUOTE_CHARACTER, new SqlServerFederationExpressionParser(SQLSERVER_QUOTE_CHARACTER));
+        Assert.assertEquals(" FROM \"default\".\"table\" ", builder.getFromClauseWithSplit("default", "", "table", split));
+        Assert.assertEquals(" FROM \"default\".\"schema\".\"table\" ", builder.getFromClauseWithSplit("default", "schema", "table", split));
     }
 
     @Test
     public void testGetPartitionWhereClauses()
     {
-        SqlServerQueryStringBuilder builder = new SqlServerQueryStringBuilder("'");
+        SqlServerQueryStringBuilder builder = new SqlServerQueryStringBuilder(SQLSERVER_QUOTE_CHARACTER, new SqlServerFederationExpressionParser(SQLSERVER_QUOTE_CHARACTER));
 
         Split split = Mockito.mock(Split.class);
         Mockito.when(split.getProperties()).thenReturn(Collections.singletonMap("partition", "0"));

--- a/athena-sqlserver/src/test/java/com/amazonaws/athena/connectors/sqlserver/SqlServerRecordHandlerTest.java
+++ b/athena-sqlserver/src/test/java/com/amazonaws/athena/connectors/sqlserver/SqlServerRecordHandlerTest.java
@@ -48,6 +48,7 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.Collections;
 
+import static com.amazonaws.athena.connectors.sqlserver.SqlServerConstants.SQLSERVER_QUOTE_CHARACTER;
 import static org.mockito.ArgumentMatchers.nullable;
 
 public class SqlServerRecordHandlerTest
@@ -71,7 +72,7 @@ public class SqlServerRecordHandlerTest
         this.connection = Mockito.mock(Connection.class);
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         Mockito.when(this.jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(this.connection);
-        jdbcSplitQueryBuilder = new SqlServerQueryStringBuilder("`");
+        jdbcSplitQueryBuilder = new SqlServerQueryStringBuilder(SQLSERVER_QUOTE_CHARACTER ,new SqlServerFederationExpressionParser(SQLSERVER_QUOTE_CHARACTER));
         final DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", SqlServerConstants.NAME,
                 "sqlserver://jdbc:sqlserver://hostname;databaseName=fakedatabase");
 
@@ -111,7 +112,7 @@ public class SqlServerRecordHandlerTest
                 .put("testCol4", valueSet)
                 .build());
 
-        String expectedSql = "SELECT `testCol1`, `testCol2`, `testCol3`, `testCol4` FROM `testSchema`.`testTable`  WHERE (`testCol4` = ?) AND  $PARTITION.pf(testCol1) = 1";
+        String expectedSql = "SELECT \"testCol1\", \"testCol2\", \"testCol3\", \"testCol4\" FROM \"testSchema\".\"testTable\"  WHERE (\"testCol4\" = ?) AND  $PARTITION.pf(testCol1) = 1";
         PreparedStatement expectedPreparedStatement = Mockito.mock(PreparedStatement.class);
         Mockito.when(this.connection.prepareStatement(Mockito.eq(expectedSql))).thenReturn(expectedPreparedStatement);
         PreparedStatement preparedStatement = this.sqlServerRecordHandler.buildSplitSql(this.connection, "testCatalogName", tableName, schema, constraints, split);

--- a/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseConstants.java
+++ b/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseConstants.java
@@ -24,6 +24,7 @@ public final class SynapseConstants
     public static final String NAME = "synapse";
     public static final String DRIVER_CLASS = "com.microsoft.sqlserver.jdbc.SQLServerDriver";
     public static final int DEFAULT_PORT = 1433;
+    public static final String QUOTE_CHARACTER = "\"";
 
     private SynapseConstants() {}
 }

--- a/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseFederationExpressionParser.java
+++ b/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseFederationExpressionParser.java
@@ -1,6 +1,6 @@
 /*-
  * #%L
- * athena-datalakegen2
+ * athena-synapse
  * %%
  * Copyright (C) 2019 - 2022 Amazon Web Services
  * %%
@@ -17,14 +17,24 @@
  * limitations under the License.
  * #L%
  */
-package com.amazonaws.athena.connectors.datalakegen2;
+package com.amazonaws.athena.connectors.synapse;
 
-public class DataLakeGen2Constants
+import com.amazonaws.athena.connectors.jdbc.manager.JdbcFederationExpressionParser;
+import com.google.common.base.Joiner;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+
+import java.util.List;
+
+public class SynapseFederationExpressionParser extends JdbcFederationExpressionParser
 {
-    public static final String NAME = "datalakegentwo";
-    public static final String DRIVER_CLASS = "com.microsoft.sqlserver.jdbc.SQLServerDriver";
-    public static final int DEFAULT_PORT = 1433;
-    public static final String QUOTE_CHARACTER = "\"";
+    public SynapseFederationExpressionParser(String quoteChar)
+    {
+        super(quoteChar);
+    }
 
-    private DataLakeGen2Constants() {}
+    @Override
+    public String writeArrayConstructorClause(ArrowType type, List<String> arguments)
+    {
+        return Joiner.on(", ").join(arguments);
+    }    
 }

--- a/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseMetadataHandler.java
+++ b/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseMetadataHandler.java
@@ -28,12 +28,20 @@ import com.amazonaws.athena.connector.lambda.data.SchemaBuilder;
 import com.amazonaws.athena.connector.lambda.data.SupportedTypes;
 import com.amazonaws.athena.connector.lambda.domain.Split;
 import com.amazonaws.athena.connector.lambda.domain.TableName;
+import com.amazonaws.athena.connector.lambda.domain.predicate.functions.StandardFunctions;
 import com.amazonaws.athena.connector.lambda.domain.spill.SpillLocation;
+import com.amazonaws.athena.connector.lambda.metadata.GetDataSourceCapabilitiesRequest;
+import com.amazonaws.athena.connector.lambda.metadata.GetDataSourceCapabilitiesResponse;
 import com.amazonaws.athena.connector.lambda.metadata.GetSplitsRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetSplitsResponse;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableLayoutRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableResponse;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.DataSourceOptimizations;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.OptimizationSubType;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.pushdown.ComplexExpressionPushdownSubType;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.pushdown.FilterPushdownSubType;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.pushdown.TopNPushdownSubType;
 import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionConfig;
 import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionInfo;
 import com.amazonaws.athena.connectors.jdbc.connection.JdbcConnectionFactory;
@@ -44,6 +52,7 @@ import com.amazonaws.services.athena.AmazonAthena;
 import com.amazonaws.services.secretsmanager.AWSSecretsManager;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.ArrowType;
@@ -61,12 +70,15 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import static com.amazonaws.athena.connector.lambda.domain.predicate.functions.StandardFunctions.IS_DISTINCT_FROM_OPERATOR_FUNCTION_NAME;
 
 public class SynapseMetadataHandler extends JdbcMetadataHandler
 {
@@ -104,6 +116,29 @@ public class SynapseMetadataHandler extends JdbcMetadataHandler
         java.util.Map<String, String> configOptions)
     {
         super(databaseConnectionConfig, secretsManager, athena, jdbcConnectionFactory, configOptions);
+    }
+
+    @Override
+    public GetDataSourceCapabilitiesResponse doGetDataSourceCapabilities(BlockAllocator allocator, GetDataSourceCapabilitiesRequest request)
+    {
+        Set<StandardFunctions> unSupportedFunctions = ImmutableSet.of(IS_DISTINCT_FROM_OPERATOR_FUNCTION_NAME);
+        ImmutableMap.Builder<String, List<OptimizationSubType>> capabilities = ImmutableMap.builder();
+
+        capabilities.put(DataSourceOptimizations.SUPPORTS_FILTER_PUSHDOWN.withSupportedSubTypes(
+                FilterPushdownSubType.SORTED_RANGE_SET, FilterPushdownSubType.NULLABLE_COMPARISON
+        ));
+        capabilities.put(DataSourceOptimizations.SUPPORTS_COMPLEX_EXPRESSION_PUSHDOWN.withSupportedSubTypes(
+                ComplexExpressionPushdownSubType.SUPPORTED_FUNCTION_EXPRESSION_TYPES
+                        .withSubTypeProperties(Arrays.stream(StandardFunctions.values())
+                                .filter(values -> !unSupportedFunctions.contains(values))
+                                .map(standardFunctions -> standardFunctions.getFunctionName().getFunctionName())
+                                .toArray(String[]::new))
+        ));
+        capabilities.put(DataSourceOptimizations.SUPPORTS_TOP_N_PUSHDOWN.withSupportedSubTypes(
+                TopNPushdownSubType.SUPPORTS_ORDER_BY
+        ));
+
+        return new GetDataSourceCapabilitiesResponse(request.getCatalogName(), capabilities.build());
     }
 
     @Override

--- a/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseQueryStringBuilder.java
+++ b/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseQueryStringBuilder.java
@@ -20,6 +20,7 @@
 package com.amazonaws.athena.connectors.synapse;
 
 import com.amazonaws.athena.connector.lambda.domain.Split;
+import com.amazonaws.athena.connectors.jdbc.manager.FederationExpressionParser;
 import com.amazonaws.athena.connectors.jdbc.manager.JdbcSplitQueryBuilder;
 import com.google.common.base.Strings;
 import org.slf4j.Logger;
@@ -31,9 +32,9 @@ import java.util.List;
 public class SynapseQueryStringBuilder extends JdbcSplitQueryBuilder
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(SynapseQueryStringBuilder.class);
-    public SynapseQueryStringBuilder(String quoteCharacters)
+    public SynapseQueryStringBuilder(String quoteCharacters, final FederationExpressionParser federationExpressionParser)
     {
-        super(quoteCharacters);
+        super(quoteCharacters, federationExpressionParser);
     }
 
     @Override

--- a/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseRecordHandler.java
+++ b/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseRecordHandler.java
@@ -53,10 +53,11 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Map;
 
+import static com.amazonaws.athena.connectors.synapse.SynapseConstants.QUOTE_CHARACTER;
+
 public class SynapseRecordHandler extends JdbcRecordHandler
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(SynapseRecordHandler.class);
-    private static final String QUOTE_CHARACTER = "\"";
     private static final int FETCH_SIZE = 1000;
     private final JdbcSplitQueryBuilder jdbcSplitQueryBuilder;
     public SynapseRecordHandler(java.util.Map<String, String> configOptions)
@@ -68,7 +69,7 @@ public class SynapseRecordHandler extends JdbcRecordHandler
         this(databaseConnectionConfig, AmazonS3ClientBuilder.defaultClient(), AWSSecretsManagerClientBuilder.defaultClient(),
                 AmazonAthenaClientBuilder.defaultClient(), new SynapseJdbcConnectionFactory(databaseConnectionConfig,
                         SynapseMetadataHandler.JDBC_PROPERTIES, new DatabaseConnectionInfo(SynapseConstants.DRIVER_CLASS, SynapseConstants.DEFAULT_PORT)),
-                new SynapseQueryStringBuilder(QUOTE_CHARACTER), configOptions);
+                new SynapseQueryStringBuilder(QUOTE_CHARACTER, new SynapseFederationExpressionParser(QUOTE_CHARACTER)), configOptions);
     }
 
     @VisibleForTesting

--- a/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/SynapseQueryStringBuilderTest.java
+++ b/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/SynapseQueryStringBuilderTest.java
@@ -27,9 +27,11 @@ import org.testng.Assert;
 import java.util.ArrayList;
 import java.util.Collections;
 
+import static com.amazonaws.athena.connectors.synapse.SynapseConstants.QUOTE_CHARACTER;
+
 public class SynapseQueryStringBuilderTest
 {
-    SynapseQueryStringBuilder builder = new SynapseQueryStringBuilder("'");
+    SynapseQueryStringBuilder builder = new SynapseQueryStringBuilder(QUOTE_CHARACTER, new SynapseFederationExpressionParser(QUOTE_CHARACTER));
 
     @Test
     public void testQueryBuilder()
@@ -40,8 +42,8 @@ public class SynapseQueryStringBuilderTest
 
         builder.getFromClauseWithSplit("default", "", "table", split);
         builder.getFromClauseWithSplit("default", "schema", "table", split);
-        Assert.assertEquals(" FROM 'default'.'table' ", builder.getFromClauseWithSplit("default", "", "table", split));
-        Assert.assertEquals(" FROM 'default'.'schema'.'table' ", builder.getFromClauseWithSplit("default", "schema", "table", split));
+        Assert.assertEquals(" FROM \"default\".\"table\" ", builder.getFromClauseWithSplit("default", "", "table", split));
+        Assert.assertEquals(" FROM \"default\".\"schema\".\"table\" ", builder.getFromClauseWithSplit("default", "schema", "table", split));
     }
 
     @Test

--- a/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/SynapseRecordHandlerTest.java
+++ b/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/SynapseRecordHandlerTest.java
@@ -48,6 +48,7 @@ import java.sql.SQLException;
 import java.util.Collections;
 import java.util.Map;
 
+import static com.amazonaws.athena.connectors.synapse.SynapseConstants.QUOTE_CHARACTER;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.nullable;
 
@@ -71,7 +72,7 @@ public class SynapseRecordHandlerTest
         this.connection = Mockito.mock(Connection.class);
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         Mockito.when(this.jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(this.connection);
-        jdbcSplitQueryBuilder = new SynapseQueryStringBuilder("`");
+        jdbcSplitQueryBuilder = new SynapseQueryStringBuilder(QUOTE_CHARACTER, new SynapseFederationExpressionParser(QUOTE_CHARACTER));
         final DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", SynapseConstants.NAME,
                 "synapse://jdbc:sqlserver://hostname;databaseName=fakedatabase");
 
@@ -111,7 +112,7 @@ public class SynapseRecordHandlerTest
                 .put("testCol4", valueSet)
                 .build());
 
-        String expectedSql = "SELECT `testCol1`, `testCol2`, `testCol3`, `testCol4` FROM `testSchema`.`testTable`  WHERE (`testCol4` = ?) AND id > 100000 and id <= 300000";
+        String expectedSql = "SELECT \"testCol1\", \"testCol2\", \"testCol3\", \"testCol4\" FROM \"testSchema\".\"testTable\"  WHERE (\"testCol4\" = ?) AND id > 100000 and id <= 300000";
         PreparedStatement expectedPreparedStatement = Mockito.mock(PreparedStatement.class);
         Mockito.when(this.connection.prepareStatement(Mockito.eq(expectedSql))).thenReturn(expectedPreparedStatement);
         PreparedStatement preparedStatement = this.synapseRecordHandler.buildSplitSql(this.connection, "testCatalogName", tableName, schema, constraints, split);

--- a/athena-teradata/src/main/java/com/amazonaws/athena/connectors/teradata/TeradataConstants.java
+++ b/athena-teradata/src/main/java/com/amazonaws/athena/connectors/teradata/TeradataConstants.java
@@ -25,6 +25,7 @@ public final class TeradataConstants
     public static final String TERADATA_NAME = "teradata";
     public static final String TERADATA_DRIVER_CLASS = "com.teradata.jdbc.TeraDriver";
     public static final int TERADATA_DEFAULT_PORT = 1025;
+    public static final String TERADATA_QUOTE_CHARACTER = "\"";
 
     private TeradataConstants() {}
 }

--- a/athena-teradata/src/main/java/com/amazonaws/athena/connectors/teradata/TeradataFederationExpressionParser.java
+++ b/athena-teradata/src/main/java/com/amazonaws/athena/connectors/teradata/TeradataFederationExpressionParser.java
@@ -1,0 +1,85 @@
+/*-
+ * #%L
+ * athena-teradata
+ * %%
+ * Copyright (C) 2019 - 2022 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.teradata;
+
+import com.amazonaws.athena.connector.lambda.domain.predicate.functions.FunctionName;
+import com.amazonaws.athena.connector.lambda.domain.predicate.functions.OperatorType;
+import com.amazonaws.athena.connector.lambda.domain.predicate.functions.StandardFunctions;
+import com.amazonaws.athena.connectors.jdbc.manager.JdbcFederationExpressionParser;
+import com.google.common.base.Joiner;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+
+import java.util.List;
+
+public class TeradataFederationExpressionParser extends JdbcFederationExpressionParser
+{
+    public TeradataFederationExpressionParser(String quoteChar)
+    {
+        super(quoteChar);
+    }
+
+    @Override
+    public String writeArrayConstructorClause(ArrowType type, List<String> arguments)
+    {
+        return Joiner.on(", ").join(arguments);
+    }
+    @Override
+    public String mapFunctionToDataSourceSyntax(FunctionName functionName, ArrowType type, List<String> arguments)
+    {
+        StandardFunctions functionEnum = StandardFunctions.fromFunctionName(functionName);
+        OperatorType operatorType = functionEnum.getOperatorType();
+
+        if (arguments == null || arguments.size() == 0) {
+            throw new IllegalArgumentException("Arguments cannot be null or empty.");
+        }
+        switch (operatorType) {
+            case UNARY:
+                if (arguments.size() != 1) {
+                    throw new IllegalArgumentException("Unary function type " + functionName.getFunctionName() + " was provided with " + arguments.size() + " arguments.");
+                }
+                break;
+            case BINARY:
+                if (arguments.size() != 2) {
+                    throw new IllegalArgumentException("Binary function type " + functionName.getFunctionName() + " was provided with " + arguments.size() + " arguments.");
+                }
+                break;
+            case VARARG:
+                break;
+            default:
+                throw new RuntimeException("A new operator type was introduced without adding support for it.");
+        }
+
+        String clause = "";
+        switch (functionEnum) {
+            case MODULUS_FUNCTION_NAME:
+                clause = Joiner.on(" MOD ").join(arguments);
+                break;
+            case ARRAY_CONSTRUCTOR_FUNCTION_NAME:
+                clause = writeArrayConstructorClause(type, arguments);
+                break;
+            default:
+                clause = super.mapFunctionToDataSourceSyntax(functionName, type, arguments);
+        }
+        if (clause == null) {
+            return "";
+        }
+        return "(" + clause + ")";
+    }
+}

--- a/athena-teradata/src/main/java/com/amazonaws/athena/connectors/teradata/TeradataQueryStringBuilder.java
+++ b/athena-teradata/src/main/java/com/amazonaws/athena/connectors/teradata/TeradataQueryStringBuilder.java
@@ -21,6 +21,7 @@
 package com.amazonaws.athena.connectors.teradata;
 
 import com.amazonaws.athena.connector.lambda.domain.Split;
+import com.amazonaws.athena.connectors.jdbc.manager.FederationExpressionParser;
 import com.amazonaws.athena.connectors.jdbc.manager.JdbcSplitQueryBuilder;
 import com.google.common.base.Strings;
 
@@ -29,9 +30,9 @@ import java.util.List;
 
 public class TeradataQueryStringBuilder extends JdbcSplitQueryBuilder
 {
-    public TeradataQueryStringBuilder(String quoteCharacters)
+    public TeradataQueryStringBuilder(String quoteCharacters, final FederationExpressionParser federationExpressionParser)
     {
-        super(quoteCharacters);
+        super(quoteCharacters, federationExpressionParser);
     }
 
     @Override

--- a/athena-teradata/src/main/java/com/amazonaws/athena/connectors/teradata/TeradataRecordHandler.java
+++ b/athena-teradata/src/main/java/com/amazonaws/athena/connectors/teradata/TeradataRecordHandler.java
@@ -43,9 +43,10 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
+import static com.amazonaws.athena.connectors.teradata.TeradataConstants.TERADATA_QUOTE_CHARACTER;
+
 public class TeradataRecordHandler extends JdbcRecordHandler
 {
-    private static final String TERADATA_QUOTE_CHARACTER = "\"";
     private static final int FETCH_SIZE = 1000;
     private final JdbcSplitQueryBuilder jdbcSplitQueryBuilder;
     public TeradataRecordHandler(java.util.Map<String, String> configOptions)
@@ -60,7 +61,7 @@ public class TeradataRecordHandler extends JdbcRecordHandler
     public TeradataRecordHandler(DatabaseConnectionConfig databaseConnectionConfig, JdbcConnectionFactory jdbcConnectionFactory, java.util.Map<String, String> configOptions)
     {
         this(databaseConnectionConfig, AmazonS3ClientBuilder.defaultClient(), AWSSecretsManagerClientBuilder.defaultClient(), AmazonAthenaClientBuilder.defaultClient(),
-                jdbcConnectionFactory, new TeradataQueryStringBuilder(TERADATA_QUOTE_CHARACTER), configOptions);
+                jdbcConnectionFactory, new TeradataQueryStringBuilder(TERADATA_QUOTE_CHARACTER, new TeradataFederationExpressionParser(TERADATA_QUOTE_CHARACTER)), configOptions);
     }
 
     @VisibleForTesting

--- a/athena-teradata/src/test/java/com/amazonaws/athena/connectors/teradata/TeradataRecordHandlerTest.java
+++ b/athena-teradata/src/test/java/com/amazonaws/athena/connectors/teradata/TeradataRecordHandlerTest.java
@@ -23,7 +23,11 @@ import com.amazonaws.athena.connector.lambda.data.FieldBuilder;
 import com.amazonaws.athena.connector.lambda.data.SchemaBuilder;
 import com.amazonaws.athena.connector.lambda.domain.Split;
 import com.amazonaws.athena.connector.lambda.domain.TableName;
-import com.amazonaws.athena.connector.lambda.domain.predicate.*;
+import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
+import com.amazonaws.athena.connector.lambda.domain.predicate.Marker;
+import com.amazonaws.athena.connector.lambda.domain.predicate.Range;
+import com.amazonaws.athena.connector.lambda.domain.predicate.SortedRangeSet;
+import com.amazonaws.athena.connector.lambda.domain.predicate.ValueSet;
 import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionConfig;
 import com.amazonaws.athena.connectors.jdbc.connection.JdbcConnectionFactory;
 import com.amazonaws.athena.connectors.jdbc.connection.JdbcCredentialProvider;
@@ -45,7 +49,7 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.Collections;
 
-import static org.mockito.ArgumentMatchers.any;
+import static com.amazonaws.athena.connectors.teradata.TeradataConstants.TERADATA_QUOTE_CHARACTER;
 import static org.mockito.ArgumentMatchers.nullable;
 
 public class TeradataRecordHandlerTest
@@ -68,7 +72,7 @@ public class TeradataRecordHandlerTest
         this.connection = Mockito.mock(Connection.class);
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         Mockito.when(this.jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(this.connection);
-        jdbcSplitQueryBuilder = new TeradataQueryStringBuilder("`");
+        jdbcSplitQueryBuilder = new TeradataQueryStringBuilder(TERADATA_QUOTE_CHARACTER, new TeradataFederationExpressionParser(TERADATA_QUOTE_CHARACTER));
         final DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", TeradataConstants.TERADATA_NAME,
                 "teradata://jdbc:teradata://115.113.87.100/TMODE=ANSI,CHARSET=UTF8,DATABASE=TEST,USER=DBC,PASSWORD=DBC");
 


### PR DESCRIPTION
Issue #, if available:
Changes for predicate pushdown for Oracle, SQL server, Snowflake, Db2, Cloudera Hive, Synapse, DatalakeGen2 and Saphana connectors.

Description of changes:
Predicate pushdown changes in Oracle, SQL server, Snowflake, Db2, Cloudera Hive, Synapse, DatalakeGen2 and Saphana  connectors.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
