### PR TITLE
fixing mysql connector syntax for top N

### DIFF
--- a/athena-mysql/src/main/java/com/amazonaws/athena/connectors/mysql/MySqlQueryStringBuilder.java
+++ b/athena-mysql/src/main/java/com/amazonaws/athena/connectors/mysql/MySqlQueryStringBuilder.java
@@ -20,12 +20,16 @@
 package com.amazonaws.athena.connectors.mysql;
 
 import com.amazonaws.athena.connector.lambda.domain.Split;
+import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
+import com.amazonaws.athena.connector.lambda.domain.predicate.OrderByField;
 import com.amazonaws.athena.connectors.jdbc.manager.FederationExpressionParser;
 import com.amazonaws.athena.connectors.jdbc.manager.JdbcSplitQueryBuilder;
 import com.google.common.base.Strings;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Extends {@link JdbcSplitQueryBuilder} and implements MySql specific SQL clauses for split.
@@ -66,5 +70,35 @@ public class MySqlQueryStringBuilder
     protected List<String> getPartitionWhereClauses(final Split split)
     {
         return Collections.emptyList();
+    }
+
+    @Override
+    protected String extractOrderByClause(Constraints constraints)
+    {
+        List<OrderByField> orderByClause = constraints.getOrderByClause();
+        if (orderByClause == null || orderByClause.size() == 0) {
+            return "";
+        }
+        return "ORDER BY " + orderByClause.stream()
+                .flatMap(orderByField -> {
+                    String ordering = orderByField.getDirection().isAscending() ? "ASC" : "DESC";
+                    String columnSorting = String.format("%s %s", quote(orderByField.getColumnName()), ordering);
+                    switch (orderByField.getDirection()) {
+                        case ASC_NULLS_FIRST:
+                            // In MySQL ASC implies NULLS FIRST
+                        case DESC_NULLS_LAST:
+                            // In MySQL DESC implies NULLS LAST
+                            return Stream.of(columnSorting);
+                        case ASC_NULLS_LAST:
+                            return Stream.of(String.format("ISNULL(%s) ASC", quote(orderByField.getColumnName())),
+                                    columnSorting);
+                        case DESC_NULLS_FIRST:
+                            return Stream.of(
+                                    String.format("ISNULL(%s) DESC", quote(orderByField.getColumnName())),
+                                    columnSorting);
+                    }
+                    throw new UnsupportedOperationException("Unsupported sort order: " + orderByField.getDirection());
+                })
+                .collect(Collectors.joining(", "));
     }
 }

--- a/athena-mysql/src/test/java/com/amazonaws/athena/connectors/mysql/MySqlRecordHandlerTest.java
+++ b/athena-mysql/src/test/java/com/amazonaws/athena/connectors/mysql/MySqlRecordHandlerTest.java
@@ -145,7 +145,7 @@ public class MySqlRecordHandlerTest
             100L
         );
 
-        String expectedSql = "SELECT `testCol1`, `testCol2`, `testCol3`, `testCol4`, `testCol5`, `testCol6`, `testCol7`, `testCol8` FROM `testSchema`.`testTable` PARTITION(p0)  WHERE (`testCol1` IN (?,?)) AND ((`testCol2` >= ? AND `testCol2` < ?)) AND ((`testCol3` > ? AND `testCol3` <= ?)) AND (`testCol4` = ?) AND (`testCol5` = ?) AND (`testCol6` = ?) AND (`testCol7` = ?) AND (`testCol8` = ?) ORDER BY `testCol1` ASC NULLS FIRST, `testCol3` DESC NULLS FIRST LIMIT 100";
+        String expectedSql = "SELECT `testCol1`, `testCol2`, `testCol3`, `testCol4`, `testCol5`, `testCol6`, `testCol7`, `testCol8` FROM `testSchema`.`testTable` PARTITION(p0)  WHERE (`testCol1` IN (?,?)) AND ((`testCol2` >= ? AND `testCol2` < ?)) AND ((`testCol3` > ? AND `testCol3` <= ?)) AND (`testCol4` = ?) AND (`testCol5` = ?) AND (`testCol6` = ?) AND (`testCol7` = ?) AND (`testCol8` = ?) ORDER BY `testCol1` ASC, ISNULL(`testCol3`) DESC, `testCol3` DESC LIMIT 100";
         PreparedStatement expectedPreparedStatement = Mockito.mock(PreparedStatement.class);
         Mockito.when(this.connection.prepareStatement(Mockito.eq(expectedSql))).thenReturn(expectedPreparedStatement);
 


### PR DESCRIPTION
fixing syntax for TOP N queries for mysql connector. 

MySQL doesn't allow NULLS LAST LIMIT 100;


