### PR TITLE
Fix for cloudwatch-metrics pagination bug

### DIFF
--- a/athena-cloudwatch-metrics/src/main/java/com/amazonaws/athena/connectors/cloudwatch/metrics/MetricsMetadataHandler.java
+++ b/athena-cloudwatch-metrics/src/main/java/com/amazonaws/athena/connectors/cloudwatch/metrics/MetricsMetadataHandler.java
@@ -258,9 +258,15 @@ public class MetricsMetadataHandler
                 }
             }
 
+            String continuationToken = null;
+            if (result.getNextToken() != null &&
+                    !result.getNextToken().equalsIgnoreCase(listMetricsRequest.getNextToken())) {
+                continuationToken = result.getNextToken();
+            }
+
             if (CollectionUtils.isNullOrEmpty(metricStats)) {
                 logger.info("No metric stats present after filtering predicates.");
-                return new GetSplitsResponse(getSplitsRequest.getCatalogName(), splits, null);
+                return new GetSplitsResponse(getSplitsRequest.getCatalogName(), splits, continuationToken);
             }
 
             List<List<MetricStat>> partitions = Lists.partition(metricStats, calculateSplitSize(metricStats.size()));
@@ -269,12 +275,6 @@ public class MetricsMetadataHandler
                 splits.add(Split.newBuilder(makeSpillLocation(getSplitsRequest), makeEncryptionKey())
                         .add(MetricStatSerDe.SERIALIZED_METRIC_STATS_FIELD_NAME, serializedMetricStats)
                         .build());
-            }
-
-            String continuationToken = null;
-            if (result.getNextToken() != null &&
-                    !result.getNextToken().equalsIgnoreCase(listMetricsRequest.getNextToken())) {
-                continuationToken = result.getNextToken();
             }
 
             return new GetSplitsResponse(getSplitsRequest.getCatalogName(), splits, continuationToken);

--- a/athena-cloudwatch-metrics/src/test/java/com/amazonaws/athena/connectors/cloudwatch/metrics/MetricsMetadataHandlerTest.java
+++ b/athena-cloudwatch-metrics/src/test/java/com/amazonaws/athena/connectors/cloudwatch/metrics/MetricsMetadataHandlerTest.java
@@ -75,6 +75,7 @@ import static com.amazonaws.athena.connectors.cloudwatch.metrics.tables.Table.NA
 import static com.amazonaws.athena.connectors.cloudwatch.metrics.tables.Table.STATISTIC_FIELD;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.when;
@@ -337,6 +338,7 @@ public class MetricsMetadataHandlerTest
         for (Split nextSplit : response.getSplits()) {
             assertNotNull(nextSplit.getProperty(SERIALIZED_METRIC_STATS_FIELD_NAME));
         }
+        assertNull(continuationToken);
 
         logger.info("doGetMetricSamplesSplits: exit");
     }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
When using this connector I noticed that some of my queries on highly-dimensional namespaces returned zero results.  The root cause it that if no MetricStats are produced in the first ListMetrics page (the constraints don't match), then the connector would return no splits *and no continuation token even if there is one*.  This change fixes that bug by returning the continuation token so that GetSplits gets called again. And I updated a unit test to verify.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
