### PR TITLE
Add athena connector exception class to classify Runtime Exception

### DIFF
--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/exceptions/AthenaConnectorException.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/exceptions/AthenaConnectorException.java
@@ -1,0 +1,65 @@
+package com.amazonaws.athena.connector.lambda.exceptions;
+
+import com.amazonaws.services.glue.model.ErrorDetails;
+
+import javax.annotation.Nonnull;
+import java.util.Objects;
+
+/**
+ * Exception that should be thrown by each individual Connector when an error is encountered.
+ * That error will be using these following ErrorCode
+ *
+ * FederationSourceErrorCode:
+ *     AccessDeniedException("AccessDeniedException"),
+ *     EntityNotFoundException("EntityNotFoundException"),
+ *     InvalidCredentialsException("InvalidCredentialsException"),
+ *     InvalidInputException("InvalidInputException"),
+ *     InvalidResponseException("InvalidResponseException"),
+ *     OperationTimeoutException("OperationTimeoutException"),
+ *     OperationNotSupportedException("OperationNotSupportedException"),
+ *     InternalServiceException("InternalServiceException"),
+ *     PartialFailureException("PartialFailureException"),
+ *     ThrottlingException("ThrottlingException");
+ *
+ */
+public class AthenaConnectorException extends RuntimeException {
+    private final Object response;
+
+    private final ErrorDetails errorDetails;
+
+    public AthenaConnectorException(@Nonnull final Object response,
+                                    @Nonnull final String message,
+                                    @Nonnull final ErrorDetails errorDetails) {
+        super(message);
+        this.errorDetails = Objects.requireNonNull(errorDetails);
+        this.response = Objects.requireNonNull(response);
+        Objects.requireNonNull(message);
+    }
+
+    public AthenaConnectorException(@Nonnull final String message,
+                                    @Nonnull final ErrorDetails errorDetails) {
+        super(message);
+        response = null;
+        this.errorDetails = Objects.requireNonNull(errorDetails);
+        Objects.requireNonNull(message);
+    }
+
+    public AthenaConnectorException(@Nonnull final Object response,
+                                    @Nonnull final String message,
+                                    @Nonnull final Exception e,
+                                    @Nonnull final ErrorDetails errorDetails) {
+        super(message, e);
+        this.errorDetails = Objects.requireNonNull(errorDetails);
+        this.response = Objects.requireNonNull(response);
+        Objects.requireNonNull(message);
+        Objects.requireNonNull(e);
+    }
+
+    public Object getResponse() {
+        return response;
+    }
+
+    public ErrorDetails getErrorDetails() {
+        return errorDetails;
+    }
+}

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/exceptions/AthenaConnectorException.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/exceptions/AthenaConnectorException.java
@@ -1,9 +1,29 @@
+/*-
+ * #%L
+ * Amazon Athena Query Federation SDK
+ * %%
+ * Copyright (C) 2019 - 2024 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.amazonaws.athena.connector.lambda.exceptions;
 
 import com.amazonaws.services.glue.model.ErrorDetails;
 
 import javax.annotation.Nonnull;
-import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * Exception that should be thrown by each individual Connector when an error is encountered.
@@ -22,44 +42,52 @@ import java.util.Objects;
  *     ThrottlingException("ThrottlingException");
  *
  */
-public class AthenaConnectorException extends RuntimeException {
+
+public class AthenaConnectorException extends RuntimeException
+{
     private final Object response;
 
     private final ErrorDetails errorDetails;
 
     public AthenaConnectorException(@Nonnull final Object response,
                                     @Nonnull final String message,
-                                    @Nonnull final ErrorDetails errorDetails) {
+                                    @Nonnull final ErrorDetails errorDetails)
+    {
         super(message);
-        this.errorDetails = Objects.requireNonNull(errorDetails);
-        this.response = Objects.requireNonNull(response);
-        Objects.requireNonNull(message);
+        this.errorDetails = requireNonNull(errorDetails);
+        this.response = requireNonNull(response);
+        requireNonNull(message);
     }
 
     public AthenaConnectorException(@Nonnull final String message,
-                                    @Nonnull final ErrorDetails errorDetails) {
+                                    @Nonnull final ErrorDetails errorDetails)
+    {
         super(message);
         response = null;
-        this.errorDetails = Objects.requireNonNull(errorDetails);
-        Objects.requireNonNull(message);
+        this.errorDetails = requireNonNull(errorDetails);
+        requireNonNull(message);
     }
 
     public AthenaConnectorException(@Nonnull final Object response,
                                     @Nonnull final String message,
                                     @Nonnull final Exception e,
-                                    @Nonnull final ErrorDetails errorDetails) {
+
+                                    @Nonnull final ErrorDetails errorDetails)
+    {
         super(message, e);
-        this.errorDetails = Objects.requireNonNull(errorDetails);
-        this.response = Objects.requireNonNull(response);
-        Objects.requireNonNull(message);
-        Objects.requireNonNull(e);
+        this.errorDetails = requireNonNull(errorDetails);
+        this.response = requireNonNull(response);
+        requireNonNull(message);
+        requireNonNull(e);
     }
 
-    public Object getResponse() {
+    public Object getResponse()
+    {
         return response;
     }
 
-    public ErrorDetails getErrorDetails() {
+    public ErrorDetails getErrorDetails()
+    {
         return errorDetails;
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This is to classify the RuntimeException in each athena connector to be more specific, including a error message and a error code. The plan is to re-use the FederationSourceErrorCode and ErrorDetails from com.amazonaws.services.glue.model

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
