### PR TITLE
Make VPC optional in multiple connectors

### DIFF
--- a/athena-datalakegen2/athena-datalakegen2.yaml
+++ b/athena-datalakegen2/athena-datalakegen2.yaml
@@ -45,17 +45,21 @@ Parameters:
     Default: 'false'
     Type: String
   SecurityGroupIds:
-    Description: 'One or more SecurityGroup IDs corresponding to the SecurityGroup that should be applied to the Lambda function. (e.g. sg1,sg2,sg3)'
-    Type: 'List<AWS::EC2::SecurityGroup::Id>'
+    Description: '(Optional) One or more SecurityGroup IDs corresponding to the SecurityGroup that should be applied to the Lambda function. (e.g. sg1,sg2,sg3)'
+    Type: CommaDelimitedList
+    Default: ""
   SubnetIds:
-    Description: 'One or more Subnet IDs corresponding to the Subnet that the Lambda function can use to access you data source. (e.g. subnet1,subnet2)'
-    Type: 'List<AWS::EC2::Subnet::Id>'
+    Description: '(Optional) One or more Subnet IDs corresponding to the Subnet that the Lambda function can use to access you data source. (e.g. subnet1,subnet2)'
+    Type: CommaDelimitedList
+    Default: ""
   PermissionsBoundaryARN:
     Description: "(Optional) An IAM policy ARN to use as the PermissionsBoundary for the created Lambda function's execution role"
     Default: ''
     Type: String
 Conditions:
   HasPermissionsBoundary: !Not [ !Equals [ !Ref PermissionsBoundaryARN, "" ] ]
+  HasSecurityGroups: !Not [ !Equals [ !Join ["", !Ref SecurityGroupIds], "" ] ]
+  HasSubnets: !Not [ !Equals [ !Join ["", !Ref SubnetIds], "" ] ]
 Resources:
   JdbcConnectorConfig:
     Type: 'AWS::Serverless::Function'
@@ -108,5 +112,5 @@ Resources:
         #VPCAccessPolicy allows our connector to run in a VPC so that it can access your data source.
         - VPCAccessPolicy: {}
       VpcConfig:
-        SecurityGroupIds: !Ref SecurityGroupIds
-        SubnetIds: !Ref SubnetIds
+        SecurityGroupIds: !If [ HasSecurityGroups, !Ref SecurityGroupIds, !Ref "AWS::NoValue" ]
+        SubnetIds: !If [ HasSubnets, !Ref SubnetIds, !Ref "AWS::NoValue" ]

--- a/athena-datalakegen2/athena-datalakegen2.yaml
+++ b/athena-datalakegen2/athena-datalakegen2.yaml
@@ -60,7 +60,6 @@ Conditions:
   HasPermissionsBoundary: !Not [ !Equals [ !Ref PermissionsBoundaryARN, "" ] ]
   HasSecurityGroups: !Not [ !Equals [ !Join ["", !Ref SecurityGroupIds], "" ] ]
   HasSubnets: !Not [ !Equals [ !Join ["", !Ref SubnetIds], "" ] ]
-  IsVPCAccessSelected: !And [ !Condition HasSecurityGroups, !Condition HasSubnets ]
 Resources:
   JdbcConnectorConfig:
     Type: 'AWS::Serverless::Function'
@@ -113,5 +112,5 @@ Resources:
         #VPCAccessPolicy allows our connector to run in a VPC so that it can access your data source.
         - VPCAccessPolicy: {}
       VpcConfig:
-        SecurityGroupIds: !If [ IsVPCAccessSelected, !Ref SecurityGroupIds, !Ref "AWS::NoValue" ]
-        SubnetIds: !If [ IsVPCAccessSelected, !Ref SubnetIds, !Ref "AWS::NoValue" ]
+        SecurityGroupIds: !If [ HasSecurityGroups, !Ref SecurityGroupIds, !Ref "AWS::NoValue" ]
+        SubnetIds: !If [ HasSubnets, !Ref SubnetIds, !Ref "AWS::NoValue" ]

--- a/athena-datalakegen2/athena-datalakegen2.yaml
+++ b/athena-datalakegen2/athena-datalakegen2.yaml
@@ -60,6 +60,7 @@ Conditions:
   HasPermissionsBoundary: !Not [ !Equals [ !Ref PermissionsBoundaryARN, "" ] ]
   HasSecurityGroups: !Not [ !Equals [ !Join ["", !Ref SecurityGroupIds], "" ] ]
   HasSubnets: !Not [ !Equals [ !Join ["", !Ref SubnetIds], "" ] ]
+  IsVPCAccessSelected: !And [ !Condition HasSecurityGroups, !Condition HasSubnets ]
 Resources:
   JdbcConnectorConfig:
     Type: 'AWS::Serverless::Function'
@@ -112,5 +113,5 @@ Resources:
         #VPCAccessPolicy allows our connector to run in a VPC so that it can access your data source.
         - VPCAccessPolicy: {}
       VpcConfig:
-        SecurityGroupIds: !If [ HasSecurityGroups, !Ref SecurityGroupIds, !Ref "AWS::NoValue" ]
-        SubnetIds: !If [ HasSubnets, !Ref SubnetIds, !Ref "AWS::NoValue" ]
+        SecurityGroupIds: !If [ IsVPCAccessSelected, !Ref SecurityGroupIds, !Ref "AWS::NoValue" ]
+        SubnetIds: !If [ IsVPCAccessSelected, !Ref SubnetIds, !Ref "AWS::NoValue" ]

--- a/athena-google-bigquery/athena-google-bigquery.yaml
+++ b/athena-google-bigquery/athena-google-bigquery.yaml
@@ -65,6 +65,7 @@ Conditions:
   HasPermissionsBoundary: !Not [ !Equals [ !Ref PermissionsBoundaryARN, "" ] ]
   HasSecurityGroups: !Not [ !Equals [ !Join ["", !Ref SecurityGroupIds], "" ] ]
   HasSubnets: !Not [ !Equals [ !Join ["", !Ref SubnetIds], "" ] ]
+  IsVPCAccessSelected: !And [ !Condition HasSecurityGroups, !Condition HasSubnets ]
 Resources:
   AthenaBigQueryConnector:
     Type: 'AWS::Serverless::Function'
@@ -120,5 +121,5 @@ Resources:
         #VPCAccessPolicy allows our connector to run in a VPC so that it can access your data source.
         - VPCAccessPolicy: { }
       VpcConfig:
