### PR TITLE
limit clause pushdown fix for certain data sources

### DIFF
--- a/athena-datalakegen2/src/main/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2QueryStringBuilder.java
+++ b/athena-datalakegen2/src/main/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2QueryStringBuilder.java
@@ -20,6 +20,7 @@
 package com.amazonaws.athena.connectors.datalakegen2;
 
 import com.amazonaws.athena.connector.lambda.domain.Split;
+import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
 import com.amazonaws.athena.connectors.jdbc.manager.FederationExpressionParser;
 import com.amazonaws.athena.connectors.jdbc.manager.JdbcSplitQueryBuilder;
 import com.google.common.base.Strings;
@@ -61,5 +62,12 @@ public class DataLakeGen2QueryStringBuilder extends JdbcSplitQueryBuilder
     {
         LOGGER.debug("Fetching data ");
         return Collections.emptyList();
+    }
+
+    //Returning empty string as DatalakeGen2 does not support LIMIT clause
+    @Override
+    protected String appendLimitOffset(Split split, Constraints constraints)
+    {
+        return emptyString;
     }
 }

--- a/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeQueryStringBuilderTest.java
+++ b/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeQueryStringBuilderTest.java
@@ -20,6 +20,7 @@
 package com.amazonaws.athena.connectors.datalakegen2;
 
 import com.amazonaws.athena.connector.lambda.domain.Split;
+import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.testng.Assert;
@@ -55,5 +56,15 @@ public class DataLakeQueryStringBuilderTest
         Mockito.when(split.getProperties()).thenReturn(Collections.singletonMap("partition", "p0"));
         Mockito.when(split.getProperty(Mockito.eq("partition"))).thenReturn("p0");
         Assert.assertEquals(new ArrayList<>(), builder.getPartitionWhereClauses(split));
+    }
+
+    @Test
+    public void testLimitClause()
+    {
+        Split split = Mockito.mock(Split.class);
+        DataLakeGen2QueryStringBuilder builder = new DataLakeGen2QueryStringBuilder(QUOTE_CHARACTER, new DataLakeGen2FederationExpressionParser(QUOTE_CHARACTER));
+        Constraints constraints = Mockito.mock(Constraints.class);
+        Mockito.when(constraints.getLimit()).thenReturn(5L);
+        org.testng.Assert.assertEquals("", builder.appendLimitOffset(split, constraints));
     }
 }

--- a/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeRecordHandlerTest.java
+++ b/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeRecordHandlerTest.java
@@ -108,6 +108,7 @@ public class DataLakeRecordHandlerTest
         Mockito.when(constraints.getSummary()).thenReturn(new ImmutableMap.Builder<String, ValueSet>()
                 .put("testCol4", valueSet)
                 .build());
+        Mockito.when(constraints.getLimit()).thenReturn(5L);
 
         String expectedSql = "SELECT \"testCol1\", \"testCol2\", \"testCol3\", \"testCol4\" FROM \"testSchema\".\"testTable\"  WHERE (\"testCol4\" = ?)";
         PreparedStatement expectedPreparedStatement = Mockito.mock(PreparedStatement.class);

--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcSplitQueryBuilder.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcSplitQueryBuilder.java
@@ -63,7 +63,7 @@ public abstract class JdbcSplitQueryBuilder
     private static final int MILLIS_SHIFT = 12;
 
     private final String quoteCharacters;
-    private final String emptyString = "";
+    protected final String emptyString = "";
 
     private final FederationExpressionParser jdbcFederationExpressionParser;
 

--- a/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleQueryStringBuilder.java
+++ b/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleQueryStringBuilder.java
@@ -20,6 +20,7 @@
 package com.amazonaws.athena.connectors.oracle;
 
 import com.amazonaws.athena.connector.lambda.domain.Split;
+import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
 import com.amazonaws.athena.connectors.jdbc.manager.FederationExpressionParser;
 import com.amazonaws.athena.connectors.jdbc.manager.JdbcSplitQueryBuilder;
 import com.google.common.base.Strings;
@@ -69,5 +70,12 @@ public class OracleQueryStringBuilder
     protected List<String> getPartitionWhereClauses(final Split split)
     {
         return Collections.emptyList();
+    }
+
+    //Returning empty string as Oracle does not support LIMIT clause
+    @Override
+    protected String appendLimitOffset(Split split, Constraints constraints)
+    {
+        return emptyString;
     }
 }

--- a/athena-oracle/src/test/java/com/amazonaws/athena/connectors/oracle/OracleRecordHandlerTest.java
+++ b/athena-oracle/src/test/java/com/amazonaws/athena/connectors/oracle/OracleRecordHandlerTest.java
@@ -133,10 +133,11 @@ public class OracleRecordHandlerTest
                 .put("testCol8", valueSet8)
                 .build());
 
