### PR TITLE
Case insensitive table name search in JDBC connectors

### DIFF
--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandler.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandler.java
@@ -238,7 +238,7 @@ public abstract class JdbcMetadataHandler
         }
     }
 
-    private TableName caseInsensitiveTableSearch(Connection connection, final String databaseName,
+    protected TableName caseInsensitiveTableSearch(Connection connection, final String databaseName,
                                                      final String tableName) throws Exception
     {
         List<TableName> tables = listTables(connection, databaseName)

--- a/athena-mysql/src/main/java/com/amazonaws/athena/connectors/mysql/MySqlMetadataHandler.java
+++ b/athena-mysql/src/main/java/com/amazonaws/athena/connectors/mysql/MySqlMetadataHandler.java
@@ -218,25 +218,7 @@ public class MySqlMetadataHandler
     protected TableName caseInsensitiveTableSearch(Connection connection, final String databaseName,
                                                      final String tableName) throws Exception
     {
-        String resolvedName = null;
-        String sql = getTableNameQuery(tableName);
-        PreparedStatement statement = connection.prepareStatement(sql);
-        try (ResultSet resultSet = statement.executeQuery()) {
-            if (resultSet.next()) {
-                resolvedName = resultSet.getString("table_name");
-                LOGGER.info("Resolved name from Case Insensitive look up : {}", resolvedName);
-            }
-            else {
-                throw new RuntimeException(String.format("Could not find Table %s in Database %s", tableName, databaseName));
-            }
-        }
-        return new TableName(databaseName, resolvedName);
-    }
-
-    private String getTableNameQuery(String tableName)
-    {
-        return String.format("SELECT table_name, lower(table_name) FROM information_schema.tables " + 
-        "WHERE table_name = '%s' or lower(table_name) = '%s' LIMIT 1", tableName, tableName);
+        return JDBCUtil.informationSchemaCaseInsensitiveTableMatch(connection, databaseName, tableName);
     }
 
     private int decodeContinuationToken(GetSplitsRequest request)

--- a/athena-postgresql/src/main/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlMetadataHandler.java
+++ b/athena-postgresql/src/main/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlMetadataHandler.java
@@ -252,25 +252,7 @@ public class PostGreSqlMetadataHandler
     protected TableName caseInsensitiveTableSearch(Connection connection, final String databaseName,
                                                      final String tableName) throws Exception
     {
-        String resolvedName = null;
-        String sql = getTableNameQuery(tableName);
-        PreparedStatement statement = connection.prepareStatement(sql);
-        try (ResultSet resultSet = statement.executeQuery()) {
-            if (resultSet.next()) {
-                resolvedName = resultSet.getString("table_name");
-                LOGGER.info("Resolved name from Case Insensitive look up : {}", resolvedName);
-            }
-            else {
-                throw new RuntimeException(String.format("Could not find Table %s in Database %s", tableName, databaseName));
-            }
-        }
-        return new TableName(databaseName, resolvedName);
-    }
-
-    private String getTableNameQuery(String tableName)
-    {
-        return String.format("SELECT table_name, lower(table_name) FROM information_schema.tables " + 
-        "WHERE table_name = '%s' or lower(table_name) = '%s' LIMIT 1", tableName, tableName);
+        return JDBCUtil.informationSchemaCaseInsensitiveTableMatch(connection, databaseName, tableName);
     }
 
     private int decodeContinuationToken(GetSplitsRequest request)

--- a/athena-postgresql/src/main/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlMetadataHandler.java
+++ b/athena-postgresql/src/main/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlMetadataHandler.java
@@ -25,6 +25,7 @@ import com.amazonaws.athena.connector.lambda.data.BlockAllocator;
 import com.amazonaws.athena.connector.lambda.data.BlockWriter;
 import com.amazonaws.athena.connector.lambda.data.SchemaBuilder;
 import com.amazonaws.athena.connector.lambda.domain.Split;
+import com.amazonaws.athena.connector.lambda.domain.TableName;
 import com.amazonaws.athena.connector.lambda.domain.predicate.functions.StandardFunctions;
 import com.amazonaws.athena.connector.lambda.domain.spill.SpillLocation;
 import com.amazonaws.athena.connector.lambda.metadata.GetDataSourceCapabilitiesRequest;
@@ -245,6 +246,31 @@ public class PostGreSqlMetadataHandler
         }
 
         return new GetSplitsResponse(getSplitsRequest.getCatalogName(), splits, null);
+    }
+
+    @Override
+    protected TableName caseInsensitiveTableSearch(Connection connection, final String databaseName,
+                                                     final String tableName) throws Exception
+    {
+        String resolvedName = null;
+        String sql = getTableNameQuery(tableName);
+        PreparedStatement statement = connection.prepareStatement(sql);
+        try (ResultSet resultSet = statement.executeQuery()) {
+            if (resultSet.next()) {
+                resolvedName = resultSet.getString("table_name");
+                LOGGER.info("Resolved name from Case Insensitive look up : {}", resolvedName);
+            }
+            else {
+                throw new RuntimeException(String.format("Could not find Table %s in Database %s", tableName, databaseName));
+            }
+        }
+        return new TableName(databaseName, resolvedName);
+    }
+
+    private String getTableNameQuery(String tableName)
+    {
+        return String.format("SELECT table_name, lower(table_name) FROM information_schema.tables " + 
+        "WHERE table_name = '%s' or lower(table_name) = '%s' LIMIT 1", tableName, tableName);
     }
 
     private int decodeContinuationToken(GetSplitsRequest request)

