### PR TITLE
Migrate Cloudwatch Metrics connector to v2

### DIFF
--- a/athena-cloudwatch-metrics/pom.xml
+++ b/athena-cloudwatch-metrics/pom.xml
@@ -16,9 +16,9 @@
             <classifier>withdep</classifier>
         </dependency>
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-cloudwatch</artifactId>
-            <version>${aws-sdk.version}</version>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>cloudwatch</artifactId>
+            <version>${aws-sdk-v2.version}</version>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
                 <exclusion>

--- a/athena-cloudwatch-metrics/src/main/java/com/amazonaws/athena/connectors/cloudwatch/metrics/MetricStatSerDe.java
+++ b/athena-cloudwatch-metrics/src/main/java/com/amazonaws/athena/connectors/cloudwatch/metrics/MetricStatSerDe.java
@@ -19,11 +19,11 @@
  */
 package com.amazonaws.athena.connectors.cloudwatch.metrics;
 
-import com.amazonaws.services.cloudwatch.model.MetricStat;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import software.amazon.awssdk.services.cloudwatch.model.MetricStat;
 
 import java.io.IOException;
 import java.util.List;

--- a/athena-cloudwatch-metrics/src/main/java/com/amazonaws/athena/connectors/cloudwatch/metrics/MetricStatSerDe.java
+++ b/athena-cloudwatch-metrics/src/main/java/com/amazonaws/athena/connectors/cloudwatch/metrics/MetricStatSerDe.java
@@ -19,14 +19,14 @@
  */
 package com.amazonaws.athena.connectors.cloudwatch.metrics;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.CollectionType;
 import software.amazon.awssdk.services.cloudwatch.model.MetricStat;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Used to serialize and deserialize Cloudwatch Metrics MetricStat objects. This is used