+        Mockito.when(constraints.getLimit()).thenReturn(5L);
+
         String expectedSql = "SELECT \"testCol1\", \"testCol2\", \"testCol3\", \"testCol4\", \"testCol5\", \"testCol6\", \"testCol7\", \"testCol8\" FROM \"testSchema\".\"testTable\" PARTITION (p0)  WHERE (\"testCol1\" IN (?,?)) AND ((\"testCol2\" >= ? AND \"testCol2\" < ?)) AND ((\"testCol3\" > ? AND \"testCol3\" <= ?)) AND (\"testCol4\" = ?) AND (\"testCol5\" = ?) AND (\"testCol6\" = ?) AND (\"testCol7\" = ?) AND (\"testCol8\" = ?)";
         PreparedStatement expectedPreparedStatement = Mockito.mock(PreparedStatement.class);
         Mockito.when(this.connection.prepareStatement(Mockito.eq(expectedSql))).thenReturn(expectedPreparedStatement);
-
         PreparedStatement preparedStatement = this.oracleRecordHandler.buildSplitSql(this.connection, "testCatalogName", tableName, schema, constraints, split);
 
         Assert.assertEquals(expectedPreparedStatement, preparedStatement);

--- a/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerQueryStringBuilder.java
+++ b/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerQueryStringBuilder.java
@@ -20,6 +20,7 @@
 package com.amazonaws.athena.connectors.sqlserver;
 
 import com.amazonaws.athena.connector.lambda.domain.Split;
+import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
 import com.amazonaws.athena.connectors.jdbc.manager.FederationExpressionParser;
 import com.amazonaws.athena.connectors.jdbc.manager.JdbcSplitQueryBuilder;
 import com.google.common.base.Strings;
@@ -73,5 +74,11 @@ public class SqlServerQueryStringBuilder extends JdbcSplitQueryBuilder
             LOGGER.info("Fetching data without Partition");
         }
         return Collections.emptyList();
+    }
+    //Returning empty string as SQLServer does not support LIMIT clause
+    @Override
+    protected String appendLimitOffset(Split split, Constraints constraints)
+    {
+        return emptyString;
     }
 }

--- a/athena-sqlserver/src/test/java/com/amazonaws/athena/connectors/sqlserver/SqlServerQueryStringBuilderTest.java
+++ b/athena-sqlserver/src/test/java/com/amazonaws/athena/connectors/sqlserver/SqlServerQueryStringBuilderTest.java
@@ -20,6 +20,7 @@
 package com.amazonaws.athena.connectors.sqlserver;
 
 import com.amazonaws.athena.connector.lambda.domain.Split;
+import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.testng.Assert;
@@ -63,4 +64,15 @@ public class SqlServerQueryStringBuilderTest
         Assert.assertEquals(Collections.singletonList(" $PARTITION.pf(col) = 1"), builder.getPartitionWhereClauses(split1));
 
     }
+
+    @Test
+    public void testLimitClause()
+    {
+        Split split = Mockito.mock(Split.class);
+        SqlServerQueryStringBuilder builder = new SqlServerQueryStringBuilder(SQLSERVER_QUOTE_CHARACTER, new SqlServerFederationExpressionParser(SQLSERVER_QUOTE_CHARACTER));
+        Constraints constraints = Mockito.mock(Constraints.class);
+        Mockito.when(constraints.getLimit()).thenReturn(5L);
+        Assert.assertEquals("", builder.appendLimitOffset(split, constraints));
+    }
+
 }

--- a/athena-sqlserver/src/test/java/com/amazonaws/athena/connectors/sqlserver/SqlServerRecordHandlerTest.java
+++ b/athena-sqlserver/src/test/java/com/amazonaws/athena/connectors/sqlserver/SqlServerRecordHandlerTest.java
@@ -112,6 +112,7 @@ public class SqlServerRecordHandlerTest
                 .put("testCol4", valueSet)
                 .build());
 
+        Mockito.when(constraints.getLimit()).thenReturn(5L);
         String expectedSql = "SELECT \"testCol1\", \"testCol2\", \"testCol3\", \"testCol4\" FROM \"testSchema\".\"testTable\"  WHERE (\"testCol4\" = ?) AND  $PARTITION.pf(testCol1) = 1";
         PreparedStatement expectedPreparedStatement = Mockito.mock(PreparedStatement.class);
         Mockito.when(this.connection.prepareStatement(Mockito.eq(expectedSql))).thenReturn(expectedPreparedStatement);

--- a/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseQueryStringBuilder.java
+++ b/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseQueryStringBuilder.java
@@ -20,6 +20,7 @@
 package com.amazonaws.athena.connectors.synapse;
 
 import com.amazonaws.athena.connector.lambda.domain.Split;
+import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
 import com.amazonaws.athena.connectors.jdbc.manager.FederationExpressionParser;
 import com.amazonaws.athena.connectors.jdbc.manager.JdbcSplitQueryBuilder;
 import com.google.common.base.Strings;
@@ -93,5 +94,12 @@ public class SynapseQueryStringBuilder extends JdbcSplitQueryBuilder
             LOGGER.debug("Fetching data without Partition");
         }
         return Collections.emptyList();
+    }
+
+    //Returning empty string as Synapse does not support LIMIT clause
+    @Override
+    protected String appendLimitOffset(Split split, Constraints constraints)
+    {
+        return emptyString;
     }
 }

