### PR TITLE
Get rid of powermock and mockito.legacy.version entirely

### DIFF
--- a/athena-federation-sdk/pom.xml
+++ b/athena-federation-sdk/pom.xml
@@ -295,12 +295,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-reflect</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>3.12.0</version>

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/handlers/CompositeHandlerTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/handlers/CompositeHandlerTest.java
@@ -50,12 +50,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.commons.lang3.reflect.FieldUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
-import org.powermock.reflect.Whitebox;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -212,7 +212,7 @@ public class CompositeHandlerTest
         when(req.getRequestType()).thenReturn(MetadataRequestType.GET_SPLITS);
         SpillLocationVerifier mockVerifier = mock(SpillLocationVerifier.class);
         doNothing().when(mockVerifier).checkBucketAuthZ(nullable(String.class));
-        Whitebox.setInternalState(mockMetadataHandler, "verifier", mockVerifier);
+        FieldUtils.writeField(mockMetadataHandler, "verifier", mockVerifier, true);
         compositeHandler.handleRequest(allocator, req, new ByteArrayOutputStream(), objectMapper);
         verify(mockMetadataHandler, times(1)).doGetSplits(nullable(BlockAllocatorImpl.class), nullable(GetSplitsRequest.class));
     }

--- a/pom.xml
+++ b/pom.xml
@@ -19,9 +19,7 @@
         <aws-cdk.version>1.201.0</aws-cdk.version>
         <jsii.version>1.81.0</jsii.version>
         <slf4j-log4j.version>2.0.7</slf4j-log4j.version>
-        <mockito.legacy.version>3.3.3</mockito.legacy.version>
         <mockito.version>4.11.0</mockito.version>
-        <powermock.version>2.0.9</powermock.version>
         <junit.version>4.13.2</junit.version>
         <jqwik.version>1.7.3</jqwik.version>
         <assertj.version>3.24.2</assertj.version>


### PR DESCRIPTION



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
