### PR TITLE
Add case insensitive schema functionality

### DIFF
--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JDBCUtil.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JDBCUtil.java
@@ -29,6 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -142,8 +143,21 @@ public final class JDBCUtil
     public static TableName informationSchemaCaseInsensitiveTableMatch(Connection connection, final String databaseName,
                                                      final String tableName) throws Exception
     {
+        // Gets case insensitive schema name
+        String resolvedSchemaName = null;
+        PreparedStatement statement = getSchemaNameQuery(connection, databaseName);
+        try (ResultSet resultSet = statement.executeQuery()) {
+            if (resultSet.next()) {
+                resolvedSchemaName = resultSet.getString("schema_name");
+            }
+            else {
+                throw new RuntimeException(String.format("During SCHEMA Case Insensitive look up could not find Database '%s'", databaseName));
+            }
+        }
+
+        // passes actual cased schema name to query for tableName
         String resolvedName = null;
-        PreparedStatement statement = getTableNameQuery(connection, tableName, databaseName);
+        statement = getTableNameQuery(connection, tableName, resolvedSchemaName);
         try (ResultSet resultSet = statement.executeQuery()) {
             if (resultSet.next()) {
                 resolvedName = resultSet.getString("table_name");
@@ -153,10 +167,11 @@ public final class JDBCUtil
                 LOGGER.info("Resolved name from Case Insensitive look up : {}", resolvedName);
             }
             else {
-                throw new RuntimeException(String.format("During Case Insensitive look up could not find Table '%s' in Database '%s'", tableName, databaseName));
+                throw new RuntimeException(String.format("During TABLE Case Insensitive look up could not find Table '%s' in Database '%s'", tableName, databaseName));
             }
         }
-        return new TableName(databaseName, resolvedName);
+
+        return new TableName(resolvedSchemaName, resolvedName);
     }
 
     public static PreparedStatement getTableNameQuery(Connection connection, String tableName, String databaseName) throws SQLException
@@ -167,6 +182,15 @@ public final class JDBCUtil
         preparedStatement.setString(2, tableName);
         preparedStatement.setString(3, databaseName);
         LOGGER.debug("Prepared Statement for getting table name with Case Insensitive Look Up in schema {} : {}", databaseName, preparedStatement);
+        return preparedStatement;
+    }
+
+    public static PreparedStatement getSchemaNameQuery(Connection connection, String databaseName) throws SQLException
+    {
+        String sql = "SELECT schema_name FROM information_schema.schemata WHERE (schema_name = ? or lower(schema_name) = ?)";
+        PreparedStatement preparedStatement = connection.prepareStatement(sql);
+        preparedStatement.setString(1, databaseName);
+        preparedStatement.setString(2, databaseName);
         return preparedStatement;
     }
 

--- a/athena-redshift/src/test/java/com/amazonaws/athena/connectors/redshift/RedshiftMetadataHandlerTest.java
+++ b/athena-redshift/src/test/java/com/amazonaws/athena/connectors/redshift/RedshiftMetadataHandlerTest.java
@@ -330,11 +330,23 @@ public class RedshiftMetadataHandlerTest
                 .forEach(expectedSchemaBuilder::addField);
         Schema expected = expectedSchemaBuilder.build();
 
+        ResultSet caseInsensitiveSchemaResult = Mockito.mock(ResultSet.class);
+        String sql = "SELECT nspname FROM pg_namespace WHERE (nspname = ? or lower(nspname) = ?)";
+        PreparedStatement preparedSchemaStatement = connection.prepareStatement(sql);
+        preparedSchemaStatement.setString(1, "testschema");
+        preparedSchemaStatement.setString(2, "testschema");
+
+        String[] columnNames = new String[] {"nspname"};
+        String[][] tableNameValues = new String[][]{new String[] {"testSchema"}};
+        caseInsensitiveSchemaResult = mockResultSet(columnNames, tableNameValues, new AtomicInteger(-1));
+
+        Mockito.when(preparedSchemaStatement.executeQuery()).thenReturn(caseInsensitiveSchemaResult);
+
         TableName inputTableName = new TableName("testSchema", "testtable");