-        SecurityGroupIds: !If [ HasSecurityGroups, !Ref SecurityGroupIds, !Ref "AWS::NoValue" ]
-        SubnetIds: !If [ HasSubnets, !Ref SubnetIds, !Ref "AWS::NoValue" ]
+        SecurityGroupIds: !If [ IsVPCAccessSelected, !Ref SecurityGroupIds, !Ref "AWS::NoValue" ]
+        SubnetIds: !If [ IsVPCAccessSelected, !Ref SubnetIds, !Ref "AWS::NoValue" ]

--- a/athena-google-bigquery/athena-google-bigquery.yaml
+++ b/athena-google-bigquery/athena-google-bigquery.yaml
@@ -65,7 +65,6 @@ Conditions:
   HasPermissionsBoundary: !Not [ !Equals [ !Ref PermissionsBoundaryARN, "" ] ]
   HasSecurityGroups: !Not [ !Equals [ !Join ["", !Ref SecurityGroupIds], "" ] ]
   HasSubnets: !Not [ !Equals [ !Join ["", !Ref SubnetIds], "" ] ]
-  IsVPCAccessSelected: !And [ !Condition HasSecurityGroups, !Condition HasSubnets ]
 Resources:
   AthenaBigQueryConnector:
     Type: 'AWS::Serverless::Function'
@@ -121,5 +120,5 @@ Resources:
         #VPCAccessPolicy allows our connector to run in a VPC so that it can access your data source.
         - VPCAccessPolicy: { }
       VpcConfig:
-        SecurityGroupIds: !If [ IsVPCAccessSelected, !Ref SecurityGroupIds, !Ref "AWS::NoValue" ]
-        SubnetIds: !If [ IsVPCAccessSelected, !Ref SubnetIds, !Ref "AWS::NoValue" ]
+        SecurityGroupIds: !If [ HasSecurityGroups, !Ref SecurityGroupIds, !Ref "AWS::NoValue" ]
+        SubnetIds: !If [ HasSubnets, !Ref SubnetIds, !Ref "AWS::NoValue" ]

--- a/athena-hortonworks-hive/athena-hortonworks-hive.yaml
+++ b/athena-hortonworks-hive/athena-hortonworks-hive.yaml
@@ -43,17 +43,21 @@ Parameters:
     Default: 'false'
     Type: String
   SecurityGroupIds:
-    Description: 'One or more SecurityGroup IDs corresponding to the SecurityGroup that should be applied to the Lambda function. (e.g. sg1,sg2,sg3)'
-    Type: 'List<AWS::EC2::SecurityGroup::Id>'
+    Description: '(Optional) One or more SecurityGroup IDs corresponding to the SecurityGroup that should be applied to the Lambda function. (e.g. sg1,sg2,sg3)'
+    Type: CommaDelimitedList
+    Default: ""
   SubnetIds:
-    Description: 'One or more Subnet IDs corresponding to the Subnet that the Lambda function can use to access you data source. (e.g. subnet1,subnet2)'
-    Type: 'List<AWS::EC2::Subnet::Id>'
+    Description: '(Optional) One or more Subnet IDs corresponding to the Subnet that the Lambda function can use to access you data source. (e.g. subnet1,subnet2)'
+    Type: CommaDelimitedList
+    Default: ""
   PermissionsBoundaryARN:
     Description: "(Optional) An IAM policy ARN to use as the PermissionsBoundary for the created Lambda function's execution role"
     Default: ''
     Type: String
 Conditions:
   HasPermissionsBoundary: !Not [ !Equals [ !Ref PermissionsBoundaryARN, "" ] ]
+  HasSecurityGroups: !Not [ !Equals [ !Join ["", !Ref SecurityGroupIds], "" ] ]
+  HasSubnets: !Not [ !Equals [ !Join ["", !Ref SubnetIds], "" ] ]
 Resources:
   JdbcConnectorConfig:
     Type: 'AWS::Serverless::Function'
@@ -106,5 +110,5 @@ Resources:
         #VPCAccessPolicy allows our connector to run in a VPC so that it can access your data source.
         - VPCAccessPolicy: {}
       VpcConfig:
-        SecurityGroupIds: !Ref SecurityGroupIds
-        SubnetIds: !Ref SubnetIds
+        SecurityGroupIds: !If [ HasSecurityGroups, !Ref SecurityGroupIds, !Ref "AWS::NoValue" ]
+        SubnetIds: !If [ HasSubnets, !Ref SubnetIds, !Ref "AWS::NoValue" ]

--- a/athena-hortonworks-hive/athena-hortonworks-hive.yaml
+++ b/athena-hortonworks-hive/athena-hortonworks-hive.yaml
@@ -58,6 +58,7 @@ Conditions:
   HasPermissionsBoundary: !Not [ !Equals [ !Ref PermissionsBoundaryARN, "" ] ]
   HasSecurityGroups: !Not [ !Equals [ !Join ["", !Ref SecurityGroupIds], "" ] ]
   HasSubnets: !Not [ !Equals [ !Join ["", !Ref SubnetIds], "" ] ]
+  IsVPCAccessSelected: !And [ !Condition HasSecurityGroups, !Condition HasSubnets ]
 Resources:
   JdbcConnectorConfig:
     Type: 'AWS::Serverless::Function'
@@ -110,5 +111,5 @@ Resources:
         #VPCAccessPolicy allows our connector to run in a VPC so that it can access your data source.
         - VPCAccessPolicy: {}
       VpcConfig:
-        SecurityGroupIds: !If [ HasSecurityGroups, !Ref SecurityGroupIds, !Ref "AWS::NoValue" ]
-        SubnetIds: !If [ HasSubnets, !Ref SubnetIds, !Ref "AWS::NoValue" ]
+        SecurityGroupIds: !If [ IsVPCAccessSelected, !Ref SecurityGroupIds, !Ref "AWS::NoValue" ]
+        SubnetIds: !If [ IsVPCAccessSelected, !Ref SubnetIds, !Ref "AWS::NoValue" ]

--- a/athena-hortonworks-hive/athena-hortonworks-hive.yaml
+++ b/athena-hortonworks-hive/athena-hortonworks-hive.yaml
@@ -58,7 +58,6 @@ Conditions:
   HasPermissionsBoundary: !Not [ !Equals [ !Ref PermissionsBoundaryARN, "" ] ]
   HasSecurityGroups: !Not [ !Equals [ !Join ["", !Ref SecurityGroupIds], "" ] ]
   HasSubnets: !Not [ !Equals [ !Join ["", !Ref SubnetIds], "" ] ]
-  IsVPCAccessSelected: !And [ !Condition HasSecurityGroups, !Condition HasSubnets ]
 Resources:
   JdbcConnectorConfig:
     Type: 'AWS::Serverless::Function'
