### PR TITLE
Remove s3:listAllMyBuckets permission

### DIFF
--- a/athena-aws-cmdb/athena-aws-cmdb.yaml
+++ b/athena-aws-cmdb/athena-aws-cmdb.yaml
@@ -70,7 +70,6 @@ Resources:
                 - rds:Describe*
                 - rds:ListTagsForResource
                 - athena:GetQueryExecution
-                - s3:ListAllMyBuckets
                 - s3:ListBucket
                 - athena:GetQueryExecution
               Effect: Allow

--- a/athena-clickhouse/athena-clickhouse.yaml
+++ b/athena-clickhouse/athena-clickhouse.yaml
@@ -128,7 +128,6 @@ Resources:
             Resource: !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${LambdaFunctionName}:*'
           - Action:
             - athena:GetQueryExecution
-            - s3:ListAllMyBuckets
             Effect: Allow
             Resource: '*'
           - Action:

--- a/athena-cloudera-hive/athena-cloudera-hive.yaml
+++ b/athena-cloudera-hive/athena-cloudera-hive.yaml
@@ -95,7 +95,6 @@ Resources:
         - Statement:
           - Action:
               - athena:GetQueryExecution
-              - s3:ListAllMyBuckets
             Effect: Allow
             Resource: '*'
           Version: '2012-10-17'

--- a/athena-cloudera-impala/athena-cloudera-impala.yaml
+++ b/athena-cloudera-impala/athena-cloudera-impala.yaml
@@ -100,7 +100,6 @@ Resources:
         - Statement:
           - Action:
               - athena:GetQueryExecution
-              - s3:ListAllMyBuckets
             Effect: Allow
             Resource: '*'
           Version: '2012-10-17'

--- a/athena-cloudwatch-metrics/athena-cloudwatch-metrics.yaml
+++ b/athena-cloudwatch-metrics/athena-cloudwatch-metrics.yaml
@@ -66,7 +66,6 @@ Resources:
                 - cloudwatch:Get*
                 - cloudwatch:List*
                 - athena:GetQueryExecution
-                - s3:ListAllMyBuckets
               Effect: Allow
               Resource: '*'
           Version: '2012-10-17'

--- a/athena-cloudwatch/athena-cloudwatch.yaml
+++ b/athena-cloudwatch/athena-cloudwatch.yaml
@@ -108,7 +108,6 @@ Resources:
               - logs:TestMetricFilter
               - logs:FilterLogEvents
               - athena:GetQueryExecution
-              - s3:ListAllMyBuckets
             Effect: Allow
             Resource: '*'
           - Action:

--- a/athena-datalakegen2/athena-datalakegen2.yaml
+++ b/athena-datalakegen2/athena-datalakegen2.yaml
@@ -101,7 +101,6 @@ Resources:
         - Statement:
             - Action:
                 - athena:GetQueryExecution
-                - s3:ListAllMyBuckets
               Effect: Allow
               Resource: '*'
           Version: '2012-10-17'

--- a/athena-db2-as400/athena-db2-as400.yaml
+++ b/athena-db2-as400/athena-db2-as400.yaml
@@ -98,7 +98,6 @@ Resources:
         - Statement:
             - Action:
                 - athena:GetQueryExecution
-                - s3:ListAllMyBuckets
               Effect: Allow
               Resource: '*'
           Version: '2012-10-17'

--- a/athena-db2/athena-db2.yaml
+++ b/athena-db2/athena-db2.yaml
@@ -98,7 +98,6 @@ Resources:
         - Statement:
             - Action:
                 - athena:GetQueryExecution
-                - s3:ListAllMyBuckets
               Effect: Allow
               Resource: '*'
           Version: '2012-10-17'

--- a/athena-docdb/athena-docdb.yaml
+++ b/athena-docdb/athena-docdb.yaml
@@ -91,7 +91,6 @@ Resources:
                 - glue:GetPartition
                 - glue:GetDatabase
                 - athena:GetQueryExecution
-                - s3:ListAllMyBuckets
               Effect: Allow
               Resource: '*'
           Version: '2012-10-17'

