### PR TITLE
issue-types is not a valid parameter, though it is documented in the …

### DIFF
--- a/.github/workflows/stalled.yml
+++ b/.github/workflows/stalled.yml
@@ -10,7 +10,6 @@ jobs:
     steps:
     - uses: aws-actions/stale-issue-cleanup@v3
       with:
-        issue-types: pull_requests
         stale-pr-label: 'stalled'
         stale-pr-message: 'This PR is stalled because it has been open for 30 days with no activity.'
         days-before-stale: 30


### PR DESCRIPTION
…stale-issue-cleanup documentation

*Issue #, if available:*
#1981 

*Description of changes:*
removed the issue-types parameter

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
