### PR TITLE
chore: change group to specific labels to avoid workflow_job webhook …

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,8 +24,7 @@ jobs:
   CodeQL-Build:
     needs: pre_job
     if: needs.pre_job.outputs.should_skip != 'true'
-    runs-on:
-      group: aws-athena-query-federation
+    runs-on: aws-athena-query-federation_ubuntu-latest_8-core
     permissions:
       security-events: write
     steps:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,7 +24,7 @@ jobs:
   CodeQL-Build:
     needs: pre_job
     if: needs.pre_job.outputs.should_skip != 'true'
-    runs-on: aws-athena-query-federation_ubuntu-latest_8-core
+    runs-on: aws-athena-query-federation_ubuntu-latest_16-core
     permissions:
       security-events: write
     steps:

--- a/.github/workflows/cut_release.yml
+++ b/.github/workflows/cut_release.yml
@@ -6,8 +6,7 @@ on:
 jobs:
   cut_release:
     name: Cut a release
-    runs-on:
-      group: aws-athena-query-federation
+    runs-on: aws-athena-query-federation_ubuntu-latest_8-core
     steps:
       - name: Setup dependencies
         run: |

--- a/.github/workflows/cut_release.yml
+++ b/.github/workflows/cut_release.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   cut_release:
     name: Cut a release
-    runs-on: aws-athena-query-federation_ubuntu-latest_8-core
+    runs-on: aws-athena-query-federation_ubuntu-latest_16-core
     steps:
       - name: Setup dependencies
         run: |

--- a/.github/workflows/javadoc_sync.yaml
+++ b/.github/workflows/javadoc_sync.yaml
@@ -5,7 +5,7 @@ on:
       - master
 jobs:
   build-and-deploy:
-    runs-on: aws-athena-query-federation_ubuntu-latest_8-core
+    runs-on: aws-athena-query-federation_ubuntu-latest_16-core
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/javadoc_sync.yaml
+++ b/.github/workflows/javadoc_sync.yaml
@@ -5,8 +5,7 @@ on:
       - master
 jobs:
   build-and-deploy:
-    runs-on:
-      group: aws-athena-query-federation
+    runs-on: aws-athena-query-federation_ubuntu-latest_8-core
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/maven_push.yml
+++ b/.github/workflows/maven_push.yml
@@ -18,7 +18,7 @@ jobs:
   build:
     needs: pre_job
     if: needs.pre_job.outputs.should_skip != 'true'
-    runs-on: aws-athena-query-federation_ubuntu-latest_8-core
+    runs-on: aws-athena-query-federation_ubuntu-latest_16-core
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 11

--- a/.github/workflows/maven_push.yml
+++ b/.github/workflows/maven_push.yml
@@ -18,8 +18,7 @@ jobs:
   build:
     needs: pre_job
     if: needs.pre_job.outputs.should_skip != 'true'
-    runs-on:
-      group: aws-athena-query-federation
+    runs-on: aws-athena-query-federation_ubuntu-latest_8-core
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 11


### PR DESCRIPTION
…request missing label data.

*Description of changes:*

The `runs-on` is currently using a `group` value, bouncing between 8-core and 16-core large runner.
Specify 8 core runner to clean up the runner config and avoid `workflow_job.completed` missing label data.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
