### PR TITLE
[FEATURE] Add Support for querying Avro/Protobuf Data in athena-msk Connector

### DIFF
--- a/athena-msk/pom.xml
+++ b/athena-msk/pom.xml
@@ -13,6 +13,63 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
     </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-stdlib</artifactId>
+                <version>1.9.10</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-stdlib-common</artifactId>
+                <version>1.9.10</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-stdlib-jdk8</artifactId>
+                <version>1.9.10</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-reflect</artifactId>
+                <version>1.9.10</version>
+                <scope>runtime</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.squareup.wire</groupId>
+                <artifactId>wire-schema</artifactId>
+                <version>4.9.0</version>
+            </dependency>
+            <dependency>
+                <groupId>com.squareup.wire</groupId>
+                <artifactId>wire-schema-jvm</artifactId>
+                <version>4.9.0</version>
+            </dependency>
+            <dependency>
+                <groupId>com.squareup.wire</groupId>
+                <artifactId>wire-runtime-jvm</artifactId>
+                <version>4.9.0</version>
+                <scope>runtime</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.squareup.wire</groupId>
+                <artifactId>wire-compiler</artifactId>
+                <version>4.9.0</version>
+                <scope>runtime</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.amazonaws</groupId>
+                <artifactId>aws-java-sdk-sts</artifactId>
+                <version>1.12.660</version>
+            </dependency>
+            <dependency>
+                <groupId>software.amazon.msk</groupId>
+                <artifactId>aws-msk-iam-auth</artifactId>
+                <version>2.1.1</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <!-- Only use the simple logger for testing so that we can see the output -->
@@ -25,6 +82,46 @@
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
             <version>3.8.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+            <version>1.11.3</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>3.19.4</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.glue</groupId>
+            <artifactId>schema-registry-serde</artifactId>
+            <version>1.1.20</version>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-protobuf-provider</artifactId>
+            <version>7.6.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+            <version>1.11.3</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>3.19.4</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.glue</groupId>
+            <artifactId>schema-registry-serde</artifactId>
+            <version>1.1.20</version>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-protobuf-provider</artifactId>
+            <version>7.6.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -82,12 +179,10 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-sts</artifactId>
-            <version>${aws-sdk.version}</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.msk</groupId>
             <artifactId>aws-msk-iam-auth</artifactId>
-            <version>2.2.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.amazonaws</groupId>
@@ -206,4 +301,10 @@
             </plugin>
         </plugins>
     </build>
+    <repositories>
+        <repository>
+            <id>confluent</id>
+            <url>https://packages.confluent.io/maven/</url>
+        </repository>
+    </repositories>
 </project>

--- a/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/AmazonMskConstants.java
+++ b/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/AmazonMskConstants.java
@@ -64,6 +64,9 @@ public class AmazonMskConstants
 
     public static final int MAX_RECORDS_IN_SPLIT = 10_000;
 
+    public static final String AVRO_DATA_FORMAT = "avro";
+    public static final String PROTOBUF_DATA_FORMAT = "protobuf";
+
     private AmazonMskConstants()
     {
     }

--- a/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/AmazonMskMetadataHandler.java
+++ b/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/AmazonMskMetadataHandler.java
@@ -37,6 +37,7 @@ import com.amazonaws.athena.connector.lambda.metadata.ListSchemasResponse;
 import com.amazonaws.athena.connector.lambda.metadata.ListTablesRequest;
 import com.amazonaws.athena.connector.lambda.metadata.ListTablesResponse;
 import com.amazonaws.athena.connector.util.PaginatedRequestIterator;
+import com.amazonaws.athena.connectors.msk.dto.AvroTopicSchema;
 import com.amazonaws.athena.connectors.msk.dto.SplitParameters;
 import com.amazonaws.athena.connectors.msk.dto.TopicPartitionPiece;
 import com.amazonaws.athena.connectors.msk.dto.TopicSchema;
@@ -50,6 +51,8 @@ import com.amazonaws.services.glue.model.ListSchemasResult;
 import com.amazonaws.services.glue.model.RegistryId;
 import com.amazonaws.services.glue.model.RegistryListItem;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.protobuf.Descriptors;
+import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.types.pojo.Schema;
@@ -68,7 +71,9 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.amazonaws.athena.connector.lambda.metadata.ListTablesRequest.UNLIMITED_PAGE_SIZE_VALUE;
+import static com.amazonaws.athena.connectors.msk.AmazonMskConstants.AVRO_DATA_FORMAT;
 import static com.amazonaws.athena.connectors.msk.AmazonMskConstants.MAX_RECORDS_IN_SPLIT;
