### PR TITLE
Revert "build(deps): bump aws-cdk-lib from 2.63.2 to 2.80.0 in /validation_testing/cdk_federation_infra_provisioning/app"

### DIFF
--- a/validation_testing/cdk_federation_infra_provisioning/app/package.json
+++ b/validation_testing/cdk_federation_infra_provisioning/app/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@aws-cdk/aws-glue-alpha": "2.63.2-alpha.0",
     "@aws-cdk/aws-redshift-alpha": "2.63.2-alpha.0",
-    "aws-cdk-lib": "2.80.0",
+    "aws-cdk-lib": "2.63.2",
     "dotenv": "^16.0.3",
     "source-map-support": "^0.5.21",
     "typescript": "4.9.5"


### PR DESCRIPTION
Reverts awslabs/aws-athena-query-federation#1424