--- a/athena-postgresql/src/test/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlMetadataHandlerTest.java
+++ b/athena-postgresql/src/test/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlMetadataHandlerTest.java
@@ -70,6 +70,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.nullable;
 
 public class PostGreSqlMetadataHandlerTest
@@ -328,6 +329,11 @@ public class PostGreSqlMetadataHandlerTest
         Schema expected = expectedSchemaBuilder.build();
 
         TableName inputTableName = new TableName("testSchema", "testTable");
+        String[] columnNames = new String[] {"table_name"};
+        String[][] tableNameValues = new String[][]{new String[] {"testTable"}};
+        ResultSet resultSetName = mockResultSet(columnNames, tableNameValues, new AtomicInteger(-1));
+        String sql = "SELECT table_name, lower(table_name) FROM information_schema.tables WHERE table_name = 'testTable' or lower(table_name) = 'testTable' LIMIT 1";
+        Mockito.when(this.connection.prepareStatement(sql).executeQuery()).thenReturn(resultSetName);
         Mockito.when(connection.getMetaData().getColumns("testCatalog", inputTableName.getSchemaName(), inputTableName.getTableName(), null)).thenReturn(resultSet);
         Mockito.when(connection.getCatalog()).thenReturn("testCatalog");
 

--- a/athena-redshift/src/test/java/com/amazonaws/athena/connectors/redshift/RedshiftMetadataHandlerTest.java
+++ b/athena-redshift/src/test/java/com/amazonaws/athena/connectors/redshift/RedshiftMetadataHandlerTest.java
@@ -71,7 +71,9 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.nullable;
+
 
 public class RedshiftMetadataHandlerTest
         extends TestBase
@@ -329,6 +331,11 @@ public class RedshiftMetadataHandlerTest
         Schema expected = expectedSchemaBuilder.build();
 
         TableName inputTableName = new TableName("testSchema", "testTable");
+        String[] columnNames = new String[] {"table_name"};
+        String[][] tableNameValues = new String[][]{new String[] {"testTable"}};
+        ResultSet resultSetName = mockResultSet(columnNames, tableNameValues, new AtomicInteger(-1));
+        String sql = "SELECT table_name, lower(table_name) FROM information_schema.tables WHERE table_name = 'testTable' or lower(table_name) = 'testTable' LIMIT 1";
+        Mockito.when(this.connection.prepareStatement(sql).executeQuery()).thenReturn(resultSetName);
         Mockito.when(connection.getMetaData().getColumns("testCatalog", inputTableName.getSchemaName(), inputTableName.getTableName(), null)).thenReturn(resultSet);
         Mockito.when(connection.getCatalog()).thenReturn("testCatalog");
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/aws-athena-query-federation/issues/61

*Description of changes:* In doGetTable method, if a table is not found in the database, then do a lookup for all tables in the database, and then do a local case-insensitive search for table name. 
This is similar to how DynamoDB connector does case-insensitive search https://github.com/awslabs/aws-athena-query-federation/blob/b99bba84302a9299f5d53e3a4da1cb0d9f67ab2e/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/resolver/DynamoDBTableResolver.java#L148-L172

Note that if database contains a table with all lowercase letters, then that table will always be returned even if there are other tables with uppercase letters. This is because lowercase table name will be returned in the first call to getTable, so code flow will never reach where we lookup all tables in the database. This is existing behavior even without this change.  For example, if the database contains users, Users and USers, then table *users* will be returned for all possible case variations of *users* in the query. 

If the query is for table Users, but database only contains tables uSers, then uSers will be returned as we don't know the actual case of the table specified in the query. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