@@ -111,5 +110,5 @@ Resources:
         #VPCAccessPolicy allows our connector to run in a VPC so that it can access your data source.
         - VPCAccessPolicy: {}
       VpcConfig:
-        SecurityGroupIds: !If [ IsVPCAccessSelected, !Ref SecurityGroupIds, !Ref "AWS::NoValue" ]
-        SubnetIds: !If [ IsVPCAccessSelected, !Ref SubnetIds, !Ref "AWS::NoValue" ]
+        SecurityGroupIds: !If [ HasSecurityGroups, !Ref SecurityGroupIds, !Ref "AWS::NoValue" ]
+        SubnetIds: !If [ HasSubnets, !Ref SubnetIds, !Ref "AWS::NoValue" ]

--- a/athena-oracle/athena-oracle.yaml
+++ b/athena-oracle/athena-oracle.yaml
@@ -43,17 +43,21 @@ Parameters:
     Default: 'false'
     Type: String
   SecurityGroupIds:
-    Description: 'One or more SecurityGroup IDs corresponding to the SecurityGroup that should be applied to the Lambda function. (e.g. sg1,sg2,sg3)'
-    Type: 'List<AWS::EC2::SecurityGroup::Id>'
+    Description: '(Optional) One or more SecurityGroup IDs corresponding to the SecurityGroup that should be applied to the Lambda function. (e.g. sg1,sg2,sg3)'
+    Type: CommaDelimitedList
+    Default: ""
   SubnetIds:
-    Description: 'One or more Subnet IDs corresponding to the Subnet that the Lambda function can use to access you data source. (e.g. subnet1,subnet2)'
-    Type: 'List<AWS::EC2::Subnet::Id>'
+    Description: '(Optional) One or more Subnet IDs corresponding to the Subnet that the Lambda function can use to access you data source. (e.g. subnet1,subnet2)'
+    Type: CommaDelimitedList
+    Default: ""
   PermissionsBoundaryARN:
     Description: "(Optional) An IAM policy ARN to use as the PermissionsBoundary for the created Lambda function's execution role"
     Default: ''
     Type: String
 Conditions:
   HasPermissionsBoundary: !Not [ !Equals [ !Ref PermissionsBoundaryARN, "" ] ]
+  HasSecurityGroups: !Not [ !Equals [ !Join ["", !Ref SecurityGroupIds], "" ] ]
+  HasSubnets: !Not [ !Equals [ !Join ["", !Ref SubnetIds], "" ] ]
 Resources:
   JdbcConnectorConfig:
     Type: 'AWS::Serverless::Function'
@@ -106,5 +110,5 @@ Resources:
         #VPCAccessPolicy allows our connector to run in a VPC so that it can access your data source.
         - VPCAccessPolicy: {}
       VpcConfig:
-        SecurityGroupIds: !Ref SecurityGroupIds
-        SubnetIds: !Ref SubnetIds
+        SecurityGroupIds: !If [ HasSecurityGroups, !Ref SecurityGroupIds, !Ref "AWS::NoValue" ]
+        SubnetIds: !If [ HasSubnets, !Ref SubnetIds, !Ref "AWS::NoValue" ]

--- a/athena-oracle/athena-oracle.yaml
+++ b/athena-oracle/athena-oracle.yaml
@@ -58,6 +58,7 @@ Conditions:
   HasPermissionsBoundary: !Not [ !Equals [ !Ref PermissionsBoundaryARN, "" ] ]
   HasSecurityGroups: !Not [ !Equals [ !Join ["", !Ref SecurityGroupIds], "" ] ]
   HasSubnets: !Not [ !Equals [ !Join ["", !Ref SubnetIds], "" ] ]
+  IsVPCAccessSelected: !And [ !Condition HasSecurityGroups, !Condition HasSubnets ]
 Resources:
   JdbcConnectorConfig:
     Type: 'AWS::Serverless::Function'
@@ -110,5 +111,5 @@ Resources:
         #VPCAccessPolicy allows our connector to run in a VPC so that it can access your data source.
         - VPCAccessPolicy: {}
       VpcConfig:
-        SecurityGroupIds: !If [ HasSecurityGroups, !Ref SecurityGroupIds, !Ref "AWS::NoValue" ]
-        SubnetIds: !If [ HasSubnets, !Ref SubnetIds, !Ref "AWS::NoValue" ]
+        SecurityGroupIds: !If [ IsVPCAccessSelected, !Ref SecurityGroupIds, !Ref "AWS::NoValue" ]
+        SubnetIds: !If [ IsVPCAccessSelected, !Ref SubnetIds, !Ref "AWS::NoValue" ]

--- a/athena-oracle/athena-oracle.yaml
+++ b/athena-oracle/athena-oracle.yaml
@@ -58,7 +58,6 @@ Conditions:
   HasPermissionsBoundary: !Not [ !Equals [ !Ref PermissionsBoundaryARN, "" ] ]
   HasSecurityGroups: !Not [ !Equals [ !Join ["", !Ref SecurityGroupIds], "" ] ]
   HasSubnets: !Not [ !Equals [ !Join ["", !Ref SubnetIds], "" ] ]
-  IsVPCAccessSelected: !And [ !Condition HasSecurityGroups, !Condition HasSubnets ]
 Resources:
   JdbcConnectorConfig:
     Type: 'AWS::Serverless::Function'
@@ -111,5 +110,5 @@ Resources:
         #VPCAccessPolicy allows our connector to run in a VPC so that it can access your data source.
         - VPCAccessPolicy: {}
       VpcConfig:
-        SecurityGroupIds: !If [ IsVPCAccessSelected, !Ref SecurityGroupIds, !Ref "AWS::NoValue" ]
-        SubnetIds: !If [ IsVPCAccessSelected, !Ref SubnetIds, !Ref "AWS::NoValue" ]
+        SecurityGroupIds: !If [ HasSecurityGroups, !Ref SecurityGroupIds, !Ref "AWS::NoValue" ]
+        SubnetIds: !If [ HasSubnets, !Ref SubnetIds, !Ref "AWS::NoValue" ]

--- a/athena-saphana/athena-saphana.yaml
+++ b/athena-saphana/athena-saphana.yaml
@@ -43,17 +43,21 @@ Parameters:
     Default: 'false'
     Type: String
   SecurityGroupIds:
-    Description: 'One or more SecurityGroup IDs corresponding to the SecurityGroup that should be applied to the Lambda function. (e.g. sg1,sg2,sg3)'
-    Type: 'List<AWS::EC2::SecurityGroup::Id>'
+    Description: '(Optional) One or more SecurityGroup IDs corresponding to the SecurityGroup that should be applied to the Lambda function. (e.g. sg1,sg2,sg3)'
+    Type: CommaDelimitedList
+    Default: ""
   SubnetIds:
