### PR TITLE
JDBC connectors integrated to use Glue Connection properties

### DIFF
--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/connection/DatabaseConnectionConfigBuilder.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/connection/DatabaseConnectionConfigBuilder.java
@@ -43,6 +43,12 @@ public class DatabaseConnectionConfigBuilder
     private static final String SECRET_PATTERN_STRING = "\\$\\{(([a-z-]+!)?[a-zA-Z0-9:/_+=.@-]+)}";
     public static final Pattern SECRET_PATTERN = Pattern.compile(SECRET_PATTERN_STRING);
 
+    // Config variables used when glue connection supplements connection properties
+    public static final String DEFAULT_JDBC_CONNECTION_URL_PROPERTY = "default_connection_string";
+    public static final String DEFAULT_SECRET_PROPERTY = "secret_name";
+
+    public static final String DEFAULT_GLUE_CONNECTION = "glue_connection";
+
     private Map<String, String> properties;
 
     private String engine;
@@ -87,31 +93,37 @@ public class DatabaseConnectionConfigBuilder
     public List<DatabaseConnectionConfig> build()
     {
         Validate.notEmpty(this.properties, "properties must not be empty");
-        Validate.notBlank(this.properties.get(DEFAULT_CONNECTION_STRING_PROPERTY), "Default connection string must be present");
+        Validate.isTrue(properties.containsKey(DEFAULT_CONNECTION_STRING_PROPERTY) || properties.containsKey(DEFAULT_JDBC_CONNECTION_URL_PROPERTY), "Default connection string must be present");
 
         List<DatabaseConnectionConfig> databaseConnectionConfigs = new ArrayList<>();
 
         int numberOfCatalogs = 0;
-        for (Map.Entry<String, String> property : this.properties.entrySet()) {
-            final String key = property.getKey();
-            final String value = property.getValue();
-
-            String catalogName;
-            if (DEFAULT_CONNECTION_STRING_PROPERTY.equals(key.toLowerCase())) {
-                catalogName = key.toLowerCase();
-            }
-            else if (key.endsWith(CONNECTION_STRING_PROPERTY_SUFFIX)) {
-                catalogName = key.replace(CONNECTION_STRING_PROPERTY_SUFFIX, "");
-            }
-            else {
-                // unknown property ignore
-                continue;
-            }
-            databaseConnectionConfigs.add(extractDatabaseConnectionConfig(catalogName, value));
-
+        if (!StringUtils.isBlank(properties.get(DEFAULT_GLUE_CONNECTION))) {
+            databaseConnectionConfigs.add(extractDatabaseGlueConnectionConfig(DEFAULT_CONNECTION_STRING_PROPERTY));
             numberOfCatalogs++;
-            if (numberOfCatalogs > MUX_CATALOG_LIMIT) {
-                throw new RuntimeException("Too many database instances in mux. Max supported is " + MUX_CATALOG_LIMIT);
+        }
+        else {
+            for (Map.Entry<String, String> property : this.properties.entrySet()) {
+                final String key = property.getKey();
+                final String value = property.getValue();
+    
+                String catalogName;
+                if (DEFAULT_CONNECTION_STRING_PROPERTY.equals(key.toLowerCase())) {
+                    catalogName = key.toLowerCase();
+                }
+                else if (key.endsWith(CONNECTION_STRING_PROPERTY_SUFFIX)) {
+                    catalogName = key.replace(CONNECTION_STRING_PROPERTY_SUFFIX, "");
+                }
+                else {
+                    // unknown property ignore
+                    continue;
+                }
+                databaseConnectionConfigs.add(extractDatabaseConnectionConfig(catalogName, value));
+    
+                numberOfCatalogs++;
+                if (numberOfCatalogs > MUX_CATALOG_LIMIT) {
+                    throw new RuntimeException("Too many database instances in mux. Max supported is " + MUX_CATALOG_LIMIT);
+                }
             }
         }
 
@@ -139,6 +151,14 @@ public class DatabaseConnectionConfigBuilder
 
         return optionalSecretName.map(s -> new DatabaseConnectionConfig(catalogName, this.engine, jdbcConnectionString, s))
                 .orElseGet(() -> new DatabaseConnectionConfig(catalogName, this.engine, jdbcConnectionString));
+    }
+
+    private DatabaseConnectionConfig extractDatabaseGlueConnectionConfig(final String catalogName)
+    {
+        final String jdbcConnectionString = properties.get(DEFAULT_JDBC_CONNECTION_URL_PROPERTY);
+        final String secretName = properties.get(DEFAULT_SECRET_PROPERTY);
+        Validate.notBlank(jdbcConnectionString, "JDBC Connection string must not be blank.");
+        return StringUtils.isBlank(secretName) ? new DatabaseConnectionConfig(catalogName, this.engine, jdbcConnectionString) : new DatabaseConnectionConfig(catalogName, this.engine, jdbcConnectionString, secretName);
     }
 
     private Optional<String> extractSecretName(final String jdbcConnectionString)

--- a/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/connection/DatabaseConnectionConfigBuilderTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/connection/DatabaseConnectionConfigBuilderTest.java
@@ -33,6 +33,9 @@ public class DatabaseConnectionConfigBuilderTest
     private static final String CONNECTION_STRING2 = "postgres://jdbc:postgresql://hostname/user=testUser&password=testPassword";
     private static final String CONNECTION_STRING3 = "redshift://jdbc:redshift://hostname:5439/dev?${arn:aws:secretsmanager:us-east-1:1234567890:secret:redshift/user/secret}";
     private static final String CONNECTION_STRING4 = "postgres://jdbc:postgresql://hostname:5439/dev?${arn:aws:secretsmanager:us-east-1:1234567890:secret:postgresql/user/secret}";
+    private static final String CONNECTION_STRING5 = "jdbc:postgresql://hostname/test";
+    private static final String CONNECTION_STRING5_SECRET = "testSecret";
+    private static final String MOCK_GLUE_CONNECTION_NAME = "postgresql-connection";
 
     @Test
     public void build()
@@ -122,4 +125,40 @@ public class DatabaseConnectionConfigBuilderTest
                 Assert.assertEquals(secrets[i], databaseConnectionConfigs.get(i).getSecret());
         }
     }
