### PR TITLE
Modified JDBC connectors to fetch metadata from underlying system tables.

### DIFF
--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandler.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandler.java
@@ -168,13 +168,13 @@ public abstract class JdbcMetadataHandler
         }
     }
 
-    private List<TableName> listTables(final Connection jdbcConnection, final String databaseName)
+    protected List<TableName> listTables(final Connection jdbcConnection, final String databaseName)
             throws SQLException
     {
         try (ResultSet resultSet = getTables(jdbcConnection, databaseName)) {
             ImmutableList.Builder<TableName> list = ImmutableList.builder();
             while (resultSet.next()) {
-                list.add(getSchemaTableName(resultSet));
+                list.add(JDBCUtil.getSchemaTableName(resultSet));
             }
             return list.build();
         }
@@ -190,14 +190,6 @@ public abstract class JdbcMetadataHandler
                 escapeNamePattern(schemaName, escape),
                 null,
                 new String[] {"TABLE", "VIEW", "EXTERNAL TABLE", "MATERIALIZED VIEW"});
-    }
-
-    private TableName getSchemaTableName(final ResultSet resultSet)
-            throws SQLException
-    {
-        return new TableName(
-                resultSet.getString("TABLE_SCHEM"),
-                resultSet.getString("TABLE_NAME"));
     }
 
     protected String escapeNamePattern(final String name, final String escape)

--- a/athena-mysql/src/main/java/com/amazonaws/athena/connectors/mysql/MySqlMetadataHandler.java
+++ b/athena-mysql/src/main/java/com/amazonaws/athena/connectors/mysql/MySqlMetadataHandler.java
@@ -57,6 +57,7 @@ import org.slf4j.LoggerFactory;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -212,6 +213,14 @@ public class MySqlMetadataHandler
         }
 
         return new GetSplitsResponse(getSplitsRequest.getCatalogName(), splits, null);
+    }
+
+    @Override
+    protected List<TableName> listTables(final Connection jdbcConnection, final String databaseName)
+            throws SQLException
+    {
+        // Gets list of Tables and Views using Information Schema.tables
+        return JDBCUtil.getTables(jdbcConnection, databaseName);
     }
 
     @Override

--- a/athena-mysql/src/test/java/com/amazonaws/athena/connectors/mysql/MySqlMetadataHandlerTest.java
+++ b/athena-mysql/src/test/java/com/amazonaws/athena/connectors/mysql/MySqlMetadataHandlerTest.java
@@ -287,7 +287,7 @@ public class MySqlMetadataHandlerTest
         String[] columnNames = new String[] {"table_name"};
         String[][] tableNameValues = new String[][]{new String[] {"testTable"}, new String[] {"TestTable"}};
         ResultSet resultSetName = mockResultSet(columnNames, tableNameValues, new AtomicInteger(-1));
-        String sql = "SELECT table_name, lower(table_name) FROM information_schema.tables WHERE (table_name = 'testtable' or lower(table_name) = 'testtable') AND table_schema = 'testSchema'";
+        String sql = "SELECT table_name FROM information_schema.tables WHERE (table_name = 'testtable' or lower(table_name) = 'testtable') AND table_schema = 'testSchema'";
         Mockito.when(this.connection.prepareStatement(sql).executeQuery()).thenReturn(resultSetName);
 
         GetTableResponse getTableResponse = this.mySqlMetadataHandler.doGetTable(this.blockAllocator,
@@ -301,7 +301,7 @@ public class MySqlMetadataHandlerTest
         TableName inputTableName = new TableName("testSchema", "testtable");
         ResultSet resultSetName = Mockito.mock(ResultSet.class, Mockito.RETURNS_DEEP_STUBS);
         Mockito.when(resultSetName.next()).thenReturn(false);
-        String sql = "SELECT table_name, lower(table_name) FROM information_schema.tables WHERE (table_name = 'testtable' or lower(table_name) = 'testtable') AND table_schema = 'testSchema'";
+        String sql = "SELECT table_name FROM information_schema.tables WHERE (table_name = 'testtable' or lower(table_name) = 'testtable') AND table_schema = 'testSchema'";
         Mockito.when(this.connection.prepareStatement(sql).executeQuery()).thenReturn(resultSetName);
 
         GetTableResponse getTableResponse = this.mySqlMetadataHandler.doGetTable(this.blockAllocator,

--- a/athena-redshift/src/test/java/com/amazonaws/athena/connectors/redshift/RedshiftMetadataHandlerTest.java
+++ b/athena-redshift/src/test/java/com/amazonaws/athena/connectors/redshift/RedshiftMetadataHandlerTest.java
@@ -334,8 +334,12 @@ public class RedshiftMetadataHandlerTest
         String[] columnNames = new String[] {"table_name"};
         String[][] tableNameValues = new String[][]{new String[] {"testTable"}};
         ResultSet resultSetName = mockResultSet(columnNames, tableNameValues, new AtomicInteger(-1));
-        String sql = "SELECT table_name, lower(table_name) FROM information_schema.tables WHERE (table_name = 'testtable' or lower(table_name) = 'testtable') AND table_schema = 'testSchema'";
-        Mockito.when(this.connection.prepareStatement(sql).executeQuery()).thenReturn(resultSetName);
+        String sql = "SELECT table_name FROM information_schema.tables WHERE (table_name = ? or lower(table_name) = ?) AND table_schema = ?";
+        PreparedStatement preparedStatement = this.connection.prepareStatement(sql);
+        preparedStatement.setString(1, "testtable");
+        preparedStatement.setString(2, "testtable");
+        preparedStatement.setString(3, "testSchema");
+        Mockito.when(preparedStatement.executeQuery()).thenReturn(resultSetName);
         String resolvedTableName = "testTable";
         Mockito.when(connection.getMetaData().getColumns("testCatalog", inputTableName.getSchemaName(), resolvedTableName, null)).thenReturn(resultSet);
         Mockito.when(connection.getCatalog()).thenReturn("testCatalog");


### PR DESCRIPTION
Modified select JDBC connectors to fetch tables, views and materialized views from internal, system tables of underlying data source, to respect user access privileges.

*Issue #, if available:*
#1464
#1462
#1450 

*Description of changes:*
Metadata returned from JDBC driver cannot be hidden, therefore, user can still see the structure, despite not being able to access if not granted permission. Therefore, all tables were being populated and not just the ones the user had permissions to. Therefore, this change involves looking up metadata from internal system tables instead, respecting user access privileges.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