--- a/athena-dynamodb/athena-dynamodb.yaml
+++ b/athena-dynamodb/athena-dynamodb.yaml
@@ -115,7 +115,6 @@ Resources:
              - glue:GetPartition
              - glue:GetDatabase
              - athena:GetQueryExecution
-             - s3:ListAllMyBuckets
             Effect: Allow
             Resource: '*'
           - Action:

--- a/athena-elasticsearch/athena-elasticsearch.yaml
+++ b/athena-elasticsearch/athena-elasticsearch.yaml
@@ -130,7 +130,6 @@ Resources:
                 - glue:GetPartition
                 - glue:GetDatabase
                 - athena:GetQueryExecution
-                - s3:ListAllMyBuckets
               Effect: Allow
               Resource: '*'
           Version: '2012-10-17'

--- a/athena-example/athena-example.yaml
+++ b/athena-example/athena-example.yaml
@@ -64,7 +64,6 @@ Resources:
         - Statement:
             - Action:
                 - athena:GetQueryExecution
-                - s3:ListAllMyBuckets
               Effect: Allow
               Resource: '*'
           Version: '2012-10-17'

--- a/athena-federation-integ-test/src/main/java/com/amazonaws/athena/connector/integ/stacks/ConnectorStack.java
+++ b/athena-federation-integ-test/src/main/java/com/amazonaws/athena/connector/integ/stacks/ConnectorStack.java
@@ -189,7 +189,6 @@ public class ConnectorStack extends Stack
         statementActionsPolicy.add("glue:GetPartition");
         statementActionsPolicy.add("glue:GetDatabase");
         statementActionsPolicy.add("athena:GetQueryExecution");