-        String[] columnNames = new String[] {"table_name"};
-        String[][] tableNameValues = new String[][]{new String[] {"testTable"}};
+        columnNames = new String[] {"table_name"};
+        tableNameValues = new String[][]{new String[] {"testTable"}};
         ResultSet resultSetName = mockResultSet(columnNames, tableNameValues, new AtomicInteger(-1));
-        String sql = "SELECT table_name FROM information_schema.tables WHERE (table_name = ? or lower(table_name) = ?) AND table_schema = ?";
+        sql = "SELECT table_name FROM information_schema.tables WHERE (table_name = ? or lower(table_name) = ?) AND table_schema = ?";
         PreparedStatement preparedStatement = this.connection.prepareStatement(sql);
         preparedStatement.setString(1, "testtable");
         preparedStatement.setString(2, "testtable");

--- a/validation_testing/cdk_federation_infra_provisioning/app/glue_scripts/mysql_create_case_insensitive_data.py
+++ b/validation_testing/cdk_federation_infra_provisioning/app/glue_scripts/mysql_create_case_insensitive_data.py
@@ -1,0 +1,27 @@
+import sys
+import pymysql
+import pymysql.cursors
+from awsglue.utils import getResolvedOptions
+
+args = getResolvedOptions(sys.argv,
+                          ['db_url',
+                           'username',
+                           'password'])
+
+connection = pymysql.connect(host=args['db_url'], user=args['username'], password=args['password'])
+cursor = connection.cursor()
+
+cursor.execute('CREATE DATABASE camelCaseTest')
+cursor.execute('USE camelCaseTest')
+cursor.execute('CREATE TABLE camelCase (ID int)')
+cursor.execute('INSERT INTO camelCase VALUES (5)')
+cursor.execute('CREATE TABLE UPPERCASE (ID int)')
+cursor.execute('INSERT INTO UPPERCASE VALUES (7)')
+
+cursor.execute('CREATE DATABASE UPPERCASETEST')
+cursor.execute('USE UPPERCASETEST')
+cursor.execute('CREATE TABLE camelCase (ID int)')
+cursor.execute('INSERT INTO camelCase VALUES (4)')
+cursor.execute('CREATE TABLE UPPERCASE (ID int)')
+cursor.execute('INSERT INTO UPPERCASE VALUES (6)')
+

--- a/validation_testing/cdk_federation_infra_provisioning/app/glue_scripts/postgresql_create_case_insensitive_data.py
+++ b/validation_testing/cdk_federation_infra_provisioning/app/glue_scripts/postgresql_create_case_insensitive_data.py
@@ -1,0 +1,24 @@
+import sys
+from awsglue.utils import getResolvedOptions
+import pg
+
+args = getResolvedOptions(sys.argv,
+                          ['db_url',
+                           'username',
+                           'password'])
+
+connection = pg.DB( host=args['db_url'], user=args['username'], passwd=args['password'], dbname='test')
+
+connection.query('CREATE SCHEMA "camelCaseTest"')
+connection.query('CREATE TABLE "camelCaseTest"."camelCase" (ID int)')
+connection.query('INSERT INTO "camelCaseTest"."camelCase" VALUES (5)')
+connection.query('CREATE TABLE "camelCaseTest"."UPPERCASE" (ID int)')
+connection.query('INSERT INTO "camelCaseTest"."UPPERCASE" VALUES (7)')
+
+connection.query('CREATE SCHEMA "UPPERCASETEST"')
+connection.query('CREATE TABLE "UPPERCASETEST"."camelCase" (ID int)')
+connection.query('INSERT INTO "UPPERCASETEST"."camelCase" VALUES (4)')
+connection.query('CREATE TABLE "UPPERCASETEST"."UPPERCASE" (ID int)')
+connection.query('INSERT INTO "UPPERCASETEST"."UPPERCASE" VALUES (6)')
+
+connection.query('CREATE MATERIALIZED VIEW "UPPERCASETEST"."camelCaseView" AS SELECT * FROM "camelCaseTest"."camelCase"')

