### PR TITLE
Updated prepare_dev_env.sh script

### DIFF
--- a/tools/prepare_dev_env.sh
+++ b/tools/prepare_dev_env.sh
@@ -38,16 +38,18 @@ while true; do
 done
 
 set -e
-sudo wget https://archive.apache.org/dist/maven/maven-3/3.5.4/binaries/apache-maven-3.5.4-bin.tar.gz -O /tmp/apache-maven-3.5.4-bin.tar.gz
-sudo tar xf /tmp/apache-maven-3.5.4-bin.tar.gz -C /opt
-echo "export M2_HOME=/opt/apache-maven-3.5.4" >> ~/.profile
+sudo wget https://archive.apache.org/dist/maven/maven-3/3.9.6/binaries/apache-maven-3.9.6-bin.tar.gz -O /tmp/apache-maven-3.9.6-bin.tar.gz
+sudo tar xf /tmp/apache-maven-3.9.6-bin.tar.gz -C /opt
+echo "export M2_HOME=/opt/apache-maven-3.9.6" >> ~/.profile
 echo "export PATH=\${M2_HOME}/bin:\${PATH}" >> ~/.profile
-echo "export M2_HOME=/opt/apache-maven-3.5.4" >> ~/.bash_profile
+echo "export M2_HOME=/opt/apache-maven-3.9.6" >> ~/.bash_profile
 echo "export PATH=\${M2_HOME}/bin:\${PATH}" >> ~/.bash_profile
 
 sudo yum -y install java-11-openjdk-devel
-# If using amazon linux and the above doesn't work, you can try this line instead
+# If using amazon linux 2 and the above doesn't work, you can try this line instead
 # sudo amazon-linux-extras install -y java-openjdk11
+# For amazon linux 2023, use the following line instead
+# sudo dnf install java-11-amazon-corretto
 
 echo "Set the default to the Java 11 installation"
 sudo update-alternatives --config java


### PR DESCRIPTION
*Description of changes:*
When setting up an environment recently, was using the prepare_dev_env.sh script and noticed it had not been updated; the maven version fetched was not new enough for building and the recommended instruction for amazon linux was not updated for Amazon Linux 2023. Updated to maven 3.9.6 and added a note for Amazon Linux 2023 compatible command.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