-    Description: 'One or more Subnet IDs corresponding to the Subnet that the Lambda function can use to access you data source. (e.g. subnet1,subnet2)'
-    Type: 'List<AWS::EC2::Subnet::Id>'
+    Description: '(Optional) One or more Subnet IDs corresponding to the Subnet that the Lambda function can use to access you data source. (e.g. subnet1,subnet2)'
+    Type: CommaDelimitedList
+    Default: ""
   PermissionsBoundaryARN:
     Description: "(Optional) An IAM policy ARN to use as the PermissionsBoundary for the created Lambda function's execution role"
     Default: ''
     Type: String
 Conditions:
   HasPermissionsBoundary: !Not [ !Equals [ !Ref PermissionsBoundaryARN, "" ] ]
+  HasSecurityGroups: !Not [ !Equals [ !Join ["", !Ref SecurityGroupIds], "" ] ]
+  HasSubnets: !Not [ !Equals [ !Join ["", !Ref SubnetIds], "" ] ]
 Resources:
   JdbcConnectorConfig:
     Type: 'AWS::Serverless::Function'
@@ -106,5 +110,5 @@ Resources:
         #VPCAccessPolicy allows our connector to run in a VPC so that it can access your data source.
         - VPCAccessPolicy: {}
       VpcConfig:
-        SecurityGroupIds: !Ref SecurityGroupIds
-        SubnetIds: !Ref SubnetIds
+        SecurityGroupIds: !If [ HasSecurityGroups, !Ref SecurityGroupIds, !Ref "AWS::NoValue" ]
+        SubnetIds: !If [ HasSubnets, !Ref SubnetIds, !Ref "AWS::NoValue" ]

--- a/athena-saphana/athena-saphana.yaml
+++ b/athena-saphana/athena-saphana.yaml
@@ -58,6 +58,7 @@ Conditions:
   HasPermissionsBoundary: !Not [ !Equals [ !Ref PermissionsBoundaryARN, "" ] ]
   HasSecurityGroups: !Not [ !Equals [ !Join ["", !Ref SecurityGroupIds], "" ] ]
   HasSubnets: !Not [ !Equals [ !Join ["", !Ref SubnetIds], "" ] ]
+  IsVPCAccessSelected: !And [ !Condition HasSecurityGroups, !Condition HasSubnets ]
 Resources:
   JdbcConnectorConfig:
     Type: 'AWS::Serverless::Function'
@@ -110,5 +111,5 @@ Resources:
         #VPCAccessPolicy allows our connector to run in a VPC so that it can access your data source.
         - VPCAccessPolicy: {}
       VpcConfig:
-        SecurityGroupIds: !If [ HasSecurityGroups, !Ref SecurityGroupIds, !Ref "AWS::NoValue" ]
-        SubnetIds: !If [ HasSubnets, !Ref SubnetIds, !Ref "AWS::NoValue" ]
+        SecurityGroupIds: !If [ IsVPCAccessSelected, !Ref SecurityGroupIds, !Ref "AWS::NoValue" ]
+        SubnetIds: !If [ IsVPCAccessSelected, !Ref SubnetIds, !Ref "AWS::NoValue" ]

--- a/athena-saphana/athena-saphana.yaml
+++ b/athena-saphana/athena-saphana.yaml
@@ -58,7 +58,6 @@ Conditions:
   HasPermissionsBoundary: !Not [ !Equals [ !Ref PermissionsBoundaryARN, "" ] ]
   HasSecurityGroups: !Not [ !Equals [ !Join ["", !Ref SecurityGroupIds], "" ] ]
   HasSubnets: !Not [ !Equals [ !Join ["", !Ref SubnetIds], "" ] ]
-  IsVPCAccessSelected: !And [ !Condition HasSecurityGroups, !Condition HasSubnets ]
 Resources:
   JdbcConnectorConfig:
     Type: 'AWS::Serverless::Function'
@@ -111,5 +110,5 @@ Resources:
         #VPCAccessPolicy allows our connector to run in a VPC so that it can access your data source.
         - VPCAccessPolicy: {}
       VpcConfig:
-        SecurityGroupIds: !If [ IsVPCAccessSelected, !Ref SecurityGroupIds, !Ref "AWS::NoValue" ]
-        SubnetIds: !If [ IsVPCAccessSelected, !Ref SubnetIds, !Ref "AWS::NoValue" ]
+        SecurityGroupIds: !If [ HasSecurityGroups, !Ref SecurityGroupIds, !Ref "AWS::NoValue" ]
+        SubnetIds: !If [ HasSubnets, !Ref SubnetIds, !Ref "AWS::NoValue" ]

--- a/athena-snowflake/athena-snowflake.yaml
+++ b/athena-snowflake/athena-snowflake.yaml
@@ -42,12 +42,19 @@ Parameters:
     Description: 'If set to ''false'' data spilled to S3 is encrypted with AES GCM'
     Default: 'false'
     Type: String
+  IsVPCAccess:
+    AllowedValues:
+       - 'true'
+       - 'false'
+    Default: 'false'
+    Description: "If Snowflake database is in VPC select true, [true, false] (default is false)"
+    Type: String
   SecurityGroupIds:
-    Description: '(Optional) One or more SecurityGroup IDs corresponding to the SecurityGroup that should be applied to the Lambda function. (e.g. sg1,sg2,sg3)'
+    Description: '**If IsVPCAccess is True**. Provide one or more SecurityGroup IDs corresponding to the SecurityGroup that should be applied to the Lambda function. (e.g. sg1,sg2,sg3)'
     Type: CommaDelimitedList
     Default: ""
   SubnetIds:
-    Description: '(Optional) One or more Subnet IDs corresponding to the Subnet that the Lambda function can use to access you data source. (e.g. subnet1,subnet2)'
+    Description: '**If IsVPCAccess is True**. Provide one or more Subnet IDs corresponding to the Subnet that the Lambda function can use to access you data source. (e.g. subnet1,subnet2)'
     Type: CommaDelimitedList
     Default: ""
   PermissionsBoundaryARN:
@@ -55,10 +62,8 @@ Parameters:
     Default: ''
     Type: String
 Conditions:
+  IsVPCAccessSelected: !Equals [!Ref IsVPCAccess, true]
   HasPermissionsBoundary: !Not [ !Equals [ !Ref PermissionsBoundaryARN, "" ] ]
-  HasSecurityGroups: !Not [ !Equals [ !Join ["", !Ref SecurityGroupIds], "" ] ]
-  HasSubnets: !Not [ !Equals [ !Join ["", !Ref SubnetIds], "" ] ]
-  IsVPCAccessSelected: !And [ !Condition HasSecurityGroups, !Condition HasSubnets ]
 Resources:
   JdbcConnectorConfig:
     Type: 'AWS::Serverless::Function'
