### PR TITLE
Feature/sqlserver issue 1540

### DIFF
--- a/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerMetadataHandler.java
+++ b/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerMetadataHandler.java
@@ -290,7 +290,8 @@ public class SqlServerMetadataHandler extends JdbcMetadataHandler
                 if (e.getMessage().contains("VIEW DATABASE STATE permission denied")) {
                     LOGGER.error("Permission denied to view database state for {}", e.getMessage());
                     handleSinglePartition(blockWriter);
-                } else {
+                }
+                else {
                     throw e;
                 }
             }

--- a/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerMetadataHandler.java
+++ b/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerMetadataHandler.java
@@ -288,7 +288,7 @@ public class SqlServerMetadataHandler extends JdbcMetadataHandler
             catch (SQLServerException e) {
                 // for permission denied sqlServer exception retuning single partition
                 if (e.getMessage().contains("VIEW DATABASE STATE permission denied")) {
-                    LOGGER.error("Permission denied to view database state for {}", e.getMessage());
+                    LOGGER.warn("Permission denied to view database state for {}", e.getMessage());
                     handleSinglePartition(blockWriter);
                 }
                 else {

--- a/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerMetadataHandler.java
+++ b/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerMetadataHandler.java
@@ -228,12 +228,12 @@ public class SqlServerMetadataHandler extends JdbcMetadataHandler
         List<String> params = Arrays.asList(getTableLayoutRequest.getTableName().getTableName(), getTableLayoutRequest.getTableName().getSchemaName());
 
         //check whether the input table is a view or not
-        String viewFlag = "N";
+        boolean viewFlag = false;
         try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider());
              PreparedStatement preparedStatement = new PreparedStatementBuilder().withConnection(connection).withQuery(VIEW_CHECK_QUERY).withParameters(params).build();
              ResultSet resultSet = preparedStatement.executeQuery()) {
             if (resultSet.next()) {
-                viewFlag = "VIEW".equalsIgnoreCase(resultSet.getString("TYPE_DESC")) ? "Y" : "N";
+                viewFlag = "VIEW".equalsIgnoreCase(resultSet.getString("TYPE_DESC"));
             }
             LOGGER.info("viewFlag: {}", viewFlag);
         }
@@ -253,7 +253,7 @@ public class SqlServerMetadataHandler extends JdbcMetadataHandler
                 }
 
                 // create a single split for view/non-partition table
-                if ("Y".equals(viewFlag) || rowCount == 0) {
+                if (viewFlag || rowCount == 0) {
                     handleSinglePartition(blockWriter);
                 }
                 else {


### PR DESCRIPTION
*Issue #, if available:*
#1540 athena-sqlserver without VIEW DATABASE STATE permission
*Description of changes:*
For a database user with without VIEW DATABASE STATE permission, instead of throwing an exception when retrieving partition data, return a single partition as done for views.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
