### PR TITLE
Added changes to support without kerberos authentication

### DIFF
--- a/athena-hbase/src/main/java/com/amazonaws/athena/connectors/hbase/HbaseConnectionFactory.java
+++ b/athena-hbase/src/main/java/com/amazonaws/athena/connectors/hbase/HbaseConnectionFactory.java
@@ -37,6 +37,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static com.amazonaws.athena.connectors.hbase.HbaseKerberosUtils.HBASE_RPC_PROTECTION;
+import static com.amazonaws.athena.connectors.hbase.HbaseKerberosUtils.HBASE_SECURITY_AUTHENTICATION;
 import static com.amazonaws.athena.connectors.hbase.HbaseKerberosUtils.KERBEROS_AUTH_ENABLED;
 import static com.amazonaws.athena.connectors.hbase.HbaseKerberosUtils.KERBEROS_CONFIG_FILES_S3_REFERENCE;
 import static com.amazonaws.athena.connectors.hbase.HbaseKerberosUtils.PRINCIPAL_NAME;
@@ -129,6 +130,8 @@ public class HbaseConnectionFactory
             logger.info("Kerberos Authentication Enabled: " + kerberosAuthEnabled);
             if (kerberosAuthEnabled) {
                 String keytabLocation = null;
+                config.set("hbase.security.authentication", HBASE_SECURITY_AUTHENTICATION);
+                config.set("hadoop.security.authentication", HBASE_SECURITY_AUTHENTICATION);
                 config.set("hbase.rpc.protection", configOptions.get(HBASE_RPC_PROTECTION));
                 logger.info("hbase.rpc.protection: " + config.get("hbase.rpc.protection"));
                 String s3uri = configOptions.get(KERBEROS_CONFIG_FILES_S3_REFERENCE);

--- a/athena-hbase/src/main/java/com/amazonaws/athena/connectors/hbase/HbaseKerberosUtils.java
+++ b/athena-hbase/src/main/java/com/amazonaws/athena/connectors/hbase/HbaseKerberosUtils.java
@@ -55,6 +55,7 @@ public class HbaseKerberosUtils
     public static final String PRINCIPAL_NAME = "principal_name";
     public static final String HBASE_RPC_PROTECTION = "hbase_rpc_protection";
     public static final String KERBEROS_AUTH_ENABLED = "kerberos_auth_enabled";
+    public static final String HBASE_SECURITY_AUTHENTICATION = "kerberos";
 
     private HbaseKerberosUtils() {}
 

--- a/athena-hbase/src/main/java/com/amazonaws/athena/connectors/hbase/connection/HbaseConnectionFactory.java
+++ b/athena-hbase/src/main/java/com/amazonaws/athena/connectors/hbase/connection/HbaseConnectionFactory.java
@@ -35,6 +35,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static com.amazonaws.athena.connectors.hbase.HbaseKerberosUtils.HBASE_RPC_PROTECTION;
+import static com.amazonaws.athena.connectors.hbase.HbaseKerberosUtils.HBASE_SECURITY_AUTHENTICATION;
 import static com.amazonaws.athena.connectors.hbase.HbaseKerberosUtils.KERBEROS_AUTH_ENABLED;
 import static com.amazonaws.athena.connectors.hbase.HbaseKerberosUtils.KERBEROS_CONFIG_FILES_S3_REFERENCE;
 import static com.amazonaws.athena.connectors.hbase.HbaseKerberosUtils.PRINCIPAL_NAME;
@@ -131,6 +132,8 @@ public class HbaseConnectionFactory
         logger.info("Kerberos Authentication Enabled: " + kerberosAuthEnabled);
         if (kerberosAuthEnabled) {
             String keytabLocation = null;
+            config.set("hbase.security.authentication", HBASE_SECURITY_AUTHENTICATION);
+            config.set("hadoop.security.authentication", HBASE_SECURITY_AUTHENTICATION);
             config.set("hbase.rpc.protection", configOptions.get(HBASE_RPC_PROTECTION));
             logger.info("hbase.rpc.protection: " + config.get("hbase.rpc.protection"));
             String s3uri = configOptions.get(KERBEROS_CONFIG_FILES_S3_REFERENCE);

--- a/athena-hbase/src/main/java/com/amazonaws/athena/connectors/hbase/integ/HbaseTableUtils.java
+++ b/athena-hbase/src/main/java/com/amazonaws/athena/connectors/hbase/integ/HbaseTableUtils.java
@@ -41,6 +41,7 @@ import java.nio.file.Path;
 import java.util.List;
 
 import static com.amazonaws.athena.connectors.hbase.HbaseKerberosUtils.HBASE_RPC_PROTECTION;
+import static com.amazonaws.athena.connectors.hbase.HbaseKerberosUtils.HBASE_SECURITY_AUTHENTICATION;
 import static com.amazonaws.athena.connectors.hbase.HbaseKerberosUtils.KERBEROS_AUTH_ENABLED;
 import static com.amazonaws.athena.connectors.hbase.HbaseKerberosUtils.KERBEROS_CONFIG_FILES_S3_REFERENCE;
 import static com.amazonaws.athena.connectors.hbase.HbaseKerberosUtils.PRINCIPAL_NAME;
@@ -103,6 +104,8 @@ public class HbaseTableUtils
         logger.info("Kerberos Authentication Enabled: " + kerberosAuthEnabled);
         if (kerberosAuthEnabled) {
             String keytabLocation = null;
+            configuration.set("hbase.security.authentication", HBASE_SECURITY_AUTHENTICATION);
+            configuration.set("hadoop.security.authentication", HBASE_SECURITY_AUTHENTICATION);
             configuration.set("hbase.rpc.protection", configOptions.get(HBASE_RPC_PROTECTION));
             logger.info("hbase.rpc.protection: " + configuration.get("hbase.rpc.protection"));
             String s3uri = configOptions.get(KERBEROS_CONFIG_FILES_S3_REFERENCE);

--- a/athena-hbase/src/main/resources/core-site.xml
+++ b/athena-hbase/src/main/resources/core-site.xml
@@ -19,10 +19,6 @@
     <value>org.apache.hadoop.io.compress.DefaultCodec,org.apache.hadoop.io.compress.GzipCodec,org.apache.hadoop.io.compress.BZip2Codec,org.apache.hadoop.io.compress.DeflateCodec,org.apache.hadoop.io.compress.SnappyCodec,org.apache.hadoop.io.compress.Lz4Codec</value>
   </property>
   <property>
-    <name>hadoop.security.authentication</name>
-    <value>kerberos</value>
-  </property>
-  <property>
     <name>hadoop.security.authorization</name>
     <value>true</value>
   </property>

--- a/athena-hbase/src/main/resources/hbase-site.xml
+++ b/athena-hbase/src/main/resources/hbase-site.xml
@@ -79,10 +79,6 @@
     <value>300000</value>
   </property>
   <property>
-    <name>hbase.security.authentication</name>
-    <value>kerberos</value>
-  </property>
-  <property>
     <name>zookeeper.session.timeout</name>
     <value>60000</value>
   </property>


### PR DESCRIPTION
*Description of changes:*
Currently the default authentication is Kerberos for HBase. We made changes to allow both authentications (with or without Kerberos). We have tested HBase with both kerberos setup and without kerberos setup, it's working fine.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