+import static com.amazonaws.athena.connectors.msk.AmazonMskConstants.PROTOBUF_DATA_FORMAT;
 
 public class AmazonMskMetadataHandler extends MetadataHandler
 {
@@ -256,7 +261,7 @@ public class AmazonMskMetadataHandler extends MetadataHandler
     public GetTableResponse doGetTable(BlockAllocator blockAllocator, GetTableRequest getTableRequest) throws Exception
     {
         LOGGER.info("doGetTable request: {}", getTableRequest);
-        Schema tableSchema = null;
+        Schema tableSchema;
         try {
             tableSchema = getSchema(getTableRequest.getTableName().getSchemaName(), getTableRequest.getTableName().getTableName());
         }
@@ -323,9 +328,17 @@ public class AmazonMskMetadataHandler extends MetadataHandler
         // returning a single partition.
         String glueRegistryName = request.getTableName().getSchemaName();
         String glueSchemaName = request.getTableName().getTableName();
+        String topic;
         GlueRegistryReader registryReader = new GlueRegistryReader();
-        TopicSchema topicSchema = registryReader.getGlueSchema(glueRegistryName, glueSchemaName, TopicSchema.class);
-        String topic =  topicSchema.getTopicName();
+        String dataFormat = registryReader.getGlueSchemaType(glueRegistryName, glueSchemaName);
+        if (dataFormat.equalsIgnoreCase(AVRO_DATA_FORMAT) || dataFormat.equalsIgnoreCase(PROTOBUF_DATA_FORMAT)) {
+            //if schema type is avro/protobuf, then topic name should be glue schema name
+            topic = glueSchemaName;
+        }
+        else {
+            TopicSchema topicSchema = registryReader.getGlueSchema(glueRegistryName, glueSchemaName, TopicSchema.class);
+            topic = topicSchema.getTopicName();
+        }
 
         LOGGER.info("Retrieved topicName: {}", topic);
 
@@ -417,31 +430,70 @@ public class AmazonMskMetadataHandler extends MetadataHandler
     {
         SchemaBuilder schemaBuilder = SchemaBuilder.newBuilder();
 
-        // Get topic schema json from GLue registry as translated to TopicSchema pojo
         GlueRegistryReader registryReader = new GlueRegistryReader();
-        TopicSchema topicSchema = registryReader.getGlueSchema(glueRegistryName, glueSchemaName, TopicSchema.class);
+        String dataFormat = registryReader.getGlueSchemaType(glueRegistryName, glueSchemaName);
+        if (dataFormat.equalsIgnoreCase(AVRO_DATA_FORMAT)) {
+            // Get avro topic schema json from Glue registry as translated to AvroTopicSchema pojo
+            AvroTopicSchema avroTopicSchema = registryReader.getGlueSchema(glueRegistryName, glueSchemaName, AvroTopicSchema.class);
+            // Creating ArrowType for each field in the avro topic schema.
+            avroTopicSchema.getFields().forEach(it -> {
+                FieldType fieldType = new FieldType(
+                        true,
+                        AmazonMskUtils.toArrowType(it.getType()),
+                        null,
+                        com.google.common.collect.ImmutableMap.of(
+                                "name", it.getName(),
+                                "formatHint", it.getFormatHint(),
+                                "type", it.getType()
+                        )
+                );
+                Field field = new Field(it.getName(), fieldType, null);
+                schemaBuilder.addField(field);
+            });
+            schemaBuilder.addMetadata("dataFormat", AVRO_DATA_FORMAT);
+        }
+        else if (dataFormat.equalsIgnoreCase(PROTOBUF_DATA_FORMAT)) {
+            // Get protobuf topic schema from Glue registry
+            String glueSchema = registryReader.getSchemaDef(glueRegistryName, glueSchemaName);
+            ProtobufSchema protobufSchema = new ProtobufSchema(glueSchema);
+            Descriptors.Descriptor descriptor = protobufSchema.toDescriptor();
+            // Creating ArrowType for each field in the protobuf topic schema.
+            for (Descriptors.FieldDescriptor fieldDescriptor : descriptor.getFields()) {
+                FieldType fieldType = new FieldType(
+                        true,
+                        AmazonMskUtils.toArrowType(fieldDescriptor.getType().toString()),
+                        null
+                );
+                Field field = new Field(fieldDescriptor.getName(), fieldType, null);
+                schemaBuilder.addField(field);
+            }
+            schemaBuilder.addMetadata("dataFormat", PROTOBUF_DATA_FORMAT);
+        }
+        else {
+            // Get topic schema json from Glue registry as translated to TopicSchema pojo
+            TopicSchema topicSchema = registryReader.getGlueSchema(glueRegistryName, glueSchemaName, TopicSchema.class);
 
-        // Creating ArrowType for each fields in the topic schema.
-        // Also putting the additional column level information
-        // into the metadata in ArrowType field.
-        topicSchema.getMessage().getFields().forEach(it -> {
-            FieldType fieldType = new FieldType(
-                    true,
-                    AmazonMskUtils.toArrowType(it.getType()),
-                    null,
-                    com.google.common.collect.ImmutableMap.of(
-                            "mapping", it.getMapping(),
-                            "formatHint", it.getFormatHint(),
-                            "type", it.getType()
-                    )
-            );
-            Field field = new Field(it.getName(), fieldType, null);
-            schemaBuilder.addField(field);
-        });
+            // Creating ArrowType for each field in the json/csv topic schema.
+            // Also putting the additional column level information
+            // into the metadata in ArrowType field.
+            topicSchema.getMessage().getFields().forEach(it -> {
+                FieldType fieldType = new FieldType(
+                        true,
+                        AmazonMskUtils.toArrowType(it.getType()),
+                        null,
+                        com.google.common.collect.ImmutableMap.of(
+                                "mapping", it.getMapping(),
+                                "formatHint", it.getFormatHint(),
+                                "type", it.getType()
+                        )
+                );
+                Field field = new Field(it.getName(), fieldType, null);
+                schemaBuilder.addField(field);
+            });
 
-        // Putting the additional schema level information into the metadata in ArrowType schema.
-        schemaBuilder.addMetadata("dataFormat", topicSchema.getMessage().getDataFormat());
-
+            // Putting the additional schema level information into the metadata in ArrowType schema.
+            schemaBuilder.addMetadata("dataFormat", topicSchema.getMessage().getDataFormat());
+        }
         // NOTE: these values are being shoved in here for usage later in the calling context
         // of doGetTable() since Java doesn't have tuples.
         schemaBuilder.addMetadata("glueRegistryName", glueRegistryName);

--- a/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/AmazonMskRecordHandler.java
+++ b/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/AmazonMskRecordHandler.java
@@ -20,13 +20,14 @@
 package com.amazonaws.athena.connectors.msk;
 
 import com.amazonaws.athena.connector.lambda.QueryStatusChecker;
-import com.amazonaws.athena.connector.lambda.data.Block;
 import com.amazonaws.athena.connector.lambda.data.BlockSpiller;
 import com.amazonaws.athena.connector.lambda.handlers.RecordHandler;
 import com.amazonaws.athena.connector.lambda.records.ReadRecordsRequest;
-import com.amazonaws.athena.connectors.msk.dto.MSKField;
+import com.amazonaws.athena.connectors.msk.consumer.MskAvroConsumer;
+import com.amazonaws.athena.connectors.msk.consumer.MskConsumer;
+import com.amazonaws.athena.connectors.msk.consumer.MskDefaultConsumer;
+import com.amazonaws.athena.connectors.msk.consumer.MskProtobufConsumer;
 import com.amazonaws.athena.connectors.msk.dto.SplitParameters;
-import com.amazonaws.athena.connectors.msk.dto.TopicResultSet;
 import com.amazonaws.services.athena.AmazonAthena;
 import com.amazonaws.services.athena.AmazonAthenaClientBuilder;
 import com.amazonaws.services.s3.AmazonS3;
@@ -35,22 +36,16 @@ import com.amazonaws.services.secretsmanager.AWSSecretsManager;
 import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.kafka.clients.consumer.Consumer;
-import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.ConsumerRecords;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.common.TopicPartition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.time.Duration;
-import java.util.Collection;
-import java.util.Map;
+import static com.amazonaws.athena.connectors.msk.AmazonMskConstants.AVRO_DATA_FORMAT;
+import static com.amazonaws.athena.connectors.msk.AmazonMskConstants.PROTOBUF_DATA_FORMAT;
 
 public class AmazonMskRecordHandler
         extends RecordHandler
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(AmazonMskRecordHandler.class);
-    private static final int MAX_EMPTY_RESULT_FOUND_COUNT = 3;
 
     AmazonMskRecordHandler(java.util.Map<String, String> configOptions)
     {
@@ -80,143 +75,29 @@ public class AmazonMskRecordHandler
         // Taking the Split parameters in a readable pojo format.
         SplitParameters splitParameters = AmazonMskUtils.createSplitParam(recordsRequest.getSplit().getProperties());
         LOGGER.info("[kafka] {} RecordHandler running", splitParameters);
+        GlueRegistryReader registryReader = new GlueRegistryReader();
 
-        // Initiate new KafkaConsumer that MUST not belong to any consumer group.
-        try (Consumer<String, TopicResultSet> kafkaConsumer = AmazonMskUtils.getKafkaConsumer(recordsRequest.getSchema(), configOptions)) {
-            // Set which topic and partition we are going to read.
-            TopicPartition partition = new TopicPartition(splitParameters.topic, splitParameters.partition);
-            Collection<TopicPartition> partitions = com.google.common.collect.ImmutableList.of(partition);
+        String dataFormat = registryReader.getGlueSchemaType(recordsRequest.getTableName().getSchemaName(), recordsRequest.getTableName().getTableName());
+        MskConsumer mskConsumer;
+        Consumer<?, ?> consumer;
 
-            // Assign the topic and partition into this consumer.
-            kafkaConsumer.assign(partitions);
-
-            // Setting the start offset from where we are interested to read data from topic partition.
-            // We have configured this start offset when we had created the split on MetadataHandler.
-            kafkaConsumer.seek(partition, splitParameters.startOffset);
-
-            // If endOffsets is 0 that means there is no data close consumer and exit
-            Map<TopicPartition, Long> endOffsets = kafkaConsumer.endOffsets(partitions);
-            if (endOffsets.get(partition) == 0) {
-                LOGGER.debug("[kafka] topic does not have data, closing consumer {}", splitParameters);
-                kafkaConsumer.close();
-
-                // For debug insight
-                splitParameters.info = "endOffset is 0 i.e partition does not have data";
-                if (LOGGER.isDebugEnabled()) {
-                    LOGGER.debug(splitParameters.debug());
-                }
-                return;
-            }
-            // Consume topic data
-            consume(spiller, recordsRequest, queryStatusChecker, splitParameters, kafkaConsumer);
+        switch (dataFormat.toLowerCase()) {
+            case AVRO_DATA_FORMAT:
+                consumer = AmazonMskUtils.getAvroKafkaConsumer(configOptions);
+                mskConsumer = new MskAvroConsumer();
+                break;
+            case PROTOBUF_DATA_FORMAT:
+                consumer = AmazonMskUtils.getProtobufKafkaConsumer(configOptions);
+                mskConsumer = new MskProtobufConsumer();
+                break;
+            default:
+                consumer = AmazonMskUtils.getKafkaConsumer(recordsRequest.getSchema(), configOptions);
+                mskConsumer = new MskDefaultConsumer();
+                break;
         }
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug(splitParameters.debug());
+
+        try (Consumer<?, ?> kafkaConsumer = consumer) {
+            mskConsumer.consume(spiller, recordsRequest, queryStatusChecker, splitParameters, kafkaConsumer);
         }
-    }
-
-    /**
-     * Consume topic data as batch.
-     *
-     * @param spiller - instance of {@link BlockSpiller}
-     * @param recordsRequest - instance of {@link ReadRecordsRequest}
-     * @param queryStatusChecker - instance of {@link QueryStatusChecker}
-     * @param splitParameters - instance of {@link SplitParameters}
-     * @param kafkaConsumer - instance of {@link KafkaConsumer}
-     */
-    private void consume(
-            BlockSpiller spiller,
-            ReadRecordsRequest recordsRequest,
-            QueryStatusChecker queryStatusChecker,
-            SplitParameters splitParameters,
-            Consumer<String, TopicResultSet> kafkaConsumer)
-    {
-        LOGGER.info("[kafka] {} Polling for data", splitParameters);
-        int emptyResultFoundCount = 0;
-        try {
-            while (true) {
-                if (!queryStatusChecker.isQueryRunning()) {
-                    LOGGER.debug("[kafka]{}  Stopping and closing consumer due to query execution terminated by athena", splitParameters);
-                    splitParameters.info = "query status is false i.e no need to work";
-                    return;
-                }
-
-                // Call the poll on consumer to fetch data from kafka server
-                // poll returns data as batch which can be configured.
-                ConsumerRecords<String, TopicResultSet> records = kafkaConsumer.poll(Duration.ofSeconds(1L));
-                LOGGER.debug("[kafka] {} polled records size {}", splitParameters, records.count());
-
-                // For debug insight
-                splitParameters.pulled += records.count();
-
-                // Keep track for how many times we are getting empty result for the polling call.
-                if (records.count() == 0) {
-                    emptyResultFoundCount++;
-                }
-
-                // We will close KafkaConsumer if we are getting empty result again and again.
-                // Here we are comparing with a max threshold (MAX_EMPTY_RESULT_FOUNT_COUNT) to
-                // stop the polling.
-                if (emptyResultFoundCount >= MAX_EMPTY_RESULT_FOUND_COUNT) {
-                    LOGGER.debug("[kafka] {} Closing consumer due to getting empty result from broker", splitParameters);
-                    splitParameters.info = "always getting empty data i.e leaving from work";
-                    return;
-                }
-
-                for (ConsumerRecord<String, TopicResultSet> record : records) {
-                    // Pass batch data one by one to be processed to execute. execute method is
-                    // a kind of abstraction to keep data filtering and writing on spiller separate.
-                    execute(spiller, recordsRequest, queryStatusChecker, splitParameters, record);
-
-                    // If we have reached at the end offset of the partition. we will not continue
-                    // to call the polling.
-                    if (record.offset() >= splitParameters.endOffset) {
-                        LOGGER.debug("[kafka] {} Closing consumer due to reach at end offset (current record offset is {})", splitParameters, record.offset());
-
-                        // For debug insight
-                        splitParameters.info = String.format(
-                                "reached at the end offset i.e no need to work: condition [if(record.offset() >= splitParameters.endOffset) i.e if(%s >= %s)]",
-                                record.offset(),
-                                splitParameters.endOffset
-                        );
-                        return;
-                    }
-                }
-            }
-        }
-        finally {
-            kafkaConsumer.close();
-        }
-    }
-
-    /**
-     * Abstraction to keep the data filtering and writing on spiller separate.
-     *
-     * @param spiller - instance of {@link BlockSpiller}
-     * @param recordsRequest - instance of {@link ReadRecordsRequest}
-     * @param queryStatusChecker - instance of {@link QueryStatusChecker}
-     * @param splitParameters - instance of {@link SplitParameters}
-     * @param record - instance of {@link ConsumerRecord}
-     */
-    private void execute(
-            BlockSpiller spiller,
-            ReadRecordsRequest recordsRequest,
-            QueryStatusChecker queryStatusChecker,
-            SplitParameters splitParameters,
-            ConsumerRecord<String, TopicResultSet> record)
-    {
-        final boolean[] isExecuted = {false};
-        spiller.writeRows((Block block, int rowNum) -> {
-            for (MSKField field : record.value().getFields()) {
-                boolean isMatched = block.offerValue(field.getName(), rowNum, field.getValue());
-                if (!isMatched) {
-                    LOGGER.debug("[FailedToSpill] {} Failed to splil record, offset: {}", splitParameters, record.offset());
-                    return 0;
-                }
-            }
-            // For debug insight
-            splitParameters.spilled += 1;
-            return 1;
-        });
     }
 }

--- a/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/GlueRegistryReader.java
+++ b/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/GlueRegistryReader.java
@@ -72,4 +72,14 @@ public class GlueRegistryReader
         GetSchemaVersionResult result = getSchemaVersionResult(glueRegistryName, glueSchemaName);
         return objectMapper.readValue(result.getSchemaDefinition(), clazz);
     }
+    public String getGlueSchemaType(String glueRegistryName, String glueSchemaName)
+    {
+        GetSchemaVersionResult result = getSchemaVersionResult(glueRegistryName, glueSchemaName);
+        return result.getDataFormat();
+    }
+    public String getSchemaDef(String glueRegistryName, String glueSchemaName)
+    {
+        GetSchemaVersionResult result = getSchemaVersionResult(glueRegistryName, glueSchemaName);
+        return result.getSchemaDefinition();
+    }
 }

--- a/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/consumer/BaseMskConsumer.java
+++ b/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/consumer/BaseMskConsumer.java
@@ -1,0 +1,104 @@
+/*-
+ * #%L
+ * Athena MSK Connector
+ * %%
+ * Copyright (C) 2019 - 2024 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.msk.consumer;
+
+import com.amazonaws.athena.connector.lambda.QueryStatusChecker;
+import com.amazonaws.athena.connector.lambda.data.BlockSpiller;
+import com.amazonaws.athena.connector.lambda.records.ReadRecordsRequest;
+import com.amazonaws.athena.connectors.msk.dto.SplitParameters;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.TopicPartition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Map;
+
+public abstract class BaseMskConsumer<T> implements MskConsumer
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(BaseMskConsumer.class);
+    protected static final int MAX_EMPTY_RESULT_FOUND_COUNT = 3;
+
+    @Override
+    public void consume(BlockSpiller spiller, ReadRecordsRequest recordsRequest, QueryStatusChecker queryStatusChecker, SplitParameters splitParameters, Consumer<?, ?> consumer)
+    {
+        @SuppressWarnings("unchecked")
+        Consumer<String, T> typedConsumer = (Consumer<String, T>) consumer;
+        typedConsumer.assign(Collections.singleton(new TopicPartition(splitParameters.topic, splitParameters.partition)));
+        typedConsumer.seek(new TopicPartition(splitParameters.topic, splitParameters.partition), splitParameters.startOffset);
+
+        Map<TopicPartition, Long> endOffsets = typedConsumer.endOffsets(Collections.singleton(new TopicPartition(splitParameters.topic, splitParameters.partition)));
+        if (endOffsets.get(new TopicPartition(splitParameters.topic, splitParameters.partition)) == 0) {
+            LOGGER.debug("[kafka] topic does not have data, closing consumer {}", splitParameters);
+            typedConsumer.close();
+            splitParameters.info = "endOffset is 0 i.e partition does not have data";
+            return;
+        }
+
+        pollAndProcess(spiller, queryStatusChecker, splitParameters, typedConsumer);
+    }
+
+    private void pollAndProcess(BlockSpiller spiller, QueryStatusChecker queryStatusChecker, SplitParameters splitParameters, Consumer<String, T> consumer)
+    {
+        LOGGER.info("[kafka] {} Polling for data", splitParameters);
+        int emptyResultFoundCount = 0;
+        while (true) {
+            if (!queryStatusChecker.isQueryRunning()) {
+                LOGGER.debug("[kafka]{} Stopping and closing consumer due to query execution terminated by athena", splitParameters);
+                splitParameters.info = "query status is false i.e no need to work";
+                return;
+            }
+
+            ConsumerRecords<String, T> records = consumer.poll(Duration.ofSeconds(1L));
+            LOGGER.debug("[kafka] {} polled records size {}", splitParameters, records.count());
+
+            splitParameters.pulled += records.count();
+
+            if (records.count() == 0) {
+                emptyResultFoundCount++;
+            }
+
+            if (emptyResultFoundCount >= MAX_EMPTY_RESULT_FOUND_COUNT) {
+                LOGGER.debug("[kafka] {} Closing consumer due to getting empty result from broker", splitParameters);
+                splitParameters.info = "always getting empty data i.e leaving from work";
+                return;
+            }
+
+            for (ConsumerRecord<String, T> record : records) {
+                processRecord(spiller, splitParameters, record);
+
+                if (record.offset() >= splitParameters.endOffset) {
+                    LOGGER.debug("[kafka] {} Closing consumer due to reach at end offset (current record offset is {})", splitParameters, record.offset());
+                    splitParameters.info = String.format(
+                            "reached at the end offset i.e no need to work: condition [if(record.offset() >= splitParameters.endOffset) i.e if(%s >= %s)]",
+                            record.offset(),
+                            splitParameters.endOffset
+                    );
+                    return;
+                }
+            }
+        }
+    }
+
+    protected abstract void processRecord(BlockSpiller spiller, SplitParameters splitParameters, ConsumerRecord<String, T> record);
+}

--- a/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/consumer/MskAvroConsumer.java
+++ b/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/consumer/MskAvroConsumer.java
@@ -1,0 +1,55 @@
+/*-
+ * #%L
+ * Athena MSK Connector
+ * %%
+ * Copyright (C) 2019 - 2022 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.msk.consumer;
+
+import com.amazonaws.athena.connector.lambda.data.Block;
+import com.amazonaws.athena.connector.lambda.data.BlockSpiller;
+import com.amazonaws.athena.connectors.msk.dto.SplitParameters;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MskAvroConsumer extends BaseMskConsumer<GenericRecord>
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(MskAvroConsumer.class);
+
+    @Override
+    protected void processRecord(BlockSpiller spiller, SplitParameters splitParameters, ConsumerRecord<String, GenericRecord> record)
+    {
+        getRecordProcessor().processRecord(spiller, splitParameters, record);
+    }
+
+    private MskRecordProcessor<GenericRecord> getRecordProcessor()
+    {
+        return (spiller, splitParameters, record) -> spiller.writeRows((Block block, int rowNum) -> {
+            for (Schema.Field next : record.value().getSchema().getFields()) {
+                boolean isMatched = block.offerValue(next.name(), rowNum, record.value().get(next.name()));
+                if (!isMatched) {
+                    LOGGER.debug("[FailedToSpill] {} Failed to spill record, offset: {}", splitParameters, record.offset());
+                    return 0;
+                }
+            }
+            splitParameters.spilled += 1;
+            return 1;
+        });
+    }
+}

--- a/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/consumer/MskConsumer.java
+++ b/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/consumer/MskConsumer.java
@@ -1,0 +1,41 @@
+/*-
+ * #%L
+ * Athena MSK Connector
+ * %%
+ * Copyright (C) 2019 - 2022 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.msk.consumer;
+
+import com.amazonaws.athena.connector.lambda.QueryStatusChecker;
+import com.amazonaws.athena.connector.lambda.data.BlockSpiller;
+import com.amazonaws.athena.connector.lambda.records.ReadRecordsRequest;
+import com.amazonaws.athena.connectors.msk.dto.SplitParameters;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+
+public interface MskConsumer
+{
+    /**
+     * Consume topic data as batch.
+     *
+     * @param spiller - instance of {@link BlockSpiller}
+     * @param recordsRequest - instance of {@link ReadRecordsRequest}
+     * @param queryStatusChecker - instance of {@link QueryStatusChecker}
+     * @param splitParameters - instance of {@link SplitParameters}
+     * @param kafkaConsumer - instance of {@link KafkaConsumer}
+     */
+    void consume(BlockSpiller spiller, ReadRecordsRequest recordsRequest, QueryStatusChecker queryStatusChecker, SplitParameters splitParameters, Consumer<?, ?> kafkaConsumer);
+}

