### PR TITLE
Glue Connection Connector Integration 

### DIFF
--- a/athena-aws-cmdb/src/main/java/com/amazonaws/athena/connectors/aws/cmdb/AwsCmdbCompositeHandler.java
+++ b/athena-aws-cmdb/src/main/java/com/amazonaws/athena/connectors/aws/cmdb/AwsCmdbCompositeHandler.java
@@ -19,6 +19,7 @@
  */
 package com.amazonaws.athena.connectors.aws.cmdb;
 
+import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**
@@ -30,6 +31,6 @@ public class AwsCmdbCompositeHandler
 {
     public AwsCmdbCompositeHandler()
     {
-        super(new AwsCmdbMetadataHandler(System.getenv()), new AwsCmdbRecordHandler(System.getenv()));
+        super(new AwsCmdbMetadataHandler(GlueConnectionUtils.getGlueConnection()), new AwsCmdbRecordHandler(GlueConnectionUtils.getGlueConnection()));
     }
 }

--- a/athena-cloudera-hive/src/main/java/com/amazonaws/athena/connectors/cloudera/HiveCompositeHandler.java
+++ b/athena-cloudera-hive/src/main/java/com/amazonaws/athena/connectors/cloudera/HiveCompositeHandler.java
@@ -19,6 +19,7 @@
  */
 package com.amazonaws.athena.connectors.cloudera;
 
+import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**
@@ -32,6 +33,6 @@ public class HiveCompositeHandler
 {
     public HiveCompositeHandler()
     {
-        super(new HiveMetadataHandler(System.getenv()), new HiveRecordHandler(System.getenv()));
+        super(new HiveMetadataHandler(GlueConnectionUtils.getGlueConnection()), new HiveRecordHandler(GlueConnectionUtils.getGlueConnection()));
     }
 }

--- a/athena-cloudera-impala/src/main/java/com/amazonaws/athena/connectors/cloudera/ImpalaCompositeHandler.java
+++ b/athena-cloudera-impala/src/main/java/com/amazonaws/athena/connectors/cloudera/ImpalaCompositeHandler.java
@@ -20,6 +20,7 @@
  */
 package com.amazonaws.athena.connectors.cloudera;
 
+import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**
@@ -33,6 +34,6 @@ public class ImpalaCompositeHandler
 {
     public ImpalaCompositeHandler()
     {
-        super(new ImpalaMetadataHandler(System.getenv()), new ImpalaRecordHandler(System.getenv()));
+        super(new ImpalaMetadataHandler(GlueConnectionUtils.getGlueConnection()), new ImpalaRecordHandler(GlueConnectionUtils.getGlueConnection()));
     }
 }

--- a/athena-cloudwatch-metrics/src/main/java/com/amazonaws/athena/connectors/cloudwatch/metrics/MetricsCompositeHandler.java
+++ b/athena-cloudwatch-metrics/src/main/java/com/amazonaws/athena/connectors/cloudwatch/metrics/MetricsCompositeHandler.java
@@ -19,6 +19,7 @@
  */
 package com.amazonaws.athena.connectors.cloudwatch.metrics;
 
+import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**
@@ -30,6 +31,6 @@ public class MetricsCompositeHandler
 {
     public MetricsCompositeHandler()
     {
-        super(new MetricsMetadataHandler(System.getenv()), new MetricsRecordHandler(System.getenv()));
+        super(new MetricsMetadataHandler(GlueConnectionUtils.getGlueConnection()), new MetricsRecordHandler(GlueConnectionUtils.getGlueConnection()));
     }
 }

--- a/athena-cloudwatch/src/main/java/com/amazonaws/athena/connectors/cloudwatch/CloudwatchCompositeHandler.java
+++ b/athena-cloudwatch/src/main/java/com/amazonaws/athena/connectors/cloudwatch/CloudwatchCompositeHandler.java
@@ -19,6 +19,7 @@
  */
 package com.amazonaws.athena.connectors.cloudwatch;
 
+import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**
@@ -30,6 +31,6 @@ public class CloudwatchCompositeHandler
 {
     public CloudwatchCompositeHandler()
     {
-        super(new CloudwatchMetadataHandler(System.getenv()), new CloudwatchRecordHandler(System.getenv()));
+        super(new CloudwatchMetadataHandler(GlueConnectionUtils.getGlueConnection()), new CloudwatchRecordHandler(GlueConnectionUtils.getGlueConnection()));
     }
 }

