### PR TITLE
[Fix] Remove Trailing Whitespaces from Char Column in Postgresql/Redshift Connector

### DIFF
--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcSplitQueryBuilder.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcSplitQueryBuilder.java
@@ -108,14 +108,26 @@ public abstract class JdbcSplitQueryBuilder
             final Split split)
             throws SQLException
     {
-        StringBuilder sql = new StringBuilder();
-
         String columnNames = tableSchema.getFields().stream()
                 .map(Field::getName)
                 .filter(c -> !split.getProperties().containsKey(c))
                 .map(this::quote)
                 .collect(Collectors.joining(", "));
+        return prepareStatementWithSql(jdbcConnection, catalog, schema, table, tableSchema, constraints, split, columnNames);
+    }
 
+    protected PreparedStatement prepareStatementWithSql(
+            final Connection jdbcConnection,
+            final String catalog,
+            final String schema,
+            final String table,
+            final Schema tableSchema,
+            final Constraints constraints,
+            final Split split,
+            final String columnNames)
+            throws SQLException
+    {
+        StringBuilder sql = new StringBuilder();
         sql.append("SELECT ");
         sql.append(columnNames);
 

--- a/athena-postgresql/pom.xml
+++ b/athena-postgresql/pom.xml
@@ -33,6 +33,12 @@
             <artifactId>postgresql</artifactId>
             <version>42.7.3</version>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-rds -->
         <dependency>
             <groupId>com.amazonaws</groupId>

--- a/athena-postgresql/src/main/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlMetadataHandler.java
+++ b/athena-postgresql/src/main/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlMetadataHandler.java
@@ -62,6 +62,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -444,5 +445,32 @@ public class PostGreSqlMetadataHandler
         preparedStatement.setString(3, databaseName);
         LOGGER.debug("Prepared statement for getting name of Materialized View with Case Insensitive Look Up: {}", preparedStatement);
         return preparedStatement;
+    }
+
+    /**
+     * Retrieves the names of columns with the data type 'CHAR' for a specified table in a PostgreSQL/Redshift database.
+     *
+     * @param connection the JDBC connection to the database
+     * @param schema Postgresql/Redshift schema name
+     * @param table Postgresql/Redshift table name
+     * @return a list of column names that have the data type 'CHAR'
+     * @throws SQLException if a database access error occurs
+     */
+    public static List<String> getCharColumns(Connection connection, String schema, String table) throws SQLException
+    {
+        List<String> charColumns = new ArrayList<>();
+        String query = "SELECT column_name " +
+                "FROM information_schema.columns " +
+                "WHERE table_schema = ? AND table_name = ? AND data_type = 'character'";
+        try (PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, schema);
+            statement.setString(2, table);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                while (resultSet.next()) {
+                    charColumns.add(resultSet.getString("column_name"));
+                }
+            }
+        }
+        return charColumns;
     }
 }

--- a/athena-postgresql/src/test/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlRecordHandlerTest.java
+++ b/athena-postgresql/src/test/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlRecordHandlerTest.java
@@ -41,9 +41,11 @@ import com.google.common.collect.ImmutableMap;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Schema;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,6 +60,7 @@ import java.util.concurrent.TimeUnit;
 
 import static com.amazonaws.athena.connectors.postgresql.PostGreSqlConstants.POSTGRES_NAME;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.nullable;
 
 public class PostGreSqlRecordHandlerTest extends TestBase
@@ -71,6 +74,7 @@ public class PostGreSqlRecordHandlerTest extends TestBase
     private AmazonS3 amazonS3;
     private AWSSecretsManager secretsManager;
     private AmazonAthena athena;
+    private MockedStatic<PostGreSqlMetadataHandler> mockedPostGreSqlMetadataHandler;
 
     @Before
     public void setup()
@@ -87,6 +91,13 @@ public class PostGreSqlRecordHandlerTest extends TestBase
                 "postgres://jdbc:postgresql://hostname/user=A&password=B");
 
         this.postGreSqlRecordHandler = new PostGreSqlRecordHandler(databaseConnectionConfig, amazonS3, secretsManager, athena, jdbcConnectionFactory, jdbcSplitQueryBuilder, com.google.common.collect.ImmutableMap.of());
