### PR TITLE
Updated SigV4 signing library in Gremlin connection for Neptune connector

### DIFF
--- a/athena-neptune/pom.xml
+++ b/athena-neptune/pom.xml
@@ -9,7 +9,8 @@
     <artifactId>athena-neptune</artifactId>
     <version>2022.47.1</version>
     <properties>
-        <gremlinDriverVersion>3.7.2</gremlinDriverVersion>
+        <!-- make sure gremlin driver version stays within the Neptune supported range -->
+        <gremlinDriverVersion>3.6.5</gremlinDriverVersion>
         <neptune.sigv4.signer.version>2.4.0</neptune.sigv4.signer.version>
     </properties>
     <dependencies>

--- a/athena-neptune/src/main/java/com/amazonaws/athena/connectors/neptune/NeptuneConnection.java
+++ b/athena-neptune/src/main/java/com/amazonaws/athena/connectors/neptune/NeptuneConnection.java
@@ -21,6 +21,7 @@ package com.amazonaws.athena.connectors.neptune;
 
 import com.amazonaws.athena.connectors.neptune.propertygraph.NeptuneGremlinConnection;
 import com.amazonaws.athena.connectors.neptune.rdf.NeptuneSparqlConnection;
+import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.neptune.auth.NeptuneNettyHttpSigV4Signer;
 import com.amazonaws.neptune.auth.NeptuneSigV4SignerException;
