### PR TITLE
Query Passthrough for Redis Connector

### DIFF
--- a/athena-redis/athena-redis.yaml
+++ b/athena-redis/athena-redis.yaml
@@ -49,6 +49,22 @@ Parameters:
     Description: "(Optional) An IAM policy ARN to use as the PermissionsBoundary for the created Lambda function's execution role"
     Default: ''
     Type: String
+  QPTConnectionEndpoint:
+    Description: "(Optional) The hostname:port:password of the Redis server that contains data for this table optionally using SecretsManager (e.g. ${secret_name}). Used for Query Pass Through queries only."
+    Default: ''
+    Type: String
+  QPTConnectionSSL:
+    Description: "(Optional) When True, creates a Redis connection that uses SSL/TLS. Used for Query Pass Through queries only."
+    Default: 'false'
+    Type: String
+  QPTConnectionCluster:
+    Description: "(Optional) When True, enables support for clustered Redis instances. Used for Query Pass Through queries only."
+    Default: 'false'
+    Type: String
+  QPTConnectionDBNumber:
+    Description: "(Optional) Set this number (for example 1, 2, or 3) to read from a non-default Redis database. Used for Query Pass Through queries only."
+    Default: 0
+    Type: Number
 Conditions:
   HasPermissionsBoundary: !Not [ !Equals [ !Ref PermissionsBoundaryARN, "" ] ]
 Resources:
@@ -60,6 +76,10 @@ Resources:
           disable_spill_encryption: !Ref DisableSpillEncryption
           spill_bucket: !Ref SpillBucket
           spill_prefix: !Ref SpillPrefix
+          qpt_endpoint: !Ref QPTConnectionEndpoint
+          qpt_ssl: !Ref QPTConnectionSSL
+          qpt_cluster: !Ref QPTConnectionCluster
+          qpt_db_number: !Ref QPTConnectionDBNumber
       FunctionName: !Ref AthenaCatalogName
       Handler: "com.amazonaws.athena.connectors.redis.RedisCompositeHandler"
       CodeUri: "./target/athena-redis-2022.47.1.jar"

--- a/athena-redis/src/main/java/com/amazonaws/athena/connectors/redis/RedisMetadataHandler.java
+++ b/athena-redis/src/main/java/com/amazonaws/athena/connectors/redis/RedisMetadataHandler.java
@@ -242,8 +242,6 @@ public class RedisMetadataHandler
         Map<String, String> queryPassthroughArgs = request.getQueryPassthroughArguments();
         queryPassthrough.verify(queryPassthroughArgs);
 
-        logger.debug("doGetQueryPassthroughSchema configOptions: " + configOptions.toString());
-
         SchemaBuilder schemaBuilder = SchemaBuilder.newBuilder();
         schemaBuilder.addField(QPT_COLUMN_NAME, Types.MinorType.VARCHAR.getType());
         schemaBuilder.addMetadata(VALUE_TYPE_TABLE_PROP, "literal");

--- a/athena-redis/src/main/java/com/amazonaws/athena/connectors/redis/RedisMetadataHandler.java
+++ b/athena-redis/src/main/java/com/amazonaws/athena/connectors/redis/RedisMetadataHandler.java
@@ -29,6 +29,8 @@ import com.amazonaws.athena.connector.lambda.data.SchemaBuilder;
 import com.amazonaws.athena.connector.lambda.domain.Split;
 import com.amazonaws.athena.connector.lambda.domain.spill.SpillLocation;
 import com.amazonaws.athena.connector.lambda.handlers.GlueMetadataHandler;
+import com.amazonaws.athena.connector.lambda.metadata.GetDataSourceCapabilitiesRequest;
+import com.amazonaws.athena.connector.lambda.metadata.GetDataSourceCapabilitiesResponse;
 import com.amazonaws.athena.connector.lambda.metadata.GetSplitsRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetSplitsResponse;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableLayoutRequest;
@@ -39,15 +41,18 @@ import com.amazonaws.athena.connector.lambda.metadata.ListSchemasResponse;
 import com.amazonaws.athena.connector.lambda.metadata.ListTablesRequest;
 import com.amazonaws.athena.connector.lambda.metadata.ListTablesResponse;
 import com.amazonaws.athena.connector.lambda.metadata.glue.DefaultGlueType;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.OptimizationSubType;
 import com.amazonaws.athena.connector.lambda.security.EncryptionKeyFactory;
 import com.amazonaws.athena.connectors.redis.lettuce.RedisCommandsWrapper;
 import com.amazonaws.athena.connectors.redis.lettuce.RedisConnectionFactory;
 import com.amazonaws.athena.connectors.redis.lettuce.RedisConnectionWrapper;
