### PR TITLE
Extended QPT to JDBC Multiplexing

### DIFF
--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/MultiplexingJdbcMetadataHandler.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/MultiplexingJdbcMetadataHandler.java
@@ -127,6 +127,14 @@ public class MultiplexingJdbcMetadataHandler
     }
 
     @Override
+    public GetTableResponse doGetQueryPassthroughSchema(final BlockAllocator blockAllocator, final GetTableRequest getTableRequest)
+          throws Exception
+    {
+      validateMultiplexer(getTableRequest.getCatalogName());
+      return this.metadataHandlerMap.get(getTableRequest.getCatalogName()).doGetQueryPassthroughSchema(blockAllocator, getTableRequest);
+    }
+
+    @Override
     public void getPartitions(final BlockWriter blockWriter, final GetTableLayoutRequest getTableLayoutRequest, QueryStatusChecker queryStatusChecker)
             throws Exception
     {


### PR DESCRIPTION
*Issue #, if available:*
QPT was not working with Mutli-plexed connector; this is due to the missing logic in the `MultiplexingJdbcMetadataHandler` class.

*Description of changes:*
Added logic for the QPT get schema method in the `MultiplexingJdbcMetadataHandler` class.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
