### PR TITLE
DocDB select query with _id issue fix

### DIFF
--- a/athena-docdb/src/test/java/com/amazonaws/athena/connectors/docdb/QueryUtilsTest.java
+++ b/athena-docdb/src/test/java/com/amazonaws/athena/connectors/docdb/QueryUtilsTest.java
@@ -1,0 +1,106 @@
+/*-
+ * #%L
+ * athena-docdb
+ * %%
+ * Copyright (C) 2019 - 2024 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.docdb;
+
+import com.amazonaws.athena.connector.lambda.data.BlockAllocatorImpl;
+import com.amazonaws.athena.connector.lambda.domain.predicate.Range;
+import com.amazonaws.athena.connector.lambda.domain.predicate.SortedRangeSet;
+import com.amazonaws.athena.connector.lambda.domain.predicate.ValueSet;
+import com.google.common.collect.ImmutableList;
+import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class QueryUtilsTest
+{
+    private final BlockAllocatorImpl allocator = new BlockAllocatorImpl();
+
+    @Test
+    public void testMakePredicateWithSortedRangeSet()
+    {
+        Field field = new Field("year", FieldType.nullable(new ArrowType.Int(32, true)), null);
+
+        ValueSet rangeSet = SortedRangeSet.copyOf(
+                Types.MinorType.INT.getType(),
+                ImmutableList.of(
+                        Range.lessThan(allocator, Types.MinorType.INT.getType(), 1950),
+                        Range.equal(allocator, Types.MinorType.INT.getType(), 1952),
+                        Range.range(allocator, Types.MinorType.INT.getType(), 1955, false, 1972, true),
+                        Range.greaterThanOrEqual(allocator, Types.MinorType.INT.getType(), 2010)),
+                false
+        );
+        Document result = QueryUtils.makePredicate(field, rangeSet);
+        assertNotNull(result);
+        Document expected = new Document("$or", ImmutableList.of(
+                new Document("year", new Document("$lt", 1950)),
+                new Document("year", new Document("$gt", 1955).append("$lte", 1972)),
+                new Document("year", new Document("$gte", 2010)),
+                new Document("year", new Document("$eq", 1952))
+        ));
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testMakePredicateWithId()
+    {
+        Field field = new Field("_id", FieldType.nullable(new ArrowType.Utf8()), null);
+
+        ValueSet rangeSet = SortedRangeSet.copyOf(
+                Types.MinorType.VARCHAR.getType(),
+                ImmutableList.of(
+                        Range.equal(allocator, Types.MinorType.VARCHAR.getType(), "4ecbe7f9e8c1c9092c000027")),
+                false
+        );
+        Document result = QueryUtils.makePredicate(field, rangeSet);
+        assertNotNull(result);
+        Document expected =
+                new Document("_id", new Document("$eq", new ObjectId("4ecbe7f9e8c1c9092c000027")));
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testParseFilter()
+    {
+        String jsonFilter = "{ \"field\": { \"$eq\": \"value\" } }";
+
+        Document result = QueryUtils.parseFilter(jsonFilter);
+        assertNotNull(result);
+        assertEquals("value", ((Document) result.get("field")).get("$eq"));
+    }
+
+    @Test
+    public void testParseFilterInvalidJson()
+    {
+        String invalidJsonFilter = "{ field: { $eq: value } }";
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            QueryUtils.parseFilter(invalidJsonFilter);
+        });
+    }
+}
+


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-athena-query-federation/issues/507 
*Description of changes:*
Converting String to ObjectId when querying using _id column in docdb.
In DocumentDB _id column data type is ObjectId when we query with _id as String it won't return any results so converting String to ObjectId will return results. PFA testing doc for the same.
[DocumentDB test with _id.docx](https://github.com/user-attachments/files/16233803/DocumentDB.test.with._id.docx)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