+import com.amazonaws.athena.connectors.redis.qpt.RedisQueryPassthrough;
 import com.amazonaws.services.athena.AmazonAthena;
 import com.amazonaws.services.glue.AWSGlue;
 import com.amazonaws.services.glue.model.Database;
 import com.amazonaws.services.glue.model.Table;
 import com.amazonaws.services.secretsmanager.AWSSecretsManager;
+import com.google.common.collect.ImmutableMap;
 import io.lettuce.core.KeyScanCursor;
 import io.lettuce.core.Range;
 import io.lettuce.core.ScanArgs;
@@ -62,6 +67,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -92,6 +98,14 @@ public class RedisMetadataHandler
     protected static final String KEY_COLUMN_NAME = "_key_";
     protected static final String SPLIT_START_INDEX = "start-index";
     protected static final String SPLIT_END_INDEX = "end-index";
+
+    //The name of the column added for Query Passthrough requests
+    protected static final String QPT_COLUMN_NAME = "_value_";
+    //The names of the lambda environment variables used for QPT connections
+    protected static final String QPT_ENDPOINT_ENV_VAR = "qpt_endpoint";
+    protected static final String QPT_SSL_ENV_VAR = "qpt_ssl";
+    protected static final String QPT_CLUSTER_ENV_VAR = "qpt_cluster";
+    protected static final String QPT_DB_NUMBER_ENV_VAR = "qpt_db_number";
 
     //Defines the table property name used to set the Redis Key Type for the table. (e.g. prefix, zset)
     protected static final String KEY_TYPE = "redis-key-type";
@@ -125,6 +139,8 @@ public class RedisMetadataHandler
     private final AWSGlue awsGlue;
     private final RedisConnectionFactory redisConnectionFactory;
 
