### PR TITLE
Updating Teradata connector to accept both 'partitioncount' and 'partition_count' from Config

### DIFF
--- a/athena-teradata/src/main/java/com/amazonaws/athena/connectors/teradata/TeradataMetadataHandler.java
+++ b/athena-teradata/src/main/java/com/amazonaws/athena/connectors/teradata/TeradataMetadataHandler.java
@@ -244,7 +244,7 @@ public class TeradataMetadataHandler extends JdbcMetadataHandler
     {
         final String getPartitionsCountQuery = "Select  count(distinct partition ) as partition_count FROM " + getTableLayoutRequest.getTableName().getSchemaName() + "." +
                 getTableLayoutRequest.getTableName().getTableName() + " where 1= ?";
-        String partitioncount = configOptions.get("partitioncount");
+        String partitioncount = configOptions.containsKey("partition_count") ? configOptions.get("partition_count") : configOptions.getOrDefault("partitioncount", "500");
         int totalPartitionCount = Integer.parseInt(partitioncount);
         int  partitionCount = 0;
         boolean nonPartitionApproach = false;


### PR DESCRIPTION
*Description of changes:*
This change adds backwards compatibility, once connector is integrated to supplement properties from glue connection. Connection properties follow a snakecase naming convention, therefore, to follow that `partitioncount` was renamed to `partition_count`. As well as added default value.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
