### PR TITLE
Fix case insensitive table name search bug

### DIFF
--- a/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandlerTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandlerTest.java
@@ -223,19 +223,6 @@ public class JdbcMetadataHandlerTest
     }
 
     @Test(expected = RuntimeException.class)
-    public void doGetTableCaseInsensitiveNoTablesFound()
-            throws Exception
-    {
-        TableName inputTableName = new TableName("testSchema", "testtable");
-        Object[][] values1 = {{"testSchema", "a"}, {"testSchema", "b"}};
-
-        setupMocksDoGetTableCaseInsensitive(inputTableName, values1, null);
-
-        GetTableResponse getTableResponse = this.jdbcMetadataHandler.doGetTable(this.blockAllocator,
-                new GetTableRequest(this.federatedIdentity, "testQueryId", "testCatalog", inputTableName));
-    }
-
-    @Test(expected = RuntimeException.class)
     public void doGetTableNoColumns()
             throws Exception
     {

--- a/athena-mysql/src/test/java/com/amazonaws/athena/connectors/mysql/MySqlMetadataHandlerTest.java
+++ b/athena-mysql/src/test/java/com/amazonaws/athena/connectors/mysql/MySqlMetadataHandlerTest.java
@@ -31,6 +31,8 @@ import com.amazonaws.athena.connector.lambda.metadata.GetSplitsRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetSplitsResponse;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableLayoutRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableLayoutResponse;
+import com.amazonaws.athena.connector.lambda.metadata.GetTableResponse;
+import com.amazonaws.athena.connector.lambda.metadata.GetTableRequest;
 import com.amazonaws.athena.connector.lambda.security.FederatedIdentity;
 import com.amazonaws.athena.connectors.jdbc.TestBase;
 import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionConfig;
@@ -76,6 +78,7 @@ public class MySqlMetadataHandlerTest
     private FederatedIdentity federatedIdentity;
     private AWSSecretsManager secretsManager;
     private AmazonAthena athena;
+    private BlockAllocator blockAllocator;
 
     @Before
     public void setup()
@@ -89,6 +92,7 @@ public class MySqlMetadataHandlerTest
         Mockito.when(this.secretsManager.getSecretValue(Mockito.eq(new GetSecretValueRequest().withSecretId("testSecret")))).thenReturn(new GetSecretValueResult().withSecretString("{\"username\": \"testUser\", \"password\": \"testPassword\"}"));
         this.mySqlMetadataHandler = new MySqlMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, this.jdbcConnectionFactory, com.google.common.collect.ImmutableMap.of());
         this.federatedIdentity = Mockito.mock(FederatedIdentity.class);
+        this.blockAllocator = Mockito.mock(BlockAllocator.class);
     }
 
     @Test
@@ -273,5 +277,34 @@ public class MySqlMetadataHandlerTest
         Assert.assertEquals(expectedSplits.size(), getSplitsResponse.getSplits().size());
         Set<Map<String, String>> actualSplits = getSplitsResponse.getSplits().stream().map(Split::getProperties).collect(Collectors.toSet());
         Assert.assertEquals(expectedSplits, actualSplits);
