### PR TITLE
DocDB skip collections that user has no permission

### DIFF
--- a/athena-docdb/src/main/java/com/amazonaws/athena/connectors/docdb/SchemaUtils.java
+++ b/athena-docdb/src/main/java/com/amazonaws/athena/connectors/docdb/SchemaUtils.java
@@ -111,6 +111,7 @@ public class SchemaUtils
             }
 
             Schema schema = schemaBuilder.build();
+            logger.warn("inferSchema, schema: " + docCount);
             if (schema.getFields().isEmpty()) {
                 throw new RuntimeException("No columns found after scanning " + fieldCount + " values across " +
                         docCount + " documents. Please ensure the collection is not empty and contains at least 1 supported column type.");

--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandler.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandler.java
@@ -188,7 +188,7 @@ public abstract class JdbcMetadataHandler
                 connection.getCatalog(),
                 escapeNamePattern(schemaName, escape),
                 null,
-                new String[] {"TABLE", "VIEW", "EXTERNAL TABLE"});
+                new String[] {"TABLE", "VIEW", "EXTERNAL TABLE", "MATERIALIZED VIEW"});
     }
 
     private TableName getSchemaTableName(final ResultSet resultSet)

--- a/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandlerTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandlerTest.java
@@ -138,7 +138,7 @@ public class JdbcMetadataHandlerTest
         AtomicInteger rowNumber = new AtomicInteger(-1);
         ResultSet resultSet = mockResultSet(schema, values, rowNumber);
 
-        Mockito.when(connection.getMetaData().getTables("testCatalog", "testSchema", null, new String[] {"TABLE", "VIEW", "EXTERNAL TABLE"})).thenReturn(resultSet);
+        Mockito.when(connection.getMetaData().getTables("testCatalog", "testSchema", null, new String[] {"TABLE", "VIEW", "EXTERNAL TABLE", "MATERIALIZED VIEW"})).thenReturn(resultSet);
         ListTablesResponse listTablesResponse = this.jdbcMetadataHandler.doListTables(
                 this.blockAllocator, new ListTablesRequest(this.federatedIdentity, "testQueryId",
                         "testCatalog", "testSchema", null, UNLIMITED_PAGE_SIZE_VALUE));
@@ -154,7 +154,7 @@ public class JdbcMetadataHandlerTest
         TableName[] expected = {new TableName("test_Schema", "testTable"), new TableName("test_Schema", "testtable2")};
         AtomicInteger rowNumber = new AtomicInteger(-1);
         ResultSet resultSet = mockResultSet(schema, values, rowNumber);
-        Mockito.when(connection.getMetaData().getTables("testCatalog", "test\\_Schema", null, new String[] {"TABLE", "VIEW", "EXTERNAL TABLE"})).thenReturn(resultSet);
+        Mockito.when(connection.getMetaData().getTables("testCatalog", "test\\_Schema", null, new String[] {"TABLE", "VIEW", "EXTERNAL TABLE", "MATERIALIZED VIEW"})).thenReturn(resultSet);
         Mockito.when(connection.getMetaData().getSearchStringEscape()).thenReturn("\\");
         ListTablesResponse listTablesResponse = this.jdbcMetadataHandler.doListTables(
                 this.blockAllocator, new ListTablesRequest(this.federatedIdentity, "testQueryId",


### PR DESCRIPTION
DocDB skip collections that user has no permission to access by using mongoDB command

*Issue #, if available:*
https://github.com/awslabs/aws-athena-query-federation/issues/506
*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