@@ -48,7 +48,7 @@ public class MetricStatSerDe
     public static String serialize(List<MetricStat> metricStats)
     {
         try {
-            return mapper.writeValueAsString(new MetricStatHolder(metricStats));
+            return mapper.writeValueAsString(metricStats.stream().map(stat -> stat.toBuilder()).collect(Collectors.toList()));
         }
         catch (JsonProcessingException ex) {
             throw new RuntimeException(ex);
@@ -64,30 +64,11 @@ public class MetricStatSerDe
     public static List<MetricStat> deserialize(String serializedMetricStats)
     {
         try {
-            return mapper.readValue(serializedMetricStats, MetricStatHolder.class).getMetricStats();
+            CollectionType metricStatBuilderCollection = mapper.getTypeFactory().constructCollectionType(List.class, MetricStat.serializableBuilderClass());
+            return ((List<MetricStat.Builder>) mapper.readValue(serializedMetricStats, metricStatBuilderCollection)).stream().map(stat -> stat.build()).collect(Collectors.toList());
         }
         catch (IOException ex) {
             throw new RuntimeException(ex);
-        }
-    }
-
-    /**
-     * Helper which allows us to use Jackson's Object Mapper to serialize a List of MetricStats.
-     */
-    private static class MetricStatHolder
-    {
-        private final List<MetricStat> metricStats;
-
-        @JsonCreator
-        public MetricStatHolder(@JsonProperty("metricStats") List<MetricStat> metricStats)
-        {
-            this.metricStats = metricStats;
-        }
-
-        @JsonProperty
-        public List<MetricStat> getMetricStats()
-        {
-            return metricStats;
         }
     }
 }

--- a/athena-cloudwatch-metrics/src/main/java/com/amazonaws/athena/connectors/cloudwatch/metrics/MetricsExceptionFilter.java
+++ b/athena-cloudwatch-metrics/src/main/java/com/amazonaws/athena/connectors/cloudwatch/metrics/MetricsExceptionFilter.java
@@ -20,8 +20,8 @@
 package com.amazonaws.athena.connectors.cloudwatch.metrics;
 
 import com.amazonaws.athena.connector.lambda.ThrottlingInvoker;
-import com.amazonaws.services.cloudwatch.model.AmazonCloudWatchException;
-import com.amazonaws.services.cloudwatch.model.LimitExceededException;
+import software.amazon.awssdk.services.cloudwatch.model.CloudWatchException;
+import software.amazon.awssdk.services.cloudwatch.model.LimitExceededException;
 
 /**
  * Used to identify Exceptions that are related to Cloudwatch Metrics throttling events.
@@ -36,11 +36,11 @@ public class MetricsExceptionFilter
     @Override
     public boolean isMatch(Exception ex)
     {
-        if (ex instanceof AmazonCloudWatchException && ex.getMessage().startsWith("Rate exceeded")) {
+        if (ex instanceof CloudWatchException && ex.getMessage().startsWith("Rate exceeded")) {
             return true;
         }
 
-        if (ex instanceof AmazonCloudWatchException && ex.getMessage().startsWith("Request has been throttled")) {
+        if (ex instanceof CloudWatchException && ex.getMessage().startsWith("Request has been throttled")) {
             return true;
         }
 

--- a/athena-cloudwatch-metrics/src/main/java/com/amazonaws/athena/connectors/cloudwatch/metrics/MetricsMetadataHandler.java
+++ b/athena-cloudwatch-metrics/src/main/java/com/amazonaws/athena/connectors/cloudwatch/metrics/MetricsMetadataHandler.java
@@ -42,18 +42,17 @@ import com.amazonaws.athena.connector.lambda.security.EncryptionKeyFactory;
 import com.amazonaws.athena.connectors.cloudwatch.metrics.tables.MetricSamplesTable;
 import com.amazonaws.athena.connectors.cloudwatch.metrics.tables.MetricsTable;
 import com.amazonaws.athena.connectors.cloudwatch.metrics.tables.Table;
-import com.amazonaws.services.cloudwatch.AmazonCloudWatch;
-import com.amazonaws.services.cloudwatch.AmazonCloudWatchClientBuilder;
-import com.amazonaws.services.cloudwatch.model.ListMetricsRequest;
-import com.amazonaws.services.cloudwatch.model.ListMetricsResult;
-import com.amazonaws.services.cloudwatch.model.Metric;
-import com.amazonaws.services.cloudwatch.model.MetricStat;
 import com.amazonaws.util.CollectionUtils;
 import com.google.common.collect.Lists;
 import org.apache.arrow.util.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.athena.AthenaClient;
+import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
+import software.amazon.awssdk.services.cloudwatch.model.ListMetricsRequest;
+import software.amazon.awssdk.services.cloudwatch.model.ListMetricsResponse;
+import software.amazon.awssdk.services.cloudwatch.model.Metric;
+import software.amazon.awssdk.services.cloudwatch.model.MetricStat;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 
 import java.util.ArrayList;
@@ -107,7 +106,7 @@ public class MetricsMetadataHandler
     //Used to handle throttling events by applying AIMD congestion control
     private final ThrottlingInvoker invoker;
 
-    private final AmazonCloudWatch metrics;
+    private final CloudWatchClient metrics;
 
     static {
         //The statistics supported by Cloudwatch Metrics by default
@@ -133,13 +132,13 @@ public class MetricsMetadataHandler
     public MetricsMetadataHandler(java.util.Map<String, String> configOptions)
     {
         super(SOURCE_TYPE, configOptions);
-        this.metrics = AmazonCloudWatchClientBuilder.standard().build();
+        this.metrics = CloudWatchClient.create();
         this.invoker = ThrottlingInvoker.newDefaultBuilder(EXCEPTION_FILTER, configOptions).build();
     }
 
     @VisibleForTesting
     protected MetricsMetadataHandler(
-        AmazonCloudWatch metrics,
+        CloudWatchClient metrics,
         EncryptionKeyFactory keyFactory,
         SecretsManagerClient secretsManager,
         AthenaClient athena,
@@ -235,33 +234,36 @@ public class MetricsMetadataHandler
         try (ConstraintEvaluator constraintEvaluator = new ConstraintEvaluator(blockAllocator,
                 METRIC_DATA_TABLE.getSchema(),
                 getSplitsRequest.getConstraints())) {
-            ListMetricsRequest listMetricsRequest = new ListMetricsRequest();
-            MetricUtils.pushDownPredicate(getSplitsRequest.getConstraints(), listMetricsRequest);
-            listMetricsRequest.setNextToken(getSplitsRequest.getContinuationToken());
+            ListMetricsRequest.Builder listMetricsRequestBuilder = ListMetricsRequest.builder();
+            MetricUtils.pushDownPredicate(getSplitsRequest.getConstraints(), listMetricsRequestBuilder);
+            listMetricsRequestBuilder.nextToken(getSplitsRequest.getContinuationToken());
 
             String period = getPeriodFromConstraint(getSplitsRequest.getConstraints());
             Set<Split> splits = new HashSet<>();
-            ListMetricsResult result = invoker.invoke(() -> metrics.listMetrics(listMetricsRequest));
+            ListMetricsRequest listMetricsRequest = listMetricsRequestBuilder.build();
+            ListMetricsResponse result = invoker.invoke(() -> metrics.listMetrics(listMetricsRequest));
 
             List<MetricStat> metricStats = new ArrayList<>(100);
-            for (Metric nextMetric : result.getMetrics()) {
+            for (Metric nextMetric : result.metrics()) {
                 for (String nextStatistic : STATISTICS) {
                     if (MetricUtils.applyMetricConstraints(constraintEvaluator, nextMetric, nextStatistic)) {
-                        metricStats.add(new MetricStat()
-                                .withMetric(new Metric()
-                                        .withNamespace(nextMetric.getNamespace())
-                                        .withMetricName(nextMetric.getMetricName())
-                                        .withDimensions(nextMetric.getDimensions()))
-                                .withPeriod(Integer.valueOf(period))
-                                .withStat(nextStatistic));
+                        metricStats.add(MetricStat.builder()
+                                .metric(Metric.builder()
+                                        .namespace(nextMetric.namespace())
+                                        .metricName(nextMetric.metricName())
+                                        .dimensions(nextMetric.dimensions())
+                                        .build())
+                                .period(Integer.valueOf(period))
+                                .stat(nextStatistic)
+                                .build());
                     }
                 }
             }
 
             String continuationToken = null;
-            if (result.getNextToken() != null &&
-                    !result.getNextToken().equalsIgnoreCase(listMetricsRequest.getNextToken())) {
-                continuationToken = result.getNextToken();
+            if (result.nextToken() != null &&
+                    !result.nextToken().equalsIgnoreCase(listMetricsRequest.nextToken())) {
+                continuationToken = result.nextToken();
             }
 
             if (CollectionUtils.isNullOrEmpty(metricStats)) {

--- a/athena-cloudwatch-metrics/src/test/java/com/amazonaws/athena/connectors/cloudwatch/metrics/MetricStatSerDeTest.java
+++ b/athena-cloudwatch-metrics/src/test/java/com/amazonaws/athena/connectors/cloudwatch/metrics/MetricStatSerDeTest.java
@@ -19,12 +19,12 @@
  */
 package com.amazonaws.athena.connectors.cloudwatch.metrics;
 
-import com.amazonaws.services.cloudwatch.model.Dimension;
-import com.amazonaws.services.cloudwatch.model.Metric;
-import com.amazonaws.services.cloudwatch.model.MetricStat;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.cloudwatch.model.Dimension;
+import software.amazon.awssdk.services.cloudwatch.model.Metric;
+import software.amazon.awssdk.services.cloudwatch.model.MetricStat;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -48,17 +48,19 @@ public class MetricStatSerDeTest
         String namespace = "namespace";
 
         List<Dimension> dimensions = new ArrayList<>();
-        dimensions.add(new Dimension().withName("dim_name1").withValue("dim_value1"));
-        dimensions.add(new Dimension().withName("dim_name2").withValue("dim_value2"));
+        dimensions.add(Dimension.builder().name("dim_name1").value("dim_value1").build());
+        dimensions.add(Dimension.builder().name("dim_name2").value("dim_value2").build());
 
         List<MetricStat> metricStats = new ArrayList<>();
-        metricStats.add(new MetricStat()
-                .withMetric(new Metric()
-                        .withNamespace(namespace)
-                        .withMetricName(metricName)
-                        .withDimensions(dimensions))
-                .withPeriod(60)
-                .withStat(statistic));
+        metricStats.add(MetricStat.builder()
+                .metric(Metric.builder()
+                        .namespace(namespace)
+                        .metricName(metricName)
+                        .dimensions(dimensions)
+                        .build())
+                .period(60)
+                .stat(statistic)
+                .build());
         String actualSerialization = MetricStatSerDe.serialize(metricStats);
         logger.info("serializeTest: {}", actualSerialization);
         List<MetricStat> actual = MetricStatSerDe.deserialize(actualSerialization);

--- a/athena-cloudwatch-metrics/src/test/java/com/amazonaws/athena/connectors/cloudwatch/metrics/MetricStatSerDeTest.java
+++ b/athena-cloudwatch-metrics/src/test/java/com/amazonaws/athena/connectors/cloudwatch/metrics/MetricStatSerDeTest.java
@@ -34,8 +34,8 @@ import static org.junit.Assert.*;
 public class MetricStatSerDeTest
 {
     private static final Logger logger = LoggerFactory.getLogger(MetricStatSerDeTest.class);
-    private static final String EXPECTED_SERIALIZATION = "{\"metricStats\":[{\"metric\":{\"namespace\":\"namespace\",\"metricName\":\"metricName\",\"dimensions\":[" +
-            "{\"name\":\"dim_name1\",\"value\":\"dim_value1\"},{\"name\":\"dim_name2\",\"value\":\"dim_value2\"}]},\"period\":60,\"stat\":\"p90\",\"unit\":null}]}";
+    private static final String EXPECTED_SERIALIZATION = "[{\"metric\":{\"namespace\":\"namespace\",\"metricName\":\"metricName\",\"dimensions\":[" +
+             "{\"name\":\"dim_name1\",\"value\":\"dim_value1\"},{\"name\":\"dim_name2\",\"value\":\"dim_value2\"}]},\"period\":60,\"stat\":\"p90\",\"unit\":null}]";
 
     @Test
     public void serializeTest()

--- a/athena-cloudwatch-metrics/src/test/java/com/amazonaws/athena/connectors/cloudwatch/metrics/MetricUtilsTest.java
+++ b/athena-cloudwatch-metrics/src/test/java/com/amazonaws/athena/connectors/cloudwatch/metrics/MetricUtilsTest.java
@@ -31,18 +31,18 @@ import com.amazonaws.athena.connector.lambda.domain.predicate.SortedRangeSet;
 import com.amazonaws.athena.connector.lambda.domain.predicate.ValueSet;
 import com.amazonaws.athena.connector.lambda.records.ReadRecordsRequest;
 import com.amazonaws.athena.connector.lambda.security.FederatedIdentity;
-import com.amazonaws.services.cloudwatch.model.Dimension;
-import com.amazonaws.services.cloudwatch.model.DimensionFilter;
-import com.amazonaws.services.cloudwatch.model.GetMetricDataRequest;
-import com.amazonaws.services.cloudwatch.model.ListMetricsRequest;
-import com.amazonaws.services.cloudwatch.model.Metric;
-import com.amazonaws.services.cloudwatch.model.MetricStat;
 import org.apache.arrow.vector.types.pojo.Schema;
 import com.google.common.collect.ImmutableList;
 import org.apache.arrow.vector.types.Types;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import software.amazon.awssdk.services.cloudwatch.model.Dimension;
+import software.amazon.awssdk.services.cloudwatch.model.DimensionFilter;
+import software.amazon.awssdk.services.cloudwatch.model.GetMetricDataRequest;
+import software.amazon.awssdk.services.cloudwatch.model.ListMetricsRequest;
+import software.amazon.awssdk.services.cloudwatch.model.Metric;
+import software.amazon.awssdk.services.cloudwatch.model.MetricStat;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -100,33 +100,21 @@ public class MetricUtilsTest
 
         ConstraintEvaluator constraintEvaluator = new ConstraintEvaluator(allocator, schema, new Constraints(constraintsMap, Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT));
 
-        Metric metric = new Metric()
-                .withNamespace("match1")
-                .withMetricName("match2")
-                .withDimensions(new Dimension().withName("match4").withValue("match5"));
+        Metric metric = Metric.builder()
+                .namespace("match1")
+                .metricName("match2")
+                .dimensions(Dimension.builder().name("match4").value("match5").build())
+                .build();
         String statistic = "match3";
         assertTrue(MetricUtils.applyMetricConstraints(constraintEvaluator, metric, statistic));
 
-        assertFalse(MetricUtils.applyMetricConstraints(constraintEvaluator, copyMetric(metric).withNamespace("no_match"), statistic));
-        assertFalse(MetricUtils.applyMetricConstraints(constraintEvaluator, copyMetric(metric).withMetricName("no_match"), statistic));
+        assertFalse(MetricUtils.applyMetricConstraints(constraintEvaluator, metric.toBuilder().namespace("no_match").build(), statistic));
+        assertFalse(MetricUtils.applyMetricConstraints(constraintEvaluator, metric.toBuilder().metricName("no_match").build(), statistic));
         assertFalse(MetricUtils.applyMetricConstraints(constraintEvaluator,
-                copyMetric(metric).withDimensions(Collections.singletonList(new Dimension().withName("no_match").withValue("match5"))), statistic));
+                metric.toBuilder().dimensions(Collections.singletonList(Dimension.builder().name("no_match").value("match5").build())).build(), statistic));
         assertFalse(MetricUtils.applyMetricConstraints(constraintEvaluator,
-                copyMetric(metric).withDimensions(Collections.singletonList(new Dimension().withName("match4").withValue("no_match"))), statistic));
-        assertFalse(MetricUtils.applyMetricConstraints(constraintEvaluator, copyMetric(metric), "no_match"));
-    }
-
-    private Metric copyMetric(Metric metric)
-    {
-        Metric newMetric = new Metric()
-                .withNamespace(metric.getNamespace())
-                .withMetricName(metric.getMetricName());
-
-        List<Dimension> dims = new ArrayList<>();
-        for (Dimension next : metric.getDimensions()) {
-            dims.add(new Dimension().withName(next.getName()).withValue(next.getValue()));
-        }
-        return newMetric.withDimensions(dims);
+                metric.toBuilder().dimensions(Collections.singletonList(Dimension.builder().name("match4").value("no_match").build())).build(), statistic));
+        assertFalse(MetricUtils.applyMetricConstraints(constraintEvaluator, metric, "no_match"));
     }
 
     @Test
