### PR TITLE
CMDB connector - Add EC2 and RDS instance tags to output

### DIFF
--- a/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/RdsTableProviderTest.java
+++ b/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/RdsTableProviderTest.java
@@ -31,7 +31,6 @@ import com.amazonaws.services.elasticmapreduce.model.DescribeClusterRequest;
 import com.amazonaws.services.elasticmapreduce.model.DescribeClusterResult;
 import com.amazonaws.services.elasticmapreduce.model.ListClustersRequest;
 import com.amazonaws.services.elasticmapreduce.model.ListClustersResult;
-import com.amazonaws.services.elasticmapreduce.model.Tag;
 import com.amazonaws.services.rds.AmazonRDS;
 import com.amazonaws.services.rds.model.DBInstance;
 import com.amazonaws.services.rds.model.DBInstanceStatusInfo;
@@ -44,6 +43,8 @@ import com.amazonaws.services.rds.model.DescribeDBInstancesResult;
 import com.amazonaws.services.rds.model.DomainMembership;
 import com.amazonaws.services.rds.model.Endpoint;
 import com.amazonaws.services.rds.model.Subnet;
+import com.amazonaws.services.rds.model.Tag;
+
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.Field;
@@ -232,6 +233,7 @@ public class RdsTableProviderTest
                 .withInstanceCreateTime(new Date(100000))
                 .withIops(100)
                 .withMultiAZ(true)
-                .withPubliclyAccessible(true);
+                .withPubliclyAccessible(true)
+                .withTagList(new Tag().withKey("key").withValue("value"));
     }
 }

--- a/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/ec2/Ec2TableProviderTest.java
+++ b/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/ec2/Ec2TableProviderTest.java
@@ -34,6 +34,8 @@ import com.amazonaws.services.ec2.model.InstanceNetworkInterface;
 import com.amazonaws.services.ec2.model.InstanceState;
 import com.amazonaws.services.ec2.model.Reservation;
 import com.amazonaws.services.ec2.model.StateReason;
+import com.amazonaws.services.ec2.model.Tag;
+
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.Field;
@@ -194,7 +196,8 @@ public class Ec2TableProviderTest
                 .withLaunchTime(new Date(100_000))
                 .withState(new InstanceState().withCode(100).withName("name"))
                 .withStateReason(new StateReason().withCode("code").withMessage("message"))
-                .withEbsOptimized(true);
+                .withEbsOptimized(true)
+                .withTags(new Tag("key","value"));
 
         List<InstanceNetworkInterface> interfaces = new ArrayList<>();
         interfaces.add(new InstanceNetworkInterface()


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/aws-athena-query-federation/issues/474

*Description of changes:*



```
sql > select instance_id, tags from "lambda:athena-cmdb".ec2.ec2_instances;
#	instance_id	tags
1	i-0bf77b4a77abbcbf2	[{key=Name, value=java c5.9xlarge}]
2	i-0774ea3926f865e7b	[{key=aws:elasticmapreduce:job-flow-id, value=j-L0XIA0QWQ5GC}, {key=aws:elasticmapreduce:instance-group-role, value=MASTER}]
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