+        mockedPostGreSqlMetadataHandler = Mockito.mockStatic(PostGreSqlMetadataHandler.class);
+        mockedPostGreSqlMetadataHandler.when(() -> PostGreSqlMetadataHandler.getCharColumns(any(), anyString(), anyString())).thenReturn(Collections.singletonList("testCol10"));
+    }
+
+    @After
+    public void close(){
+        mockedPostGreSqlMetadataHandler.close();
     }
 
     @Test
@@ -107,6 +118,7 @@ public class PostGreSqlRecordHandlerTest extends TestBase
         schemaBuilder.addField(FieldBuilder.newBuilder("testCol7", Types.MinorType.FLOAT8.getType()).build());
         schemaBuilder.addField(FieldBuilder.newBuilder("testCol8", Types.MinorType.BIT.getType()).build());
         schemaBuilder.addField(FieldBuilder.newBuilder("testCol9", new ArrowType.Decimal(8, 2)).build());
+        schemaBuilder.addField(FieldBuilder.newBuilder("testCol10", new ArrowType.Utf8()).build());
         schemaBuilder.addField(FieldBuilder.newBuilder("partition_schema_name", Types.MinorType.VARCHAR.getType()).build());
         schemaBuilder.addField(FieldBuilder.newBuilder("partition_name", Types.MinorType.VARCHAR.getType()).build());
         Schema schema = schemaBuilder.build();
@@ -133,6 +145,7 @@ public class PostGreSqlRecordHandlerTest extends TestBase
         ValueSet valueSet7 = getSingleValueSet(1.2d);
         ValueSet valueSet8 = getSingleValueSet(true);
         ValueSet valueSet9 = getSingleValueSet(BigDecimal.valueOf(12.34));
+        ValueSet valueSet10 = getSingleValueSet("A");
 
         Constraints constraints = Mockito.mock(Constraints.class);
         Mockito.when(constraints.getSummary()).thenReturn(new ImmutableMap.Builder<String, ValueSet>()
@@ -145,9 +158,10 @@ public class PostGreSqlRecordHandlerTest extends TestBase
                 .put("testCol7", valueSet7)
                 .put("testCol8", valueSet8)
                 .put("testCol9", valueSet9)
+                .put("testCol10", valueSet10)
                 .build());
 
-        String expectedSql = "SELECT \"testCol1\", \"testCol2\", \"testCol3\", \"testCol4\", \"testCol5\", \"testCol6\", \"testCol7\", \"testCol8\", \"testCol9\" FROM \"s0\".\"p0\"  WHERE (\"testCol1\" IN (?,?)) AND ((\"testCol2\" >= ? AND \"testCol2\" < ?)) AND ((\"testCol3\" > ? AND \"testCol3\" <= ?)) AND (\"testCol4\" = ?) AND (\"testCol5\" = ?) AND (\"testCol6\" = ?) AND (\"testCol7\" = ?) AND (\"testCol8\" = ?) AND (\"testCol9\" = ?)";
+        String expectedSql = "SELECT \"testCol1\", \"testCol2\", \"testCol3\", \"testCol4\", \"testCol5\", \"testCol6\", \"testCol7\", \"testCol8\", \"testCol9\", RTRIM(\"testCol10\") AS \"testCol10\" FROM \"s0\".\"p0\"  WHERE (\"testCol1\" IN (?,?)) AND ((\"testCol2\" >= ? AND \"testCol2\" < ?)) AND ((\"testCol3\" > ? AND \"testCol3\" <= ?)) AND (\"testCol4\" = ?) AND (\"testCol5\" = ?) AND (\"testCol6\" = ?) AND (\"testCol7\" = ?) AND (\"testCol8\" = ?) AND (\"testCol9\" = ?) AND (\"testCol10\" = ?)";
         PreparedStatement expectedPreparedStatement = Mockito.mock(PreparedStatement.class);
         Mockito.when(this.connection.prepareStatement(Mockito.eq(expectedSql))).thenReturn(expectedPreparedStatement);
 
@@ -166,6 +180,7 @@ public class PostGreSqlRecordHandlerTest extends TestBase
         Mockito.verify(preparedStatement, Mockito.times(1)).setDouble(10, 1.2d);
         Mockito.verify(preparedStatement, Mockito.times(1)).setBoolean(11, true);
         Mockito.verify(preparedStatement, Mockito.times(1)).setBigDecimal(12, BigDecimal.valueOf(12.34));
+        Mockito.verify(preparedStatement, Mockito.times(1)).setString(13, "A");
 
         logger.info("buildSplitSqlTest - exit");
     }