+
+    @Test
+    public void buildUsingGlueConnectionWithSecret()
+    {
+        DatabaseConnectionConfig glueSupplementedConnection = new DatabaseConnectionConfig("default", "postgres",
+                "jdbc:postgresql://hostname/test", "testSecret");
+
+        List<DatabaseConnectionConfig> databaseConnectionConfigs = new DatabaseConnectionConfigBuilder()
+                .engine("postgres")
+                .properties(ImmutableMap.of(
+                        "default", CONNECTION_STRING2,
+                        "default_connection_string", CONNECTION_STRING5,
+                        "secret_name", CONNECTION_STRING5_SECRET,
+                        "glue_connection", MOCK_GLUE_CONNECTION_NAME))
+                .build();
+
+        Assert.assertEquals(Arrays.asList(glueSupplementedConnection), databaseConnectionConfigs);
+    }
+
+    @Test
+    public void buildUsingGlueConnectionNoSecret()
+    {
+        DatabaseConnectionConfig glueSupplementedConnection = new DatabaseConnectionConfig("default", "postgres",
+                "jdbc:postgresql://hostname/test");
+
+        List<DatabaseConnectionConfig> databaseConnectionConfigs = new DatabaseConnectionConfigBuilder()
+                .engine("postgres")
+                .properties(ImmutableMap.of(
+                        "default", CONNECTION_STRING2,
+                        "default_connection_string", CONNECTION_STRING5,
+                        "glue_connection", MOCK_GLUE_CONNECTION_NAME))
+                .build();
+
+        Assert.assertEquals(Arrays.asList(glueSupplementedConnection), databaseConnectionConfigs);
+    }
 }
+


### PR DESCRIPTION
*Description of changes:*
Added functionality to JDBC connectors where properties `default_connection_string` and `secret_name` can be used to supplement connection properties. Aligns with Glue Connection property implementation.

Example object:

```
"AthenaProperties": {
  "driverProperties": {
    "default_connection_string": "jdbc:mysql://mysql-test-cluster.com:3306/test",
    "secret_name": "test-secret" // (Optional) default: ""
  },
  "connectorProperties": {
    "spill_bucket": "athena-spill-bucket",
    "spill_prefix": "athena-spill-prefix",
    "disable_spill_encryption": "true", // (Optional) default: false
    "kms_key_id": "some-kms-key-id" // (Optional) default ""
    "spill_put_request_headers": "{\"x-amz-server-side-encryption\" : \"AES256\"}" // Optional
  }
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