+    }
+
+    @org.testng.annotations.Test(expectedExceptions = {RuntimeException.class}, expectedExceptionsMessageRegExp = "More than one table that matches 'testtable' was returned from Database testSchema")
+    public void doGetTableCaseInsensitiveDuplicateTableNames()
+            throws Exception
+    {
+        TableName inputTableName = new TableName("testSchema", "testtable");
+        String[] columnNames = new String[] {"table_name"};
+        String[][] tableNameValues = new String[][]{new String[] {"testTable"}, new String[] {"TestTable"}};
+        ResultSet resultSetName = mockResultSet(columnNames, tableNameValues, new AtomicInteger(-1));
+        String sql = "SELECT table_name, lower(table_name) FROM information_schema.tables WHERE (table_name = 'testtable' or lower(table_name) = 'testtable') AND table_schema = 'testSchema'";
+        Mockito.when(this.connection.prepareStatement(sql).executeQuery()).thenReturn(resultSetName);
+
+        GetTableResponse getTableResponse = this.mySqlMetadataHandler.doGetTable(this.blockAllocator,
+                new GetTableRequest(this.federatedIdentity, "testQueryId", "testCatalog", inputTableName));
+    }
+
+    @org.testng.annotations.Test(expectedExceptions = {RuntimeException.class}, expectedExceptionsMessageRegExp = "During Case Insensitive look up could not find Table testtable in Database testSchema")
+    public void doGetTableCaseInsensitiveNoTablesFound()
+            throws Exception
+    {
+        TableName inputTableName = new TableName("testSchema", "testtable");
+        ResultSet resultSetName = Mockito.mock(ResultSet.class, Mockito.RETURNS_DEEP_STUBS);
+        Mockito.when(resultSetName.next()).thenReturn(false);
+        String sql = "SELECT table_name, lower(table_name) FROM information_schema.tables WHERE (table_name = 'testtable' or lower(table_name) = 'testtable') AND table_schema = 'testSchema'";
+        Mockito.when(this.connection.prepareStatement(sql).executeQuery()).thenReturn(resultSetName);
+
+        GetTableResponse getTableResponse = this.mySqlMetadataHandler.doGetTable(this.blockAllocator,
+                new GetTableRequest(this.federatedIdentity, "testQueryId", "testCatalog", inputTableName));
     }
 }

--- a/athena-redshift/src/test/java/com/amazonaws/athena/connectors/redshift/RedshiftMetadataHandlerTest.java
+++ b/athena-redshift/src/test/java/com/amazonaws/athena/connectors/redshift/RedshiftMetadataHandlerTest.java
@@ -330,13 +330,14 @@ public class RedshiftMetadataHandlerTest
                 .forEach(expectedSchemaBuilder::addField);
         Schema expected = expectedSchemaBuilder.build();
 
-        TableName inputTableName = new TableName("testSchema", "testTable");
+        TableName inputTableName = new TableName("testSchema", "testtable");
         String[] columnNames = new String[] {"table_name"};
         String[][] tableNameValues = new String[][]{new String[] {"testTable"}};
         ResultSet resultSetName = mockResultSet(columnNames, tableNameValues, new AtomicInteger(-1));
-        String sql = "SELECT table_name, lower(table_name) FROM information_schema.tables WHERE table_name = 'testTable' or lower(table_name) = 'testTable' LIMIT 1";
+        String sql = "SELECT table_name, lower(table_name) FROM information_schema.tables WHERE (table_name = 'testtable' or lower(table_name) = 'testtable') AND table_schema = 'testSchema'";
         Mockito.when(this.connection.prepareStatement(sql).executeQuery()).thenReturn(resultSetName);
-        Mockito.when(connection.getMetaData().getColumns("testCatalog", inputTableName.getSchemaName(), inputTableName.getTableName(), null)).thenReturn(resultSet);
+        String resolvedTableName = "testTable";
+        Mockito.when(connection.getMetaData().getColumns("testCatalog", inputTableName.getSchemaName(), resolvedTableName, null)).thenReturn(resultSet);
         Mockito.when(connection.getCatalog()).thenReturn("testCatalog");
 
         GetTableResponse getTableResponse = this.redshiftMetadataHandler.doGetTable(new BlockAllocatorImpl(),
@@ -344,8 +345,9 @@ public class RedshiftMetadataHandlerTest
 
         logger.info("Schema: {}", getTableResponse.getSchema());
 
+        TableName expectedTableName = new TableName("testSchema", "testTable");
         Assert.assertEquals(expected, getTableResponse.getSchema());
-        Assert.assertEquals(inputTableName, getTableResponse.getTableName());
+        Assert.assertEquals(expectedTableName, getTableResponse.getTableName());
         Assert.assertEquals("testCatalog", getTableResponse.getCatalogName());
 
         logger.info("doGetTableWithArrayColumns - exit");


### PR DESCRIPTION
*Description of changes:*
When performing case insensitive table name look up for JDBC data sources it is now done on the specific database, while also checking for duplicate table names.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