@@ -139,13 +127,14 @@ public class MetricUtilsTest
         constraintsMap.put(DIMENSION_NAME_FIELD, makeStringEquals(allocator, "match4"));
         constraintsMap.put(DIMENSION_VALUE_FIELD, makeStringEquals(allocator, "match5"));
 
-        ListMetricsRequest request = new ListMetricsRequest();
-        MetricUtils.pushDownPredicate(new Constraints(constraintsMap, Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT), request);
+        ListMetricsRequest.Builder requestBuilder = ListMetricsRequest.builder();
+        MetricUtils.pushDownPredicate(new Constraints(constraintsMap, Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT), requestBuilder);
+        ListMetricsRequest request = requestBuilder.build();
 
-        assertEquals("match1", request.getNamespace());
-        assertEquals("match2", request.getMetricName());
-        assertEquals(1, request.getDimensions().size());
-        assertEquals(new DimensionFilter().withName("match4").withValue("match5"), request.getDimensions().get(0));
+        assertEquals("match1", request.namespace());
+        assertEquals("match2", request.metricName());
+        assertEquals(1, request.dimensions().size());
+        assertEquals(DimensionFilter.builder().name("match4").value("match5").build(), request.dimensions().get(0));
     }
 
     @Test
@@ -159,17 +148,19 @@ public class MetricUtilsTest
         String namespace = "namespace";
 
         List<Dimension> dimensions = new ArrayList<>();
