### PR TITLE
Support map of complex types

### DIFF
--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/metadata/glue/GlueFieldLexer.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/metadata/glue/GlueFieldLexer.java
@@ -53,7 +53,7 @@ public class GlueFieldLexer
 
     private static final BaseTypeMapper DEFAULT_TYPE_MAPPER = (String type) -> DefaultGlueType.toArrowType(type);
 
-    public static final boolean MAP_DISABLED = true;
+    public static final boolean MAP_DISABLED = false;
 
     private GlueFieldLexer() {}
 
@@ -160,11 +160,11 @@ public class GlueFieldLexer
 
         FieldType keyFieldTypeNotNullable = new FieldType(false, keyType.getType(), keyType.getDictionary(), keyType.getMetadata());
         Field keyFieldNotNullable = new Field(keyType.getName(), keyFieldTypeNotNullable, keyType.getChildren());
-
+      
         return FieldBuilder.newBuilder(name, new ArrowType.Map(false))
-             .addField("ENTRIES", Types.MinorType.STRUCT.getType(), false,
-                  Arrays.asList(keyFieldNotNullable, valueType))
-             .build();
+            .addField("entries", Types.MinorType.STRUCT.getType(), false,
+                Arrays.asList(keyFieldNotNullable, valueType))
+            .build();
     }
 
     private static void expectTokenMarkerIsFieldStart(GlueTypeParser.Token token)

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/data/helpers/FieldsGenerator.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/data/helpers/FieldsGenerator.java
@@ -116,7 +116,7 @@ public class FieldsGenerator {
             , floatingPointField(nullable)
             // TODO: Known failure, Arrow has a bug with writing some types to Lists like ArrowType.Timestamp
             // Uncomment once Arrow has resolve
-            //, timestampField(nullable)
+            , timestampField(nullable)
             , Arbitraries.just(new FieldType(nullable, new ArrowType.Utf8(), null))
         );
     }

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/data/helpers/FieldsGenerator.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/data/helpers/FieldsGenerator.java
@@ -116,7 +116,7 @@ public class FieldsGenerator {
             , floatingPointField(nullable)
             // TODO: Known failure, Arrow has a bug with writing some types to Lists like ArrowType.Timestamp
             // Uncomment once Arrow has resolve
-            , timestampField(nullable)
+            //, timestampField(nullable)
             , Arbitraries.just(new FieldType(nullable, new ArrowType.Utf8(), null))
         );
     }

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/metadata/glue/GlueFieldLexerTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/metadata/glue/GlueFieldLexerTest.java
@@ -334,7 +334,7 @@ public class GlueFieldLexerTest
         // complex case
         String input = "map<array<int>, map<string, string>>";
         Field field = GlueFieldLexer.lex("SomeMap", input);
-        String expectedFieldToString = "SomeMap: Map(false)<ENTRIES: Struct<key: List<key: Int(32, true)> not null, value: Map(false)<ENTRIES: Struct<key: Utf8 not null, value: Utf8> not null>> not null>";
+        String expectedFieldToString = "SomeMap: Map(false)<entries: Struct<key: List<key: Int(32, true)> not null, value: Map(false)<entries: Struct<key: Utf8 not null, value: Utf8> not null>> not null>";
         assertEquals(expectedFieldToString, field.toString());
 
         // Extra complex case
@@ -344,7 +344,7 @@ public class GlueFieldLexerTest
             ">";
         String input2 = "map<" + innerStruct + ", map<string, " + innerStruct + ">>";
         Field field2 = GlueFieldLexer.lex("SomeMap2", input2);
-        String expectedFieldToString2 = "SomeMap2: Map(false)<ENTRIES: Struct<key: Struct<somearrfield0: List<somearrfield0: List<somearrfield0: Struct<somefield: Decimal(38, 9, 128), someset: List<someset: Decimal(11, 7, 128)>>>>, mapinner0: Struct<numberset_deep: List<numberset_deep: Decimal(23, 3, 8)>>> not null, value: Map(false)<ENTRIES: Struct<key: Utf8 not null, value: Struct<somearrfield0: List<somearrfield0: List<somearrfield0: Struct<somefield: Decimal(38, 9, 128), someset: List<someset: Decimal(11, 7, 128)>>>>, mapinner0: Struct<numberset_deep: List<numberset_deep: Decimal(23, 3, 8)>>>> not null>> not null>";
+        String expectedFieldToString2 = "SomeMap2: Map(false)<entries: Struct<key: Struct<somearrfield0: List<somearrfield0: List<somearrfield0: Struct<somefield: Decimal(38, 9, 128), someset: List<someset: Decimal(11, 7, 128)>>>>, mapinner0: Struct<numberset_deep: List<numberset_deep: Decimal(23, 3, 8)>>> not null, value: Map(false)<entries: Struct<key: Utf8 not null, value: Struct<somearrfield0: List<somearrfield0: List<somearrfield0: Struct<somefield: Decimal(38, 9, 128), someset: List<someset: Decimal(11, 7, 128)>>>>, mapinner0: Struct<numberset_deep: List<numberset_deep: Decimal(23, 3, 8)>>>> not null>> not null>";
         assertEquals(expectedFieldToString2, field2.toString());
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
Support map with complex types as values.

*Description of changes:*
Enabled map support that uses arrow changes (Refer to https://github.com/awslabs/aws-athena-query-federation/issues/361#issuecomment-1546547216)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
