### PR TITLE
v2 migration vertica issue fix

### DIFF
--- a/athena-vertica/pom.xml
+++ b/athena-vertica/pom.xml
@@ -23,6 +23,11 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna-platform</artifactId>
+            <version>5.14.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j-log4j.version}</version>

--- a/athena-vertica/src/main/java/com/amazonaws/athena/connectors/vertica/VerticaCompositeHandler.java
+++ b/athena-vertica/src/main/java/com/amazonaws/athena/connectors/vertica/VerticaCompositeHandler.java
@@ -21,6 +21,14 @@ package com.amazonaws.athena.connectors.vertica;
 
 import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 
+import java.io.IOException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateEncodingException;
+
+import static com.amazonaws.athena.connectors.vertica.VerticaSchemaUtils.installCaCertificate;
+import static com.amazonaws.athena.connectors.vertica.VerticaSchemaUtils.setupNativeEnvironmentVariables;
+
 /**
  * Boilerplate composite handler that allows us to use a single Lambda function for both
  * Metadata and Data.
@@ -28,8 +36,10 @@ import com.amazonaws.athena.connector.lambda.handlers.CompositeHandler;
 public class VerticaCompositeHandler
         extends CompositeHandler
 {
-    public VerticaCompositeHandler()
+    public VerticaCompositeHandler() throws CertificateEncodingException, IOException, NoSuchAlgorithmException, KeyStoreException
     {
         super(new VerticaMetadataHandler(System.getenv()), new VerticaRecordHandler(System.getenv()));
+        installCaCertificate();
+        setupNativeEnvironmentVariables();
     }
 }

--- a/athena-vertica/src/main/java/com/amazonaws/athena/connectors/vertica/VerticaConstants.java
+++ b/athena-vertica/src/main/java/com/amazonaws/athena/connectors/vertica/VerticaConstants.java
@@ -28,5 +28,13 @@ public final class VerticaConstants
     public static final String VERTICA_SPLIT_EXPORT_BUCKET = "exportBucket";
     public static final String VERTICA_SPLIT_OBJECT_KEY = "s3ObjectKey";
 
+    /**
+     * A ssl file location constant to store the SSL certificate
+     * The file location is fixed at /tmp directory
+     * to retrieve ssl certificate location
+     */
+    public static final String SSL_CERT_FILE_LOCATION = "SSL_CERT_FILE";
+    public static final String SSL_CERT_FILE_LOCATION_VALUE = "/tmp/cacert.pem";
+
     private VerticaConstants() {}
 }

--- a/athena-vertica/src/main/java/com/amazonaws/athena/connectors/vertica/VerticaSchemaUtils.java
+++ b/athena-vertica/src/main/java/com/amazonaws/athena/connectors/vertica/VerticaSchemaUtils.java
@@ -21,18 +21,38 @@ package com.amazonaws.athena.connectors.vertica;
 
 import com.amazonaws.athena.connector.lambda.data.SchemaBuilder;
 import com.amazonaws.athena.connector.lambda.domain.TableName;
+import com.sun.jna.platform.unix.LibC;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.X509Certificate;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Base64;
+
+import static com.amazonaws.athena.connectors.vertica.VerticaConstants.SSL_CERT_FILE_LOCATION;
+import static com.amazonaws.athena.connectors.vertica.VerticaConstants.SSL_CERT_FILE_LOCATION_VALUE;
 
 public class VerticaSchemaUtils
 {
     private static final Logger logger = LoggerFactory.getLogger(VerticaSchemaUtils.class);
+
+    private static final String BEGIN_CERT = "-----BEGIN CERTIFICATE-----";
+    private static final String END_CERT = "-----END CERTIFICATE-----";
+    private static final String LINE_SEPARATOR = System.getProperty("line.separator");
 
     //Builds the table schema
     protected Schema buildTableSchema(Connection connection, TableName name)
@@ -123,6 +143,47 @@ public class VerticaSchemaUtils
 
             default:
                 tableSchemaBuilder.addStringField(colName);
+        }
+    }
+
+    /**
+     * Write out the cacerts that we trust from the default java truststore.
+     *
+     */
+    public static void installCaCertificate() throws IOException, NoSuchAlgorithmException, KeyStoreException, CertificateEncodingException
+    {
+        FileWriter caBundleWriter = new FileWriter(SSL_CERT_FILE_LOCATION_VALUE);
+        try {
+            TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            trustManagerFactory.init((KeyStore) null);
+            for (TrustManager trustManager : trustManagerFactory.getTrustManagers()) {
+                X509TrustManager x509TrustManager = (X509TrustManager) trustManager;
+                for (X509Certificate x509Certificate : x509TrustManager.getAcceptedIssuers()) {
+                    caBundleWriter.write(formatCrtFileContents(x509Certificate));
+                    caBundleWriter.write(LINE_SEPARATOR);
+                }
+            }
+        }
+        finally {
+            caBundleWriter.close();
+        }
+    }
+
+    private static String formatCrtFileContents(Certificate certificate) throws CertificateEncodingException
+    {
+        Base64.Encoder encoder = Base64.getMimeEncoder(64, LINE_SEPARATOR.getBytes());
+        byte[] rawCrtText = certificate.getEncoded();
+        String encodedCertText = new String(encoder.encode(rawCrtText));
+        String prettifiedCert = BEGIN_CERT + LINE_SEPARATOR + encodedCertText + LINE_SEPARATOR + END_CERT;
+        return prettifiedCert;
+    }
+
+    public static void setupNativeEnvironmentVariables()
+    {
+        LibC.INSTANCE.setenv(SSL_CERT_FILE_LOCATION, SSL_CERT_FILE_LOCATION_VALUE, 1);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Set native environment variables: {}: {}",
+                    SSL_CERT_FILE_LOCATION, LibC.INSTANCE.getenv(SSL_CERT_FILE_LOCATION));
         }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
While testing v2 migration changes for Vertica connector we found that it's failing to get ArrowReader object.
The issue is with getting ArrowReader from constructArrowReader() function, it seems if we want to get datasetFactory object it requires cacerts and ssl cert to be set native environment variables. Similar functionality we have seen in GCS connector and implemented same in Vertica, after that it's working fine. Please find attached logs for more details on error. 

Added changes to fix this issue.

[v2-vertica-error-logs.txt](https://github.com/user-attachments/files/16686245/v2-vertica-error-logs.txt)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