-        dimensions.add(new Dimension().withName("dim_name1").withValue("dim_value1"));
-        dimensions.add(new Dimension().withName("dim_name2").withValue("dim_value2"));
+        dimensions.add(Dimension.builder().name("dim_name1").value("dim_value1").build());
+        dimensions.add(Dimension.builder().name("dim_name2").value("dim_value2").build());
 
         List<MetricStat> metricStats = new ArrayList<>();
-        metricStats.add(new MetricStat()
-                .withMetric(new Metric()
-                        .withNamespace(namespace)
-                        .withMetricName(metricName)
-                        .withDimensions(dimensions))
-                .withPeriod(60)
-                .withStat(statistic));
+        metricStats.add(MetricStat.builder()
+                .metric(Metric.builder()
+                        .namespace(namespace)
+                        .metricName(metricName)
+                        .dimensions(dimensions)
+                        .build())
+                .period(60)
+                .stat(statistic)
+                .build());
 
         Split split = Split.newBuilder(null, null)
                 .add(NAMESPACE_FIELD, namespace)
@@ -198,16 +189,16 @@ public class MetricUtilsTest
         );
 
         GetMetricDataRequest actual = MetricUtils.makeGetMetricDataRequest(request);
-        assertEquals(1, actual.getMetricDataQueries().size());
-        assertNotNull(actual.getMetricDataQueries().get(0).getId());
-        MetricStat metricStat = actual.getMetricDataQueries().get(0).getMetricStat();
+        assertEquals(1, actual.metricDataQueries().size());
+        assertNotNull(actual.metricDataQueries().get(0).id());
+        MetricStat metricStat = actual.metricDataQueries().get(0).metricStat();
         assertNotNull(metricStat);
