### PR TITLE
Pushing down 'not equal' to predicate

### DIFF
--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcSplitQueryBuilder.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcSplitQueryBuilder.java
@@ -254,8 +254,8 @@ public abstract class JdbcSplitQueryBuilder
                 disjuncts.add(String.format("(%s IS NULL)", quote(columnName)));
             }
 
-            Range rangeSpan = ((SortedRangeSet) valueSet).getSpan();
-            if (!valueSet.isNullAllowed() && rangeSpan.getLow().isLowerUnbounded() && rangeSpan.getHigh().isUpperUnbounded()) {
+            List<Range> rangeList = ((SortedRangeSet) valueSet).getOrderedRanges();
+            if (rangeList.size() == 1 && !valueSet.isNullAllowed() && rangeList.get(0).getLow().isLowerUnbounded() && rangeList.get(0).getHigh().isUpperUnbounded()) {
                 return String.format("(%s IS NOT NULL)", quote(columnName));
             }
 

--- a/athena-mysql/src/test/java/com/amazonaws/athena/connectors/mysql/MySqlQueryStringBuilderTest.java
+++ b/athena-mysql/src/test/java/com/amazonaws/athena/connectors/mysql/MySqlQueryStringBuilderTest.java
@@ -1,0 +1,108 @@
+/*-
+ * #%L
+ * athena-mysql
+ * %%
+ * Copyright (C) 2019 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.mysql;
+
+import com.amazonaws.athena.connector.lambda.QueryStatusChecker;
+import com.amazonaws.athena.connector.lambda.data.BlockAllocator;
+import com.amazonaws.athena.connector.lambda.data.BlockAllocatorImpl;
+import com.amazonaws.athena.connector.lambda.data.BlockWriter;
+import com.amazonaws.athena.connector.lambda.data.FieldBuilder;
+import com.amazonaws.athena.connector.lambda.data.SchemaBuilder;
+import com.amazonaws.athena.connector.lambda.domain.Split;
+import com.amazonaws.athena.connector.lambda.domain.TableName;
+import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
+import com.amazonaws.athena.connector.lambda.domain.predicate.Range;
+import com.amazonaws.athena.connector.lambda.domain.predicate.SortedRangeSet;
+import com.amazonaws.athena.connector.lambda.metadata.GetSplitsRequest;
+import com.amazonaws.athena.connector.lambda.metadata.GetSplitsResponse;
+import com.amazonaws.athena.connector.lambda.metadata.GetTableLayoutRequest;
+import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionConfig;
+import com.google.common.collect.ImmutableMap;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.logging.log4j.core.config.plugins.validation.Constraint;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertEquals;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.amazonaws.athena.connector.lambda.domain.predicate.Constraints.DEFAULT_NO_LIMIT;
+import com.amazonaws.athena.connector.lambda.domain.spill.S3SpillLocation;
+import com.amazonaws.athena.connector.lambda.domain.predicate.ValueSet;
+import com.amazonaws.athena.connectors.jdbc.manager.DefaultJdbcFederationExpressionParser;
+
+public class MySqlQueryStringBuilderTest
+{
+    private String catalogName = "testCatalog";
+    private String schemaName = "testSchema";
+    private String tableName = "testTable";
+    private BlockAllocator allocator = new BlockAllocatorImpl("test-allocator-id");
+    private Connection connection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);
+    private S3SpillLocation s3SpillLocation = S3SpillLocation.newBuilder().withIsDirectory(true).build();
+    Split.Builder splitBuilder = Split.newBuilder(s3SpillLocation, null).add("partition_name", String.valueOf("p0"));
+    private MySqlQueryStringBuilder mySqlQueryStringBuilder = new MySqlQueryStringBuilder("`", new DefaultJdbcFederationExpressionParser());
+    Schema schema = SchemaBuilder.newBuilder()
+        .addField(FieldBuilder.newBuilder("testCol1", org.apache.arrow.vector.types.Types.MinorType.VARCHAR.getType()).build())
+        .addField(FieldBuilder.newBuilder("testCol2", org.apache.arrow.vector.types.Types.MinorType.INT.getType()).build())
+        .addField(FieldBuilder.newBuilder("testCol3", org.apache.arrow.vector.types.Types.MinorType.VARCHAR.getType()).build())
+        .addField(FieldBuilder.newBuilder("testCol4", org.apache.arrow.vector.types.Types.MinorType.FLOAT8.getType()).build())
+        .addField(FieldBuilder.newBuilder("partition_name", org.apache.arrow.vector.types.Types.MinorType.VARCHAR.getType()).build())
+        .build();
+
+    @Test
+    public void generateSqlIsNotNull() throws Exception
+    {
+        Map<String, ValueSet> constraintsMap = ImmutableMap.of("testCol2", SortedRangeSet.of(false, Range.all(allocator, org.apache.arrow.vector.types.Types.MinorType.INT.getType())));
+        Constraints constraints = new Constraints(constraintsMap, Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT);
+
+        String expectedSql = "SELECT `testCol1`, `testCol2`, `testCol3`, `testCol4` FROM `testCatalog`.`testTable`.`testSchema` PARTITION(p0)  WHERE (`testCol2` IS NOT NULL)";
+        PreparedStatement expectedPreparedStatement = Mockito.mock(PreparedStatement.class);
+        Mockito.when(connection.prepareStatement(Mockito.eq(expectedSql))).thenReturn(expectedPreparedStatement);
+
+        PreparedStatement preparedStatement = mySqlQueryStringBuilder.buildSql(connection, catalogName, tableName, schemaName, schema, constraints, splitBuilder.build());
+
+        assertEquals(expectedPreparedStatement, preparedStatement);
+
+    }
+
+    @Test
+    public void generateSqlIsNotEqual() throws Exception
+    {
+        Map<String, ValueSet> constraintsMap = ImmutableMap.of("testCol2", SortedRangeSet.of(false, Range.lessThan(allocator, org.apache.arrow.vector.types.Types.MinorType.INT.getType(), 138), Range.greaterThan(allocator, org.apache.arrow.vector.types.Types.MinorType.INT.getType(), 138)));
+        Constraints constraints = new Constraints(constraintsMap, Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT);
+
+        String expectedSql = "SELECT `testCol1`, `testCol2`, `testCol3`, `testCol4` FROM `testCatalog`.`testTable`.`testSchema` PARTITION(p0)  WHERE ((`testCol2` < ?) OR (`testCol2` > ?))";
+        PreparedStatement expectedPreparedStatement = Mockito.mock(PreparedStatement.class);
+        Mockito.when(connection.prepareStatement(Mockito.eq(expectedSql))).thenReturn(expectedPreparedStatement);
+
+        PreparedStatement preparedStatement = mySqlQueryStringBuilder.buildSql(connection, catalogName, tableName, schemaName, schema, constraints, splitBuilder.build());
+
+        assertEquals(expectedPreparedStatement, preparedStatement);
+
+    }
+}


### PR DESCRIPTION
**Description of changes:**
Modified statement that is responsible for adding `IS NOT NULL` clause to generate sql for JDBC connectors.
Prior to change, when evaluating a `not equal to` predicate it would short circuit and not push down all predicates to sql statement.
For Example:
`SELECT * FROM item WHERE i_manufact_id <> 138`
Would be translated to:
`SELECT * FROM item WHERE (i_manufact_id IS NOT NULL)`

This is the result of calling `getSpan()` on `SortedRangeSet`, which returns a Range that is a summary of the lowest lower bound and the highest upper bound that represents this ValueSet.

Therefore, the following ValueSet from statement with `i_manufact_id <> 138` predicate:

```
        i_manufact_id=SortedRangeSet{
            type=Int(64, true), nullAllowed=false, lowIndexedRanges={
                Marker{
                   valueBlock=Int(64, true), nullValue=true, valueBlock=true, bound=ABOVE
                   }=Range{
                        low=Marker{
                            valueBlock=Int(64, true), nullValue=true, valueBlock=true, bound=ABOVE
                           }, 
                        high=Marker{
                            valueBlock=Int(64, true), nullValue=false, valueBlock=138, bound=BELOW
                        }
                   }, 
                Marker{
                   valueBlock=Int(64, true), nullValue=false, valueBlock=138, bound=ABOVE
                   }=Range{
                        low=Marker{
                            valueBlock=Int(64, true), nullValue=false, valueBlock=138, bound=ABOVE
                        }, 
                        high=Marker{
                            valueBlock=Int(64, true), nullValue=true, valueBlock=true, bound=BELOW
                        }
                   }
               }
           }
       }
```

and  the following ValueSet from statement with `i_manufact_id IS NOT NULL` predicate:

```
i_manufact_id=SortedRangeSet{
            type=Int(64, true), nullAllowed=false, lowIndexedRanges={
                Marker{
                    valueBlock=Int(64, true), nullValue=true, valueBlock=true, bound=ABOVE
                }
                =Range{
                    low=Marker{
                        valueBlock=Int(64, true), nullValue=true, valueBlock=true, bound=ABOVE
                    }, 
                    high=Marker{
                        valueBlock=Int(64, true), nullValue=true, valueBlock=true, bound=BELOW
                    }
                }
           }
        }
```

evaluate to the same `Range` when called `getSpan` on and they exit at the same condition.

According to ANSI SQL standards, when assessing a predicate comparison involving a `NULL` value, it does not yield true or false outcomes and is consequently excluded from the result set. This means that if there is more than one comparison operator performed on a single column, it will automatically drop `NULL` values, so `IS NOT NULL` only needs to be pushed down if it that's the only one.

So for example, in the following statement:
`SELECT * FROM item WHERE i_manufact_id <> 138 AND i_manufact_id IS NOT NULL`
the latter part will be inherently be achieved by pushing down first part.

The change results in 'IS NOT NULL' predicate only being pushed down if there's one Range present in ValueSet.

Generated SQL After Change: 
`SELECT * FROM item WHERE ((i_manufact_id < 138) OR (i_manufact_id > 138))`


***Testing:***
Because `JdbcSplitQueryBuilder` is an abstract class and can't be initialized, I added unit tests to the `MySqlQueryStringBuilder` to verify proper behavior for generated SQL string, when predicates `!=` and `IS NOT NULL` are being used.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