--- a/validation_testing/cdk_federation_infra_provisioning/app/glue_scripts/redshift.py
+++ b/validation_testing/cdk_federation_infra_provisioning/app/glue_scripts/redshift.py
@@ -25,7 +25,7 @@ def process_single_table(table_name):
     connection_type='redshift',
     connection_options={
         'url': args['db_url'],
-        'dbtable': table_name,
+        'dbtable': "public."+table_name,
         'user': args['username'],
         'password': args['password'],
         'redshiftTmpDir': args['redshiftTmpDir']

--- a/validation_testing/cdk_federation_infra_provisioning/app/glue_scripts/redshift_create_case_insensitive_data.py
+++ b/validation_testing/cdk_federation_infra_provisioning/app/glue_scripts/redshift_create_case_insensitive_data.py
@@ -1,0 +1,33 @@
+import sys
+from awsglue.utils import getResolvedOptions
+import redshift_connector
+
+args = getResolvedOptions(sys.argv,
+                          ['db_url',
+                           'username',
+                           'password'])
+
+connection = redshift_connector.connect(
+    host=args['db_url'],
+    database='test',
+    user=args['username'],
+    password=args['password']
+)
+
+cursor = connection.cursor()
+
+cursor.execute('CREATE SCHEMA "camelCaseTest"')
+cursor.execute('CREATE TABLE "camelCaseTest"."camelCase" (ID int)')
+cursor.execute('INSERT INTO "camelCaseTest"."camelCase" VALUES (5)')
+cursor.execute('CREATE TABLE "camelCaseTest"."UPPERCASE" (ID int)')
+cursor.execute('INSERT INTO "camelCaseTest"."UPPERCASE" VALUES (7)')
+
+cursor.execute('CREATE SCHEMA "UPPERCASETEST"')
+cursor.execute('CREATE TABLE "UPPERCASETEST"."camelCase" (ID int)')
+cursor.execute('INSERT INTO "UPPERCASETEST"."camelCase" VALUES (4)')
+cursor.execute('CREATE TABLE "UPPERCASETEST"."UPPERCASE" (ID int)')
+cursor.execute('INSERT INTO "UPPERCASETEST"."UPPERCASE" VALUES (6)')
+
+cursor.execute('CREATE MATERIALIZED VIEW "UPPERCASETEST"."camelCaseView" AS SELECT * FROM "camelCaseTest"."camelCase"')
+
+cursor.execute('COMMIT')

--- a/validation_testing/cdk_federation_infra_provisioning/app/lib/stacks/rds-generic-stack.ts
+++ b/validation_testing/cdk_federation_infra_provisioning/app/lib/stacks/rds-generic-stack.ts
@@ -119,6 +119,24 @@ export class RdsGenericStack extends cdk.Stack {
         }
       });
     }
+
+    const glueJob = new glue.Job(this, `${db_type}_glue_job_create_case_insensitive_data`, {
+      executable: glue.JobExecutable.pythonShell({
+        glueVersion: glue.GlueVersion.V1_0,
+        pythonVersion: (db_type == 'mysql') ? glue.PythonVersion.THREE_NINE : glue.PythonVersion.THREE,
+        script: glue.Code.fromAsset(path.join(__dirname, `../../../glue_scripts/${db_type}_create_case_insensitive_data.py`))
+      }),
+      role: glue_role,
+      connections: [
+          glueConnection
+      ],
+      defaultArguments: {
+        '--db_url': cluster.clusterEndpoint.hostname,
+        '--username': 'athena',
+        '--password': password
+      }
+    });
+
     const cfn_template_file = connector_yaml_path;
     var connectionStringPrefix = '';
     if (db_type == 'mysql') connectionStringPrefix = 'mysql';


### PR DESCRIPTION
Add MySQL, PostgreSQL, and Redshift case insensitive schema functionality and requirements for validation testing.

*Issue #, if available:*

*Description of changes:*
Allow users to query MySQL, PostgreSQL, and Redshift tables with mixed cases. Also, added tests under validation_testing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