@@ -206,7 +221,7 @@ public class PostGreSqlRecordHandlerTest extends TestBase
         //month – 0 to 11
         //day – 1 to 31
         //Start date = 1992-1-1
-        Date expectedDate = new Date(120, 0, 5);
+        Date expectedDate = new Date(120, 0, 4);
         Assert.assertEquals(expectedPreparedStatement, preparedStatement);
         Mockito.verify(preparedStatement, Mockito.times(1))
                 .setDate(1, expectedDate);

--- a/athena-postgresql/src/test/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlRecordHandlerTest.java
+++ b/athena-postgresql/src/test/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlRecordHandlerTest.java
@@ -221,7 +221,7 @@ public class PostGreSqlRecordHandlerTest extends TestBase
         //month – 0 to 11
         //day – 1 to 31
         //Start date = 1992-1-1
-        Date expectedDate = new Date(120, 0, 4);
+        Date expectedDate = new Date(120, 0, 5);
         Assert.assertEquals(expectedPreparedStatement, preparedStatement);
         Mockito.verify(preparedStatement, Mockito.times(1))
                 .setDate(1, expectedDate);

--- a/athena-redshift/pom.xml
+++ b/athena-redshift/pom.xml
@@ -26,6 +26,12 @@
             <version>2.1.0.29</version>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
             <version>2022.47.1</version>

--- a/athena-redshift/src/test/java/com/amazonaws/athena/connectors/redshift/RedshiftRecordHandlerTest.java
+++ b/athena-redshift/src/test/java/com/amazonaws/athena/connectors/redshift/RedshiftRecordHandlerTest.java
@@ -44,9 +44,11 @@ import com.google.common.collect.ImmutableMap;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Schema;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,6 +62,8 @@ import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
 import static com.amazonaws.athena.connectors.redshift.RedshiftConstants.REDSHIFT_NAME;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.nullable;
 
 public class RedshiftRecordHandlerTest
@@ -74,6 +78,7 @@ public class RedshiftRecordHandlerTest
     private AmazonS3 amazonS3;
     private AWSSecretsManager secretsManager;
     private AmazonAthena athena;
+    private MockedStatic<PostGreSqlMetadataHandler> mockedPostGreSqlMetadataHandler;
 
     @Before
     public void setup()
@@ -90,6 +95,13 @@ public class RedshiftRecordHandlerTest
                 "redshift://jdbc:redshift://hostname/user=A&password=B");
 
         this.redshiftRecordHandler = new RedshiftRecordHandler(databaseConnectionConfig, amazonS3, secretsManager, athena, jdbcConnectionFactory, jdbcSplitQueryBuilder, com.google.common.collect.ImmutableMap.of());
+        mockedPostGreSqlMetadataHandler = Mockito.mockStatic(PostGreSqlMetadataHandler.class);
+        mockedPostGreSqlMetadataHandler.when(() -> PostGreSqlMetadataHandler.getCharColumns(any(), anyString(), anyString())).thenReturn(Collections.singletonList("testCol10"));
+    }
+
+    @After
+    public void close(){
+        mockedPostGreSqlMetadataHandler.close();
     }
 
     @Test
@@ -110,6 +122,7 @@ public class RedshiftRecordHandlerTest
         schemaBuilder.addField(FieldBuilder.newBuilder("testCol7", Types.MinorType.FLOAT8.getType()).build());
         schemaBuilder.addField(FieldBuilder.newBuilder("testCol8", Types.MinorType.BIT.getType()).build());
         schemaBuilder.addField(FieldBuilder.newBuilder("testCol9", new ArrowType.Decimal(8, 2)).build());
+        schemaBuilder.addField(FieldBuilder.newBuilder("testCol10", new ArrowType.Utf8()).build());
         schemaBuilder.addField(FieldBuilder.newBuilder("partition_schema_name", Types.MinorType.VARCHAR.getType()).build());
         schemaBuilder.addField(FieldBuilder.newBuilder("partition_name", Types.MinorType.VARCHAR.getType()).build());
         Schema schema = schemaBuilder.build();
@@ -136,6 +149,7 @@ public class RedshiftRecordHandlerTest
         ValueSet valueSet7 = getSingleValueSet(1.2d);
         ValueSet valueSet8 = getSingleValueSet(true);
         ValueSet valueSet9 = getSingleValueSet(BigDecimal.valueOf(12.34));
