### PR TITLE
make vpc optional in snowflake template

### DIFF
--- a/athena-snowflake/athena-snowflake.yaml
+++ b/athena-snowflake/athena-snowflake.yaml
@@ -42,17 +42,27 @@ Parameters:
     Description: 'If set to ''false'' data spilled to S3 is encrypted with AES GCM'
     Default: 'false'
     Type: String
+  IsVPCAccess:
+    AllowedValues:
+       - 'true'
+       - 'false'
+    Default: 'false'
+    Description: "If Snowflake database is in VPC select true, [true, false] (default is false)"
+    Type: String
   SecurityGroupIds:
-    Description: 'One or more SecurityGroup IDs corresponding to the SecurityGroup that should be applied to the Lambda function. (e.g. sg1,sg2,sg3)'
-    Type: 'List<AWS::EC2::SecurityGroup::Id>'
+    Description: '**If IsVPCAccess is True**. Provide one or more SecurityGroup IDs corresponding to the SecurityGroup that should be applied to the Lambda function. (e.g. sg1,sg2,sg3)'
+    Type: CommaDelimitedList
+    Default: ""
   SubnetIds:
-    Description: 'One or more Subnet IDs corresponding to the Subnet that the Lambda function can use to access you data source. (e.g. subnet1,subnet2)'
-    Type: 'List<AWS::EC2::Subnet::Id>'
+    Description: '**If IsVPCAccess is True**. Provide one or more Subnet IDs corresponding to the Subnet that the Lambda function can use to access you data source. (e.g. subnet1,subnet2)'
+    Type: CommaDelimitedList
+    Default: ""
   PermissionsBoundaryARN:
     Description: "(Optional) An IAM policy ARN to use as the PermissionsBoundary for the created Lambda function's execution role"
     Default: ''
     Type: String
 Conditions:
+  IsVPCAccessSelected: !Equals [!Ref IsVPCAccess, true]
   HasPermissionsBoundary: !Not [ !Equals [ !Ref PermissionsBoundaryARN, "" ] ]
 Resources:
   JdbcConnectorConfig:
@@ -106,5 +116,15 @@ Resources:
         #VPCAccessPolicy allows our connector to run in a VPC so that it can access your data source.
         - VPCAccessPolicy: {}
       VpcConfig:
-        SecurityGroupIds: !Ref SecurityGroupIds
-        SubnetIds: !Ref SubnetIds
+          SecurityGroupIds:
+            !If
+              - IsVPCAccessSelected
+              -
+                !Ref SecurityGroupIds
+              - !Ref "AWS::NoValue"
+          SubnetIds:
+            !If
+              - IsVPCAccessSelected
+              -
+                !Ref SubnetIds
+              - !Ref "AWS::NoValue"


### PR DESCRIPTION
Update the snowflake cfn template so that the connector does not need to be within a VPC. Changes modeled from the elasticsearch connector, which has the optional VPC connection.