+    private final RedisQueryPassthrough queryPassthrough = new RedisQueryPassthrough();
+
     public RedisMetadataHandler(java.util.Map<String, String> configOptions)
     {
         super(SOURCE_TYPE, configOptions);
@@ -147,6 +163,15 @@ public class RedisMetadataHandler
         super(awsGlue, keyFactory, secretsManager, athena, SOURCE_TYPE, spillBucket, spillPrefix, configOptions);
         this.awsGlue = awsGlue;
         this.redisConnectionFactory = redisConnectionFactory;
+    }
+    
+    @Override
+    public GetDataSourceCapabilitiesResponse doGetDataSourceCapabilities(BlockAllocator allocator, GetDataSourceCapabilitiesRequest request)
+    {
+        ImmutableMap.Builder<String, List<OptimizationSubType>> capabilities = ImmutableMap.builder();
+        queryPassthrough.addQueryPassthroughCapabilityIfEnabled(capabilities, configOptions);
+
+        return new GetDataSourceCapabilitiesResponse(request.getCatalogName(), capabilities.build());
     }
 
     /**
@@ -206,6 +231,29 @@ public class RedisMetadataHandler
         schemaBuilder.addField(KEY_COLUMN_NAME, Types.MinorType.VARCHAR.getType());
 
         return new GetTableResponse(response.getCatalogName(), response.getTableName(), schemaBuilder.build());
+    }
+
+    @Override
+    public GetTableResponse doGetQueryPassthroughSchema(BlockAllocator allocator, GetTableRequest request) throws Exception
+    {
+        if (!request.isQueryPassthrough()) {
+            throw new IllegalArgumentException("No Query passed through [{}]" + request);
+        }
+        Map<String, String> queryPassthroughArgs = request.getQueryPassthroughArguments();
+        queryPassthrough.verify(queryPassthroughArgs);
+
+        logger.debug("doGetQueryPassthroughSchema configOptions: " + configOptions.toString());
+
+        SchemaBuilder schemaBuilder = SchemaBuilder.newBuilder();
+        schemaBuilder.addField(QPT_COLUMN_NAME, Types.MinorType.VARCHAR.getType());
+        schemaBuilder.addMetadata(VALUE_TYPE_TABLE_PROP, "literal");
+        schemaBuilder.addMetadata(KEY_PREFIX_TABLE_PROP, "*");
+        schemaBuilder.addMetadata(REDIS_SSL_FLAG, configOptions.get(QPT_SSL_ENV_VAR));
+        schemaBuilder.addMetadata(REDIS_ENDPOINT_PROP, configOptions.get(QPT_ENDPOINT_ENV_VAR));
+        schemaBuilder.addMetadata(REDIS_CLUSTER_FLAG, configOptions.get(QPT_CLUSTER_ENV_VAR));
+        schemaBuilder.addMetadata(REDIS_DB_NUMBER, configOptions.get(QPT_DB_NUMBER_ENV_VAR));
+
+        return new GetTableResponse(request.getCatalogName(), request.getTableName(), schemaBuilder.build());
     }
 
     @Override

--- a/athena-redis/src/main/java/com/amazonaws/athena/connectors/redis/RedisRecordHandler.java
+++ b/athena-redis/src/main/java/com/amazonaws/athena/connectors/redis/RedisRecordHandler.java
@@ -182,12 +182,14 @@ public class RedisRecordHandler
         String keys = queryPassthroughArgs.get(RedisQueryPassthrough.KEYS);
         String[] keysArray = new String[0];
         if (!keys.isEmpty()) {
+            // to convert string formatted as "[value1, value2, ...]" to array of strings
             keysArray = keys.substring(1, keys.length() - 1).split(",\\s*");
         }
 
         String argv = queryPassthroughArgs.get(RedisQueryPassthrough.ARGV);
         String[] argvArray = new String[0];
         if (!argv.isEmpty()) {
+            // to convert string formatted as "[value1, value2, ...]" to array of strings
             argvArray = argv.substring(1, argv.length() - 1).split(",\\s*");
         }
 
@@ -290,6 +292,9 @@ public class RedisRecordHandler
      */
     private void flattenRow(Object value, StringBuilder builder)
     {
+        if (value == null) {
+            return;
+        }
         if (value instanceof String) {
             if (builder.length() != 0) {
                 builder.append(", ");

--- a/athena-redis/src/main/java/com/amazonaws/athena/connectors/redis/RedisRecordHandler.java
+++ b/athena-redis/src/main/java/com/amazonaws/athena/connectors/redis/RedisRecordHandler.java
@@ -174,8 +174,6 @@ public class RedisRecordHandler
         Map<String, String> queryPassthroughArgs = recordsRequest.getConstraints().getQueryPassthroughArguments();
         queryPassthrough.verify(queryPassthroughArgs);
 
-        logger.debug("handleQueryPassthrough we have QPT");
-
         RedisCommandsWrapper<String, String> syncCommands = getSyncCommands(recordsRequest);
 
         String script = queryPassthroughArgs.get(RedisQueryPassthrough.SCRIPT);
@@ -193,11 +191,7 @@ public class RedisRecordHandler
             argvArray = argv.substring(1, argv.length() - 1).split(",\\s*");
         }
 
-        logger.debug("Query Passthrough Script: " + script);
         List<Object> result = syncCommands.evalReadOnly(scriptBytes, ScriptOutputType.MULTI, keysArray, argvArray);
-        logger.debug("evalReadOnly multi result: " + result.toString());
-        logger.debug("evalReadOnly multi result index 0: " + result.get(0).toString());
-        logger.debug("evalReadOnly multi result index 0 type: " + result.get(0).getClass().toString());
         loadSingleColumn(result, spiller, queryStatusChecker);
     }
 
@@ -285,7 +279,6 @@ public class RedisRecordHandler
             }
             spiller.writeRows((Block block, int row) -> {
                 boolean literalMatched = block.offerValue(QPT_COLUMN_NAME, row, builder.toString());
-                logger.debug("Attempted to write " + builder.toString() + " to row. Success: " + literalMatched);
                 return literalMatched ? 1 : 0;
             });
         });
