### PR TITLE
Add Redshift Serverless SDK

### DIFF
--- a/athena-redshift/pom.xml
+++ b/athena-redshift/pom.xml
@@ -38,6 +38,11 @@
             <artifactId>aws-java-sdk-redshift</artifactId>
             <version>${aws-sdk.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-redshiftserverless</artifactId>
+            <version>${aws-sdk.version}</version>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awscdk/redshift -->
         <dependency>
             <groupId>software.amazon.awscdk</groupId>


### PR DESCRIPTION
Fixes #1944. Fixes a NoClassDefFoundError that is thrown by some features that are looking for classes in the Redshift Serverless SDK.

*Issue #:* #1944 

*Description of changes:* Added aws-java-sdk-redshiftserverless to the dependency list for athena-redshift


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
