### PR TITLE
Glue connection integration for Elasticsearch connector

### DIFF
--- a/athena-elasticsearch/src/main/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchCredential.java
+++ b/athena-elasticsearch/src/main/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchCredential.java
@@ -1,0 +1,73 @@
+/*-
+ * #%L
+ * athena-elasticsearch
+ * %%
+ * Copyright (C) 2019 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.elasticsearch;
+
+import org.apache.commons.lang3.Validate;
+
+import java.util.Objects;
+
+/**
+ * Encapsulates database connection user name and password information.
+ */
+public class ElasticsearchCredential
+{
+    private final String user;
+    private final String password;
+
+    /**
+     * @param user Database user name.
+     * @param password Database password.
+     */
+    public ElasticsearchCredential(String user, String password)
+    {
+        this.user = Validate.notBlank(user, "User must not be blank");
+        this.password = Validate.notBlank(password, "Password must not be blank");
+    }
+
+    public String getUser()
+    {
+        return user;
+    }
+
+    public String getPassword()
+    {
+        return password;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ElasticsearchCredential that = (ElasticsearchCredential) o;
+        return Objects.equals(getUser(), that.getUser()) &&
+                Objects.equals(getPassword(), that.getPassword());
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(getUser(), getPassword());
+    }
+}

--- a/athena-elasticsearch/src/main/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchCredentialProvider.java
+++ b/athena-elasticsearch/src/main/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchCredentialProvider.java
@@ -1,0 +1,63 @@
+/*-
+ * #%L
+ * athena-elasticsearch
+ * %%
+ * Copyright (C) 2019 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.elasticsearch;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Encapsulates Elasticsearch secrets deserialization, stored in following JSON format (showing minimal required for extraction):
+ * <code>
+ * {
+ *     "username": "${user}",
+ *     "password": "${password}"
+ * }
+ * </code>
+ */
+public class ElasticsearchCredentialProvider
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(ElasticsearchCredentialProvider.class);
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private final ElasticsearchCredential elasticsearchCredential;
+
+    public ElasticsearchCredentialProvider(final String secretString)
+    {
+        Map<String, String> elasticsearchSecrets;
+        try {
+            elasticsearchSecrets = OBJECT_MAPPER.readValue(secretString, HashMap.class);
+        }
+        catch (IOException ioException) {
+            throw new RuntimeException("Could not deserialize Elasticsearch credentials into HashMap", ioException);
+        }
+
+        this.elasticsearchCredential = new ElasticsearchCredential(elasticsearchSecrets.get("username"), elasticsearchSecrets.get("password"));
+    }
+
+    public ElasticsearchCredential getCredential()
+    {
+        return this.elasticsearchCredential;
+    }
+}

--- a/athena-elasticsearch/src/main/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchMetadataHandler.java
+++ b/athena-elasticsearch/src/main/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchMetadataHandler.java
@@ -44,6 +44,7 @@ import com.google.common.collect.ImmutableMap;
 import org.apache.arrow.util.VisibleForTesting;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.commons.lang3.StringUtils;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.indices.GetDataStreamRequest;
 import org.elasticsearch.client.indices.GetIndexRequest;
@@ -54,6 +55,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -85,8 +87,19 @@ public class ElasticsearchMetadataHandler
     // this environment variable is fed into the domainSplitter to populate the domainMap where the key = domain-name,
     // and the value = endpoint.
     private static final String DOMAIN_MAPPING = "domain_mapping";
+
+    // Individual domain endpoint which is associated with a Glue Connection
+    private static final String DOMAIN_ENDPOINT = "domain_endpoint";
+    // Secret Name that provides credentials 
+    private static final String SECRET_NAME = "secret_name";
+
+    // credential keys of secret
+    protected static final String SECRET_USERNAME = "username";
+    protected static final String SECRET_PASSWORD = "password";
+
     // A Map of the domain-names and their respective endpoints.
     private Map<String, String> domainMap;
+    private Map<String, ElasticsearchCredentialProvider> secretMap;
 
     // Env. variable that holds the query timeout period for the Cluster-Health queries.
     private static final String QUERY_TIMEOUT_CLUSTER = "query_timeout_cluster";
@@ -117,7 +130,8 @@ public class ElasticsearchMetadataHandler
         this.awsGlue = getAwsGlue();
         this.autoDiscoverEndpoint = configOptions.getOrDefault(AUTO_DISCOVER_ENDPOINT, "").equalsIgnoreCase("true");
         this.domainMapProvider = new ElasticsearchDomainMapProvider(this.autoDiscoverEndpoint);
-        this.domainMap = domainMapProvider.getDomainMap(resolveSecrets(configOptions.getOrDefault(DOMAIN_MAPPING, "")));
+        this.domainMap = resolveDomainMap(configOptions);
+        this.secretMap = new HashMap<>();
         this.clientFactory = new AwsRestHighLevelClientFactory(this.autoDiscoverEndpoint);
         this.glueTypeMapper = new ElasticsearchGlueTypeMapper();
         this.queryTimeout = Long.parseLong(configOptions.getOrDefault(QUERY_TIMEOUT_CLUSTER, ""));
