### PR TITLE
BigQuery empty table and projectId casing issues fix

### DIFF
--- a/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryMetadataHandler.java
+++ b/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryMetadataHandler.java
@@ -83,7 +83,8 @@ public class BigQueryMetadataHandler
     extends MetadataHandler
 {
     private static final Logger logger = LoggerFactory.getLogger(BigQueryMetadataHandler.class);
-    private final String projectName = configOptions.get(BigQueryConstants.GCP_PROJECT_ID);
+    private final String projectName = configOptions.get(BigQueryConstants.GCP_PROJECT_ID) != null ?
+            configOptions.get(BigQueryConstants.GCP_PROJECT_ID).toLowerCase() : null;
 
     private final BigQueryQueryPassthrough queryPassthrough = new BigQueryQueryPassthrough();
 

--- a/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryRecordHandler.java
+++ b/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryRecordHandler.java
@@ -127,7 +127,7 @@ public class BigQueryRecordHandler
                                      List<QueryParameterValue> parameterValues,
                                      BigQuery bigQueryClient) throws Exception
     {
-        String projectName = configOptions.get(BigQueryConstants.GCP_PROJECT_ID);
+        String projectName = configOptions.get(BigQueryConstants.GCP_PROJECT_ID).toLowerCase();
         String datasetName = fixCaseForDatasetName(projectName, recordsRequest.getTableName().getSchemaName(), bigQueryClient);
         String tableName = fixCaseForTableName(projectName, datasetName, recordsRequest.getTableName().getTableName(), bigQueryClient);
 

--- a/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryRecordHandler.java
+++ b/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryRecordHandler.java
@@ -263,7 +263,13 @@ public class BigQueryRecordHandler
                 // data available.  If no sessions are available for an anonymous (cached) table, consider
                 // writing results of a query to a named table rather than consuming cached results
                 // directly.
-                Preconditions.checkState(session.getStreamsCount() > 0);
+                try {
+                    Preconditions.checkState(session.getStreamsCount() > 0);
+                }
+                catch (IllegalStateException exp) {
+                    logger.warn("No records found in the table: " + tableName);
+                    return;
+                }
 
                 // Use the first stream to perform reading.
                 String streamName = session.getStreams(0).getName();

--- a/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryUtils.java
+++ b/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryUtils.java
@@ -98,7 +98,7 @@ public class BigQueryUtils
         if (StringUtils.isNotEmpty(endpoint)) {
             bigqueryBuilder.setHost(endpoint);
         }
-        bigqueryBuilder.setProjectId(configOptions.get(BigQueryConstants.GCP_PROJECT_ID));
+        bigqueryBuilder.setProjectId(configOptions.get(BigQueryConstants.GCP_PROJECT_ID).toLowerCase());
         bigqueryBuilder.setCredentials(getCredentialsFromSecretsManager(configOptions));
         return bigqueryBuilder.build().getService();
     }


### PR DESCRIPTION
[BigQueryIssue.docx](https://github.com/user-attachments/files/16085413/BigQueryIssue.docx)
*Issue #, if available:*
Issue 1: Select count(*) on empty table returns a java exception
Details - They ran a query - SELECT COUNT(*) FROM SOME_EMPTY_TABLE_IN_BIG_QUERY caused a Java ILLEGALSTATEEXCEPTION

Issue 2: Connector does not update the case of projectId

*Description of changes:*
If table doesn't have any data, then we are throwing IllegalStateException. This issue is fixed with these changes, If table doesn't have any data, we will return zero and I have attached the test results as well. 
And projectId casing issue also fixed in this PR, as per official documentation big query projectId should contain only lowercase letters, numbers, and hyphens. So, we are converting projectId to lowercase to solve projectId casing issue.
Ref: https://cloud.google.com/resource-manager/docs/creating-managing-projects 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