@@ -111,5 +116,15 @@ Resources:
         #VPCAccessPolicy allows our connector to run in a VPC so that it can access your data source.
         - VPCAccessPolicy: {}
       VpcConfig:
-        SecurityGroupIds: !If [ IsVPCAccessSelected, !Ref SecurityGroupIds, !Ref "AWS::NoValue" ]
-        SubnetIds: !If [ IsVPCAccessSelected, !Ref SubnetIds, !Ref "AWS::NoValue" ]
+          SecurityGroupIds:
+            !If
+              - IsVPCAccessSelected
+              -
+                !Ref SecurityGroupIds
+              - !Ref "AWS::NoValue"
+          SubnetIds:
+            !If
+              - IsVPCAccessSelected
+              -
+                !Ref SubnetIds
+              - !Ref "AWS::NoValue"

--- a/athena-snowflake/athena-snowflake.yaml
+++ b/athena-snowflake/athena-snowflake.yaml
@@ -42,17 +42,27 @@ Parameters:
     Description: 'If set to ''false'' data spilled to S3 is encrypted with AES GCM'
     Default: 'false'
     Type: String
+  IsVPCAccess:
+    AllowedValues:
+       - 'true'
+       - 'false'
+    Default: 'false'
+    Description: "If Snowflake database is in VPC select true, [true, false] (default is false)"
+    Type: String
   SecurityGroupIds:
-    Description: 'One or more SecurityGroup IDs corresponding to the SecurityGroup that should be applied to the Lambda function. (e.g. sg1,sg2,sg3)'
-    Type: 'List<AWS::EC2::SecurityGroup::Id>'
+    Description: '**If IsVPCAccess is True**. Provide one or more SecurityGroup IDs corresponding to the SecurityGroup that should be applied to the Lambda function. (e.g. sg1,sg2,sg3)'
+    Type: CommaDelimitedList
+    Default: ""
   SubnetIds:
-    Description: 'One or more Subnet IDs corresponding to the Subnet that the Lambda function can use to access you data source. (e.g. subnet1,subnet2)'
-    Type: 'List<AWS::EC2::Subnet::Id>'
+    Description: '**If IsVPCAccess is True**. Provide one or more Subnet IDs corresponding to the Subnet that the Lambda function can use to access you data source. (e.g. subnet1,subnet2)'
+    Type: CommaDelimitedList
+    Default: ""
   PermissionsBoundaryARN:
     Description: "(Optional) An IAM policy ARN to use as the PermissionsBoundary for the created Lambda function's execution role"
     Default: ''
     Type: String
 Conditions:
+  IsVPCAccessSelected: !Equals [!Ref IsVPCAccess, true]
   HasPermissionsBoundary: !Not [ !Equals [ !Ref PermissionsBoundaryARN, "" ] ]
 Resources:
   JdbcConnectorConfig:
@@ -106,5 +116,15 @@ Resources:
         #VPCAccessPolicy allows our connector to run in a VPC so that it can access your data source.
         - VPCAccessPolicy: {}
       VpcConfig:
-        SecurityGroupIds: !Ref SecurityGroupIds
-        SubnetIds: !Ref SubnetIds
+          SecurityGroupIds:
+            !If
+              - IsVPCAccessSelected
+              -
+                !Ref SecurityGroupIds
+              - !Ref "AWS::NoValue"
+          SubnetIds:
+            !If
+              - IsVPCAccessSelected
+              -
+                !Ref SubnetIds
+              - !Ref "AWS::NoValue"

--- a/athena-snowflake/athena-snowflake.yaml
+++ b/athena-snowflake/athena-snowflake.yaml
@@ -42,19 +42,12 @@ Parameters:
     Description: 'If set to ''false'' data spilled to S3 is encrypted with AES GCM'
     Default: 'false'
     Type: String
-  IsVPCAccess:
-    AllowedValues:
-       - 'true'
-       - 'false'
-    Default: 'false'
-    Description: "If Snowflake database is in VPC select true, [true, false] (default is false)"
-    Type: String
   SecurityGroupIds:
-    Description: '**If IsVPCAccess is True**. Provide one or more SecurityGroup IDs corresponding to the SecurityGroup that should be applied to the Lambda function. (e.g. sg1,sg2,sg3)'
+    Description: '(Optional) One or more SecurityGroup IDs corresponding to the SecurityGroup that should be applied to the Lambda function. (e.g. sg1,sg2,sg3)'
     Type: CommaDelimitedList
     Default: ""
   SubnetIds:
-    Description: '**If IsVPCAccess is True**. Provide one or more Subnet IDs corresponding to the Subnet that the Lambda function can use to access you data source. (e.g. subnet1,subnet2)'
+    Description: '(Optional) One or more Subnet IDs corresponding to the Subnet that the Lambda function can use to access you data source. (e.g. subnet1,subnet2)'
     Type: CommaDelimitedList
     Default: ""
   PermissionsBoundaryARN:
@@ -62,8 +55,10 @@ Parameters:
     Default: ''
     Type: String
 Conditions:
-  IsVPCAccessSelected: !Equals [!Ref IsVPCAccess, true]
   HasPermissionsBoundary: !Not [ !Equals [ !Ref PermissionsBoundaryARN, "" ] ]
+  HasSecurityGroups: !Not [ !Equals [ !Join ["", !Ref SecurityGroupIds], "" ] ]
+  HasSubnets: !Not [ !Equals [ !Join ["", !Ref SubnetIds], "" ] ]
+  IsVPCAccessSelected: !And [ !Condition HasSecurityGroups, !Condition HasSubnets ]
 Resources:
   JdbcConnectorConfig:
     Type: 'AWS::Serverless::Function'
@@ -116,15 +111,5 @@ Resources:
         #VPCAccessPolicy allows our connector to run in a VPC so that it can access your data source.
         - VPCAccessPolicy: {}
       VpcConfig:
-          SecurityGroupIds:
-            !If
-              - IsVPCAccessSelected
-              -
-                !Ref SecurityGroupIds
-              - !Ref "AWS::NoValue"
-          SubnetIds:
-            !If
-              - IsVPCAccessSelected
-              -
-                !Ref SubnetIds
-              - !Ref "AWS::NoValue"
+        SecurityGroupIds: !If [ IsVPCAccessSelected, !Ref SecurityGroupIds, !Ref "AWS::NoValue" ]
+        SubnetIds: !If [ IsVPCAccessSelected, !Ref SubnetIds, !Ref "AWS::NoValue" ]