-        assertEquals(metricName, metricStat.getMetric().getMetricName());
-        assertEquals(namespace, metricStat.getMetric().getNamespace());
-        assertEquals(statistic, metricStat.getStat());
-        assertEquals(period, metricStat.getPeriod());
-        assertEquals(2, metricStat.getMetric().getDimensions().size());
-        assertEquals(1000L, actual.getStartTime().getTime());
-        assertTrue(actual.getStartTime().getTime() <= System.currentTimeMillis() + 1_000);
+        assertEquals(metricName, metricStat.metric().metricName());
+        assertEquals(namespace, metricStat.metric().namespace());
+        assertEquals(statistic, metricStat.stat());
+        assertEquals(period, metricStat.period());
+        assertEquals(2, metricStat.metric().dimensions().size());
+        assertEquals(1000L, actual.startTime().toEpochMilli());
+        assertTrue(actual.startTime().toEpochMilli() <= System.currentTimeMillis() + 1_000);
     }
 }

--- a/athena-cloudwatch-metrics/src/test/java/com/amazonaws/athena/connectors/cloudwatch/metrics/MetricsRecordHandlerTest.java
+++ b/athena-cloudwatch-metrics/src/test/java/com/amazonaws/athena/connectors/cloudwatch/metrics/MetricsRecordHandlerTest.java
@@ -37,16 +37,6 @@ import com.amazonaws.athena.connector.lambda.security.LocalKeyFactory;
 import com.amazonaws.athena.connectors.cloudwatch.metrics.tables.MetricSamplesTable;
 import com.amazonaws.athena.connectors.cloudwatch.metrics.tables.MetricsTable;
 import com.amazonaws.athena.connectors.cloudwatch.metrics.tables.Table;
