### PR TITLE
Add table allowlisting and some missing template parameters.

### DIFF
--- a/athena-dynamodb/athena-dynamodb.yaml
+++ b/athena-dynamodb/athena-dynamodb.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.47.1
+    SemanticVersion: 1.0.0
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AthenaCatalogName:
@@ -24,6 +24,28 @@ Parameters:
     Description: 'The prefix within SpillBucket where this function can spill data.'
     Type: String
     Default: athena-spill
+  SpillPutRequestHeaders:
+    Description: '(Optional) A JSON encoded map of request headers and values for the Amazon S3 putObject request that is used for spilling. (for example, {"x-amz-server-side-encryption" : "aws:kms"}).'
+    Type: String
+  DisableGlue:
+    Description: "(Optional) If present and set to 'true', the connector does not attempt to retrieve supplemental metadata from AWS Glue."
+    Default: 'false'
+    Type: String
+    AllowedValues:
+      - true
+      - false
+  DisableProjectionAndCasing:
+    Description: "(Optional) Disables projection and casing. Use if you want to query DynamoDB tables that have casing in their column names and you do not want to specify a columnMapping property on your AWS Glue table. Can be set to 'auto' or 'always', set to 'auto' by default. See documentation for more information."
+    Default: 'auto'
+    Type: String
+    AllowedValues:
+      - auto
+      - always
+  AllowedTables:
+    Description: "(Optional) List of ';' delimited table names that should be fetched from DynamoDB, no other tables will be scanned if supplied."
+    Type: String
+    AllowedPattern: ^(?!.*;$)[^;]*(;[^;]*)*$
+    Default: ""
   LambdaTimeout:
     Description: 'Maximum Lambda invocation runtime in seconds. (min 1 - 900 max)'
     Default: 900
@@ -51,6 +73,8 @@ Parameters:
 
 Conditions:
   HasKMSKeyId: !Not [!Equals [!Ref KMSKeyId, ""]]
+  HasAllowedTables: !Not [!Equals [!Ref AllowedTables, ""]]
+  HasSpillPutRequestHeaders: !Not [!Equals [!Ref SpillPutRequestHeaders, ""]]
   NotHasLambdaRole: !Equals [!Ref LambdaRole, ""]
   HasPermissionsBoundary: !Not [ !Equals [ !Ref PermissionsBoundaryARN, "" ] ]
   CreateKMSPolicy: !And [!Condition HasKMSKeyId, !Condition NotHasLambdaRole]
@@ -62,6 +86,10 @@ Resources:
       Environment:
         Variables:
           disable_spill_encryption: !Ref DisableSpillEncryption
+          disable_projection_and_casing: !Ref DisableProjectionAndCasing
+          disable_glue: !Ref DisableGlue
+          spill_put_request_headers: !If [HasSpillPutRequestHeaders, !Ref SpillPutRequestHeaders, !Ref "AWS::NoValue"]
+          allowed_tables: !If [HasAllowedTables, !Ref AllowedTables, !Ref "AWS::NoValue"]
           spill_bucket: !Ref SpillBucket
           spill_prefix: !Ref SpillPrefix
           kms_key_id: !If [HasKMSKeyId, !Ref KMSKeyId, !Ref "AWS::NoValue"]

--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBMetadataHandler.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBMetadataHandler.java
@@ -71,6 +71,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -119,6 +120,7 @@ public class DynamoDBMetadataHandler
     @VisibleForTesting
     static final int MAX_SPLITS_PER_REQUEST = 1000;
     private static final Logger logger = LoggerFactory.getLogger(DynamoDBMetadataHandler.class);
+    private static final String ALLOWED_TABLES_ENV = "allowed_tables";
     static final String DYNAMODB = "dynamodb";
     private static final String SOURCE_TYPE = "ddb";
     // defines the value that should be present in the Glue Database URI to enable the DB for DynamoDB.
@@ -143,7 +145,14 @@ public class DynamoDBMetadataHandler
                 .build();
         this.glueClient = getAwsGlue();
         this.invoker = ThrottlingInvoker.newDefaultBuilder(EXCEPTION_FILTER, configOptions).build();
-        this.tableResolver = new DynamoDBTableResolver(invoker, ddbClient);
+
+        String allowedTablesEnvStr = configOptions.getOrDefault(ALLOWED_TABLES_ENV, "");
+        List<String> allowedTables = new ArrayList<>();
+        if (!allowedTablesEnvStr.isEmpty()) {
+            allowedTables = Arrays.asList(allowedTablesEnvStr.split(";", -1));
+        }
+
+        this.tableResolver = new DynamoDBTableResolver(invoker, ddbClient, allowedTables);
     }
 
     @VisibleForTesting
@@ -161,7 +170,7 @@ public class DynamoDBMetadataHandler
         this.glueClient = glueClient;
         this.ddbClient = ddbClient;
         this.invoker = ThrottlingInvoker.newDefaultBuilder(EXCEPTION_FILTER, configOptions).build();
-        this.tableResolver = new DynamoDBTableResolver(invoker, ddbClient);
+        this.tableResolver = new DynamoDBTableResolver(invoker, ddbClient, new ArrayList<>());
     }
 
     /**
@@ -197,6 +206,7 @@ public class DynamoDBMetadataHandler
      * <p>
      * If the specified schema is "default", this also returns an intersection with actual tables in DynamoDB.
      * Pagination only implemented for DynamoDBTableResolver.listTables()
+     *
      * @see GlueMetadataHandler
      */
     @Override
@@ -210,7 +220,7 @@ public class DynamoDBMetadataHandler
             try {
                 // does not validate that the tables are actually DDB tables
                 combinedTables.addAll(super.doListTables(allocator, new ListTablesRequest(request.getIdentity(), request.getQueryId(), request.getCatalogName(),
-                                request.getSchemaName(), null, UNLIMITED_PAGE_SIZE_VALUE), TABLE_FILTER).getTables());
+                        request.getSchemaName(), null, UNLIMITED_PAGE_SIZE_VALUE), TABLE_FILTER).getTables());
             }
             catch (RuntimeException e) {
                 logger.warn("doListTables: Unable to retrieve tables from AWSGlue in database/schema {}", request.getSchemaName(), e);


### PR DESCRIPTION
*Description of changes:*
By default the connector lists all of the DynamoDB tables in the account and tries to query/scan all of them, the issue with this is that there is no way to hide confidential tables from showing up in Athena as it is not possible to restrict access through Athena and restricting scan/query access to the tables result in a runtime exception.

This PR adds the possibility to explicitly specify the list of tables which you would like to show in Athena, through the `AllowedTables` template parameter. Not supplying this parameter will end up showing all of the tables, as in the original connector.

Additionally to this configuration option 3 of the missing configuration parameters were added to the template for ease of configuration, namely `SpillPutRequestHeaders`, `DisableProjectionAndCasing`, `DisableGlue`. The code for handling these options were already present in the original connector code, but were left out of the template, to keep it as simple as possible, but we love complexity.