--- a/athena-snowflake/athena-snowflake.yaml
+++ b/athena-snowflake/athena-snowflake.yaml
@@ -42,19 +42,12 @@ Parameters:
     Description: 'If set to ''false'' data spilled to S3 is encrypted with AES GCM'
     Default: 'false'
     Type: String
-  IsVPCAccess:
-    AllowedValues:
-       - 'true'
-       - 'false'
-    Default: 'false'
-    Description: "If Snowflake database is in VPC select true, [true, false] (default is false)"
-    Type: String
   SecurityGroupIds:
-    Description: '**If IsVPCAccess is True**. Provide one or more SecurityGroup IDs corresponding to the SecurityGroup that should be applied to the Lambda function. (e.g. sg1,sg2,sg3)'
+    Description: '(Optional) One or more SecurityGroup IDs corresponding to the SecurityGroup that should be applied to the Lambda function. (e.g. sg1,sg2,sg3)'
     Type: CommaDelimitedList
     Default: ""
   SubnetIds:
-    Description: '**If IsVPCAccess is True**. Provide one or more Subnet IDs corresponding to the Subnet that the Lambda function can use to access you data source. (e.g. subnet1,subnet2)'
+    Description: '(Optional) One or more Subnet IDs corresponding to the Subnet that the Lambda function can use to access you data source. (e.g. subnet1,subnet2)'
     Type: CommaDelimitedList
     Default: ""
   PermissionsBoundaryARN:
@@ -62,8 +55,9 @@ Parameters:
     Default: ''
     Type: String
 Conditions:
-  IsVPCAccessSelected: !Equals [!Ref IsVPCAccess, true]
   HasPermissionsBoundary: !Not [ !Equals [ !Ref PermissionsBoundaryARN, "" ] ]
+  HasSecurityGroups: !Not [ !Equals [ !Join ["", !Ref SecurityGroupIds], "" ] ]
+  HasSubnets: !Not [ !Equals [ !Join ["", !Ref SubnetIds], "" ] ]
 Resources:
   JdbcConnectorConfig:
     Type: 'AWS::Serverless::Function'
@@ -116,15 +110,5 @@ Resources:
         #VPCAccessPolicy allows our connector to run in a VPC so that it can access your data source.
         - VPCAccessPolicy: {}
       VpcConfig:
-          SecurityGroupIds:
-            !If
-              - IsVPCAccessSelected
-              -
-                !Ref SecurityGroupIds
-              - !Ref "AWS::NoValue"
-          SubnetIds:
-            !If
-              - IsVPCAccessSelected
-              -
-                !Ref SubnetIds
-              - !Ref "AWS::NoValue"
+        SecurityGroupIds: !If [ HasSecurityGroups, !Ref SecurityGroupIds, !Ref "AWS::NoValue" ]
+        SubnetIds: !If [ HasSubnets, !Ref SubnetIds, !Ref "AWS::NoValue" ]

--- a/athena-sqlserver/athena-sqlserver.yaml
+++ b/athena-sqlserver/athena-sqlserver.yaml
@@ -65,7 +65,6 @@ Conditions:
   NotHasLambdaRole: !Equals [!Ref LambdaRoleARN, ""]
   HasSecurityGroups: !Not [ !Equals [ !Join ["", !Ref SecurityGroupIds], "" ] ]
   HasSubnets: !Not [ !Equals [ !Join ["", !Ref SubnetIds], "" ] ]
-  IsVPCAccessSelected: !And [ !Condition HasSecurityGroups, !Condition HasSubnets ]
 Resources:
   JdbcConnectorConfig:
     Type: 'AWS::Serverless::Function'
@@ -86,8 +85,8 @@ Resources:
       PermissionsBoundary: !If [ HasPermissionsBoundary, !Ref PermissionsBoundaryARN, !Ref "AWS::NoValue" ]
       Role: !If [NotHasLambdaRole, !GetAtt FunctionRole.Arn, !Ref LambdaRoleARN]
       VpcConfig:
-        SecurityGroupIds: !If [ IsVPCAccessSelected, !Ref SecurityGroupIds, !Ref "AWS::NoValue" ]
-        SubnetIds: !If [ IsVPCAccessSelected, !Ref SubnetIds, !Ref "AWS::NoValue" ]
+        SecurityGroupIds: !If [ HasSecurityGroups, !Ref SecurityGroupIds, !Ref "AWS::NoValue" ]
+        SubnetIds: !If [ HasSubnets, !Ref SubnetIds, !Ref "AWS::NoValue" ]
   FunctionRole:
     Condition: NotHasLambdaRole
     Type: AWS::IAM::Role

--- a/athena-sqlserver/athena-sqlserver.yaml
+++ b/athena-sqlserver/athena-sqlserver.yaml
@@ -49,11 +49,13 @@ Parameters:
     Default: 'false'
     Type: String
   SecurityGroupIds:
-    Description: 'One or more SecurityGroup IDs corresponding to the SecurityGroup that should be applied to the Lambda function. (e.g. sg1,sg2,sg3)'
-    Type: 'List<AWS::EC2::SecurityGroup::Id>'
+    Description: '(Optional) One or more SecurityGroup IDs corresponding to the SecurityGroup that should be applied to the Lambda function. (e.g. sg1,sg2,sg3)'
+    Type: CommaDelimitedList
+    Default: ""
   SubnetIds:
-    Description: 'One or more Subnet IDs corresponding to the Subnet that the Lambda function can use to access you data source. (e.g. subnet1,subnet2)'
-    Type: 'List<AWS::EC2::Subnet::Id>'
+    Description: '(Optional) One or more Subnet IDs corresponding to the Subnet that the Lambda function can use to access you data source. (e.g. subnet1,subnet2)'
+    Type: CommaDelimitedList
+    Default: ""
   PermissionsBoundaryARN:
     Description: "(Optional) An IAM policy ARN to use as the PermissionsBoundary for the created Lambda function's execution role"
     Default: ''
@@ -61,6 +63,8 @@ Parameters:
 Conditions:
   HasPermissionsBoundary: !Not [ !Equals [ !Ref PermissionsBoundaryARN, "" ] ]
   NotHasLambdaRole: !Equals [!Ref LambdaRoleARN, ""]
+  HasSecurityGroups: !Not [ !Equals [ !Join ["", !Ref SecurityGroupIds], "" ] ]
+  HasSubnets: !Not [ !Equals [ !Join ["", !Ref SubnetIds], "" ] ]
 Resources:
   JdbcConnectorConfig:
     Type: 'AWS::Serverless::Function'