-import com.amazonaws.services.cloudwatch.AmazonCloudWatch;
-import com.amazonaws.services.cloudwatch.model.Dimension;
-import com.amazonaws.services.cloudwatch.model.GetMetricDataRequest;
-import com.amazonaws.services.cloudwatch.model.GetMetricDataResult;
-import com.amazonaws.services.cloudwatch.model.ListMetricsRequest;
-import com.amazonaws.services.cloudwatch.model.ListMetricsResult;
-import com.amazonaws.services.cloudwatch.model.Metric;
-import com.amazonaws.services.cloudwatch.model.MetricDataQuery;
-import com.amazonaws.services.cloudwatch.model.MetricDataResult;
-import com.amazonaws.services.cloudwatch.model.MetricStat;
 import com.google.common.io.ByteStreams;
 import org.junit.After;
 import org.junit.Before;
@@ -58,19 +48,29 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.services.athena.AthenaClient;
-import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
-
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.athena.AthenaClient;
+import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
+import software.amazon.awssdk.services.cloudwatch.model.Dimension;
+import software.amazon.awssdk.services.cloudwatch.model.GetMetricDataRequest;
+import software.amazon.awssdk.services.cloudwatch.model.GetMetricDataResponse;
+import software.amazon.awssdk.services.cloudwatch.model.ListMetricsRequest;
+import software.amazon.awssdk.services.cloudwatch.model.ListMetricsResponse;
+import software.amazon.awssdk.services.cloudwatch.model.Metric;
+import software.amazon.awssdk.services.cloudwatch.model.MetricDataQuery;
+import software.amazon.awssdk.services.cloudwatch.model.MetricDataResult;
+import software.amazon.awssdk.services.cloudwatch.model.MetricStat;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -115,7 +115,7 @@ public class MetricsRecordHandlerTest
     private EncryptionKeyFactory keyFactory = new LocalKeyFactory();
 
     @Mock
