### PR TITLE
Fix ddb join issue with partition and sort key

### DIFF
--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBRecordHandler.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBRecordHandler.java
@@ -265,6 +265,7 @@ public class DynamoDBRecordHandler
                 })
                 .collect(Collectors.joining(","));
 
+        logger.info("SPLIT SEGMENT ID PROPERTY: " + split.getProperty(SEGMENT_ID_PROPERTY));
         boolean isQuery = split.getProperty(SEGMENT_ID_PROPERTY) == null;
 
         if (isQuery) {


### PR DESCRIPTION
when dynamodb tables are joined with sort key but have a partition key in where clause, the connector treats the request as QueryRequest instead of a ScanRequest

*Issue #, if available:*

*Description of changes:*
Check if rangeKey is being used in the request. If it is, then hashKeyValues is empty

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