@@ -81,8 +85,8 @@ Resources:
       PermissionsBoundary: !If [ HasPermissionsBoundary, !Ref PermissionsBoundaryARN, !Ref "AWS::NoValue" ]
       Role: !If [NotHasLambdaRole, !GetAtt FunctionRole.Arn, !Ref LambdaRoleARN]
       VpcConfig:
-        SecurityGroupIds: !Ref SecurityGroupIds
-        SubnetIds: !Ref SubnetIds
+        SecurityGroupIds: !If [ HasSecurityGroups, !Ref SecurityGroupIds, !Ref "AWS::NoValue" ]
+        SubnetIds: !If [ HasSubnets, !Ref SubnetIds, !Ref "AWS::NoValue" ]
   FunctionRole:
     Condition: NotHasLambdaRole
     Type: AWS::IAM::Role

--- a/athena-sqlserver/athena-sqlserver.yaml
+++ b/athena-sqlserver/athena-sqlserver.yaml
@@ -65,6 +65,7 @@ Conditions:
   NotHasLambdaRole: !Equals [!Ref LambdaRoleARN, ""]
   HasSecurityGroups: !Not [ !Equals [ !Join ["", !Ref SecurityGroupIds], "" ] ]
   HasSubnets: !Not [ !Equals [ !Join ["", !Ref SubnetIds], "" ] ]
+  IsVPCAccessSelected: !And [ !Condition HasSecurityGroups, !Condition HasSubnets ]
 Resources:
   JdbcConnectorConfig:
     Type: 'AWS::Serverless::Function'
@@ -85,8 +86,8 @@ Resources:
       PermissionsBoundary: !If [ HasPermissionsBoundary, !Ref PermissionsBoundaryARN, !Ref "AWS::NoValue" ]
       Role: !If [NotHasLambdaRole, !GetAtt FunctionRole.Arn, !Ref LambdaRoleARN]
       VpcConfig:
-        SecurityGroupIds: !If [ HasSecurityGroups, !Ref SecurityGroupIds, !Ref "AWS::NoValue" ]
-        SubnetIds: !If [ HasSubnets, !Ref SubnetIds, !Ref "AWS::NoValue" ]
+        SecurityGroupIds: !If [ IsVPCAccessSelected, !Ref SecurityGroupIds, !Ref "AWS::NoValue" ]
+        SubnetIds: !If [ IsVPCAccessSelected, !Ref SubnetIds, !Ref "AWS::NoValue" ]
   FunctionRole:
     Condition: NotHasLambdaRole
     Type: AWS::IAM::Role

--- a/athena-synapse/athena-synapse.yaml
+++ b/athena-synapse/athena-synapse.yaml
@@ -53,15 +53,19 @@ Parameters:
     Default: 'false'
     Type: String
   SecurityGroupIds:
-    Description: 'One or more SecurityGroup IDs corresponding to the SecurityGroup that should be applied to the Lambda function. (e.g. sg1,sg2,sg3)'
-    Type: 'List<AWS::EC2::SecurityGroup::Id>'
+    Description: '(Optional) One or more SecurityGroup IDs corresponding to the SecurityGroup that should be applied to the Lambda function. (e.g. sg1,sg2,sg3)'
+    Type: CommaDelimitedList
+    Default: ""
   SubnetIds:
-    Description: 'One or more Subnet IDs corresponding to the Subnet that the Lambda function can use to access you data source. (e.g. subnet1,subnet2)'
-    Type: 'List<AWS::EC2::Subnet::Id>'
+    Description: '(Optional) One or more Subnet IDs corresponding to the Subnet that the Lambda function can use to access you data source. (e.g. subnet1,subnet2)'
+    Type: CommaDelimitedList
+    Default: ""
 
 Conditions:
   NotHasLambdaRole: !Equals [!Ref LambdaRoleARN, ""]
   HasPermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundaryARN, ""]]
+  HasSecurityGroups: !Not [ !Equals [ !Join ["", !Ref SecurityGroupIds], "" ] ]
+  HasSubnets: !Not [ !Equals [ !Join ["", !Ref SubnetIds], "" ] ]
 
 Resources:
   JdbcConnectorConfig:
@@ -82,8 +86,8 @@ Resources:
       MemorySize: !Ref LambdaMemory
       Role: !If [NotHasLambdaRole, !GetAtt FunctionRole.Arn, !Ref LambdaRoleARN]
       VpcConfig:
-        SecurityGroupIds: !Ref SecurityGroupIds
-        SubnetIds: !Ref SubnetIds
+        SecurityGroupIds: !If [ HasSecurityGroups, !Ref SecurityGroupIds, !Ref "AWS::NoValue" ]
+        SubnetIds: !If [ HasSubnets, !Ref SubnetIds, !Ref "AWS::NoValue" ]
 
   FunctionRole:
     Condition: NotHasLambdaRole

--- a/athena-synapse/athena-synapse.yaml
+++ b/athena-synapse/athena-synapse.yaml
@@ -66,6 +66,7 @@ Conditions:
   HasPermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundaryARN, ""]]
   HasSecurityGroups: !Not [ !Equals [ !Join ["", !Ref SecurityGroupIds], "" ] ]
   HasSubnets: !Not [ !Equals [ !Join ["", !Ref SubnetIds], "" ] ]
+  IsVPCAccessSelected: !And [ !Condition HasSecurityGroups, !Condition HasSubnets ]
 
 Resources:
   JdbcConnectorConfig:
@@ -86,8 +87,8 @@ Resources:
       MemorySize: !Ref LambdaMemory
       Role: !If [NotHasLambdaRole, !GetAtt FunctionRole.Arn, !Ref LambdaRoleARN]
       VpcConfig:
-        SecurityGroupIds: !If [ HasSecurityGroups, !Ref SecurityGroupIds, !Ref "AWS::NoValue" ]
-        SubnetIds: !If [ HasSubnets, !Ref SubnetIds, !Ref "AWS::NoValue" ]
+        SecurityGroupIds: !If [ IsVPCAccessSelected, !Ref SecurityGroupIds, !Ref "AWS::NoValue" ]
+        SubnetIds: !If [ IsVPCAccessSelected, !Ref SubnetIds, !Ref "AWS::NoValue" ]
 
   FunctionRole:
     Condition: NotHasLambdaRole

--- a/athena-synapse/athena-synapse.yaml
+++ b/athena-synapse/athena-synapse.yaml
@@ -66,7 +66,6 @@ Conditions:
   HasPermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundaryARN, ""]]
   HasSecurityGroups: !Not [ !Equals [ !Join ["", !Ref SecurityGroupIds], "" ] ]
   HasSubnets: !Not [ !Equals [ !Join ["", !Ref SubnetIds], "" ] ]