-    private AmazonCloudWatch mockMetrics;
+    private CloudWatchClient mockMetrics;
 
     @Mock
     private S3Client mockS3;
@@ -182,17 +182,23 @@ public class MetricsRecordHandlerTest
             ListMetricsRequest request = invocation.getArgument(0, ListMetricsRequest.class);
             numCalls.incrementAndGet();
             //assert that the namespace filter was indeed pushed down
-            assertEquals(namespace, request.getNamespace());
-            String nextToken = (request.getNextToken() == null) ? "valid" : null;
+            assertEquals(namespace, request.namespace());
+            String nextToken = (request.nextToken() == null) ? "valid" : null;
             List<Metric> metrics = new ArrayList<>();
 
             for (int i = 0; i < numMetrics; i++) {
-                metrics.add(new Metric().withNamespace(namespace).withMetricName("metric-" + i)
-                        .withDimensions(new Dimension().withName(dimName).withValue(dimValue)));
-                metrics.add(new Metric().withNamespace(namespace + i).withMetricName("metric-" + i));
+                metrics.add(Metric.builder()
+                        .namespace(namespace)
+                        .metricName("metric-" + i)
+                        .dimensions(Dimension.builder()
+                                .name(dimName)
+                                .value(dimValue)
+                                .build())
+                        .build());
+                metrics.add(Metric.builder().namespace(namespace + i).metricName("metric-" + i).build());
             }
 
-            return new ListMetricsResult().withNextToken(nextToken).withMetrics(metrics);
+            return ListMetricsResponse.builder().nextToken(nextToken).metrics(metrics).build();
         });
 
         Map<String, ValueSet> constraintsMap = new HashMap<>();
@@ -245,7 +251,7 @@ public class MetricsRecordHandlerTest
         String period = "60";
         String dimName = "dimName";
         String dimValue = "dimValue";
-        List<Dimension> dimensions = Collections.singletonList(new Dimension().withName(dimName).withValue(dimValue));
+        List<Dimension> dimensions = Collections.singletonList(Dimension.builder().name(dimName).value(dimValue).build());
 
         int numMetrics = 10;
         int numSamples = 10;
@@ -269,13 +275,15 @@ public class MetricsRecordHandlerTest
                 .build();
 
         List<MetricStat> metricStats = new ArrayList<>();
