### PR TITLE
Fixing weak pseudorandom number generation

### DIFF
--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/security/LocalKeyFactory.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/security/LocalKeyFactory.java
@@ -24,11 +24,6 @@ import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
 
 import java.security.SecureRandom;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 /**
  * An EncryptionKeyFactory that is backed by a local source of randomness.
@@ -38,36 +33,19 @@ import java.util.concurrent.TimeoutException;
 public class LocalKeyFactory
         implements EncryptionKeyFactory
 {
-    private static ExecutorService es = Executors.newSingleThreadExecutor();
-
     public EncryptionKey create()
     {
-        // Try to generate the key in a separate thread
-        Future<EncryptionKey> future = es.submit(() -> {
-            SecureRandom random = SecureRandom.getInstanceStrong();
+        try {
+            SecureRandom random = new SecureRandom();
             KeyGenerator keyGen = KeyGenerator.getInstance(AesGcmBlockCrypto.KEYSPEC);
             keyGen.init(AesGcmBlockCrypto.KEY_BYTES * 8, random);
             SecretKey key = keyGen.generateKey();
             final byte[] nonce = new byte[AesGcmBlockCrypto.NONCE_BYTES];
             random.nextBytes(nonce);
             return new EncryptionKey(key.getEncoded(), nonce);
-        });
-
-        // Now wait at most 1 second for it to finish.
-        // If it doesn't finish within a second, its blocked on /dev/random, so we'll
-        // cancel the future and interrupt the thread.
-        try {
-            return future.get(1000, TimeUnit.MILLISECONDS);
-        }
-        catch (TimeoutException ex) {
-            throw new RuntimeException("Attempt to generate key took too long. There may be an issue where your platform does not have enough entropy in /dev/random. Consider using KmsKeyFactory instead", ex);
         }
         catch (Exception ex) {
-            // Rethrow unchecked because the underlying interface doesn't declare any throws
             throw new RuntimeException(ex);
-        }
-        finally {
-            future.cancel(true);
         }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
#1489

*Description of changes:*
Addresses high severity security finding from AWS Inspector, by replacing all use cases of `getInstanceStrong` to instantiate a [java.security.SecureRandom](https://docs.oracle.com/javase/8/docs/api/java/security/SecureRandom.html) object, with `new SecureRandom()`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