@@ -29,11 +30,14 @@ import org.apache.tinkerpop.gremlin.driver.Cluster;
 import org.apache.tinkerpop.gremlin.driver.remote.DriverRemoteConnection;
 import org.apache.tinkerpop.gremlin.process.traversal.AnonymousTraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class NeptuneConnection
 {
     private static Cluster cluster = null;
-    
+    private static final Logger logger = LoggerFactory.getLogger(NeptuneConnection.class);
+
     private String neptuneEndpoint;
     private String neptunePort;
     private boolean enabledIAM;
@@ -47,14 +51,17 @@ public class NeptuneConnection
                .enableSsl(true);
                
         if (enabledIAM) {
+            logger.info("Connecting with IAM auth to https://" + neptuneEndpoint + ":" + neptunePort + " in " + region);
+            final AWSCredentialsProvider awsCredentialsProvider = new DefaultAWSCredentialsProviderChain();
             builder.handshakeInterceptor(r ->
                     {
                         try {
                             NeptuneNettyHttpSigV4Signer sigV4Signer =
-                                    new NeptuneNettyHttpSigV4Signer(region, new DefaultAWSCredentialsProviderChain());
+                                    new NeptuneNettyHttpSigV4Signer(region, awsCredentialsProvider);
                             sigV4Signer.signRequest(r);
                         }
                         catch (NeptuneSigV4SignerException e) {
+                            logger.error("SIGV4 exception", e);
                             throw new RuntimeException("Exception occurred while signing the request", e);
                         }
                         return r;

--- a/athena-neptune/src/main/java/com/amazonaws/athena/connectors/neptune/propertygraph/NeptuneGremlinConnection.java
+++ b/athena-neptune/src/main/java/com/amazonaws/athena/connectors/neptune/propertygraph/NeptuneGremlinConnection.java
@@ -20,6 +20,7 @@
 package com.amazonaws.athena.connectors.neptune.propertygraph;
 
 import com.amazonaws.athena.connectors.neptune.NeptuneConnection;
+import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.neptune.auth.NeptuneNettyHttpSigV4Signer;
 import com.amazonaws.neptune.auth.NeptuneSigV4SignerException;
@@ -28,9 +29,12 @@ import org.apache.tinkerpop.gremlin.driver.Cluster;
 import org.apache.tinkerpop.gremlin.driver.remote.DriverRemoteConnection;
 import org.apache.tinkerpop.gremlin.process.traversal.AnonymousTraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class NeptuneGremlinConnection extends NeptuneConnection 
 {
+    private static final Logger logger = LoggerFactory.getLogger(NeptuneGremlinConnection.class);
     private static Cluster cluster = null;
 
     public NeptuneGremlinConnection(String neptuneEndpoint, String neptunePort, boolean enabledIAM, String region)
@@ -42,14 +46,17 @@ public class NeptuneGremlinConnection extends NeptuneConnection
                .enableSsl(true);
                
         if (enabledIAM) {
+            logger.info("Connecting with IAM auth to https://" + neptuneEndpoint + ":" + neptunePort + " in " + region);
+            final AWSCredentialsProvider awsCredentialsProvider = new DefaultAWSCredentialsProviderChain();
             builder.handshakeInterceptor(r ->
                     {
                         try {
                             NeptuneNettyHttpSigV4Signer sigV4Signer =
-                                    new NeptuneNettyHttpSigV4Signer(region, new DefaultAWSCredentialsProviderChain());
+                                    new NeptuneNettyHttpSigV4Signer(region, awsCredentialsProvider);
                             sigV4Signer.signRequest(r);
                         }
                         catch (NeptuneSigV4SignerException e) {
+                            logger.error("SIGV4 exception", e);
                             throw new RuntimeException("Exception occurred while signing the request", e);
                         }
                         return r;

--- a/athena-neptune/src/main/java/com/amazonaws/athena/connectors/neptune/propertygraph/NeptuneGremlinConnection.java
+++ b/athena-neptune/src/main/java/com/amazonaws/athena/connectors/neptune/propertygraph/NeptuneGremlinConnection.java
@@ -20,9 +20,11 @@
 package com.amazonaws.athena.connectors.neptune.propertygraph;
 
 import com.amazonaws.athena.connectors.neptune.NeptuneConnection;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.neptune.auth.NeptuneNettyHttpSigV4Signer;
+import com.amazonaws.neptune.auth.NeptuneSigV4SignerException;
 import org.apache.tinkerpop.gremlin.driver.Client;
 import org.apache.tinkerpop.gremlin.driver.Cluster;
-import org.apache.tinkerpop.gremlin.driver.SigV4WebSocketChannelizer;
 import org.apache.tinkerpop.gremlin.driver.remote.DriverRemoteConnection;
 import org.apache.tinkerpop.gremlin.process.traversal.AnonymousTraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
@@ -40,7 +42,19 @@ public class NeptuneGremlinConnection extends NeptuneConnection
                .enableSsl(true);
                
         if (enabledIAM) {
-            builder = builder.channelizer(SigV4WebSocketChannelizer.class);
+            builder.handshakeInterceptor(r ->
+                    {
+                        try {
+                            NeptuneNettyHttpSigV4Signer sigV4Signer =
+                                    new NeptuneNettyHttpSigV4Signer(region, new DefaultAWSCredentialsProviderChain());
+                            sigV4Signer.signRequest(r);
+                        }
+                        catch (NeptuneSigV4SignerException e) {
+                            throw new RuntimeException("Exception occurred while signing the request", e);
+                        }
+                        return r;
+                    }
+            );
         }
         
         cluster = builder.create();


### PR DESCRIPTION
*Issue #, if available:*
#1574

*Description of changes:*
The SigV4 library used for IAM in Gremlin connection in Neptune connector is a deprecated library, this PR updates it to use the new maintained library for signing. The deprecated library is only recommended to be used with 3.4.x Gremlin drivers, and may work when using 3.5.x and earlier 3.6.x driver versions, but will no longer work with 3.7.x.

Also downgraded the Gremlin driver version used by the connector to within the supported range for Neptune (currently 3.6.5 is the max). 

I was able to reproduce the error on 3.7.1 gremlin console, trying to connect to IAM enabled cluster using the old SigV4 signing library:
![image](https://github.com/awslabs/aws-athena-query-federation/assets/55853655/14fc8b99-caff-48d1-b1db-05e4d0e7be32)

I have tested the fix in this PR by deploying a customer connector and querying an IAM enabled cluster, and was successfull:
![image](https://github.com/awslabs/aws-athena-query-federation/assets/55853655/da761405-71d8-4065-a870-6e2e461d70d7)
<img width="1379" alt="Screenshot 2024-01-19 at 5 26 13 PM" src="https://github.com/awslabs/aws-athena-query-federation/assets/55853655/ac72aa22-7ebc-48ea-b157-f82412c1d594">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
