### PR TITLE
Fixes https://github.com/awslabs/aws-athena-query-federation/issues/360

### DIFF
--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcArrowTypeConverter.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcArrowTypeConverter.java
@@ -31,8 +31,6 @@ import java.sql.Types;
  */
 public final class JdbcArrowTypeConverter
 {
-    private static final int DEFAULT_PRECISION = 38;
-
     private JdbcArrowTypeConverter() {}
 
     /**
@@ -45,18 +43,8 @@ public final class JdbcArrowTypeConverter
      */
     public static ArrowType toArrowType(final int jdbcType, final int precision, final int scale, java.util.Map<String, String> configOptions)
     {
-        int defaultScale = Integer.parseInt(configOptions.getOrDefault("default_scale", "0"));
-        int resolvedPrecision = precision;
-        int resolvedScale = scale;
-        boolean needsResolving = jdbcType == Types.NUMERIC && (precision == 0 && scale == 0);
-        // Resolve Precision and Scale if they're not available
-        if (needsResolving) {
-            resolvedPrecision = DEFAULT_PRECISION;
-            resolvedScale = defaultScale;
-        }
-
         ArrowType arrowType = JdbcToArrowUtils.getArrowTypeFromJdbcType(
-                new JdbcFieldInfo(jdbcType, resolvedPrecision, resolvedScale),
+                new JdbcFieldInfo(jdbcType, precision, scale),
                 null);
 
         if (arrowType instanceof ArrowType.Date) {

--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcArrowTypeConverter.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcArrowTypeConverter.java
@@ -24,8 +24,6 @@ import org.apache.arrow.adapter.jdbc.JdbcToArrowUtils;
 import org.apache.arrow.vector.types.DateUnit;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 
-import java.sql.Types;
-
 /**
  * Utility abstracts Jdbc to Arrow type conversions.
  */

--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandler.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandler.java
@@ -298,7 +298,8 @@ public abstract class JdbcMetadataHandler
         }
     }
 
-    protected ArrowType getArrowTypeFromDataType(int dataType, int columnSize, int decimalDigits) {
+    protected ArrowType getArrowTypeFromDataType(int dataType, int columnSize, int decimalDigits)
+    {
         return JdbcArrowTypeConverter.toArrowType(
                 dataType,
                 columnSize,

--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandler.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandler.java
@@ -262,11 +262,10 @@ public abstract class JdbcMetadataHandler
         try (ResultSet resultSet = getColumns(jdbcConnection.getCatalog(), tableName, jdbcConnection.getMetaData())) {
             boolean found = false;
             while (resultSet.next()) {
-                ArrowType columnType = JdbcArrowTypeConverter.toArrowType(
+                ArrowType columnType = getArrowTypeFromDataType(
                         resultSet.getInt("DATA_TYPE"),
                         resultSet.getInt("COLUMN_SIZE"),
-                        resultSet.getInt("DECIMAL_DIGITS"),
-                        configOptions);
+                        resultSet.getInt("DECIMAL_DIGITS"));
                 String columnName = resultSet.getString("COLUMN_NAME");
                 if (columnType != null && SupportedTypes.isSupported(columnType)) {
                     if (columnType instanceof ArrowType.List) {
@@ -297,6 +296,14 @@ public abstract class JdbcMetadataHandler
 
             return schemaBuilder.build();
         }
+    }
+
+    protected ArrowType getArrowTypeFromDataType(int dataType, int columnSize, int decimalDigits) {
+        return JdbcArrowTypeConverter.toArrowType(
+                dataType,
+                columnSize,
+                decimalDigits,
+                configOptions);
     }
 
     private ResultSet getColumns(final String catalogName, final TableName tableHandle, final DatabaseMetaData metadata)

--- a/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcArrowTypeConverterTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcArrowTypeConverterTest.java
@@ -39,7 +39,6 @@ public class JdbcArrowTypeConverterTest
         Assert.assertEquals(Types.MinorType.FLOAT4.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.FLOAT, 0, 0, com.google.common.collect.ImmutableMap.of()));
         Assert.assertEquals(Types.MinorType.FLOAT8.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.DOUBLE, 0, 0, com.google.common.collect.ImmutableMap.of()));
         Assert.assertEquals(new ArrowType.Decimal(5, 3), JdbcArrowTypeConverter.toArrowType(java.sql.Types.DECIMAL, 5, 3, com.google.common.collect.ImmutableMap.of()));
-        Assert.assertEquals(new ArrowType.Decimal(38, 0), JdbcArrowTypeConverter.toArrowType(java.sql.Types.NUMERIC, 0, 0, com.google.common.collect.ImmutableMap.of()));
         Assert.assertEquals(Types.MinorType.VARCHAR.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.CHAR, 0, 0, com.google.common.collect.ImmutableMap.of()));
         Assert.assertEquals(Types.MinorType.VARCHAR.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.NCHAR, 0, 0, com.google.common.collect.ImmutableMap.of()));
         Assert.assertEquals(Types.MinorType.VARCHAR.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.VARCHAR, 0, 0, com.google.common.collect.ImmutableMap.of()));

--- a/athena-postgresql/src/main/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlMetadataHandler.java
+++ b/athena-postgresql/src/main/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlMetadataHandler.java
@@ -400,7 +400,8 @@ public class PostGreSqlMetadataHandler
     }
 
     @Override
-    protected ArrowType getArrowTypeFromDataType(int dataType, int columnSize, int decimalDigits) {
+    protected ArrowType getArrowTypeFromDataType(int dataType, int columnSize, int decimalDigits)
+    {
         int defaultScale = Integer.parseInt(configOptions.getOrDefault("default_scale", "0"));
 
         int resolvedColumnSize =


### PR DESCRIPTION
*Issue #360*

*Description of changes:*

Refactor previous change to take account of the size of the column in jdbc postgresql metadata for unbounded numeric.
Specialization of the change on postgresql module.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
