### PR TITLE
Excluding large Mac/Windows Statically compiled files

### DIFF
--- a/athena-gcs/assembly.xml
+++ b/athena-gcs/assembly.xml
@@ -19,12 +19,21 @@
         </fileSet>
     </fileSets>
     <dependencySets>
-        <!-- Include all dependencies in the lib/ directory -->
         <dependencySet>
-            <outputDirectory>lib</outputDirectory>
-            <excludes>
-                <exclude>${project.groupId}:${project.artifactId}:jar:*</exclude>
-            </excludes>
-        </dependencySet>
+            <outputDirectory>/</outputDirectory>
+            <useProjectArtifact>false</useProjectArtifact>
+            <unpack>true</unpack>
+            <scope>runtime</scope>
+            <unpackOptions>
+                <excludes>
+                    <exclude>**/*.dylib</exclude>
+                    <exclude>**/*.dll</exclude>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                    <exclude>**/Log4j2Plugins.dat</exclude>
+                </excludes>
+            </unpackOptions>
+        </dependencySet> 
     </dependencySets>
 </assembly>


### PR DESCRIPTION
*Description of changes:*
After updating to Arrow 13, the athena-gcs JAR failed to publish due to increase in size. This change adds filter to exclude certain files during compilation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