+        ValueSet valueSet10 = getSingleValueSet("A");
 
         Constraints constraints = Mockito.mock(Constraints.class);
         Mockito.when(constraints.getSummary()).thenReturn(new ImmutableMap.Builder<String, ValueSet>()
@@ -148,9 +162,10 @@ public class RedshiftRecordHandlerTest
                 .put("testCol7", valueSet7)
                 .put("testCol8", valueSet8)
                 .put("testCol9", valueSet9)
+                .put("testCol10", valueSet10)
                 .build());
 
-        String expectedSql = "SELECT \"testCol1\", \"testCol2\", \"testCol3\", \"testCol4\", \"testCol5\", \"testCol6\", \"testCol7\", \"testCol8\", \"testCol9\" FROM \"s0\".\"p0\"  WHERE (\"testCol1\" IN (?,?)) AND ((\"testCol2\" >= ? AND \"testCol2\" < ?)) AND ((\"testCol3\" > ? AND \"testCol3\" <= ?)) AND (\"testCol4\" = ?) AND (\"testCol5\" = ?) AND (\"testCol6\" = ?) AND (\"testCol7\" = ?) AND (\"testCol8\" = ?) AND (\"testCol9\" = ?)";
+        String expectedSql = "SELECT \"testCol1\", \"testCol2\", \"testCol3\", \"testCol4\", \"testCol5\", \"testCol6\", \"testCol7\", \"testCol8\", \"testCol9\", RTRIM(\"testCol10\") AS \"testCol10\" FROM \"s0\".\"p0\"  WHERE (\"testCol1\" IN (?,?)) AND ((\"testCol2\" >= ? AND \"testCol2\" < ?)) AND ((\"testCol3\" > ? AND \"testCol3\" <= ?)) AND (\"testCol4\" = ?) AND (\"testCol5\" = ?) AND (\"testCol6\" = ?) AND (\"testCol7\" = ?) AND (\"testCol8\" = ?) AND (\"testCol9\" = ?) AND (\"testCol10\" = ?)";
         PreparedStatement expectedPreparedStatement = Mockito.mock(PreparedStatement.class);
         Mockito.when(this.connection.prepareStatement(Mockito.eq(expectedSql))).thenReturn(expectedPreparedStatement);
 
@@ -169,7 +184,7 @@ public class RedshiftRecordHandlerTest
         Mockito.verify(preparedStatement, Mockito.times(1)).setDouble(10, 1.2d);
         Mockito.verify(preparedStatement, Mockito.times(1)).setBoolean(11, true);
         Mockito.verify(preparedStatement, Mockito.times(1)).setBigDecimal(12, BigDecimal.valueOf(12.34));
-
+        Mockito.verify(preparedStatement, Mockito.times(1)).setString(13, "A");
         logger.info("buildSplitSqlTest - exit");
     }
 
@@ -204,7 +219,7 @@ public class RedshiftRecordHandlerTest
 
         PreparedStatement preparedStatement = this.redshiftRecordHandler.buildSplitSql(this.connection, "testCatalogName", tableName, schema, constraints, split);
 
-        Date expectedDate = new Date(120, 0, 5);
+        Date expectedDate = new Date(120, 0, 4);
         Assert.assertEquals(expectedPreparedStatement, preparedStatement);
         Mockito.verify(preparedStatement, Mockito.times(1))
                 .setDate(1, expectedDate);

--- a/athena-redshift/src/test/java/com/amazonaws/athena/connectors/redshift/RedshiftRecordHandlerTest.java
+++ b/athena-redshift/src/test/java/com/amazonaws/athena/connectors/redshift/RedshiftRecordHandlerTest.java
@@ -219,7 +219,7 @@ public class RedshiftRecordHandlerTest
 
         PreparedStatement preparedStatement = this.redshiftRecordHandler.buildSplitSql(this.connection, "testCatalogName", tableName, schema, constraints, split);
 
-        Date expectedDate = new Date(120, 0, 4);
+        Date expectedDate = new Date(120, 0, 5);
         Assert.assertEquals(expectedPreparedStatement, preparedStatement);
         Mockito.verify(preparedStatement, Mockito.times(1))
                 .setDate(1, expectedDate);


### PR DESCRIPTION
*Issue #, if available:*
[ [BUG] Redshift 'char' column constraint pushdown does not work #62 ](https://github.com/awslabs/aws-athena-query-federation/issues/62)

*Description of changes:*
PostgreSQL/Redshift database will send data along with trailing whitespaces in CHAR datatype columns. So, removed those spaces using the RTRIM() function while building the SQL query.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.