### PR TITLE
Enable glue support with docdb

### DIFF
--- a/athena-docdb/src/test/java/com/amazonaws/athena/connectors/docdb/DocDBMetadataHandlerTest.java
+++ b/athena-docdb/src/test/java/com/amazonaws/athena/connectors/docdb/DocDBMetadataHandlerTest.java
@@ -129,7 +129,7 @@ public class DocDBMetadataHandlerTest
     }
 
     @Test
-    public void doListSchemaNames()
+    public void doListSchemaNames() throws Exception
     {
         List<String> schemaNames = new ArrayList<>();
         schemaNames.add("schema1");
@@ -146,7 +146,7 @@ public class DocDBMetadataHandlerTest
     }
 
     @Test
-    public void doListTables()
+    public void doListTables() throws Exception
     {
         List<String> tableNames = new ArrayList<>();
         tableNames.add("table1");


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Previously glue worked, but console would not populate with glue databases and tables correctly. This change follows a similar structure as glue implementation in dynamodb. However, docdb glue connections must have the same glue database (schema) name and documentdb database name to perform the correct query. The glue table name can be anything as long as its "sourceTable" property is mapped to the documentdb collections name. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
