### PR TITLE
BUG 1728 : pom changes for bigquery connector

### DIFF
--- a/athena-google-bigquery/pom.xml
+++ b/athena-google-bigquery/pom.xml
@@ -55,8 +55,7 @@
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-bigquery</artifactId>
-            <!-- starting with version 2.36.0 there is a breaking change, do not update -->
-            <version>2.35.0</version>
+            <version>2.37.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.api.grpc</groupId>
@@ -67,6 +66,11 @@
                     <artifactId>grpc-google-cloud-bigquerystorage-v1beta2</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-api</artifactId>
+            <version>1.61.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.cloud</groupId>


### PR DESCRIPTION
*Issue #, if available:*
Athena Bigquery connector dependency google-cloud-bigquery update issue.

*Description of changes:*
updated google-cloud-bigquery to 2.37.0 and added grpc-api version 1.61.0 to maintain latest transitive dependecy.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
