### PR TITLE
Neptune dependency upgrade

### DIFF
--- a/athena-neptune/pom.xml
+++ b/athena-neptune/pom.xml
@@ -124,7 +124,7 @@
         <dependency>
             <groupId>org.eclipse.rdf4j</groupId>
             <artifactId>rdf4j-repository-sparql</artifactId>
-            <version>3.7.7</version>
+            <version>5.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/athena-neptune/src/main/java/com/amazonaws/athena/connectors/neptune/rdf/NeptuneSparqlConnection.java
+++ b/athena-neptune/src/main/java/com/amazonaws/athena/connectors/neptune/rdf/NeptuneSparqlConnection.java
@@ -25,7 +25,6 @@ import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.neptune.auth.NeptuneSigV4SignerException;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
-import org.eclipse.rdf4j.model.URI;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
 import org.eclipse.rdf4j.query.BindingSet;
@@ -79,7 +78,7 @@ public class NeptuneSparqlConnection extends NeptuneConnection
             this.neptuneSparqlRepo = new NeptuneSparqlRepository(this.connectionString);
         }
         logger.info("Initializing");
-        this.neptuneSparqlRepo.initialize();
+        this.neptuneSparqlRepo.init();
         logger.info("Getting connection");
         this.connection = this.neptuneSparqlRepo.getConnection();
         logger.info("Connection obtained");
@@ -106,11 +105,7 @@ public class NeptuneSparqlConnection extends NeptuneConnection
             Value val = bindingSet.getValue(varName);
             String sval = val.stringValue();
             Object oval = sval;
-            if (this.trimURI && val instanceof URI) {
-                oval = ((URI) val).getLocalName();
-                logger.debug("URI " + varName + "=" + oval);
-            } 
-            else if (this.trimURI && val instanceof IRI) {
+            if (this.trimURI && val instanceof IRI) {
                 oval = ((IRI) val).getLocalName();
                 logger.debug("IRI " + varName + "=" + oval);
             } 


### PR DESCRIPTION
*Issue #, if available:*
dependency bot upgrade rdf4j-repository-sparql 3.7.7 to 5.0.1

*Description of changes:*
After upgradation, encountered compilation errors. 
As suggested in doc., used IRI instead. removed URI part.

<img width="286" alt="URI_IMAGE" src="https://github.com/user-attachments/assets/f69fc64c-47d9-4731-b1be-15cffb81ca43">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