--- a/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/consumer/MskDefaultConsumer.java
+++ b/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/consumer/MskDefaultConsumer.java
@@ -1,0 +1,55 @@
+/*-
+ * #%L
+ * Athena MSK Connector
+ * %%
+ * Copyright (C) 2019 - 2022 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.msk.consumer;
+
+import com.amazonaws.athena.connector.lambda.data.Block;
+import com.amazonaws.athena.connector.lambda.data.BlockSpiller;
+import com.amazonaws.athena.connectors.msk.dto.MSKField;
+import com.amazonaws.athena.connectors.msk.dto.SplitParameters;
+import com.amazonaws.athena.connectors.msk.dto.TopicResultSet;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MskDefaultConsumer extends BaseMskConsumer<TopicResultSet>
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(MskDefaultConsumer.class);
+
+    @Override
+    protected void processRecord(BlockSpiller spiller, SplitParameters splitParameters, ConsumerRecord<String, TopicResultSet> record)
+    {
+        getRecordProcessor().processRecord(spiller, splitParameters, record);
+    }
+
+    private MskRecordProcessor<TopicResultSet> getRecordProcessor()
+    {
+        return (spiller, splitParameters, record) -> spiller.writeRows((Block block, int rowNum) -> {
+            for (MSKField field : record.value().getFields()) {
+                boolean isMatched = block.offerValue(field.getName(), rowNum, field.getValue());
+                if (!isMatched) {
+                    LOGGER.debug("[FailedToSpill] {} Failed to spill record, offset: {}", splitParameters, record.offset());
+                    return 0;
+                }
+            }
+            splitParameters.spilled += 1;
+            return 1;
+        });
+    }
+}

--- a/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/consumer/MskProtobufConsumer.java
+++ b/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/consumer/MskProtobufConsumer.java
@@ -1,0 +1,55 @@
+/*-
+ * #%L
+ * Athena MSK Connector
+ * %%
+ * Copyright (C) 2019 - 2022 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.msk.consumer;
+
+import com.amazonaws.athena.connector.lambda.data.Block;
+import com.amazonaws.athena.connector.lambda.data.BlockSpiller;
+import com.amazonaws.athena.connectors.msk.dto.SplitParameters;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.DynamicMessage;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MskProtobufConsumer extends BaseMskConsumer<DynamicMessage>
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(MskProtobufConsumer.class);
+
+    @Override
+    protected void processRecord(BlockSpiller spiller, SplitParameters splitParameters, ConsumerRecord<String, DynamicMessage> record)
+    {
+        getRecordProcessor().processRecord(spiller, splitParameters, record);
+    }
+
+    private MskRecordProcessor<DynamicMessage> getRecordProcessor()
+    {
+        return (spiller, splitParameters, record) -> spiller.writeRows((Block block, int rowNum) -> {
+            for (Descriptors.FieldDescriptor next : record.value().getAllFields().keySet()) {
+                boolean isMatched = block.offerValue(next.getName(), rowNum, record.value().getField(next));
+                if (!isMatched) {
+                    LOGGER.debug("[FailedToSpill] {} Failed to spill record, offset: {}", splitParameters, record.offset());
+                    return 0;
+                }
+            }
+            splitParameters.spilled += 1;
+            return 1;
+        });
+    }
+}

--- a/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/consumer/MskRecordProcessor.java
+++ b/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/consumer/MskRecordProcessor.java
@@ -1,0 +1,29 @@
+/*-
+ * #%L
+ * Athena MSK Connector
+ * %%
+ * Copyright (C) 2019 - 2024 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.msk.consumer;
+
+import com.amazonaws.athena.connector.lambda.data.BlockSpiller;
+import com.amazonaws.athena.connectors.msk.dto.SplitParameters;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+public interface MskRecordProcessor<T>
+{
+    void processRecord(BlockSpiller spiller, SplitParameters splitParameters, ConsumerRecord<String, T> record);
+}

--- a/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/dto/AvroTopicSchema.java
+++ b/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/dto/AvroTopicSchema.java
@@ -1,0 +1,63 @@
+/*-
+ * #%L
+ * Athena MSK Connector
+ * %%
+ * Copyright (C) 2019 - 2024 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.msk.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class AvroTopicSchema
+{
+    // schema Name
+    String name;
+    // Schema Type
+    String type;
+    // Schema Fields
+    List<MSKField> fields = new ArrayList<>();
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public void setName(String name)
+    {
+        this.name = name;
+    }
+
+    public String getType()
+    {
+        return type;
+    }
+
+    public void setType(String type)
+    {
+        this.type = type;
+    }
+
+    public List<MSKField> getFields()
+    {
+        return fields;
+    }
+
+    public void setFields(List<MSKField> fields)
+    {
+        this.fields = fields;
+    }
+}

--- a/athena-msk/src/test/java/com/amazonaws/athena/connectors/msk/AmazonMskMetadataHandlerTest.java
+++ b/athena-msk/src/test/java/com/amazonaws/athena/connectors/msk/AmazonMskMetadataHandlerTest.java
@@ -153,6 +153,7 @@ public class AmazonMskMetadataHandlerTest {
         getSchemaResult.setLatestSchemaVersion(latestSchemaVersion);
         getSchemaVersionResult.setSchemaArn(arn);
         getSchemaVersionResult.setSchemaVersionId(schemaVersionId);
+        getSchemaVersionResult.setDataFormat("json");
         getSchemaVersionResult.setSchemaDefinition("{\n" +
                 "\t\"topicName\": \"testtable\",\n" +
                 "\t\"message\": {\n" +
@@ -183,6 +184,7 @@ public class AmazonMskMetadataHandlerTest {
         getSchemaResult.setLatestSchemaVersion(latestSchemaVersion);
         getSchemaVersionResult.setSchemaArn(arn);
         getSchemaVersionResult.setSchemaVersionId(schemaVersionId);
+        getSchemaVersionResult.setDataFormat("json");
         getSchemaVersionResult.setSchemaDefinition("{\n" +
                 "\t\"topicName\": \"testTopic\",\n" +
                 "\t\"message\": {\n" +

--- a/athena-msk/src/test/java/com/amazonaws/athena/connectors/msk/AmazonMskRecordHandlerTest.java
+++ b/athena-msk/src/test/java/com/amazonaws/athena/connectors/msk/AmazonMskRecordHandlerTest.java
@@ -33,13 +33,22 @@ import com.amazonaws.athena.connector.lambda.security.FederatedIdentity;
 import com.amazonaws.athena.connector.lambda.security.LocalKeyFactory;
 import com.amazonaws.athena.connectors.msk.dto.*;
 import com.amazonaws.services.athena.AmazonAthena;
+import com.amazonaws.services.glue.AWSGlue;
+import com.amazonaws.services.glue.AWSGlueClientBuilder;
+import com.amazonaws.services.glue.model.GetSchemaResult;
+import com.amazonaws.services.glue.model.GetSchemaVersionResult;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.secretsmanager.AWSSecretsManager;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.DynamicMessage;
+import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.MockConsumer;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
@@ -59,6 +68,9 @@ import java.util.HashMap;
 import java.util.UUID;
 
 import static com.amazonaws.athena.connector.lambda.domain.predicate.Constraints.DEFAULT_NO_LIMIT;
+import static com.amazonaws.athena.connectors.msk.AmazonMskConstants.AVRO_DATA_FORMAT;
+import static com.amazonaws.athena.connectors.msk.AmazonMskConstants.PROTOBUF_DATA_FORMAT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.*;
 
@@ -66,6 +78,10 @@ import static org.mockito.Mockito.*;
 public class AmazonMskRecordHandlerTest {
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
+    private MockedStatic<AWSGlueClientBuilder> awsGlueClientBuilder;
+
+    @Mock
+    AWSGlue awsGlue;
 
     @Mock
     AmazonS3 amazonS3;
@@ -86,6 +102,8 @@ public class AmazonMskRecordHandlerTest {
     BlockAllocatorImpl allocator;
 
     MockConsumer<String, TopicResultSet> consumer;
+    MockConsumer<String, GenericRecord> avroConsumer;
+    MockConsumer<String, DynamicMessage> protobufConsumer;
     AmazonMskRecordHandler amazonMskRecordHandler;
     private EncryptionKeyFactory keyFactory = new LocalKeyFactory();
     private EncryptionKey encryptionKey = keyFactory.create();
@@ -108,7 +126,16 @@ public class AmazonMskRecordHandlerTest {
             consumer.addRecord(record1);
             consumer.addRecord(record2);
         });
-
+        avroConsumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
+        ConsumerRecord<String, GenericRecord> avroRecord = createAvroConsumerRecord("greetings", 0 , "k1", createGenericRecord("greetings"));
+        avroConsumer.schedulePollTask(() -> {
+            avroConsumer.addRecord(avroRecord);
+        });
+        protobufConsumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
+        ConsumerRecord<String, DynamicMessage> protobufRecord = createProtobufConsumerRecord("protobuftest", 0, "k1", createDynamicRecord());
+        protobufConsumer.schedulePollTask(() -> {
+            protobufConsumer.addRecord(protobufRecord);
+        });
         spillConfig = SpillConfig.newBuilder()
                 .withEncryptionKey(encryptionKey)
                 //This will be enough for a single block
@@ -123,11 +150,14 @@ public class AmazonMskRecordHandlerTest {
         allocator = new BlockAllocatorImpl();
         mockedMskUtils = Mockito.mockStatic(AmazonMskUtils.class, Mockito.CALLS_REAL_METHODS);
         amazonMskRecordHandler = new AmazonMskRecordHandler(amazonS3, awsSecretsManager, athena, com.google.common.collect.ImmutableMap.of());
+        awsGlueClientBuilder = Mockito.mockStatic(AWSGlueClientBuilder.class);
+        awsGlueClientBuilder.when(()-> AWSGlueClientBuilder.defaultClient()).thenReturn(awsGlue);
     }
 
     @After
     public void close(){
         mockedMskUtils.close();
+        awsGlueClientBuilder.close();
     }
 
     @Test
@@ -147,12 +177,72 @@ public class AmazonMskRecordHandlerTest {
         mockedMskUtils.when(() -> AmazonMskUtils.getKafkaConsumer(schema, com.google.common.collect.ImmutableMap.of())).thenReturn(consumer);
         mockedMskUtils.when(() -> AmazonMskUtils.createSplitParam(anyMap())).thenReturn(splitParameters);
 
+        Mockito.when(awsGlue.getSchema(any())).thenReturn(getSchemaResult());
+        Mockito.when(awsGlue.getSchemaVersion(any())).thenReturn(getJsonSchemaVersionResult());
+
         QueryStatusChecker queryStatusChecker = mock(QueryStatusChecker.class);
         when(queryStatusChecker.isQueryRunning()).thenReturn(true);
 
         ReadRecordsRequest request = createReadRecordsRequest(schema);
         BlockSpiller spiller = new S3BlockSpiller(amazonS3, spillConfig, allocator, schema, ConstraintEvaluator.emptyEvaluator(), com.google.common.collect.ImmutableMap.of());
         amazonMskRecordHandler.readWithConstraint(spiller, request, queryStatusChecker);
+    }
+    @Test
+    public void testForConsumeAvroDataFromTopic() throws Exception {
+        HashMap<TopicPartition, Long> offsets;
+        offsets = new HashMap<>();
+        offsets.put(new TopicPartition("greetings", 0), 0L);
+        avroConsumer.updateBeginningOffsets(offsets);
+
+        offsets = new HashMap<>();
+        offsets.put(new TopicPartition("greetings", 0), 1L);
+        avroConsumer.updateEndOffsets(offsets);
+
+        SplitParameters splitParameters = new SplitParameters("greetings", 0, 0, 1);
+        Schema schema = createAvroSchema(createAvroTopicSchema());
+
+        mockedMskUtils.when(() -> AmazonMskUtils.getAvroKafkaConsumer(com.google.common.collect.ImmutableMap.of())).thenReturn(avroConsumer);
+        mockedMskUtils.when(() -> AmazonMskUtils.createSplitParam(anyMap())).thenReturn(splitParameters);
+
+        Mockito.when(awsGlue.getSchema(any())).thenReturn(getSchemaResult());
+        Mockito.when(awsGlue.getSchemaVersion(any())).thenReturn(getAvroSchemaVersionResult());
+
+        QueryStatusChecker queryStatusChecker = mock(QueryStatusChecker.class);
+        when(queryStatusChecker.isQueryRunning()).thenReturn(true);
+
+        ReadRecordsRequest request = createReadRecordsRequest(schema);
+        BlockSpiller spiller = new S3BlockSpiller(amazonS3, spillConfig, allocator, schema, ConstraintEvaluator.emptyEvaluator(), com.google.common.collect.ImmutableMap.of());
+        amazonMskRecordHandler.readWithConstraint(spiller, request, queryStatusChecker);
+        assertEquals(1, spiller.getBlock().getRowCount());
+    }
+
+    @Test
+    public void testForConsumeProtobufDataFromTopic() throws Exception {
+        HashMap<TopicPartition, Long> offsets;
+        offsets = new HashMap<>();
+        offsets.put(new TopicPartition("protobuftest", 0), 0L);
+        protobufConsumer.updateBeginningOffsets(offsets);
+
+        offsets = new HashMap<>();
+        offsets.put(new TopicPartition("protobuftest", 0), 1L);
+        protobufConsumer.updateEndOffsets(offsets);
+
+        SplitParameters splitParameters = new SplitParameters("protobuftest", 0, 0, 1);
+        Schema schema = createProtobufSchema(createProtobufTopicSchema());
+
+        mockedMskUtils.when(() -> AmazonMskUtils.getProtobufKafkaConsumer(com.google.common.collect.ImmutableMap.of())).thenReturn(protobufConsumer);
+        mockedMskUtils.when(() -> AmazonMskUtils.createSplitParam(anyMap())).thenReturn(splitParameters);
+
+        Mockito.when(awsGlue.getSchema(any())).thenReturn(getSchemaResult());
+        Mockito.when(awsGlue.getSchemaVersion(any())).thenReturn(getProtobufSchemaVersionResult());
+
+        QueryStatusChecker queryStatusChecker = mock(QueryStatusChecker.class);
+        when(queryStatusChecker.isQueryRunning()).thenReturn(true);
+
+        ReadRecordsRequest request = createReadRecordsRequest(schema);
+        BlockSpiller spiller = new S3BlockSpiller(amazonS3, spillConfig, allocator, schema, ConstraintEvaluator.emptyEvaluator(), com.google.common.collect.ImmutableMap.of());
+        amazonMskRecordHandler.readWithConstraint(spiller, request, queryStatusChecker);
+        assertEquals(1, spiller.getBlock().getRowCount());
     }
 
     @Test
@@ -171,6 +261,9 @@ public class AmazonMskRecordHandlerTest {
 
         mockedMskUtils.when(() -> AmazonMskUtils.getKafkaConsumer(schema, com.google.common.collect.ImmutableMap.of())).thenReturn(consumer);
         mockedMskUtils.when(() -> AmazonMskUtils.createSplitParam(anyMap())).thenReturn(splitParameters);
+
+        Mockito.when(awsGlue.getSchema(any())).thenReturn(getSchemaResult());
+        Mockito.when(awsGlue.getSchemaVersion(any())).thenReturn(getJsonSchemaVersionResult());
 
         QueryStatusChecker queryStatusChecker = mock(QueryStatusChecker.class);
         when(queryStatusChecker.isQueryRunning()).thenReturn(false);
@@ -199,6 +292,9 @@ public class AmazonMskRecordHandlerTest {
         mockedMskUtils.when(() -> AmazonMskUtils.getKafkaConsumer(schema, com.google.common.collect.ImmutableMap.of())).thenReturn(consumer);
         mockedMskUtils.when(() -> AmazonMskUtils.createSplitParam(anyMap())).thenReturn(splitParameters);
 
+        Mockito.when(awsGlue.getSchema(any())).thenReturn(getSchemaResult());
+        Mockito.when(awsGlue.getSchemaVersion(any())).thenReturn(getJsonSchemaVersionResult());
+
         ReadRecordsRequest request = createReadRecordsRequest(schema);
         amazonMskRecordHandler.readWithConstraint(null, request, null);
     }
@@ -221,6 +317,9 @@ public class AmazonMskRecordHandlerTest {
 
         mockedMskUtils.when(() -> AmazonMskUtils.getKafkaConsumer(schema, com.google.common.collect.ImmutableMap.of())).thenReturn(consumer);
         mockedMskUtils.when(() -> AmazonMskUtils.createSplitParam(anyMap())).thenReturn(splitParameters);
+
+        Mockito.when(awsGlue.getSchema(any())).thenReturn(getSchemaResult());
+        Mockito.when(awsGlue.getSchemaVersion(any())).thenReturn(getJsonSchemaVersionResult());
 
         QueryStatusChecker queryStatusChecker = mock(QueryStatusChecker.class);
         when(queryStatusChecker.isQueryRunning()).thenReturn(true);
@@ -253,6 +352,14 @@ public class AmazonMskRecordHandlerTest {
         return new ConsumerRecord<>(topic, partition, 0, key, data);
     }
 
+    private ConsumerRecord<String, GenericRecord> createAvroConsumerRecord(String topic, int partition, String key, GenericRecord data) throws Exception {
+        return new ConsumerRecord<>(topic, partition, 0, key, data);
+    }
+
+    private ConsumerRecord<String, DynamicMessage> createProtobufConsumerRecord(String topic, int partition, String key, DynamicMessage data) throws Exception {
+        return new ConsumerRecord<>(topic, partition, 0, key, data);
+    }
+
     private TopicResultSet createTopicResultSet(String topic) {
         TopicResultSet resultSet = new TopicResultSet();
         resultSet.setTopicName(topic);
@@ -263,6 +370,38 @@ public class AmazonMskRecordHandlerTest {
         resultSet.getFields().add(new MSKField("code", "3", "TINYINT", "", Byte.parseByte("101")));
         return resultSet;
     }
+    private GenericRecord createGenericRecord(String topic) {
+        org.apache.avro.Schema.Parser parser = new org.apache.avro.Schema.Parser();
+        String schemaString = "{\"type\": \"record\",\"name\":\"" + topic + "\",\"fields\": [{\"name\": \"id\", \"type\": \"int\"},{\"name\": \"name\", \"type\": \"string\"},{\"name\": \"greeting\",\"type\": \"string\"}]}";
+        org.apache.avro.Schema schema = parser.parse(schemaString);
+        GenericRecord record = new GenericData.Record(schema);
+
+        record.put("id", 1);
+        record.put("name", "John");
+        record.put("greeting", "Hello");
+
+        return record;
+    }
+
+    private DynamicMessage createDynamicRecord() {
+        String schema = "syntax = \"proto3\";\n" +
+                "message protobuftest {\n" +
+                "string name = 1;\n" +
+                "int32 calories = 2;\n" +
+                "string colour = 3; \n" +
+                "}";
+        ProtobufSchema protobufSchema = new ProtobufSchema(schema);
+        Descriptors.Descriptor descriptor = protobufSchema.toDescriptor();
+
+        // Build the dynamic message
+        DynamicMessage.Builder builder = DynamicMessage.newBuilder(descriptor);
+        builder.setField(descriptor.findFieldByName("name"), "cake");
+        builder.setField(descriptor.findFieldByName("calories"), 260);
+        builder.setField(descriptor.findFieldByName("colour"), "white");
+
+        return builder.build();
+    }
+
 
     private Schema createSchema(TopicSchema topicSchema) throws Exception {
         SchemaBuilder schemaBuilder = SchemaBuilder.newBuilder();
@@ -285,6 +424,42 @@ public class AmazonMskRecordHandlerTest {
         return schemaBuilder.build();
     }
 
+    private Schema createAvroSchema(AvroTopicSchema avroTopicSchema) throws Exception {
+        SchemaBuilder schemaBuilder = SchemaBuilder.newBuilder();
+        avroTopicSchema.getFields().forEach(it -> {
+            FieldType fieldType = new FieldType(
+                    true,
+                    AmazonMskUtils.toArrowType(it.getType()),
+                    null,
+                    com.google.common.collect.ImmutableMap.of(
+                            "name", it.getName(),
+                            "formatHint", it.getFormatHint(),
+                            "type", it.getType()
+                    )
+            );
+            Field field = new Field(it.getName(), fieldType, null);
+            schemaBuilder.addField(field);
+        });
+        schemaBuilder.addMetadata("dataFormat", AVRO_DATA_FORMAT);
+        return schemaBuilder.build();
+    }
+
+    private Schema createProtobufSchema(ProtobufSchema protobufTopicSchema) throws Exception {
+        SchemaBuilder schemaBuilder = SchemaBuilder.newBuilder();
+        Descriptors.Descriptor descriptor = protobufTopicSchema.toDescriptor();
+        for (Descriptors.FieldDescriptor fieldDescriptor : descriptor.getFields()) {
+            FieldType fieldType = new FieldType(
+                    true,
+                    AmazonMskUtils.toArrowType(fieldDescriptor.getType().toString()),
+                    null
+            );
+            Field field = new Field(fieldDescriptor.getName(), fieldType, null);
+            schemaBuilder.addField(field);
+        }
+        schemaBuilder.addMetadata("dataFormat", PROTOBUF_DATA_FORMAT);
+        return schemaBuilder.build();
+    }
+
     private TopicSchema createCsvTopicSchema() throws JsonProcessingException {
         String csv = "{" +
                 "\"topicName\":\"test\"," +
@@ -297,5 +472,67 @@ public class AmazonMskRecordHandlerTest {
                 "{\"name\":\"code\",\"type\":\"TINYINT\",\"mapping\":\"3\",\"formatHint\": \"\"}" +
                 "]}}";
         return objectMapper.readValue(csv, TopicSchema.class);
+    }
+
+    private AvroTopicSchema createAvroTopicSchema() throws JsonProcessingException {
+        String avro = "{\"type\": \"record\",\"name\":\"greetings\",\"fields\": [{\"name\": \"id\", \"type\": \"int\"},{\"name\": \"name\", \"type\": \"string\"},{\"name\": \"greeting\",\"type\": \"string\"}]}";
+        return objectMapper.readValue(avro, AvroTopicSchema.class);
+    }
+
+    private ProtobufSchema createProtobufTopicSchema() {
+        String protobuf = "syntax = \"proto3\";\n" +
+                "message protobuftest {\n" +
+                "string name = 1;\n" +
+                "int32 calories = 2;\n" +
+                "string colour = 3; \n" +
+                "}";
+        ProtobufSchema protobufSchema = new ProtobufSchema(protobuf);
+        return protobufSchema;
+    }
+
+    private GetSchemaResult getSchemaResult() {
+
+        String arn = "defaultArn", schemaName = "defaultSchemaName";
+        Long latestSchemaVersion = 123L;
+        GetSchemaResult getSchemaResult = new GetSchemaResult();
+        getSchemaResult.setSchemaArn(arn);
+        getSchemaResult.setSchemaName(schemaName);
+        getSchemaResult.setLatestSchemaVersion(latestSchemaVersion);
+        return getSchemaResult;
+    }
+
+    private GetSchemaVersionResult getJsonSchemaVersionResult() {
+        String arn = "defaultArn", schemaVersionId = "defaultVersionId";
+        GetSchemaVersionResult getJsonSchemaVersionResult = new GetSchemaVersionResult();
+        getJsonSchemaVersionResult.setSchemaArn(arn);
+        getJsonSchemaVersionResult.setSchemaVersionId(schemaVersionId);
+        getJsonSchemaVersionResult.setDataFormat("json");
+        getJsonSchemaVersionResult.setSchemaDefinition("{\"topicName\": \"testtable\", \"\"message\": {\"dataFormat\": \"json\", \"fields\": [{\"name\": \"intcol\", \"mapping\": \"intcol\", \"type\": \"INTEGER\"}]}\"}");
+        return getJsonSchemaVersionResult;
+    }
+
+    private GetSchemaVersionResult getAvroSchemaVersionResult() {
+        String arn = "defaultArn", schemaVersionId = "defaultVersionId";
+        GetSchemaVersionResult getAvroSchemaVersionResult = new GetSchemaVersionResult();
+        getAvroSchemaVersionResult.setSchemaArn(arn);
+        getAvroSchemaVersionResult.setSchemaVersionId(schemaVersionId);
+        getAvroSchemaVersionResult.setDataFormat("avro");
+        getAvroSchemaVersionResult.setSchemaDefinition("{\"type\": \"record\",\"name\":\"greetings\",\"fields\": [{\"name\": \"id\", \"type\": \"int\"},{\"name\": \"name\", \"type\": \"string\"},{\"name\": \"greeting\",\"type\": \"string\"}]}");
+        return getAvroSchemaVersionResult;
+    }
+
+    private GetSchemaVersionResult getProtobufSchemaVersionResult() {
+        String arn = "defaultArn", schemaVersionId = "defaultVersionId";
+        GetSchemaVersionResult getProtobufSchemaVersionResult = new GetSchemaVersionResult();
+        getProtobufSchemaVersionResult.setSchemaArn(arn);
+        getProtobufSchemaVersionResult.setSchemaVersionId(schemaVersionId);
+        getProtobufSchemaVersionResult.setDataFormat("protobuf");
+        getProtobufSchemaVersionResult.setSchemaDefinition("syntax = \"proto3\";\n" +
+                "message protobuftest {\n" +
+                "string name = 1;\n" +
+                "int32 calories = 2;\n" +
+                "string colour = 3; \n" +
+                "}");
+        return getProtobufSchemaVersionResult;
     }
 }

--- a/athena-msk/src/test/java/com/amazonaws/athena/connectors/msk/AmazonMskUtilsTest.java
+++ b/athena-msk/src/test/java/com/amazonaws/athena/connectors/msk/AmazonMskUtilsTest.java
@@ -197,7 +197,7 @@ public class AmazonMskUtilsTest {
         assertEquals(Types.MinorType.INT.getType(), toArrowType("INT"));
         assertEquals(Types.MinorType.INT.getType(), toArrowType("INTEGER"));
         assertEquals(Types.MinorType.BIGINT.getType(), toArrowType("BIGINT"));
-        assertEquals(Types.MinorType.FLOAT8.getType(), toArrowType("FLOAT"));
+        assertEquals(Types.MinorType.FLOAT4.getType(), toArrowType("FLOAT"));
         assertEquals(Types.MinorType.FLOAT8.getType(), toArrowType("DOUBLE"));
         assertEquals(Types.MinorType.FLOAT8.getType(), toArrowType("DECIMAL"));
         assertEquals(Types.MinorType.DATEDAY.getType(), toArrowType("DATE"));


### PR DESCRIPTION
Support for querying Avro and Protobuf data from Amazon MSK.

Prerequisite: Define the Avro/Protobuf Schema in AWS Glue Schema Registry, select Data Format as Avro/Protocol Buffers while defining schema.
Note: Provide Glue Schema Name as MSK Topic Name with same case.
Example avro/protobuf schema in glue :
```
Avro:

{
  "type": "record",
  "namespace": "ABC_Organization",
  "name": "Employee",
  "fields": [
    {
      "name": "Name",
      "type": "string"
    },
    {
      "name": "Age",
      "type": "int"
    },
    {
      "name": "IsActive",
      "type": "boolean"
    },
    {
      "name": "Balance",
      "type": "double"
    },
    {
      "name": "Rating",
      "type": "float"
    }
  ]
}

Protobuf:

message protobuftest {
  optional string name = 1;
  optional int64 calories = 2;
  optional string colour = 3;
  optional bool isOrganic = 4;
  optional double price = 5;
  optional float weight = 6;
  optional int32 quantity = 7;
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