@@ -140,9 +154,26 @@ public class ElasticsearchMetadataHandler
         this.awsGlue = awsGlue;
         this.domainMapProvider = domainMapProvider;
         this.domainMap = this.domainMapProvider.getDomainMap(null);
+        this.secretMap = new HashMap<>();
         this.clientFactory = clientFactory;
         this.glueTypeMapper = new ElasticsearchGlueTypeMapper();
         this.queryTimeout = queryTimeout;
+    }
+
+    protected Map<String, String> resolveDomainMap(Map<String, String> config)
+    {
+        String secretName = config.getOrDefault(SECRET_NAME, "");
+        String domainEndpoint = config.getOrDefault(DOMAIN_ENDPOINT, "");
+        if (StringUtils.isNotBlank(secretName) && StringUtils.isNotBlank(domainEndpoint)) {
+            logger.info("Using Secrets Manager provided by Glue Connection secret_name.");
+            this.secretMap.put(domainEndpoint.split("=")[0], new ElasticsearchCredentialProvider(getSecret(secretName)));
+        }
+        else {
+            logger.info("No secret_name provided as Config property.");
+            domainEndpoint = resolveSecrets(config.getOrDefault(DOMAIN_MAPPING, ""));
+        }
+
+        return domainMapProvider.getDomainMap(domainEndpoint);
     }
 
     /**
@@ -288,9 +319,12 @@ public class ElasticsearchMetadataHandler
 
         // Get domain
         String domain = request.getTableName().getSchemaName();
-
         String endpoint = getDomainEndpoint(domain);
-        AwsRestHighLevelClient client = clientFactory.getOrCreateClient(endpoint);
+
+        ElasticsearchCredentialProvider creds = secretMap.get(domain);
+        String username = creds != null ? creds.getCredential().getUser() : "";
+        String password = creds != null ? creds.getCredential().getPassword() : "";
+        AwsRestHighLevelClient client = creds != null ? clientFactory.getOrCreateClient(endpoint, username, password) : clientFactory.getOrCreateClient(endpoint);
         // We send index request in case the table name is a data stream, a data stream can contains multiple indices which are created by ES
         // For non data stream, index name is same as table name
         GetIndexResponse indexResponse = client.indices().get(new GetIndexRequest(request.getTableName().getTableName()), RequestOptions.DEFAULT);
@@ -298,7 +332,7 @@ public class ElasticsearchMetadataHandler
         Set<Split> splits = Arrays.stream(indexResponse.getIndices())
                 .flatMap(index -> getShardsIDsFromES(client, index) // get all shards for an index.
                         .stream()
-                        .map(shardId -> new Split(makeSpillLocation(request), makeEncryptionKey(), ImmutableMap.of(domain, endpoint, SHARD_KEY, SHARD_VALUE + shardId.toString(), INDEX_KEY, index))) // make split for each (index + shardId) combination
+                        .map(shardId -> new Split(makeSpillLocation(request), makeEncryptionKey(), ImmutableMap.of(SECRET_USERNAME, username, SECRET_PASSWORD, password, domain, endpoint, SHARD_KEY, SHARD_VALUE + shardId.toString(), INDEX_KEY, index))) // make split for each (index + shardId) combination
                 )
                 .collect(Collectors.toSet());
 

--- a/athena-elasticsearch/src/main/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchRecordHandler.java
+++ b/athena-elasticsearch/src/main/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchRecordHandler.java
@@ -34,6 +34,7 @@ import com.amazonaws.services.secretsmanager.AWSSecretsManager;
 import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
 import org.apache.arrow.util.VisibleForTesting;
 import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.commons.lang3.StringUtils;
 import org.elasticsearch.action.search.ClearScrollRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
@@ -141,10 +142,13 @@ public class ElasticsearchRecordHandler
         String endpoint = recordsRequest.getSplit().getProperty(domain);
         String shard = recordsRequest.getSplit().getProperty(ElasticsearchMetadataHandler.SHARD_KEY);
         String index = recordsRequest.getSplit().getProperty(ElasticsearchMetadataHandler.INDEX_KEY);
+        String username = recordsRequest.getSplit().getProperty(ElasticsearchMetadataHandler.SECRET_USERNAME);
+        String password = recordsRequest.getSplit().getProperty(ElasticsearchMetadataHandler.SECRET_PASSWORD);
+        boolean useSecret = StringUtils.isNotBlank(username) && StringUtils.isNotBlank(password);
         long numRows = 0;
 
         if (queryStatusChecker.isQueryRunning()) {
-            AwsRestHighLevelClient client = clientFactory.getOrCreateClient(endpoint);
+            AwsRestHighLevelClient client = useSecret ? clientFactory.getOrCreateClient(endpoint, username, password) : clientFactory.getOrCreateClient(endpoint);
             try {
                 // Create field extractors for all data types in the schema.
                 GeneratedRowWriter rowWriter = createFieldExtractors(recordsRequest);


### PR DESCRIPTION
*Description of changes:*
Connector is backwards compatible with `domain_mapping` environment variable, however, it now also supports Config properties of `domain_endpoint` and `secret_name`.

Added `ElasticsearchCredential.java` and `ElasticsearchCredentialProvider.java` to store and create credentials which now supplement username and password to create connection.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