@@ -297,9 +290,7 @@ public class RedisRecordHandler
      */
     private void flattenRow(Object value, StringBuilder builder)
     {
-        logger.debug("flattenRow on: " + value.toString() + value.getClass().toString());
         if (value instanceof String) {
-            logger.debug("inside instanceof with " + value.toString());
             if (builder.length() != 0) {
                 builder.append(", ");
             }

--- a/athena-redis/src/main/java/com/amazonaws/athena/connectors/redis/RedisRecordHandler.java
+++ b/athena-redis/src/main/java/com/amazonaws/athena/connectors/redis/RedisRecordHandler.java
@@ -28,6 +28,7 @@ import com.amazonaws.athena.connector.lambda.records.ReadRecordsRequest;
 import com.amazonaws.athena.connectors.redis.lettuce.RedisCommandsWrapper;
 import com.amazonaws.athena.connectors.redis.lettuce.RedisConnectionFactory;
 import com.amazonaws.athena.connectors.redis.lettuce.RedisConnectionWrapper;
+import com.amazonaws.athena.connectors.redis.qpt.RedisQueryPassthrough;
 import com.amazonaws.services.athena.AmazonAthena;
 import com.amazonaws.services.athena.AmazonAthenaClientBuilder;
 import com.amazonaws.services.s3.AmazonS3;
@@ -39,6 +40,7 @@ import io.lettuce.core.ScanArgs;
 import io.lettuce.core.ScanCursor;
 import io.lettuce.core.ScoredValue;
 import io.lettuce.core.ScoredValueScanCursor;
+import io.lettuce.core.ScriptOutputType;
 import org.apache.arrow.util.VisibleForTesting;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.slf4j.Logger;
@@ -54,6 +56,7 @@ import java.util.stream.Collectors;
 import static com.amazonaws.athena.connectors.redis.RedisMetadataHandler.KEY_COLUMN_NAME;
 import static com.amazonaws.athena.connectors.redis.RedisMetadataHandler.KEY_PREFIX_TABLE_PROP;
 import static com.amazonaws.athena.connectors.redis.RedisMetadataHandler.KEY_TYPE;
+import static com.amazonaws.athena.connectors.redis.RedisMetadataHandler.QPT_COLUMN_NAME;
 import static com.amazonaws.athena.connectors.redis.RedisMetadataHandler.REDIS_CLUSTER_FLAG;
 import static com.amazonaws.athena.connectors.redis.RedisMetadataHandler.REDIS_DB_NUMBER;
 import static com.amazonaws.athena.connectors.redis.RedisMetadataHandler.REDIS_ENDPOINT_PROP;
@@ -86,6 +89,8 @@ public class RedisRecordHandler
 
     private final RedisConnectionFactory redisConnectionFactory;
     private final AmazonS3 amazonS3;
+
+    private final RedisQueryPassthrough queryPassthrough = new RedisQueryPassthrough();
 
     public RedisRecordHandler(java.util.Map<String, String> configOptions)
     {
@@ -132,19 +137,84 @@ public class RedisRecordHandler
     @Override
     protected void readWithConstraint(BlockSpiller spiller, ReadRecordsRequest recordsRequest, QueryStatusChecker queryStatusChecker)
     {
+        if (recordsRequest.getConstraints().isQueryPassThrough()) {
+            handleQueryPassthrough(spiller, recordsRequest, queryStatusChecker);
+        }
+        else {
+            handleStandardQuery(spiller, recordsRequest, queryStatusChecker);
+        }
+    }
+
+    /**
+     * Given a recordsRequest, creates the Redis connection
+     * @param recordsRequest the recordsRequest to create a connection from
+     * @return the resulting connection object
+     */
+    private RedisCommandsWrapper<String, String> getSyncCommands(ReadRecordsRequest recordsRequest)
+    {
         Split split = recordsRequest.getSplit();
-        ScanCursor keyCursor = null;
         boolean sslEnabled = Boolean.parseBoolean(split.getProperty(REDIS_SSL_FLAG));
         boolean isCluster = Boolean.parseBoolean(split.getProperty(REDIS_CLUSTER_FLAG));
         String dbNumber = split.getProperty(REDIS_DB_NUMBER);
-        ValueType valueType = ValueType.fromId(split.getProperty(VALUE_TYPE_TABLE_PROP));
-        List<Field> fieldList = recordsRequest.getSchema().getFields().stream()
-                .filter((Field next) -> !KEY_COLUMN_NAME.equals(next.getName())).collect(Collectors.toList());
 
         RedisConnectionWrapper<String, String> connection = getOrCreateClient(split.getProperty(REDIS_ENDPOINT_PROP),
                                                                               sslEnabled, isCluster, dbNumber);
         RedisCommandsWrapper<String, String> syncCommands = connection.sync();
+        return syncCommands;
+    }
 
+    /**
+     * readWithConstraint case for when the query involves Query Passthrough
+     * @see RecordHandler
+     */
+    private void handleQueryPassthrough(BlockSpiller spiller,
+                                        ReadRecordsRequest recordsRequest,
+                                        QueryStatusChecker queryStatusChecker)
+    {
+        Map<String, String> queryPassthroughArgs = recordsRequest.getConstraints().getQueryPassthroughArguments();
+        queryPassthrough.verify(queryPassthroughArgs);
+
+        logger.debug("handleQueryPassthrough we have QPT");
+
+        RedisCommandsWrapper<String, String> syncCommands = getSyncCommands(recordsRequest);
+
+        String script = queryPassthroughArgs.get(RedisQueryPassthrough.SCRIPT);
+        byte[] scriptBytes = script.getBytes();
+
+        String keys = queryPassthroughArgs.get(RedisQueryPassthrough.KEYS);
+        String[] keysArray = new String[0];
+        if (!keys.isEmpty()) {
+            keysArray = keys.substring(1, keys.length() - 1).split(",\\s*");
+        }
+
+        String argv = queryPassthroughArgs.get(RedisQueryPassthrough.ARGV);
+        String[] argvArray = new String[0];
+        if (!argv.isEmpty()) {
+            argvArray = argv.substring(1, argv.length() - 1).split(",\\s*");
+        }
+
+        logger.debug("Query Passthrough Script: " + script);
+        List<Object> result = syncCommands.evalReadOnly(scriptBytes, ScriptOutputType.MULTI, keysArray, argvArray);
+        logger.debug("evalReadOnly multi result: " + result.toString());
+        logger.debug("evalReadOnly multi result index 0: " + result.get(0).toString());
+        logger.debug("evalReadOnly multi result index 0 type: " + result.get(0).getClass().toString());
+        loadSingleColumn(result, spiller, queryStatusChecker);
+    }
+
+    /**
+     * readWithConstraint case for when the query does not involve Query Passthrough
+     * @see RecordHandler
+     */
+    private void handleStandardQuery(BlockSpiller spiller,
+                                     ReadRecordsRequest recordsRequest,
+                                     QueryStatusChecker queryStatusChecker)
+    {
+        Split split = recordsRequest.getSplit();
+        ScanCursor keyCursor = null;
+        ValueType valueType = ValueType.fromId(split.getProperty(VALUE_TYPE_TABLE_PROP));
+        List<Field> fieldList = recordsRequest.getSchema().getFields().stream()
+                .filter((Field next) -> !KEY_COLUMN_NAME.equals(next.getName())).collect(Collectors.toList());
+        RedisCommandsWrapper<String, String> syncCommands = getSyncCommands(recordsRequest);
         do {
             Set<String> keys = new HashSet<>();
             //Load all the keys associated with this split
@@ -202,6 +272,41 @@ public class RedisRecordHandler
             KeyScanCursor<String> newCursor = syncCommands.scan(cursor, scanArgs);
             keys.addAll(newCursor.getKeys());
             return newCursor;
+        }
+    }
+
+    private void loadSingleColumn(List<Object> values, BlockSpiller spiller, QueryStatusChecker queryStatusChecker)
+    {
+        values.stream().forEach((Object value) -> {
+            StringBuilder builder = new StringBuilder();
+            flattenRow(value, builder);
+            if (!queryStatusChecker.isQueryRunning()) {
+                return;
+            }
+            spiller.writeRows((Block block, int row) -> {
+                boolean literalMatched = block.offerValue(QPT_COLUMN_NAME, row, builder.toString());
+                logger.debug("Attempted to write " + builder.toString() + " to row. Success: " + literalMatched);
+                return literalMatched ? 1 : 0;
+            });
+        });
+    }
+
+    /**
+     * Redis eval calls return an object of type T, which is either a String or List<T>.
+     * This flattens it into a String using a StringBuilder.
+     */
+    private void flattenRow(Object value, StringBuilder builder)
+    {
+        logger.debug("flattenRow on: " + value.toString() + value.getClass().toString());
+        if (value instanceof String) {
+            logger.debug("inside instanceof with " + value.toString());
+            if (builder.length() != 0) {
+                builder.append(", ");
+            }
+            builder.append(value);
+        }
+        else {
+            ((List<Object>) value).forEach((Object subValue) -> flattenRow(subValue, builder));
         }
     }
 

--- a/athena-redis/src/main/java/com/amazonaws/athena/connectors/redis/lettuce/RedisCommandsWrapper.java
+++ b/athena-redis/src/main/java/com/amazonaws/athena/connectors/redis/lettuce/RedisCommandsWrapper.java
@@ -24,6 +24,7 @@ import io.lettuce.core.Range;
 import io.lettuce.core.ScanArgs;
 import io.lettuce.core.ScanCursor;
 import io.lettuce.core.ScoredValueScanCursor;
+import io.lettuce.core.ScriptOutputType;
 import io.lettuce.core.api.sync.RedisCommands;
 import io.lettuce.core.cluster.api.sync.RedisAdvancedClusterCommands;
 import org.apache.arrow.util.VisibleForTesting;
@@ -110,6 +111,16 @@ public class RedisCommandsWrapper<K, V>
     }
     else {
       return standaloneCommands.zscan(var1, var2);
+    }
+  }
+
+  public <T> T evalReadOnly(byte[] script, ScriptOutputType type, K[] keys, V... values)
+  {
+    if (isCluster) {
+      return clusterCommands.evalReadOnly(script, type, keys, values);
+    }
+    else {
+      return standaloneCommands.evalReadOnly(script, type, keys, values);
     }
   }
 

--- a/athena-redis/src/main/java/com/amazonaws/athena/connectors/redis/qpt/RedisQueryPassthrough.java
+++ b/athena-redis/src/main/java/com/amazonaws/athena/connectors/redis/qpt/RedisQueryPassthrough.java
@@ -1,0 +1,69 @@
+/*-
+ * #%L
+ * athena-redis
+ * %%
+ * Copyright (C) 2019 - 2024 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.redis.qpt;
+
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.querypassthrough.QueryPassthroughSignature;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.List;
+
+public final class RedisQueryPassthrough implements QueryPassthroughSignature
+{
+    // Constant value representing the name of the query.
+    public static final String NAME = "script";
+
+    // Constant value representing the domain of the query.
+    public static final String SCHEMA = "system";
+
+    // List of arguments for the query, statically initialized as it always contains the same value.
+    public static final String SCRIPT = "SCRIPT";
+    public static final String KEYS = "KEYS";
+    public static final String ARGV = "ARGV";
+
+    public static final List<String> ARGUMENTS = Arrays.asList(SCRIPT, KEYS, ARGV);
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RedisQueryPassthrough.class);
+    
+    @Override
+    public String getFunctionSchema()
+    {
+        return SCHEMA;
+    }
+
+    @Override
+    public String getFunctionName()
+    {
+        return NAME;
+    }
+
+    @Override
+    public List<String> getFunctionArguments()
+    {
+        return ARGUMENTS;
+    }
+
+    @Override
+    public Logger getLogger()
+    {
+        return LOGGER;
+    }
+}


### PR DESCRIPTION
*Description of changes:*
Query Passthrough changes for the Redis connector. Works by taking in 3 arguments, the script, keys, and argv. The script is a lua script passed as a string. The keys and argv arguments are strings representing arrays of additional arguments for the script. These three arguments are then passed to the Lettuce client eval_ro command. See the [redis Lua scripting documentation](https://redis.io/docs/latest/develop/interact/programmability/eval-intro/) for more details.

Because query passthrough works by running Lua scripts, query passthrough may not work for clustered instances due to the limitations around a Redis Lua script accessing data from multiple hashes.

Additionally adds 4 additional lambda environment variables for storing QPT connection information since QPT does not access any glue table so cannot retrieve glue table metadata.

Examples:
```
SELECT * FROM TABLE(system.script(
    script => 'return redis.call("GET", ARGV[1])',
    keys => '[]',
    argv => '[testKey]'
));
```
```
SELECT * FROM TABLE(system.script(
    'return {redis.call(''ZSCAN'', KEYS[1], ARGV[1]), redis.call(''ZSCAN'', KEYS[2], ARGV[1])}',
    '[zset:numbers, zset:letters]',
    '[20]'
));
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