-  IsVPCAccessSelected: !And [ !Condition HasSecurityGroups, !Condition HasSubnets ]
 
 Resources:
   JdbcConnectorConfig:
@@ -87,8 +86,8 @@ Resources:
       MemorySize: !Ref LambdaMemory
       Role: !If [NotHasLambdaRole, !GetAtt FunctionRole.Arn, !Ref LambdaRoleARN]
       VpcConfig:
-        SecurityGroupIds: !If [ IsVPCAccessSelected, !Ref SecurityGroupIds, !Ref "AWS::NoValue" ]
-        SubnetIds: !If [ IsVPCAccessSelected, !Ref SubnetIds, !Ref "AWS::NoValue" ]
+        SecurityGroupIds: !If [ HasSecurityGroups, !Ref SecurityGroupIds, !Ref "AWS::NoValue" ]
+        SubnetIds: !If [ HasSubnets, !Ref SubnetIds, !Ref "AWS::NoValue" ]
 
   FunctionRole:
     Condition: NotHasLambdaRole

--- a/athena-teradata/athena-teradata.yaml
+++ b/athena-teradata/athena-teradata.yaml
@@ -65,7 +65,6 @@ Conditions:
   HasPermissionsBoundary: !Not [ !Equals [ !Ref PermissionsBoundaryARN, "" ] ]
   HasSecurityGroups: !Not [ !Equals [ !Join ["", !Ref SecurityGroupIds], "" ] ]
   HasSubnets: !Not [ !Equals [ !Join ["", !Ref SubnetIds], "" ] ]
-  IsVPCAccessSelected: !And [ !Condition HasSecurityGroups, !Condition HasSubnets ]
 Resources:
   JdbcConnectorConfig:
     Type: 'AWS::Serverless::Function'
@@ -121,5 +120,5 @@ Resources:
         #VPCAccessPolicy allows our connector to run in a VPC so that it can access your data source.
         - VPCAccessPolicy: {}
       VpcConfig:
-        SecurityGroupIds: !If [ IsVPCAccessSelected, !Ref SecurityGroupIds, !Ref "AWS::NoValue" ]
-        SubnetIds: !If [ IsVPCAccessSelected, !Ref SubnetIds, !Ref "AWS::NoValue" ]
+        SecurityGroupIds: !If [ HasSecurityGroups, !Ref SecurityGroupIds, !Ref "AWS::NoValue" ]
+        SubnetIds: !If [ HasSubnets, !Ref SubnetIds, !Ref "AWS::NoValue" ]

--- a/athena-teradata/athena-teradata.yaml
+++ b/athena-teradata/athena-teradata.yaml
@@ -65,6 +65,7 @@ Conditions:
   HasPermissionsBoundary: !Not [ !Equals [ !Ref PermissionsBoundaryARN, "" ] ]
   HasSecurityGroups: !Not [ !Equals [ !Join ["", !Ref SecurityGroupIds], "" ] ]
   HasSubnets: !Not [ !Equals [ !Join ["", !Ref SubnetIds], "" ] ]
+  IsVPCAccessSelected: !And [ !Condition HasSecurityGroups, !Condition HasSubnets ]
 Resources:
   JdbcConnectorConfig:
     Type: 'AWS::Serverless::Function'
@@ -120,5 +121,5 @@ Resources:
         #VPCAccessPolicy allows our connector to run in a VPC so that it can access your data source.
         - VPCAccessPolicy: {}
       VpcConfig:
-        SecurityGroupIds: !If [ HasSecurityGroups, !Ref SecurityGroupIds, !Ref "AWS::NoValue" ]
-        SubnetIds: !If [ HasSubnets, !Ref SubnetIds, !Ref "AWS::NoValue" ]
+        SecurityGroupIds: !If [ IsVPCAccessSelected, !Ref SecurityGroupIds, !Ref "AWS::NoValue" ]
+        SubnetIds: !If [ IsVPCAccessSelected, !Ref SubnetIds, !Ref "AWS::NoValue" ]

--- a/athena-teradata/athena-teradata.yaml
+++ b/athena-teradata/athena-teradata.yaml
@@ -46,11 +46,13 @@ Parameters:
     Default: 'false'
     Type: String
   SecurityGroupIds:
-    Description: 'One or more SecurityGroup IDs corresponding to the SecurityGroup that should be applied to the Lambda function. (e.g. sg1,sg2,sg3)'
-    Type: 'List<AWS::EC2::SecurityGroup::Id>'
+    Description: '(Optional) One or more SecurityGroup IDs corresponding to the SecurityGroup that should be applied to the Lambda function. (e.g. sg1,sg2,sg3)'
+    Type: CommaDelimitedList
+    Default: ""
   SubnetIds:
-    Description: 'One or more Subnet IDs corresponding to the Subnet that the Lambda function can use to access you data source. (e.g. subnet1,subnet2)'
-    Type: 'List<AWS::EC2::Subnet::Id>'
+    Description: '(Optional) One or more Subnet IDs corresponding to the Subnet that the Lambda function can use to access you data source. (e.g. subnet1,subnet2)'
+    Type: CommaDelimitedList
+    Default: ""
   PartitionCount:
     Description: 'Partition Count Limit'
     Type: Number
@@ -61,6 +63,8 @@ Parameters:
     Type: String
 Conditions:
   HasPermissionsBoundary: !Not [ !Equals [ !Ref PermissionsBoundaryARN, "" ] ]
+  HasSecurityGroups: !Not [ !Equals [ !Join ["", !Ref SecurityGroupIds], "" ] ]
+  HasSubnets: !Not [ !Equals [ !Join ["", !Ref SubnetIds], "" ] ]
 Resources:
   JdbcConnectorConfig:
     Type: 'AWS::Serverless::Function'
@@ -116,5 +120,5 @@ Resources:
         #VPCAccessPolicy allows our connector to run in a VPC so that it can access your data source.
         - VPCAccessPolicy: {}
       VpcConfig:
-        SecurityGroupIds: !Ref SecurityGroupIds
-        SubnetIds: !Ref SubnetIds
+        SecurityGroupIds: !If [ HasSecurityGroups, !Ref SecurityGroupIds, !Ref "AWS::NoValue" ]
+        SubnetIds: !If [ HasSubnets, !Ref SubnetIds, !Ref "AWS::NoValue" ]


### PR DESCRIPTION
Change the following connectors to not require a VPC:

- Azure Datalake Gen2
- HortonWorks Hive
- Oracle DB
- SAP HANA
- Azure SQLServer
- Synapse
- Teradata

The change to the template for each of these was modeled off of the Google BigQuery connector template.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
