### PR TITLE
Migrate Elasticache to AWS SDK v2

### DIFF
--- a/athena-redis/pom.xml
+++ b/athena-redis/pom.xml
@@ -38,9 +38,9 @@
             <version>${slf4j-log4j.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-elasticache</artifactId>
-            <version>${aws-sdk.version}</version>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>elasticache</artifactId>
+            <version>${aws-sdk-v2.version}</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awscdk/elasticache -->

--- a/athena-redis/src/test/java/com/amazonaws/athena/connectors/redis/integ/RedisIntegTest.java
+++ b/athena-redis/src/test/java/com/amazonaws/athena/connectors/redis/integ/RedisIntegTest.java
@@ -344,7 +344,7 @@ public class RedisIntegTest extends IntegrationTestBase
      */
     private Endpoint getRedisInstanceData(String redisName, boolean isCluster)
     {
-        ElastiCacheClient elastiCacheClient = ElastiCacheClient.builder().build();
+        ElastiCacheClient elastiCacheClient = ElastiCacheClient.create();
         try {
             if (isCluster) {
                 DescribeReplicationGroupsRequest describeRequest = DescribeReplicationGroupsRequest.builder()


### PR DESCRIPTION
https://github.com/awslabs/aws-athena-query-federation/issues/2093
*Description of changes:*
Migrate Elasticache to AWS SDK v2. It is only used in integration tests of athena-redis connector.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