--- a/athena-datalakegen2/src/main/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2CompositeHandler.java
+++ b/athena-datalakegen2/src/main/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2CompositeHandler.java
@@ -19,6 +19,7 @@
  */
 package com.amazonaws.athena.connectors.datalakegen2;
 
+import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**
@@ -31,6 +32,6 @@ public class DataLakeGen2CompositeHandler extends CompositeHandler
 {
     public DataLakeGen2CompositeHandler()
     {
-        super(new DataLakeGen2MetadataHandler(System.getenv()), new DataLakeGen2RecordHandler(System.getenv()));
+        super(new DataLakeGen2MetadataHandler(GlueConnectionUtils.getGlueConnection()), new DataLakeGen2RecordHandler(GlueConnectionUtils.getGlueConnection()));
     }
 }

--- a/athena-db2-as400/src/main/java/com/amazonaws/athena/connectors/db2as400/Db2As400CompositeHandler.java
+++ b/athena-db2-as400/src/main/java/com/amazonaws/athena/connectors/db2as400/Db2As400CompositeHandler.java
@@ -19,6 +19,7 @@
  */
 package com.amazonaws.athena.connectors.db2as400;
 
+import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**
@@ -31,6 +32,6 @@ public class Db2As400CompositeHandler extends CompositeHandler
 {
     public Db2As400CompositeHandler()
     {
-        super(new Db2As400MetadataHandler(System.getenv()), new Db2As400RecordHandler(System.getenv()));
+        super(new Db2As400MetadataHandler(GlueConnectionUtils.getGlueConnection()), new Db2As400RecordHandler(GlueConnectionUtils.getGlueConnection()));
     }
 }

--- a/athena-db2/src/main/java/com/amazonaws/athena/connectors/db2/Db2CompositeHandler.java
+++ b/athena-db2/src/main/java/com/amazonaws/athena/connectors/db2/Db2CompositeHandler.java
@@ -19,6 +19,7 @@
  */
 package com.amazonaws.athena.connectors.db2;
 
+import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**
@@ -31,6 +32,6 @@ public class Db2CompositeHandler extends CompositeHandler
 {
     public Db2CompositeHandler()
     {
-        super(new Db2MetadataHandler(System.getenv()), new Db2RecordHandler(System.getenv()));
+        super(new Db2MetadataHandler(GlueConnectionUtils.getGlueConnection()), new Db2RecordHandler(GlueConnectionUtils.getGlueConnection()));
     }
 }

--- a/athena-docdb/src/main/java/com/amazonaws/athena/connectors/docdb/DocDBCompositeHandler.java
+++ b/athena-docdb/src/main/java/com/amazonaws/athena/connectors/docdb/DocDBCompositeHandler.java
@@ -19,6 +19,7 @@
  */
 package com.amazonaws.athena.connectors.docdb;
 
+import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**
@@ -30,6 +31,6 @@ public class DocDBCompositeHandler
 {
     public DocDBCompositeHandler()
     {
-        super(new DocDBMetadataHandler(System.getenv()), new DocDBRecordHandler(System.getenv()));
+        super(new DocDBMetadataHandler(GlueConnectionUtils.getGlueConnection()), new DocDBRecordHandler(GlueConnectionUtils.getGlueConnection()));
     }
 }

--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBCompositeHandler.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBCompositeHandler.java
@@ -19,6 +19,7 @@
  */
 package com.amazonaws.athena.connectors.dynamodb;
 
+import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**
@@ -30,6 +31,6 @@ public class DynamoDBCompositeHandler
 {
     public DynamoDBCompositeHandler()
     {
-        super(new DynamoDBMetadataHandler(System.getenv()), new DynamoDBRecordHandler(System.getenv()));
+        super(new DynamoDBMetadataHandler(GlueConnectionUtils.getGlueConnection()), new DynamoDBRecordHandler(GlueConnectionUtils.getGlueConnection()));
     }
 }

--- a/athena-elasticsearch/src/main/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchCompositeHandler.java
+++ b/athena-elasticsearch/src/main/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchCompositeHandler.java
@@ -19,6 +19,7 @@
  */
 package com.amazonaws.athena.connectors.elasticsearch;
 
