### PR TITLE
[FEATURE] Add Support for querying Avro Data in Kafka Connector

### DIFF
--- a/athena-kafka/athena-kafka.yaml
+++ b/athena-kafka/athena-kafka.yaml
@@ -28,6 +28,10 @@ Parameters:
   KafkaEndpoint:
     Description: 'Kafka cluster endpoint'
     Type: String
+  SchemaRegistryUrl:
+    Description: 'Schema Registry URL. Applicable for Avro Data Formatted Topics. (syntax. http://<endpoint>:<port>)'
+    Type: String
+    Default: ""
   LambdaFunctionName:
     Description: 'This is the name of the lambda function that will be created. This name must satisfy the pattern ^[a-z0-9-_]{1,64}$'
     Type: String
@@ -94,6 +98,7 @@ Resources:
           secrets_manager_secret: !Ref SecretNamePrefix
           certificates_s3_reference: !Ref CertificatesS3Reference
           kafka_endpoint: !Ref KafkaEndpoint
+          schema_registry_url: !Ref SchemaRegistryUrl
           auth_type: !Ref AuthType
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.kafka.KafkaCompositeHandler"

--- a/athena-kafka/pom.xml
+++ b/athena-kafka/pom.xml
@@ -27,6 +27,16 @@
             <version>3.7.0</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+            <version>1.11.3</version>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-avro-serializer</artifactId>
+            <version>7.6.0</version>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
             <version>${fasterxml.jackson.version}</version>
@@ -202,4 +212,10 @@
             </plugin>
         </plugins>
     </build>
+    <repositories>
+        <repository>
+            <id>confluent</id>
+            <url>https://packages.confluent.io/maven/</url>
+        </repository>
+    </repositories>
 </project>

--- a/athena-kafka/src/main/java/com/amazonaws/athena/connectors/kafka/GlueRegistryReader.java
+++ b/athena-kafka/src/main/java/com/amazonaws/athena/connectors/kafka/GlueRegistryReader.java
@@ -72,4 +72,9 @@ public class GlueRegistryReader
         GetSchemaVersionResult result = getSchemaVersionResult(glueRegistryName, glueSchemaName);
         return objectMapper.readValue(result.getSchemaDefinition(), clazz);
     }
+    public String getGlueSchemaType(String glueRegistryName, String glueSchemaName)
+    {
+        GetSchemaVersionResult result = getSchemaVersionResult(glueRegistryName, glueSchemaName);
+        return result.getDataFormat();
+    }
 }

--- a/athena-kafka/src/main/java/com/amazonaws/athena/connectors/kafka/KafkaConstants.java
+++ b/athena-kafka/src/main/java/com/amazonaws/athena/connectors/kafka/KafkaConstants.java
@@ -44,6 +44,10 @@ public class KafkaConstants
      */
     public static final String ENV_KAFKA_ENDPOINT = "kafka_endpoint";
     /**
+     * This is schema registry url
+     */
+    public static final String KAFKA_SCHEMA_REGISTRY_URL = "schema_registry_url";
+    /**
      * This is the type of authentication client has set for the cluster
      */
     public static final String AUTH_TYPE = "auth_type";
@@ -63,6 +67,8 @@ public class KafkaConstants
     public static final String AWS_SECRET_PWD = "password";
 
     public static final int MAX_RECORDS_IN_SPLIT = 10_000;
