### PR TITLE
[BUG] error occurs when using the LIMIT clause with AthenaGoogleBigQueryConnector

### DIFF
--- a/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryRecordHandler.java
+++ b/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryRecordHandler.java
@@ -232,7 +232,7 @@ public class BigQueryRecordHandler
                 for (ReadRowsResponse response : stream) {
                     Preconditions.checkState(response.hasArrowRecordBatch());
                     VectorSchemaRoot root = reader.processRows(response.getArrowRecordBatch());
-                    long rowLimit = (recordsRequest.getConstraints().getLimit() > 0) ? recordsRequest.getConstraints().getLimit() : root.getRowCount();
+                    long rowLimit = (recordsRequest.getConstraints().getLimit() > 0 && recordsRequest.getConstraints().getLimit() < root.getRowCount()) ? recordsRequest.getConstraints().getLimit() : root.getRowCount();
                     for (int rowIndex = 0; rowIndex < rowLimit; rowIndex++) {
                         outputResults(spiller, recordsRequest, root, rowIndex);
                     }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-athena-query-federation/issues/1767
*Description of changes:*
observed that it's happening when the limit value is greater than the record count. placed the condition.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