+import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**
@@ -30,6 +31,6 @@ public class ElasticsearchCompositeHandler
 {
     public ElasticsearchCompositeHandler()
     {
-        super(new ElasticsearchMetadataHandler(System.getenv()), new ElasticsearchRecordHandler(System.getenv()));
+        super(new ElasticsearchMetadataHandler(GlueConnectionUtils.getGlueConnection()), new ElasticsearchRecordHandler(GlueConnectionUtils.getGlueConnection()));
     }
 }

--- a/athena-elasticsearch/src/main/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchMetadataHandler.java
+++ b/athena-elasticsearch/src/main/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchMetadataHandler.java
@@ -120,7 +120,7 @@ public class ElasticsearchMetadataHandler
         this.domainMap = domainMapProvider.getDomainMap(resolveSecrets(configOptions.getOrDefault(DOMAIN_MAPPING, "")));
         this.clientFactory = new AwsRestHighLevelClientFactory(this.autoDiscoverEndpoint);
         this.glueTypeMapper = new ElasticsearchGlueTypeMapper();
-        this.queryTimeout = Long.parseLong(configOptions.getOrDefault(QUERY_TIMEOUT_CLUSTER, ""));
+        this.queryTimeout = Long.parseLong(configOptions.getOrDefault(QUERY_TIMEOUT_CLUSTER, "10"));
     }
 
     @VisibleForTesting

--- a/athena-elasticsearch/src/main/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchRecordHandler.java
+++ b/athena-elasticsearch/src/main/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchRecordHandler.java
@@ -91,7 +91,7 @@ public class ElasticsearchRecordHandler
 
         this.typeUtils = new ElasticsearchTypeUtils();
         this.clientFactory = new AwsRestHighLevelClientFactory(configOptions.getOrDefault(AUTO_DISCOVER_ENDPOINT, "").equalsIgnoreCase("true"));
-        this.queryTimeout = Long.parseLong(configOptions.getOrDefault(QUERY_TIMEOUT_SEARCH, ""));
+        this.queryTimeout = Long.parseLong(configOptions.getOrDefault(QUERY_TIMEOUT_SEARCH, "720"));
         this.scrollTimeout = Long.parseLong(configOptions.getOrDefault(SCROLL_TIMEOUT, "60"));
     }
 

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/GlueConnectionUtils.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/GlueConnectionUtils.java
@@ -1,0 +1,107 @@
+/*-
+ * #%L
+ * Amazon Athena Query Federation SDK
+ * %%
+ * Copyright (C) 2019 - 2023 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connector.lambda;
+
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.services.glue.AWSGlue;
+import com.amazonaws.services.glue.AWSGlueClientBuilder;
+import com.amazonaws.services.glue.model.Connection;
+import com.amazonaws.services.glue.model.GetConnectionRequest;
+import com.amazonaws.services.glue.model.GetConnectionResult;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class GlueConnectionUtils
+{
+    // config property to store glue connection reference
+    public static final String DEFAULT_GLUE_CONNECTION = "glue_connection";
+    // Connection properties storing athena specific connection details
+    public static final String GLUE_CONNECTION_ATHENA_PROPERTIES = "AthenaProperties";
+    public static final String GLUE_CONNECTION_ATHENA_CONNECTOR_PROPERTIES = "connectorProperties";
+    public static final String GLUE_CONNECTION_ATHENA_DRIVER_PROPERTIES = "driverProperties";
+    public static final String[] propertySubsets = {GLUE_CONNECTION_ATHENA_CONNECTOR_PROPERTIES, GLUE_CONNECTION_ATHENA_DRIVER_PROPERTIES};
+
+    private static final int CONNECT_TIMEOUT = 250;
+    private static final Logger logger = LoggerFactory.getLogger(GlueConnectionUtils.class);
+    private static HashMap<String, HashMap<String, String>> connectionNameCache = new HashMap<>();
+
+    private GlueConnectionUtils()
+    {
+    }
+
+    public static Map<String, String> getGlueConnection()
+    {
+        HashMap<String, String> envConfig = new HashMap<>(System.getenv());
+
+        String glueConnectionName = envConfig.get(DEFAULT_GLUE_CONNECTION);
+        if (StringUtils.isNotBlank(glueConnectionName)) {
+            HashMap<String, String> cachedConfig = connectionNameCache.get(glueConnectionName);
+            if (cachedConfig == null) {
+                try {
+                    HashMap<String, HashMap<String, String>> athenaPropertiesToMap = new HashMap<String, HashMap<String, String>>();
+
+                    AWSGlue awsGlue = AWSGlueClientBuilder.standard().withClientConfiguration(new ClientConfiguration().withConnectionTimeout(CONNECT_TIMEOUT)).build();
+                    GetConnectionResult glueConnection = awsGlue.getConnection(new GetConnectionRequest().withName(glueConnectionName));
+                    logger.debug("Successfully retrieved connection {}", glueConnectionName);
+                    Connection connection = glueConnection.getConnection();
+                    String athenaPropertiesAsString = connection.getConnectionProperties().get(GLUE_CONNECTION_ATHENA_PROPERTIES);
+                    try {
+                        ObjectMapper mapper = new ObjectMapper();
+                        athenaPropertiesToMap = mapper.readValue(athenaPropertiesAsString, new TypeReference<HashMap>(){});
+                        logger.debug("Successfully parsed connection properties");
+                    }
+                    catch (Exception err) {
+                         logger.error("Error Parsing AthenaDriverProperties JSON to Map", err.toString());
+                    }
+                    for (String subset : propertySubsets) {
+                        if (athenaPropertiesToMap.containsKey(subset)) {
+                            logger.debug("Adding {} subset from Glue Connection config.", subset);
+                            Map<String, String> properties = athenaPropertiesToMap.get(subset).entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, element -> String.valueOf(element.getValue())));
+                            logger.debug("Adding the following set of properties to config: {}", properties);
+                            envConfig.putAll(properties);
+                        }
+                        else {
+                            logger.debug("{} properties not included in Glue Connnection config.", subset);
+                        }
+                    }
+                    connectionNameCache.put(glueConnectionName, envConfig);
+                }
+                catch (Exception err) {
+                    logger.error("Failed to retrieve connection: {}, and parse the connection properties!", glueConnectionName);
+                    throw new RuntimeException(err.toString());
+                }
+            }
+            else {
+                return cachedConfig;
+            }
+        }
+        else {            
+            logger.debug("No Glue Connection name was defined in Environment Variables.");
+        }
+        return envConfig;
+    }
+}

--- a/athena-hbase/src/main/java/com/amazonaws/athena/connectors/hbase/HbaseCompositeHandler.java
+++ b/athena-hbase/src/main/java/com/amazonaws/athena/connectors/hbase/HbaseCompositeHandler.java
@@ -19,6 +19,7 @@
  */
 package com.amazonaws.athena.connectors.hbase;
 
