### PR TITLE
Added ! as valid character in Secret, due to syntax of service linked secrets

### DIFF
--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/connection/DatabaseConnectionConfigBuilder.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/connection/DatabaseConnectionConfigBuilder.java
@@ -40,7 +40,7 @@ public class DatabaseConnectionConfigBuilder
 
     private static final String CONNECTION_STRING_REGEX = "([a-zA-Z0-9]+)://(.*)";
     private static final Pattern CONNECTION_STRING_PATTERN = Pattern.compile(CONNECTION_STRING_REGEX);
-    private static final String SECRET_PATTERN_STRING = "\\$\\{([a-zA-Z0-9:/_+=.@-]+)}";
+    private static final String SECRET_PATTERN_STRING = "\\$\\{(([a-z-]+!)?[a-zA-Z0-9:/_+=.@-]+)}";
     public static final Pattern SECRET_PATTERN = Pattern.compile(SECRET_PATTERN_STRING);
 
     private Map<String, String> properties;
@@ -144,8 +144,9 @@ public class DatabaseConnectionConfigBuilder
     private Optional<String> extractSecretName(final String jdbcConnectionString)
     {
         Matcher secretMatcher = SECRET_PATTERN.matcher(jdbcConnectionString);
+        boolean isValidGroupCount = secretMatcher.groupCount() == 1 || secretMatcher.groupCount() == 2;
         String secretName = null;
-        if (secretMatcher.find() && secretMatcher.groupCount() == 1) {
+        if (secretMatcher.find() && isValidGroupCount) {
             secretName = secretMatcher.group(1);
         }
 

--- a/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/connection/DatabaseConnectionConfigBuilderTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/connection/DatabaseConnectionConfigBuilderTest.java
@@ -59,15 +59,6 @@ public class DatabaseConnectionConfigBuilderTest
     @Test(expected = RuntimeException.class)
     public void buildMultipleDatabasesFails()
     {
-        DatabaseConnectionConfig expectedDatabase1 = new DatabaseConnectionConfig("testCatalog1", "mysql",
-                "jdbc:mysql://hostname/${testSecret}", "testSecret");
-        DatabaseConnectionConfig expectedDatabase2 = new DatabaseConnectionConfig("testCatalog2", "postgres",
-                "jdbc:postgresql://hostname/user=testUser&password=testPassword");
-        DatabaseConnectionConfig expectedDatabase3 = new DatabaseConnectionConfig("testCatalog3", "redshift",
-                "jdbc:redshift://hostname:5439/dev?${arn:aws:secretsmanager:us-east-1:1234567890:secret:redshift/user/secret}", "arn:aws:secretsmanager:us-east-1:1234567890:secret:redshift/user/secret");
-        DatabaseConnectionConfig defaultConnection = new DatabaseConnectionConfig("default", "postgres",
-                "jdbc:postgresql://hostname/user=testUser&password=testPassword");
-
         List<DatabaseConnectionConfig> databaseConnectionConfigs = new DatabaseConnectionConfigBuilder()
                 .properties(ImmutableMap.of(
                         "default", CONNECTION_STRING2,
@@ -75,8 +66,6 @@ public class DatabaseConnectionConfigBuilderTest
                         "testCatalog2_connection_string", CONNECTION_STRING2,
                         "testCatalog3_connection_string", CONNECTION_STRING3))
                 .build();
-
-        Assert.assertEquals(Arrays.asList(defaultConnection, expectedDatabase1, expectedDatabase2, expectedDatabase3), databaseConnectionConfigs);
     }
 
     @Test(expected = RuntimeException.class)
@@ -95,5 +84,42 @@ public class DatabaseConnectionConfigBuilderTest
     public void buildMalformedConnectionString()
     {
         new DatabaseConnectionConfigBuilder().properties(Collections.singletonMap("testDb_connection_string", null)).build();
+    }
+
+    @Test
+    public void invalidSecretsSyntaxTest()
+    {
+        String engine = "redshift";
+        List<String> invalidConnectionStrings = Arrays.asList(
+                "redshift://jdbc:redshift://hostname:5439/dev?${inv&li$dSecret}",
+                "redshift://jdbc:redshift://hostname:5439/dev?${an*therOne))}",
+                "redshift://jdbc:redshift://hostname:5439/dev?${in^a]i?}",
+                "redshift://jdbc:redshift://hostname:5439/dev?${an*therOne))}");
+        for (String connection: invalidConnectionStrings) {
+                Assert.assertThrows(RuntimeException.class, () -> new DatabaseConnectionConfigBuilder().properties(Collections.singletonMap("testDb_connection_string", connection)).engine(engine).build());
+        }
+    }
+
+    @Test
+    public void validSecretsSyntaxTest()
+    {
+        String engine = "redshift";
+        String connectionString1 = "redshift://jdbc:redshift://hostname:5439/dev?${spec.@/Ch@rac+=r_}";
+        String connectionString2 = "redshift://jdbc:redshift://hostname:5439/dev?${rds!service-linked-secret}";
+        String connectionString3 = "redshift://jdbc:redshift://hostname:5439/dev?${redshift:credentials-secret}";
+        String connectionString4 = "redshift://jdbc:redshift://hostname:5439/dev?${opsworks-cm:credentials12}";
+        String[] secrets = new String[]{"spec.@/Ch@rac+=r_", "rds!service-linked-secret", "redshift:credentials-secret", "opsworks-cm:credentials12"};
+        List<DatabaseConnectionConfig> databaseConnectionConfigs = new DatabaseConnectionConfigBuilder()
+                .engine(engine)
+                .properties(ImmutableMap.of(
+                        "default", connectionString1,
+                        "testCatalog2_connection_string", connectionString2,
+                        "testCatalog3_connection_string", connectionString3,
+                        "testCatalog4_connection_string", connectionString4))
+                .build();
+        Assert.assertEquals(secrets.length, databaseConnectionConfigs.size());
+        for (int i = 0; i < databaseConnectionConfigs.size(); i++) {
+                Assert.assertEquals(secrets[i], databaseConnectionConfigs.get(i).getSecret());
+        }
     }
 }


### PR DESCRIPTION
*Description of changes:*
Modified regex for pattern matching secret names, because service linked secrets include the `!` character.
Added test cases as well.
[AWS Secrets Manager secrets managed by other AWS services](https://docs.aws.amazon.com/secretsmanager/latest/userguide/service-linked-secrets.html)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.