-        metricStats.add(new MetricStat()
-                .withMetric(new Metric()
-                        .withNamespace(namespace)
-                        .withMetricName(metricName)
-                        .withDimensions(dimensions))
-                .withPeriod(60)
-                .withStat(statistic));
+        metricStats.add(MetricStat.builder()
+                .metric(Metric.builder()
+                        .namespace(namespace)
+                        .metricName(metricName)
+                        .dimensions(dimensions)
+                        .build())
+                .period(60)
+                .stat(statistic)
+                .build());
 
         Split split = Split.newBuilder(spillLocation, keyFactory.create())
                 .add(MetricStatSerDe.SERIALIZED_METRIC_STATS_FIELD_NAME, MetricStatSerDe.serialize(metricStats))
@@ -309,40 +317,40 @@ public class MetricsRecordHandlerTest
         logger.info("readMetricSamplesWithConstraint: exit");
     }
 
-    private GetMetricDataResult mockMetricData(InvocationOnMock invocation, int numMetrics, int numSamples)
+    private GetMetricDataResponse mockMetricData(InvocationOnMock invocation, int numMetrics, int numSamples)
     {
         GetMetricDataRequest request = invocation.getArgument(0, GetMetricDataRequest.class);
 
         /**
          * Confirm that all available criteria were pushed down into Cloudwatch Metrics
          */
-        List<MetricDataQuery> queries = request.getMetricDataQueries();
+        List<MetricDataQuery> queries = request.metricDataQueries();
         assertEquals(1, queries.size());
         MetricDataQuery query = queries.get(0);
-        MetricStat stat = query.getMetricStat();
-        assertEquals("m1", query.getId());
-        assertNotNull(stat.getPeriod());
-        assertNotNull(stat.getMetric());
-        assertNotNull(stat.getStat());
-        assertNotNull(stat.getMetric().getMetricName());
-        assertNotNull(stat.getMetric().getNamespace());
-        assertNotNull(stat.getMetric().getDimensions());
-        assertEquals(1, stat.getMetric().getDimensions().size());
+        MetricStat stat = query.metricStat();
+        assertEquals("m1", query.id());
+        assertNotNull(stat.period());
+        assertNotNull(stat.metric());
+        assertNotNull(stat.stat());
+        assertNotNull(stat.metric().metricName());
+        assertNotNull(stat.metric().namespace());
+        assertNotNull(stat.metric().dimensions());
+        assertEquals(1, stat.metric().dimensions().size());
 
-        String nextToken = (request.getNextToken() == null) ? "valid" : null;
+        String nextToken = (request.nextToken() == null) ? "valid" : null;
         List<MetricDataResult> samples = new ArrayList<>();
 
         for (int i = 0; i < numMetrics; i++) {
             List<Double> values = new ArrayList<>();
-            List<Date> timestamps = new ArrayList<>();
+            List<Instant> timestamps = new ArrayList<>();
             for (double j = 0; j < numSamples; j++) {
                 values.add(j);
-                timestamps.add(new Date(System.currentTimeMillis() + (int) j));
+                timestamps.add(new Date(System.currentTimeMillis() + (int) j).toInstant());
             }
-            samples.add(new MetricDataResult().withValues(values).withTimestamps(timestamps).withId("m1"));
+            samples.add(MetricDataResult.builder().values(values).timestamps(timestamps).id("m1").build());
         }
 
-        return new GetMetricDataResult().withNextToken(nextToken).withMetricDataResults(samples);
+        return GetMetricDataResponse.builder().nextToken(nextToken).metricDataResults(samples).build();
     }
 
     private class ByteHolder


### PR DESCRIPTION
*Description of changes:*
Part of https://github.com/awslabs/aws-athena-query-federation/issues/2088

Migrate the cloudwatch metrics connector to AWS SDK v2.
Significant change: Changed serialization/deserialization for `MetricStatSerDe.java`. Previously, the `MetricStat` class had getters and setters which Jackson used for serialization and a `MetricStatHolder` was used to hold this. Now got rid of the `MetricStatHolder` class. Serialize by converting to `MetricStat` builders. Then Deserialize using a Jackson `CollectionType` made with the class returned by `MetricStat.serializableBuilderClass()`, and convert the returned list of `MetricStat` builders to a list of `MetricStat`s.

Referenced https://stackoverflow.com/questions/34176607/custom-deserialization-of-list-using-jackson

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