+import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**
@@ -30,6 +31,6 @@ public class HbaseCompositeHandler
 {
     public HbaseCompositeHandler()
     {
-        super(new HbaseMetadataHandler(System.getenv()), new HbaseRecordHandler(System.getenv()));
+        super(new HbaseMetadataHandler(GlueConnectionUtils.getGlueConnection()), new HbaseRecordHandler(GlueConnectionUtils.getGlueConnection()));
     }
 }

--- a/athena-hortonworks-hive/src/main/java/com/amazonaws/athena/connectors/hortonworks/HiveCompositeHandler.java
+++ b/athena-hortonworks-hive/src/main/java/com/amazonaws/athena/connectors/hortonworks/HiveCompositeHandler.java
@@ -19,6 +19,7 @@
  */
 package com.amazonaws.athena.connectors.hortonworks;
 
+import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**
@@ -32,6 +33,6 @@ public class HiveCompositeHandler
 {
     public HiveCompositeHandler()
     {
-        super(new HiveMetadataHandler(System.getenv()), new HiveRecordHandler(System.getenv()));
+        super(new HiveMetadataHandler(GlueConnectionUtils.getGlueConnection()), new HiveRecordHandler(GlueConnectionUtils.getGlueConnection()));
     }
 }

--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/MultiplexingJdbcCompositeHandler.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/MultiplexingJdbcCompositeHandler.java
@@ -19,6 +19,7 @@
  */
 package com.amazonaws.athena.connectors.jdbc;
 
+import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 import com.amazonaws.athena.connectors.jdbc.manager.JdbcMetadataHandler;
 import com.amazonaws.athena.connectors.jdbc.manager.JdbcRecordHandler;
