### PR TITLE
Remove direct dependency of Netty

### DIFF
--- a/athena-federation-sdk/pom.xml
+++ b/athena-federation-sdk/pom.xml
@@ -192,26 +192,6 @@
             <groupId>org.apache.arrow</groupId>
             <artifactId>arrow-memory-netty</artifactId>
             <version>${apache.arrow.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-buffer</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-common</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-buffer</artifactId>
-            <version>${netty.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-common</artifactId>
-            <version>${netty.version}</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>

--- a/athena-hbase/pom.xml
+++ b/athena-hbase/pom.xml
@@ -78,11 +78,6 @@
             <version>1.5.4</version>
         </dependency>
         <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-transport</artifactId>
-            <version>${netty.version}</version>
-        </dependency>
-        <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
             <version>${protobuf3.version}</version>
@@ -166,10 +161,6 @@
                 <exclusion>
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-transport</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>com.google.protobuf</groupId>

--- a/athena-vertica/src/main/java/com/amazonaws/athena/connectors/vertica/VerticaMetadataHandler.java
+++ b/athena-vertica/src/main/java/com/amazonaws/athena/connectors/vertica/VerticaMetadataHandler.java
@@ -41,7 +41,7 @@ import com.amazonaws.services.s3.model.ListObjectsRequest;
 import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.amazonaws.services.secretsmanager.AWSSecretsManager;
-import io.netty.util.internal.StringUtil;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.arrow.util.VisibleForTesting;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.types.pojo.ArrowType;
@@ -71,7 +71,7 @@ public class VerticaMetadataHandler
     private static  final String TABLE_SCHEMA = "TABLE_SCHEM";
     private static final String[] TABLE_TYPES = {"TABLE"};
     private static final String EXPORT_BUCKET_KEY = "export_bucket";
-    private static final String EMPTY_STRING = StringUtil.EMPTY_STRING;
+    private static final String EMPTY_STRING = StringUtils.EMPTY;
     private final VerticaConnectionFactory connectionFactory;
     private final QueryFactory queryFactory = new QueryFactory();
     private final VerticaSchemaUtils verticaSchemaUtils;

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,6 @@
         <surefire.failsafe.version>3.2.3</surefire.failsafe.version>
         <log4j2Version>2.22.1</log4j2Version>
         <apache.arrow.version>13.0.0</apache.arrow.version>
-        <netty.version>4.1.101.Final</netty.version>
         <guava.version>33.0.0-jre</guava.version>
         <protobuf3.version>3.25.1</protobuf3.version>
         <antlr.st4.version>4.3.4</antlr.st4.version>


### PR DESCRIPTION
### *Description of changes:*
Netty has been directly chosen as a direct dependency for Federation Repo whereas its never used directly by any code-base (except one util class that got replaces accordingly).

Most importantly; the depend-bot has been upgrading Netty; which is core to `arrow` functionality, and recently we have upgraded to latest version which caused our SDK to fail.

This change removes the burden of deciding which Netty to choose; and let the transitive dependency be resolve by the direct dependency (in this case Arrow). 

I've ran unit-tests locally; and everything looks fine; however I recommend that we run integration tests; I'll run them on my fork afterwards. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