+
+    public static final String AVRO_DATA_FORMAT = "avro";
 
     private KafkaConstants()
     {

--- a/athena-kafka/src/main/java/com/amazonaws/athena/connectors/kafka/KafkaMetadataHandler.java
+++ b/athena-kafka/src/main/java/com/amazonaws/athena/connectors/kafka/KafkaMetadataHandler.java
@@ -328,8 +328,8 @@ public class KafkaMetadataHandler extends MetadataHandler
         String topic;
         GlueRegistryReader registryReader = new GlueRegistryReader();
         if (registryReader.getGlueSchemaType(glueRegistryName, glueSchemaName).equalsIgnoreCase(AVRO_DATA_FORMAT)) {
-            AvroTopicSchema avroTopicSchema = registryReader.getGlueSchema(glueRegistryName, glueSchemaName, AvroTopicSchema.class);
-            topic = avroTopicSchema.getName();
+            //if schema type is avro, then topic name should be glue schema name
+            topic = glueSchemaName;
         }
         else {
             TopicSchema topicSchema = registryReader.getGlueSchema(glueRegistryName, glueSchemaName, TopicSchema.class);

--- a/athena-kafka/src/main/java/com/amazonaws/athena/connectors/kafka/KafkaRecordHandler.java
+++ b/athena-kafka/src/main/java/com/amazonaws/athena/connectors/kafka/KafkaRecordHandler.java
@@ -165,7 +165,7 @@ public class KafkaRecordHandler
     {
         LOGGER.info("[kafka] {} Polling for data", splitParameters);
         int emptyResultFoundCount = 0;
-        try {
+        try (Consumer<String, TopicResultSet> consumer = kafkaConsumer) {
             while (true) {
                 if (!queryStatusChecker.isQueryRunning()) {
                     LOGGER.debug("[kafka]{}  Stopping and closing consumer due to query execution terminated by athena", splitParameters);
@@ -175,7 +175,7 @@ public class KafkaRecordHandler
 
                 // Call the poll on consumer to fetch data from kafka server
                 // poll returns data as batch which can be configured.
-                ConsumerRecords<String, TopicResultSet> records = kafkaConsumer.poll(Duration.ofSeconds(1L));
+                ConsumerRecords<String, TopicResultSet> records = consumer.poll(Duration.ofSeconds(1L));
                 LOGGER.debug("[kafka] {} polled records size {}", splitParameters, records.count());
 
                 // For debug insight
@@ -215,9 +215,6 @@ public class KafkaRecordHandler
                     }
                 }
             }
-        }
-        finally {
-            kafkaConsumer.close();
         }
     }
 
@@ -261,7 +258,7 @@ public class KafkaRecordHandler
     {
         LOGGER.info("[kafka] {} Polling for data", splitParameters);
         int emptyResultFoundCount = 0;
-        try {
+        try (Consumer<String, GenericRecord> avroConsumer = kafkaAvroConsumer) {
             while (true) {
                 if (!queryStatusChecker.isQueryRunning()) {
                     LOGGER.debug("[kafka]{}  Stopping and closing consumer due to query execution terminated by athena", splitParameters);
@@ -271,7 +268,7 @@ public class KafkaRecordHandler
 
                 // Call the poll on consumer to fetch data from kafka server
                 // poll returns data as batch which can be configured.
-                ConsumerRecords<String, GenericRecord> records = kafkaAvroConsumer.poll(Duration.ofSeconds(1L));
+                ConsumerRecords<String, GenericRecord> records = avroConsumer.poll(Duration.ofSeconds(1L));
                 LOGGER.debug("[kafka] {} polled records size {}", splitParameters, records.count());
 
                 // For debug insight
@@ -311,9 +308,6 @@ public class KafkaRecordHandler
                     }
                 }
             }
-        }
-        finally {
-            kafkaAvroConsumer.close();
         }
     }
 

--- a/athena-kafka/src/main/java/com/amazonaws/athena/connectors/kafka/dto/AvroTopicSchema.java
+++ b/athena-kafka/src/main/java/com/amazonaws/athena/connectors/kafka/dto/AvroTopicSchema.java
@@ -24,7 +24,7 @@ import java.util.List;
 
 public class AvroTopicSchema
 {
-    // Kafka Topic Name
+    // schema Name
     String name;
     // Schema Type
     String type;

--- a/athena-kafka/src/main/java/com/amazonaws/athena/connectors/kafka/dto/AvroTopicSchema.java
+++ b/athena-kafka/src/main/java/com/amazonaws/athena/connectors/kafka/dto/AvroTopicSchema.java
@@ -1,0 +1,63 @@
+/*-
+ * #%L
+ * Athena Kafka Connector
+ * %%
+ * Copyright (C) 2019 - 2024 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.kafka.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class AvroTopicSchema
+{
+    // Kafka Topic Name
+    String name;
+    // Schema Type
+    String type;
+    // Schema Fields
+    List<KafkaField> fields = new ArrayList<>();
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public void setName(String name)
+    {
+        this.name = name;
+    }
+
+    public String getType()
+    {
+        return type;
+    }
+
+    public void setType(String type)
+    {
+        this.type = type;
+    }
+
+    public List<KafkaField> getFields()
+    {
+        return fields;
+    }
+
+    public void setFields(List<KafkaField> fields)
+    {
+        this.fields = fields;
+    }
+}

--- a/athena-kafka/src/test/java/com/amazonaws/athena/connectors/kafka/KafkaMetadataHandlerTest.java
+++ b/athena-kafka/src/test/java/com/amazonaws/athena/connectors/kafka/KafkaMetadataHandlerTest.java
@@ -157,6 +157,7 @@ public class KafkaMetadataHandlerTest {
         getSchemaResult.setLatestSchemaVersion(latestSchemaVersion);
         getSchemaVersionResult.setSchemaArn(arn);
         getSchemaVersionResult.setSchemaVersionId(schemaVersionId);
+        getSchemaVersionResult.setDataFormat("json");
         getSchemaVersionResult.setSchemaDefinition("{\n" +
                 "\t\"topicName\": \"testtable\",\n" +
                 "\t\"message\": {\n" +
@@ -187,6 +188,7 @@ public class KafkaMetadataHandlerTest {
         getSchemaResult.setLatestSchemaVersion(latestSchemaVersion);
         getSchemaVersionResult.setSchemaArn(arn);
         getSchemaVersionResult.setSchemaVersionId(schemaVersionId);
+        getSchemaVersionResult.setDataFormat("json");
         getSchemaVersionResult.setSchemaDefinition("{\n" +
                 "\t\"topicName\": \"testTopic\",\n" +
                 "\t\"message\": {\n" +

--- a/athena-kafka/src/test/java/com/amazonaws/athena/connectors/kafka/KafkaUtilsTest.java
+++ b/athena-kafka/src/test/java/com/amazonaws/athena/connectors/kafka/KafkaUtilsTest.java
@@ -196,7 +196,7 @@ public class KafkaUtilsTest {
         assertEquals(Types.MinorType.INT.getType(), toArrowType("INT"));
         assertEquals(Types.MinorType.INT.getType(), toArrowType("INTEGER"));
         assertEquals(Types.MinorType.BIGINT.getType(), toArrowType("BIGINT"));
-        assertEquals(Types.MinorType.FLOAT8.getType(), toArrowType("FLOAT"));
+        assertEquals(Types.MinorType.FLOAT4.getType(), toArrowType("FLOAT"));
         assertEquals(Types.MinorType.FLOAT8.getType(), toArrowType("DOUBLE"));
         assertEquals(Types.MinorType.FLOAT8.getType(), toArrowType("DECIMAL"));
         assertEquals(Types.MinorType.DATEDAY.getType(), toArrowType("DATE"));


### PR DESCRIPTION
Support for querying Avro Data from Kafka.

Prerequisite: Define the Avro Schema in AWS Glue Schema Registry, Use Data Format as AVRO.
Note: Provide Glue Schema Name as Kafka Topic Name with same case .
example avro schema in glue :
```
{
    "type": "record",
    "name": "employee",
    "fields": [
        {
            "name": "id",
            "type": "int"
        },
        {
            "name": "name",
            "type": "string"
        }
    ]
}
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