@@ -43,10 +44,10 @@ public class MultiplexingJdbcCompositeHandler
     {
         super(
             hasCatalogConnections ?
-                muxMetadataHandlerClass.getConstructor(java.util.Map.class).newInstance(System.getenv()) :
-                metadataHandlerClass.getConstructor(java.util.Map.class).newInstance(System.getenv()),
+                muxMetadataHandlerClass.getConstructor(java.util.Map.class).newInstance(GlueConnectionUtils.getGlueConnection()) :
+                metadataHandlerClass.getConstructor(java.util.Map.class).newInstance(GlueConnectionUtils.getGlueConnection()),
             hasCatalogConnections ?
-                muxRecordHandlerClass.getConstructor(java.util.Map.class).newInstance(System.getenv()) :
-                recordHandlerClass.getConstructor(java.util.Map.class).newInstance(System.getenv()));
+                muxRecordHandlerClass.getConstructor(java.util.Map.class).newInstance(GlueConnectionUtils.getGlueConnection()) :
+                recordHandlerClass.getConstructor(java.util.Map.class).newInstance(GlueConnectionUtils.getGlueConnection()));
     }
 }

--- a/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/AmazonMskCompositeHandler.java
+++ b/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/AmazonMskCompositeHandler.java
@@ -19,6 +19,7 @@
  */
 package com.amazonaws.athena.connectors.msk;
 
+import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 public class AmazonMskCompositeHandler
@@ -26,6 +27,6 @@ public class AmazonMskCompositeHandler
 {
     public AmazonMskCompositeHandler() throws Exception
     {
-        super(new AmazonMskMetadataHandler(System.getenv()), new AmazonMskRecordHandler(System.getenv()));
+        super(new AmazonMskMetadataHandler(GlueConnectionUtils.getGlueConnection()), new AmazonMskRecordHandler(GlueConnectionUtils.getGlueConnection()));
     }
 }

--- a/athena-mysql/src/main/java/com/amazonaws/athena/connectors/mysql/MySqlCompositeHandler.java
+++ b/athena-mysql/src/main/java/com/amazonaws/athena/connectors/mysql/MySqlCompositeHandler.java
@@ -19,6 +19,7 @@
  */
 package com.amazonaws.athena.connectors.mysql;
 
+import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**
@@ -32,6 +33,6 @@ public class MySqlCompositeHandler
 {
     public MySqlCompositeHandler()
     {
-        super(new MySqlMetadataHandler(System.getenv()), new MySqlRecordHandler(System.getenv()));
+        super(new MySqlMetadataHandler(GlueConnectionUtils.getGlueConnection()), new MySqlRecordHandler(GlueConnectionUtils.getGlueConnection()));
     }
 }

--- a/athena-neptune/src/main/java/com/amazonaws/athena/connectors/neptune/NeptuneCompositeHandler.java
+++ b/athena-neptune/src/main/java/com/amazonaws/athena/connectors/neptune/NeptuneCompositeHandler.java
@@ -19,6 +19,7 @@
  */
 package com.amazonaws.athena.connectors.neptune;
 
+import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**
@@ -30,6 +31,6 @@ public class NeptuneCompositeHandler
 {
     public NeptuneCompositeHandler()
     {
-        super(new NeptuneMetadataHandler(System.getenv()), new NeptuneRecordHandler(System.getenv()));
+        super(new NeptuneMetadataHandler(GlueConnectionUtils.getGlueConnection()), new NeptuneRecordHandler(GlueConnectionUtils.getGlueConnection()));
     }
 }

--- a/athena-neptune/src/main/java/com/amazonaws/athena/connectors/neptune/NeptuneRecordHandler.java
+++ b/athena-neptune/src/main/java/com/amazonaws/athena/connectors/neptune/NeptuneRecordHandler.java
@@ -74,12 +74,12 @@ public class NeptuneRecordHandler extends RecordHandler
         switch(graphType){
             case PROPERTYGRAPH: 
                 return new NeptuneGremlinConnection(configOptions.get(Constants.CFG_ENDPOINT),
-                configOptions.get(Constants.CFG_PORT), Boolean.parseBoolean(configOptions.get(Constants.CFG_IAM)), 
+                configOptions.getOrDefault(Constants.CFG_PORT, "8182"), Boolean.parseBoolean(configOptions.getOrDefault(Constants.CFG_IAM, "false")),
                 configOptions.get(Constants.CFG_REGION));
 
             case RDF:
                 return new NeptuneSparqlConnection(configOptions.get(Constants.CFG_ENDPOINT),
-                        configOptions.get(Constants.CFG_PORT), Boolean.parseBoolean(configOptions.get(Constants.CFG_IAM)), 
+                        configOptions.getOrDefault(Constants.CFG_PORT, "8182"), Boolean.parseBoolean(configOptions.getOrDefault(Constants.CFG_IAM, "false")),
                         configOptions.get(Constants.CFG_REGION));
         }
         return null;

