### PR TITLE
fix for data inconsistency in distinct clause Google BigQuery connector 

### DIFF
--- a/athena-google-bigquery/athena-google-bigquery.yaml
+++ b/athena-google-bigquery/athena-google-bigquery.yaml
@@ -45,10 +45,6 @@ Parameters:
     Description: 'Lambda memory in MB (min 128 - 3008 max).'
     Default: 3008
     Type: Number
-  ConcurrencyLimit:
-    Description: 'Concurrency Limit'
-    Default: 10
-    Type: Number
   DisableSpillEncryption:
     Description: 'If set to ''false'' data spilled to S3 is encrypted with AES GCM'
     Default: 'false'
@@ -81,7 +77,6 @@ Resources:
           secret_manager_gcp_creds_name: !Ref SecretNamePrefix
           gcp_project_id: !Ref GCPProjectID
           big_query_endpoint: !Ref BigQueryEndpoint
-          concurrencyLimit: !Ref ConcurrencyLimit
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.google.bigquery.BigQueryCompositeHandler"
       CodeUri: "./target/athena-google-bigquery-2022.47.1.jar"

--- a/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryMetadataHandler.java
+++ b/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryMetadataHandler.java
@@ -210,8 +210,6 @@ public class BigQueryMetadataHandler
     @Override
     public GetSplitsResponse doGetSplits(BlockAllocator allocator, GetSplitsRequest request) throws IOException, InterruptedException
     {
-        int constraintsSize = request.getConstraints().getSummary().size();
-
         //Every split must have a unique location if we wish to spill to avoid failures
         SpillLocation spillLocation = makeSpillLocation(request);
 

--- a/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryMetadataHandler.java
+++ b/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryMetadataHandler.java
@@ -51,14 +51,9 @@ import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.Dataset;
 import com.google.cloud.bigquery.DatasetId;
 import com.google.cloud.bigquery.Field;
-import com.google.cloud.bigquery.Job;
-import com.google.cloud.bigquery.JobId;
-import com.google.cloud.bigquery.JobInfo;
-import com.google.cloud.bigquery.QueryJobConfiguration;
 import com.google.cloud.bigquery.Table;
 import com.google.cloud.bigquery.TableDefinition;
 import com.google.cloud.bigquery.TableId;
-import com.google.cloud.bigquery.TableResult;
 import com.google.common.collect.ImmutableMap;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.slf4j.Logger;
@@ -67,12 +62,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
 
 import static com.amazonaws.athena.connector.lambda.metadata.ListTablesRequest.UNLIMITED_PAGE_SIZE_VALUE;
 import static com.amazonaws.athena.connectors.google.bigquery.BigQueryUtils.fixCaseForDatasetName;
@@ -221,47 +211,12 @@ public class BigQueryMetadataHandler
     public GetSplitsResponse doGetSplits(BlockAllocator allocator, GetSplitsRequest request) throws IOException, InterruptedException
     {
         int constraintsSize = request.getConstraints().getSummary().size();
-        if (constraintsSize > 0) {
-            //Every split must have a unique location if we wish to spill to avoid failures
-            SpillLocation spillLocation = makeSpillLocation(request);
 
-            return new GetSplitsResponse(request.getCatalogName(), Split.newBuilder(spillLocation,
-                    makeEncryptionKey()).build());
-        }
-        else {
-            BigQuery bigQuery = BigQueryUtils.getBigQueryClient(configOptions);
-            String dataSetName = fixCaseForDatasetName(projectName, request.getTableName().getSchemaName(), bigQuery);
-            String tableName = fixCaseForTableName(projectName, dataSetName, request.getTableName().getTableName(), bigQuery);
-            QueryJobConfiguration queryConfig = QueryJobConfiguration.newBuilder("SELECT count(*) FROM `" + projectName + "." + dataSetName + "." + tableName + "` ").setUseLegacySql(false).build();
-            // Create a job ID so that we can safely retry.
-            JobId jobId = JobId.of(UUID.randomUUID().toString());
-            Job queryJob = bigQuery.create(JobInfo.newBuilder(queryConfig).setJobId(jobId).build()).waitFor();
-            TableResult result = queryJob.getQueryResults();
+        //Every split must have a unique location if we wish to spill to avoid failures
+        SpillLocation spillLocation = makeSpillLocation(request);
 
-            double numberOfRows = result.iterateAll().iterator().next().get(0).getLongValue();
-            logger.debug("numberOfRows: " + numberOfRows);
-            int concurrencyLimit = Integer.parseInt(configOptions.get("concurrencyLimit"));
-            logger.debug("concurrencyLimit: " + numberOfRows);
-            long pageCount = (long) numberOfRows / concurrencyLimit;
-            long totalPageCountLimit = (pageCount == 0) ? (long) numberOfRows : pageCount;
-            double limit = (int) Math.ceil(numberOfRows / totalPageCountLimit);
-            Set<Split> splits = new HashSet<>();
-            long offSet = 0;
-
-            for (int i = 1; i <= limit; i++) {
-                if (i > 1) {
-                    offSet = offSet + totalPageCountLimit;
-                }
-                // Every split must have a unique location if we wish to spill to avoid failures
-                SpillLocation spillLocation = makeSpillLocation(request);
-                // Create a new split (added to the splits set) that includes the domain and endpoint, and
-                // shard information (to be used later by the Record Handler).
-                Map<String, String> map = new HashMap<>();
-                map.put(Long.toString(totalPageCountLimit), Long.toString(offSet));
-                splits.add(new Split(spillLocation, makeEncryptionKey(), map));
-            }
-            return new GetSplitsResponse(request.getCatalogName(), splits);
-        }
+        return new GetSplitsResponse(request.getCatalogName(), Split.newBuilder(spillLocation,
+                makeEncryptionKey()).build());
     }
 
     /**

--- a/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQuerySqlUtils.java
+++ b/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQuerySqlUtils.java
@@ -78,7 +78,7 @@ public class BigQuerySqlUtils
     {
         LOGGER.info("Inside buildSqlFromSplit(): ");
         StringBuilder sqlBuilder = new StringBuilder("SELECT ");
-        Map<String, String> limitAndOffsets = split.getProperties();
+
         StringJoiner sj = new StringJoiner(",");
         if (schema.getFields().isEmpty()) {
             sj.add("null");
@@ -111,13 +111,6 @@ public class BigQuerySqlUtils
             sqlBuilder.append(" limit " + constraints.getLimit());
         }
 
-        else if (limitAndOffsets.size() > 0) {
-            for (Map.Entry<String, String> entry : limitAndOffsets.entrySet()) {
-                LOGGER.info("entry.getValue())" + entry.getValue());
-                LOGGER.info("entry.getKey()" + entry.getKey());
-                sqlBuilder.append(" limit " + entry.getKey() + " offset " + entry.getValue());
-            }
-        }
         LOGGER.info("Generated SQL : {}", sqlBuilder.toString());
         return sqlBuilder.toString();
     }

--- a/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryMetadataHandlerTest.java
+++ b/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryMetadataHandlerTest.java
@@ -231,7 +231,7 @@ public class BigQueryMetadataHandlerTest
 
         GetSplitsResponse response = bigQueryMetadataHandler.doGetSplits(blockAllocator, request);
 
-        assertNotNull(response);
+        assertEquals(response.getSplits().size(), 1);
     }
 
     @Test


### PR DESCRIPTION
*Issue #, if available:*
fix for data inconsistency in distinct clause Google BigQuery connector.

*Description of changes:*
This is a quick fix to resolve data inconsistency in distinct clauses. for this fix, we removed multiple splits created by passing limit and offset to read query. we are using a single split as of now. 

we recommend the user pass the where clause for faster results.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