-        statementActionsPolicy.add("s3:ListAllMyBuckets");
 
         return PolicyDocument.Builder.create()
                 .statements(ImmutableList.of(PolicyStatement.Builder.create()

--- a/athena-federation-sdk/athena-federation-sdk.yaml
+++ b/athena-federation-sdk/athena-federation-sdk.yaml
@@ -53,12 +53,6 @@ Resources:
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       Policies:
-        - Statement:
-            - Action:
-                - s3:ListAllMyBuckets
-              Effect: Allow
-              Resource: '*'
-          Version: '2012-10-17'
         #S3CrudPolicy allows our connector to spill large responses to S3. You can optionally replace this pre-made policy
         #with one that is more restrictive and can only 'put' but not read,delete, or overwrite files.
         - S3CrudPolicy:

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/domain/spill/SpillLocationVerifier.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/domain/spill/SpillLocationVerifier.java
@@ -1,5 +1,3 @@
-package com.amazonaws.athena.connector.lambda.domain.spill;
-
 /*-
  * #%L
  * Amazon Athena Query Federation SDK
@@ -20,14 +18,14 @@ package com.amazonaws.athena.connector.lambda.domain.spill;
  * #L%
  */
 
+package com.amazonaws.athena.connector.lambda.domain.spill;
+
+import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.amazonaws.services.s3.model.HeadBucketRequest;
 import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * This class is used to track the bucket and its state, and check its validity
@@ -85,19 +83,21 @@ public class SpillLocationVerifier
     void updateBucketState()
     {
         try {
-            Set<String> buckets = amazons3.listBuckets().stream().map(b -> b.getName()).collect(Collectors.toSet());
-
-            if (!buckets.contains(bucket)) {
+            amazons3.headBucket(new HeadBucketRequest(bucket));
+            state = BucketState.VALID;
+        }
+        catch (AmazonServiceException ex) {
+            int statusCode = ex.getStatusCode();
+            // returns 404 if bucket was not found, 403 if bucket access is forbidden
+            if (statusCode == 404 || statusCode == 403) {
                 state = BucketState.INVALID;
             }
             else {
-                state = BucketState.VALID;
+                throw new RuntimeException("Error while checking bucket ownership for " + bucket, ex);
             }
-
-            logger.info("The state of bucket {} has been updated to {} from {}", bucket, state, BucketState.UNCHECKED);
         }
-        catch (AmazonS3Exception ex) {
-            throw new RuntimeException("Error while checking bucket ownership for " + bucket, ex);
+        finally {
+            logger.info("The state of bucket {} has been updated to {} from {}", bucket, state, BucketState.UNCHECKED);
         }
     }
 

--- a/athena-gcs/athena-gcs.yaml
+++ b/athena-gcs/athena-gcs.yaml
@@ -70,7 +70,6 @@ Resources:
         - Statement:
             - Action:
                 - athena:GetQueryExecution
-                - s3:ListAllMyBuckets
                 - glue:GetTableVersions
                 - glue:GetPartitions
                 - glue:GetTables

--- a/athena-google-bigquery/athena-google-bigquery.yaml
+++ b/athena-google-bigquery/athena-google-bigquery.yaml
@@ -109,7 +109,6 @@ Resources:
         - Statement:
             - Action:
                 - athena:GetQueryExecution
-                - s3:ListAllMyBuckets
               Effect: Allow
               Resource: '*'
           Version: '2012-10-17'

--- a/athena-hbase/athena-hbase.yaml
+++ b/athena-hbase/athena-hbase.yaml
@@ -110,7 +110,6 @@ Resources:
                 - glue:GetPartition
                 - glue:GetDatabase
                 - athena:GetQueryExecution
-                - s3:ListAllMyBuckets
                 - s3:ListBucket
                 - s3:GetObject
                 - s3:GetBucketLocation

--- a/athena-hortonworks-hive/athena-hortonworks-hive.yaml
+++ b/athena-hortonworks-hive/athena-hortonworks-hive.yaml
@@ -99,7 +99,6 @@ Resources:
         - Statement:
           - Action:
               - athena:GetQueryExecution
-              - s3:ListAllMyBuckets
             Effect: Allow
             Resource: '*'
           Version: '2012-10-17'

--- a/athena-kafka/athena-kafka.yaml
+++ b/athena-kafka/athena-kafka.yaml
@@ -152,7 +152,6 @@ Resources:
             Resource: !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${LambdaFunctionName}:*'
           - Action:
               - athena:GetQueryExecution
-              - s3:ListAllMyBuckets
               - s3:ListBucket
               - s3:GetObject
               - s3:GetBucketLocation

--- a/athena-msk/athena-msk.yaml
+++ b/athena-msk/athena-msk.yaml
@@ -147,7 +147,6 @@ Resources:
             Resource: !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${LambdaFunctionName}:*'
           - Action:
               - athena:GetQueryExecution
-              - s3:ListAllMyBuckets
               - s3:ListBucket
               - s3:GetObject
               - s3:GetBucketLocation

--- a/athena-mysql/athena-mysql.yaml
+++ b/athena-mysql/athena-mysql.yaml
@@ -121,7 +121,6 @@ Resources:
             Resource: !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${LambdaFunctionName}:*'
           - Action:
             - athena:GetQueryExecution
-            - s3:ListAllMyBuckets
             Effect: Allow
             Resource: '*'
           - Action:

--- a/athena-neptune/athena-neptune.yaml
+++ b/athena-neptune/athena-neptune.yaml
@@ -115,7 +115,6 @@ Resources:
                 - glue:GetPartition
                 - glue:GetDatabase              
                 - athena:GetQueryExecution
-                - s3:ListAllMyBuckets
               Effect: Allow
               Resource: '*'
             - Action:

--- a/athena-oracle/athena-oracle.yaml
+++ b/athena-oracle/athena-oracle.yaml
@@ -134,7 +134,6 @@ Resources:
             Resource: !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${LambdaFunctionName}:*'
           - Action:
               - athena:GetQueryExecution
-              - s3:ListAllMyBuckets
             Effect: Allow
             Resource: '*'
           - Action:

--- a/athena-postgresql/athena-postgresql.yaml
+++ b/athena-postgresql/athena-postgresql.yaml
@@ -134,7 +134,6 @@ Resources:
             Resource: !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${LambdaFunctionName}:*'
           - Action:
             - athena:GetQueryExecution
-            - s3:ListAllMyBuckets
             Effect: Allow
             Resource: '*'
           - Action:

--- a/athena-redis/athena-redis.yaml
+++ b/athena-redis/athena-redis.yaml
@@ -106,7 +106,6 @@ Resources:
                 - glue:GetPartition
                 - glue:GetDatabase
                 - athena:GetQueryExecution
-                - s3:ListAllMyBuckets
               Effect: Allow
               Resource: '*'
           Version: '2012-10-17'

--- a/athena-redshift/athena-redshift.yaml
+++ b/athena-redshift/athena-redshift.yaml
@@ -123,7 +123,6 @@ Resources:
           - Effect: Allow
             Action:
               - athena:GetQueryExecution
-              - s3:ListAllMyBuckets
             Resource: '*'
           - Effect: Allow
             Action:

--- a/athena-saphana/athena-saphana.yaml
+++ b/athena-saphana/athena-saphana.yaml
@@ -99,7 +99,6 @@ Resources:
         - Statement:
             - Action:
                 - athena:GetQueryExecution
-                - s3:ListAllMyBuckets
               Effect: Allow
               Resource: '*'
           Version: '2012-10-17'

--- a/athena-snowflake/athena-snowflake.yaml
+++ b/athena-snowflake/athena-snowflake.yaml
@@ -99,7 +99,6 @@ Resources:
         - Statement:
             - Action:
                 - athena:GetQueryExecution
-                - s3:ListAllMyBuckets
               Effect: Allow
               Resource: '*'
           Version: '2012-10-17'

--- a/athena-sqlserver/athena-sqlserver.yaml
+++ b/athena-sqlserver/athena-sqlserver.yaml
@@ -127,7 +127,6 @@ Resources:
             Resource: !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${LambdaFunctionName}:*'
           - Action:
             - athena:GetQueryExecution
-            - s3:ListAllMyBuckets
             Effect: Allow
             Resource: '*'
           - Action:

--- a/athena-synapse/athena-synapse.yaml
+++ b/athena-synapse/athena-synapse.yaml
@@ -133,7 +133,6 @@ Resources:
             Resource: !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${LambdaFunctionName}:*'
           - Action:
               - athena:GetQueryExecution
-              - s3:ListAllMyBuckets
             Effect: Allow
             Resource: '*'
           - Action:

--- a/athena-teradata/athena-teradata.yaml
+++ b/athena-teradata/athena-teradata.yaml
@@ -109,7 +109,6 @@ Resources:
         - Statement:
             - Action:
                 - athena:GetQueryExecution
-                - s3:ListAllMyBuckets
               Effect: Allow
               Resource: '*'
           Version: '2012-10-17'

--- a/athena-timestream/athena-timestream.yaml
+++ b/athena-timestream/athena-timestream.yaml
@@ -71,7 +71,6 @@ Resources:
                 - glue:GetPartition
                 - glue:GetDatabase
                 - athena:GetQueryExecution
-                - s3:ListAllMyBuckets
                 - timestream:Describe*
                 - timestream:List*
                 - timestream:Select*

--- a/athena-tpcds/athena-tpcds.yaml
+++ b/athena-tpcds/athena-tpcds.yaml
@@ -63,7 +63,6 @@ Resources:
         - Statement:
             - Action:
                 - athena:GetQueryExecution
-                - s3:ListAllMyBuckets
               Effect: Allow
               Resource: '*'
           Version: '2012-10-17'

--- a/athena-vertica/athena-vertica.yaml
+++ b/athena-vertica/athena-vertica.yaml
@@ -93,7 +93,6 @@ Resources:
         - Statement:
             - Action:
                 - athena:GetQueryExecution
-                - s3:ListAllMyBuckets
               Effect: Allow
               Resource: '*'
           Version: '2012-10-17'


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-athena-query-federation/issues/1702

*Description of changes:*
Previously, in order to validate the spill bucket could be accessed, the S3Client.listBuckets() api call was used to list all buckets the user had ownership of and check if the spill bucket was there. Now, the S3Client.headBucket(HeadBucketRequest) api call is used to check for the spill bucket only. This removes the need for the s3:ListAllMyBuckets permission as HeadBucket relies only on s3:ListBucket.

References:
* [Head Bucket AWS docs](https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadBucket.html)
* [ListBuckets AWS docs](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBuckets.html)
* [SAM S3CrudPolicy](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-policy-template-list.html#s3-crud-policy): used by many connectors to grant permissions to spill bucket, including ListBucket

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