--- a/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleCompositeHandler.java
+++ b/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleCompositeHandler.java
@@ -20,6 +20,7 @@
  */
 package com.amazonaws.athena.connectors.oracle;
 
+import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**
@@ -33,6 +34,6 @@ public class OracleCompositeHandler
 {
     public OracleCompositeHandler()
     {
-        super(new OracleMetadataHandler(System.getenv()), new OracleRecordHandler(System.getenv()));
+        super(new OracleMetadataHandler(GlueConnectionUtils.getGlueConnection()), new OracleRecordHandler(GlueConnectionUtils.getGlueConnection()));
     }
 }

--- a/athena-postgresql/src/main/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlCompositeHandler.java
+++ b/athena-postgresql/src/main/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlCompositeHandler.java
@@ -19,6 +19,7 @@
  */
 package com.amazonaws.athena.connectors.postgresql;
 
+import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**
@@ -32,6 +33,6 @@ public class PostGreSqlCompositeHandler
 {
     public PostGreSqlCompositeHandler()
     {
-        super(new PostGreSqlMetadataHandler(System.getenv()), new PostGreSqlRecordHandler(System.getenv()));
+        super(new PostGreSqlMetadataHandler(GlueConnectionUtils.getGlueConnection()), new PostGreSqlRecordHandler(GlueConnectionUtils.getGlueConnection()));
     }
 }

--- a/athena-redis/src/main/java/com/amazonaws/athena/connectors/redis/RedisCompositeHandler.java
+++ b/athena-redis/src/main/java/com/amazonaws/athena/connectors/redis/RedisCompositeHandler.java
@@ -19,6 +19,7 @@
  */
 package com.amazonaws.athena.connectors.redis;
 
+import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**
@@ -30,6 +31,6 @@ public class RedisCompositeHandler
 {
     public RedisCompositeHandler()
     {
-        super(new RedisMetadataHandler(System.getenv()), new RedisRecordHandler(System.getenv()));
+        super(new RedisMetadataHandler(GlueConnectionUtils.getGlueConnection()), new RedisRecordHandler(GlueConnectionUtils.getGlueConnection()));
     }
 }

--- a/athena-saphana/src/main/java/com/amazonaws/athena/connectors/saphana/SaphanaCompositeHandler.java
+++ b/athena-saphana/src/main/java/com/amazonaws/athena/connectors/saphana/SaphanaCompositeHandler.java
@@ -22,6 +22,7 @@
 
 package com.amazonaws.athena.connectors.saphana;
 
+import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**
@@ -35,6 +36,6 @@ public class SaphanaCompositeHandler
 {
     public SaphanaCompositeHandler()
     {
-        super(new SaphanaMetadataHandler(System.getenv()), new SaphanaRecordHandler(System.getenv()));
+        super(new SaphanaMetadataHandler(GlueConnectionUtils.getGlueConnection()), new SaphanaRecordHandler(GlueConnectionUtils.getGlueConnection()));
     }
 }

--- a/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeCompositeHandler.java
+++ b/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeCompositeHandler.java
@@ -22,6 +22,7 @@
 
 package com.amazonaws.athena.connectors.snowflake;
 
+import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**
@@ -35,6 +36,6 @@ public class SnowflakeCompositeHandler
 {
     public SnowflakeCompositeHandler()
     {
-        super(new SnowflakeMetadataHandler(System.getenv()), new SnowflakeRecordHandler(System.getenv()));
+        super(new SnowflakeMetadataHandler(GlueConnectionUtils.getGlueConnection()), new SnowflakeRecordHandler(GlueConnectionUtils.getGlueConnection()));
     }
 }

--- a/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerCompositeHandler.java
+++ b/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerCompositeHandler.java
@@ -19,12 +19,13 @@
  */
 package com.amazonaws.athena.connectors.sqlserver;
 
+import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 public class SqlServerCompositeHandler extends CompositeHandler
 {
     public SqlServerCompositeHandler()
     {
-        super(new SqlServerMetadataHandler(System.getenv()), new SqlServerRecordHandler(System.getenv()));
+        super(new SqlServerMetadataHandler(GlueConnectionUtils.getGlueConnection()), new SqlServerRecordHandler(GlueConnectionUtils.getGlueConnection()));
     }
 }

