### PR TITLE
Elasticsearch geo_point type support by converting to varchar

### DIFF
--- a/athena-elasticsearch/src/main/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchSchemaUtils.java
+++ b/athena-elasticsearch/src/main/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchSchemaUtils.java
@@ -147,6 +147,7 @@ class ElasticsearchSchemaUtils
             case "text":
             case "keyword":
             case "binary":
+            case "geo_point":
                 minorType = Types.MinorType.VARCHAR;
                 break;
             case "long":

--- a/athena-elasticsearch/src/main/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchTypeUtils.java
+++ b/athena-elasticsearch/src/main/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchTypeUtils.java
@@ -120,14 +120,8 @@ class ElasticsearchTypeUtils
             if (fieldValue instanceof String) {
                 dst.value = (String) fieldValue;
             }
-            else if (fieldValue instanceof List) {
-                Object value = ((List) fieldValue).get(0);
-                if (value instanceof String) {
-                    dst.value = (String) value;
-                }
-                else {
-                    dst.isSet = 0;
-                }
+            else if (fieldValue instanceof List || fieldValue instanceof Map) {
+                dst.value = fieldValue.toString();
             }
             else {
                 dst.isSet = 0;

--- a/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchTypeUtilsTest.java
+++ b/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchTypeUtilsTest.java
@@ -92,7 +92,7 @@ public class ElasticsearchTypeUtilsTest
 
         Map<String, Object> expectedResults = ImmutableMap.of(
                 "mytext", "My favorite Sci-Fi movie is Interstellar.",
-                "mytextlist", "Hey, this is an array!");
+                "mytextlist", "[Hey, this is an array!, Wasn't expecting this!]");
         Map<String, Object> extractedResults = testField(mapping, document);
         logger.info("makeVarCharExtractorTest - Expected: {}, Extracted: {}", expectedResults, extractedResults);
         assertEquals("Extracted results are not as expected!", expectedResults, extractedResults);


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-athena-query-federation/issues/1611 Support geopoint data type for Elasticsearch.

*Description of changes:*

To support geo_point type in elasticsearch we have few challenges in SDK side changes, so we are converting geo_point type to varchar and showing geo_point data in athena. Please find attached document for more detail analysis on this.
[Elasticsearch_geopoint_analysis.docx](https://github.com/user-attachments/files/16907035/Elasticsearch_geopoint_analysis.docx)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
