### PR TITLE
Aimethed cache regex

### DIFF
--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/security/CachableSecretsManager.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/security/CachableSecretsManager.java
@@ -46,8 +46,8 @@ public class CachableSecretsManager
     private static final long MAX_CACHE_AGE_MS = 60_000;
     protected static final int MAX_CACHE_SIZE = 10;
 
-    private static final String SECRET_PATTERN = "(\\$\\{[a-zA-Z0-9-_\\-]+\\})";
-    private static final String SECRET_NAME_PATTERN = "\\$\\{([a-zA-Z0-9-_\\-]+)\\}";
+    private static final String SECRET_PATTERN = "(\\$\\{[a-zA-Z0-9-\\/_\\-\\.\\+=@]+\\})";
+    private static final String SECRET_NAME_PATTERN = "\\$\\{([a-zA-Z0-9-\\/_\\-\\.\\+=@]+)\\}";
     private static final Pattern PATTERN = Pattern.compile(SECRET_PATTERN);
     private static final Pattern NAME_PATTERN = Pattern.compile(SECRET_NAME_PATTERN);
 
@@ -82,6 +82,7 @@ public class CachableSecretsManager
             m1.find();
             result = result.replace(nextSecret, getSecret(m1.group(1)));
         }
+        logger.debug("resolveSecrets: Input raw string: " + rawString + " result string: " + result);
         return result;
     }
 

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/security/CachableSecretsManager.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/security/CachableSecretsManager.java
@@ -82,7 +82,6 @@ public class CachableSecretsManager
             m1.find();
             result = result.replace(nextSecret, getSecret(m1.group(1)));
         }
-        logger.debug("resolveSecrets: Input raw string: " + rawString + " result string: " + result);
         return result;
     }
 

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/security/CacheableSecretsManagerTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/security/CacheableSecretsManagerTest.java
@@ -124,6 +124,10 @@ public class CacheableSecretsManagerTest
         String commonErrorsExpected = "ThisIsM}yStringWi${thTwoSecretS{uperSecretSecrets";
         assertEquals(commonErrorsExpected, cachableSecretsManager.resolveSecrets(commonErrors));
 
+        String secretAllowedSpecialChars = "ThisIs${/My}StringW${ith_}All${Of+The}${@llowed=}${Special-Characters.}";
+        String secretAllowedSpecialCharsExpected = "ThisIs/MyStringWith_AllOf+The@llowed=Special-Characters.";
+        assertEquals(secretAllowedSpecialCharsExpected, cachableSecretsManager.resolveSecrets(secretAllowedSpecialChars));
+
         String unknownSecret = "This${Unknown}";
         try {
             cachableSecretsManager.resolveSecrets(unknownSecret);


### PR DESCRIPTION
*Issue #1381*

Currently, the regex used to find aws secrets in the connection string does not allow for all of the special characters that aws secrets manager allows (see [AWS Secrets Documentation](https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_CreateSecret.html#API_CreateSecret_RequestSyntax)). This adds the all of the supported characters to the regex used.