--- a/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseCompositeHandler.java
+++ b/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseCompositeHandler.java
@@ -19,12 +19,13 @@
  */
 package com.amazonaws.athena.connectors.synapse;
 
+import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 public class SynapseCompositeHandler extends CompositeHandler
 {
     public SynapseCompositeHandler()
     {
-        super(new SynapseMetadataHandler(System.getenv()), new SynapseRecordHandler(System.getenv()));
+        super(new SynapseMetadataHandler(GlueConnectionUtils.getGlueConnection()), new SynapseRecordHandler(GlueConnectionUtils.getGlueConnection()));
     }
 }

--- a/athena-teradata/src/main/java/com/amazonaws/athena/connectors/teradata/TeradataCompositeHandler.java
+++ b/athena-teradata/src/main/java/com/amazonaws/athena/connectors/teradata/TeradataCompositeHandler.java
@@ -20,6 +20,8 @@
  */
 
 package com.amazonaws.athena.connectors.teradata;
+
+import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**
@@ -33,6 +35,6 @@ public class TeradataCompositeHandler
 {
     public TeradataCompositeHandler()
     {
-        super(new TeradataMetadataHandler(System.getenv()), new TeradataRecordHandler(System.getenv()));
+        super(new TeradataMetadataHandler(GlueConnectionUtils.getGlueConnection()), new TeradataRecordHandler(GlueConnectionUtils.getGlueConnection()));
     }
 }

--- a/athena-timestream/src/main/java/com/amazonaws/athena/connectors/timestream/TimestreamCompositeHandler.java
+++ b/athena-timestream/src/main/java/com/amazonaws/athena/connectors/timestream/TimestreamCompositeHandler.java
@@ -19,6 +19,7 @@
  */
 package com.amazonaws.athena.connectors.timestream;
 
+import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 public class TimestreamCompositeHandler
@@ -26,6 +27,6 @@ public class TimestreamCompositeHandler
 {
     public TimestreamCompositeHandler()
     {
-        super(new TimestreamMetadataHandler(System.getenv()), new TimestreamRecordHandler(System.getenv()));
+        super(new TimestreamMetadataHandler(GlueConnectionUtils.getGlueConnection()), new TimestreamRecordHandler(GlueConnectionUtils.getGlueConnection()));
     }
 }

--- a/athena-tpcds/src/main/java/com/amazonaws/athena/connectors/tpcds/TPCDSCompositeHandler.java
+++ b/athena-tpcds/src/main/java/com/amazonaws/athena/connectors/tpcds/TPCDSCompositeHandler.java
@@ -19,6 +19,7 @@
  */
 package com.amazonaws.athena.connectors.tpcds;
 
+import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 public class TPCDSCompositeHandler
@@ -26,6 +27,6 @@ public class TPCDSCompositeHandler
 {
     public TPCDSCompositeHandler()
     {
-        super(new TPCDSMetadataHandler(System.getenv()), new TPCDSRecordHandler(System.getenv()));
+        super(new TPCDSMetadataHandler(GlueConnectionUtils.getGlueConnection()), new TPCDSRecordHandler(GlueConnectionUtils.getGlueConnection()));
     }
 }

--- a/athena-vertica/src/main/java/com/amazonaws/athena/connectors/vertica/VerticaCompositeHandler.java
+++ b/athena-vertica/src/main/java/com/amazonaws/athena/connectors/vertica/VerticaCompositeHandler.java
@@ -19,6 +19,7 @@
  */
 package com.amazonaws.athena.connectors.vertica;
 
+import com.amazonaws.athena.connector.lambda.GlueConnectionUtils;
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
 /**
@@ -30,6 +31,6 @@ public class VerticaCompositeHandler
 {
     public VerticaCompositeHandler()
     {
-        super(new VerticaMetadataHandler(System.getenv()), new VerticaRecordHandler(System.getenv()));
+        super(new VerticaMetadataHandler(GlueConnectionUtils.getGlueConnection()), new VerticaRecordHandler(GlueConnectionUtils.getGlueConnection()));
     }
 }


### PR DESCRIPTION
*Description of changes:*
Integrating connectors to be able to supplement connection properties from glue if connection is provided as environment variable `glue_connection`.
```
Example of how it may look in connector: 
glue_connection: "datasource-connection"
```
Introduced util class, reaches out to Glue, parses connection properties into a config map and supplements it to the connectors handlers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