--- a/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/SynapseQueryStringBuilderTest.java
+++ b/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/SynapseQueryStringBuilderTest.java
@@ -20,6 +20,7 @@
 package com.amazonaws.athena.connectors.synapse;
 
 import com.amazonaws.athena.connector.lambda.domain.Split;
+import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.testng.Assert;
@@ -77,5 +78,15 @@ public class SynapseQueryStringBuilderTest
         Mockito.when(split4.getProperty(SynapseMetadataHandler.PARTITION_BOUNDARY_FROM)).thenReturn("");
         Mockito.when(split4.getProperty(SynapseMetadataHandler.PARTITION_BOUNDARY_TO)).thenReturn("");
         Assert.assertEquals(Collections.emptyList(), builder.getPartitionWhereClauses(split4));
+    }
+
+    @Test
+    public void testLimitClause()
+    {
+        Split split = Mockito.mock(Split.class);
+        SynapseQueryStringBuilder builder = new SynapseQueryStringBuilder(QUOTE_CHARACTER, new SynapseFederationExpressionParser(QUOTE_CHARACTER));
+        Constraints constraints = Mockito.mock(Constraints.class);
+        Mockito.when(constraints.getLimit()).thenReturn(5L);
+        org.testng.Assert.assertEquals("", builder.appendLimitOffset(split, constraints));
     }
 }

--- a/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/SynapseRecordHandlerTest.java
+++ b/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/SynapseRecordHandlerTest.java
@@ -112,6 +112,8 @@ public class SynapseRecordHandlerTest
                 .put("testCol4", valueSet)
                 .build());
 
+        Mockito.when(constraints.getLimit()).thenReturn(5L);
+
         String expectedSql = "SELECT \"testCol1\", \"testCol2\", \"testCol3\", \"testCol4\" FROM \"testSchema\".\"testTable\"  WHERE (\"testCol4\" = ?) AND id > 100000 and id <= 300000";
         PreparedStatement expectedPreparedStatement = Mockito.mock(PreparedStatement.class);
         Mockito.when(this.connection.prepareStatement(Mockito.eq(expectedSql))).thenReturn(expectedPreparedStatement);

--- a/athena-teradata/src/main/java/com/amazonaws/athena/connectors/teradata/TeradataQueryStringBuilder.java
+++ b/athena-teradata/src/main/java/com/amazonaws/athena/connectors/teradata/TeradataQueryStringBuilder.java
@@ -21,6 +21,7 @@
 package com.amazonaws.athena.connectors.teradata;
 
 import com.amazonaws.athena.connector.lambda.domain.Split;
+import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
 import com.amazonaws.athena.connectors.jdbc.manager.FederationExpressionParser;
 import com.amazonaws.athena.connectors.jdbc.manager.JdbcSplitQueryBuilder;
 import com.google.common.base.Strings;
@@ -58,5 +59,12 @@ public class TeradataQueryStringBuilder extends JdbcSplitQueryBuilder
         }
 
         return Collections.emptyList();
+    }
+
+    //Returning empty string as Teradata does not support LIMIT clause
+    @Override
+    protected String appendLimitOffset(Split split, Constraints constraints)
+    {
+        return emptyString;
     }
 }

--- a/athena-teradata/src/test/java/com/amazonaws/athena/connectors/teradata/TeradataRecordHandlerTest.java
+++ b/athena-teradata/src/test/java/com/amazonaws/athena/connectors/teradata/TeradataRecordHandlerTest.java
@@ -152,6 +152,7 @@ public class TeradataRecordHandlerTest
                 .put("testCol8", valueSet8)
                 .build());
 
+        Mockito.when(constraints.getLimit()).thenReturn(5L);
         PreparedStatement expectedPreparedStatement = Mockito.mock(PreparedStatement.class);
         Mockito.when(this.connection.prepareStatement(nullable(String.class))).thenReturn(expectedPreparedStatement);
         PreparedStatement preparedStatement = this.teradataRecordHandler.buildSplitSql(this.connection, "testCatalogName", tableName, schema, constraints, split);
@@ -168,5 +169,15 @@ public class TeradataRecordHandlerTest
         Mockito.verify(preparedStatement, Mockito.times(1)).setByte(9, (byte) 0);
         Mockito.verify(preparedStatement, Mockito.times(1)).setDouble(10, 1.2d);
         Mockito.verify(preparedStatement, Mockito.times(1)).setBoolean(11, true);
+    }
+
+    @Test
+    public void testLimitClause()
+    {
+        Split split = Mockito.mock(Split.class);
+        TeradataQueryStringBuilder builder = new TeradataQueryStringBuilder(TERADATA_QUOTE_CHARACTER, new TeradataFederationExpressionParser(TERADATA_QUOTE_CHARACTER));
+        Constraints constraints = Mockito.mock(Constraints.class);
+        Mockito.when(constraints.getLimit()).thenReturn(5L);
+        org.testng.Assert.assertEquals("", builder.appendLimitOffset(split, constraints));
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Certain data sources does not support limit clause, when for these data sources , a limit query is executed in Athena, it throws exception, as currently limit clause is pushed down.  The fix is to solve the error raised due to limit clause pushdown.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
