### PR TITLE
migrate awslogs to cloudwatchlogs (v1 to v2)

### DIFF
--- a/athena-cloudwatch/pom.xml
+++ b/athena-cloudwatch/pom.xml
@@ -29,14 +29,34 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-logs</artifactId>
-            <version>${aws-sdk.version}</version>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>cloudwatchlogs</artifactId>
+            <version>2.28.2</version>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
                 <exclusion>
                     <groupId>commons-logging</groupId>
                     <artifactId>commons-logging</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>netty-nio-client</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>cloudwatch</artifactId>
+            <version>${aws-sdk-v2.version}</version>
+            <exclusions>
+                <!-- replaced with jcl-over-slf4j -->
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>netty-nio-client</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/athena-cloudwatch/src/main/java/com/amazonaws/athena/connectors/cloudwatch/CloudwatchExceptionFilter.java
+++ b/athena-cloudwatch/src/main/java/com/amazonaws/athena/connectors/cloudwatch/CloudwatchExceptionFilter.java
@@ -20,8 +20,8 @@
 package com.amazonaws.athena.connectors.cloudwatch;
 
 import com.amazonaws.athena.connector.lambda.ThrottlingInvoker;
-import com.amazonaws.services.logs.model.AWSLogsException;
-import com.amazonaws.services.logs.model.LimitExceededException;
+import software.amazon.awssdk.services.cloudwatch.model.LimitExceededException;
+import software.amazon.awssdk.services.cloudwatchlogs.model.CloudWatchLogsException;
 
 /**
  * Used to identify Exceptions that are related to Cloudwatch Logs throttling events.
@@ -36,7 +36,7 @@ public class CloudwatchExceptionFilter
     @Override
     public boolean isMatch(Exception ex)
     {
-        if (ex instanceof AWSLogsException && ex.getMessage().startsWith("Rate exceeded")) {
+        if (ex instanceof CloudWatchLogsException && ex.getMessage().startsWith("Rate exceeded")) {
             return true;
         }
 

--- a/athena-cloudwatch/src/test/java/com/amazonaws/athena/connectors/cloudwatch/CloudwatchMetadataHandlerTest.java
+++ b/athena-cloudwatch/src/test/java/com/amazonaws/athena/connectors/cloudwatch/CloudwatchMetadataHandlerTest.java
@@ -43,13 +43,6 @@ import com.amazonaws.athena.connector.lambda.metadata.MetadataRequestType;
 import com.amazonaws.athena.connector.lambda.metadata.MetadataResponse;
 import com.amazonaws.athena.connector.lambda.security.FederatedIdentity;
 import com.amazonaws.athena.connector.lambda.security.LocalKeyFactory;
-import com.amazonaws.services.logs.AWSLogs;
-import com.amazonaws.services.logs.model.DescribeLogGroupsRequest;
-import com.amazonaws.services.logs.model.DescribeLogGroupsResult;
-import com.amazonaws.services.logs.model.DescribeLogStreamsRequest;
-import com.amazonaws.services.logs.model.DescribeLogStreamsResult;
-import com.amazonaws.services.logs.model.LogGroup;
-import com.amazonaws.services.logs.model.LogStream;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Schema;
@@ -64,6 +57,13 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.athena.AthenaClient;
+import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
+import software.amazon.awssdk.services.cloudwatchlogs.model.DescribeLogGroupsRequest;
+import software.amazon.awssdk.services.cloudwatchlogs.model.DescribeLogGroupsResponse;
+import software.amazon.awssdk.services.cloudwatchlogs.model.DescribeLogStreamsRequest;
+import software.amazon.awssdk.services.cloudwatchlogs.model.DescribeLogStreamsResponse;
+import software.amazon.awssdk.services.cloudwatchlogs.model.LogGroup;
+import software.amazon.awssdk.services.cloudwatchlogs.model.LogStream;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 
 import java.util.ArrayList;
@@ -92,7 +92,7 @@ public class CloudwatchMetadataHandlerTest
     private BlockAllocator allocator;
 
     @Mock
-    private AWSLogs mockAwsLogs;
+    private CloudWatchLogsClient mockAwsLogs;
 
     @Mock
     private SecretsManagerClient mockSecretsManager;
@@ -105,13 +105,19 @@ public class CloudwatchMetadataHandlerTest
             throws Exception
     {
         Mockito.lenient().when(mockAwsLogs.describeLogStreams(nullable(DescribeLogStreamsRequest.class))).thenAnswer((InvocationOnMock invocationOnMock) -> {
-            return new DescribeLogStreamsResult().withLogStreams(new LogStream().withLogStreamName("table-9"),
-                    new LogStream().withLogStreamName("table-10"));
+            return DescribeLogStreamsResponse.builder()
+                    .logStreams(
+                            LogStream.builder().logStreamName("table-9").build(),
+                            LogStream.builder().logStreamName("table-10").build())
+                    .build();
         });
 
         when(mockAwsLogs.describeLogGroups(nullable(DescribeLogGroupsRequest.class))).thenAnswer((InvocationOnMock invocationOnMock) -> {
-            return new DescribeLogGroupsResult().withLogGroups(new LogGroup().withLogGroupName("schema-1"),
-                    new LogGroup().withLogGroupName("schema-20"));
+            return DescribeLogGroupsResponse.builder()
+                    .logGroups(
+                            LogGroup.builder().logGroupName("schema-1").build(),
+                            LogGroup.builder().logGroupName("schema-20").build())
+                    .build();
         });
         handler = new CloudwatchMetadataHandler(mockAwsLogs, new LocalKeyFactory(), mockSecretsManager, mockAthena, "spillBucket", "spillPrefix", com.google.common.collect.ImmutableMap.of());
         allocator = new BlockAllocatorImpl();
@@ -133,34 +139,33 @@ public class CloudwatchMetadataHandlerTest
         when(mockAwsLogs.describeLogGroups(nullable(DescribeLogGroupsRequest.class))).thenAnswer((InvocationOnMock invocationOnMock) -> {
             DescribeLogGroupsRequest request = (DescribeLogGroupsRequest) invocationOnMock.getArguments()[0];
 
-            DescribeLogGroupsResult result = new DescribeLogGroupsResult();
+            DescribeLogGroupsResponse.Builder responseBuilder = DescribeLogGroupsResponse.builder();
 
             Integer nextToken;
-            if (request.getNextToken() == null) {
+            if (request.nextToken() == null) {
                 nextToken = 1;
             }
-            else if (Integer.valueOf(request.getNextToken()) < 3) {
-                nextToken = Integer.valueOf(request.getNextToken()) + 1;
+            else if (Integer.valueOf(request.nextToken()) < 3) {
+                nextToken = Integer.valueOf(request.nextToken()) + 1;
             }
             else {
                 nextToken = null;
             }
 
             List<LogGroup> logGroups = new ArrayList<>();
-            if (request.getNextToken() == null || Integer.valueOf(request.getNextToken()) < 3) {
+            if (request.nextToken() == null || Integer.valueOf(request.nextToken()) < 3) {
                 for (int i = 0; i < 10; i++) {
-                    LogGroup nextLogGroup = new LogGroup();
-                    nextLogGroup.setLogGroupName("schema-" + String.valueOf(i));
+                    LogGroup nextLogGroup = LogGroup.builder().logGroupName("schema-" + String.valueOf(i)).build();
                     logGroups.add(nextLogGroup);
                 }
             }
 
-            result.withLogGroups(logGroups);
+            responseBuilder.logGroups(logGroups);
             if (nextToken != null) {
-                result.setNextToken(String.valueOf(nextToken));
+                responseBuilder.nextToken(String.valueOf(nextToken));
             }
 
-            return result;
+            return responseBuilder.build();
         });
 
         ListSchemasRequest req = new ListSchemasRequest(identity, "queryId", "default");
@@ -183,34 +188,33 @@ public class CloudwatchMetadataHandlerTest
         when(mockAwsLogs.describeLogStreams(nullable(DescribeLogStreamsRequest.class))).thenAnswer((InvocationOnMock invocationOnMock) -> {
             DescribeLogStreamsRequest request = (DescribeLogStreamsRequest) invocationOnMock.getArguments()[0];
 
-            DescribeLogStreamsResult result = new DescribeLogStreamsResult();
+            DescribeLogStreamsResponse.Builder responseBuilder = DescribeLogStreamsResponse.builder();
 
             Integer nextToken;
-            if (request.getNextToken() == null) {
+            if (request.nextToken() == null) {
                 nextToken = 1;
             }
-            else if (Integer.valueOf(request.getNextToken()) < 3) {
-                nextToken = Integer.valueOf(request.getNextToken()) + 1;
+            else if (Integer.valueOf(request.nextToken()) < 3) {
+                nextToken = Integer.valueOf(request.nextToken()) + 1;
             }
             else {
                 nextToken = null;
             }
 
             List<LogStream> logStreams = new ArrayList<>();
-            if (request.getNextToken() == null || Integer.valueOf(request.getNextToken()) < 3) {
+            if (request.nextToken() == null || Integer.valueOf(request.nextToken()) < 3) {
                 for (int i = 0; i < 10; i++) {
-                    LogStream nextLogStream = new LogStream();
-                    nextLogStream.setLogStreamName("table-" + String.valueOf(i));
+                    LogStream nextLogStream = LogStream.builder().logStreamName("table-" + String.valueOf(i)).build();
                     logStreams.add(nextLogStream);
                 }
             }
 
-            result.withLogStreams(logStreams);
+            responseBuilder.logStreams(logStreams);
             if (nextToken != null) {
-                result.setNextToken(String.valueOf(nextToken));
+                responseBuilder.nextToken(String.valueOf(nextToken));
             }
 
-            return result;
+            return responseBuilder.build();
         });
 
         ListTablesRequest req = new ListTablesRequest(identity, "queryId", "default",
@@ -238,35 +242,34 @@ public class CloudwatchMetadataHandlerTest
         when(mockAwsLogs.describeLogStreams(nullable(DescribeLogStreamsRequest.class))).thenAnswer((InvocationOnMock invocationOnMock) -> {
             DescribeLogStreamsRequest request = (DescribeLogStreamsRequest) invocationOnMock.getArguments()[0];
 
-            assertTrue(request.getLogGroupName().equals(expectedSchema));
-            DescribeLogStreamsResult result = new DescribeLogStreamsResult();
+            assertTrue(request.logGroupName().equals(expectedSchema));
+            DescribeLogStreamsResponse.Builder responseBuilder = DescribeLogStreamsResponse.builder();
 
             Integer nextToken;
-            if (request.getNextToken() == null) {
+            if (request.nextToken() == null) {
                 nextToken = 1;
             }
-            else if (Integer.valueOf(request.getNextToken()) < 3) {
-                nextToken = Integer.valueOf(request.getNextToken()) + 1;
+            else if (Integer.valueOf(request.nextToken()) < 3) {
+                nextToken = Integer.valueOf(request.nextToken()) + 1;
             }
             else {
                 nextToken = null;
             }
 
             List<LogStream> logStreams = new ArrayList<>();
-            if (request.getNextToken() == null || Integer.valueOf(request.getNextToken()) < 3) {
+            if (request.nextToken() == null || Integer.valueOf(request.nextToken()) < 3) {
                 for (int i = 0; i < 10; i++) {
-                    LogStream nextLogStream = new LogStream();
-                    nextLogStream.setLogStreamName("table-" + String.valueOf(i));
+                    LogStream nextLogStream = LogStream.builder().logStreamName("table-" + String.valueOf(i)).build();
                     logStreams.add(nextLogStream);
                 }
             }
 
-            result.withLogStreams(logStreams);
+            responseBuilder.logStreams(logStreams);
             if (nextToken != null) {
-                result.setNextToken(String.valueOf(nextToken));
+                responseBuilder.nextToken(String.valueOf(nextToken));
             }
 
-            return result;
+            return responseBuilder.build();
         });
 
         GetTableRequest req = new GetTableRequest(identity, "queryId", "default", new TableName(expectedSchema, "table-9"), Collections.emptyMap());
@@ -290,36 +293,37 @@ public class CloudwatchMetadataHandlerTest
         when(mockAwsLogs.describeLogStreams(nullable(DescribeLogStreamsRequest.class))).thenAnswer((InvocationOnMock invocationOnMock) -> {
             DescribeLogStreamsRequest request = (DescribeLogStreamsRequest) invocationOnMock.getArguments()[0];
 
-            DescribeLogStreamsResult result = new DescribeLogStreamsResult();
+            DescribeLogStreamsResponse.Builder responseBuilder = DescribeLogStreamsResponse.builder();
 
             Integer nextToken;
-            if (request.getNextToken() == null) {
+            if (request.nextToken() == null) {
                 nextToken = 1;
             }
-            else if (Integer.valueOf(request.getNextToken()) < 3) {
-                nextToken = Integer.valueOf(request.getNextToken()) + 1;
+            else if (Integer.valueOf(request.nextToken()) < 3) {
+                nextToken = Integer.valueOf(request.nextToken()) + 1;
             }
             else {
                 nextToken = null;
             }
 
             List<LogStream> logStreams = new ArrayList<>();
-            if (request.getNextToken() == null || Integer.valueOf(request.getNextToken()) < 3) {
-                int continuation = request.getNextToken() == null ? 0 : Integer.valueOf(request.getNextToken());
+            if (request.nextToken() == null || Integer.valueOf(request.nextToken()) < 3) {
+                int continuation = request.nextToken() == null ? 0 : Integer.valueOf(request.nextToken());
                 for (int i = 0 + continuation * 100; i < 300; i++) {
-                    LogStream nextLogStream = new LogStream();
-                    nextLogStream.setLogStreamName("table-" + String.valueOf(i));
-                    nextLogStream.setStoredBytes(i * 1000L);
+                    LogStream nextLogStream = LogStream.builder()
+                            .logStreamName("table-" + String.valueOf(i))
+                            .storedBytes(i * 1000L)
+                            .build();
                     logStreams.add(nextLogStream);
                 }
             }
 
-            result.withLogStreams(logStreams);
+            responseBuilder.logStreams(logStreams);
             if (nextToken != null) {
-                result.setNextToken(String.valueOf(nextToken));
+                responseBuilder.nextToken(String.valueOf(nextToken));
             }
 
-            return result;
+            return responseBuilder.build();
         });
 
         Map<String, ValueSet> constraintsMap = new HashMap<>();

--- a/athena-cloudwatch/src/test/java/com/amazonaws/athena/connectors/cloudwatch/integ/CloudwatchIntegTest.java
+++ b/athena-cloudwatch/src/test/java/com/amazonaws/athena/connectors/cloudwatch/integ/CloudwatchIntegTest.java
@@ -20,11 +20,6 @@
 package com.amazonaws.athena.connectors.cloudwatch.integ;
 
 import com.amazonaws.athena.connector.integ.IntegrationTestBase;
-import com.amazonaws.services.logs.AWSLogs;
-import com.amazonaws.services.logs.AWSLogsClientBuilder;
-import com.amazonaws.services.logs.model.DeleteLogGroupRequest;
-import com.amazonaws.services.logs.model.InputLogEvent;
-import com.amazonaws.services.logs.model.PutLogEventsRequest;
 import com.google.common.collect.ImmutableList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,6 +33,9 @@ import software.amazon.awscdk.services.iam.PolicyStatement;
 import software.amazon.awscdk.services.logs.LogGroup;
 import software.amazon.awscdk.services.logs.LogStream;
 import software.amazon.awssdk.services.athena.model.Row;
+import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
+import software.amazon.awssdk.services.cloudwatchlogs.model.InputLogEvent;
+import software.amazon.awssdk.services.cloudwatchlogs.model.PutLogEventsRequest;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -134,20 +132,21 @@ public class CloudwatchIntegTest extends IntegrationTestBase
         logger.info("Setting up Log Group: {}, Log Stream: {}", logGroupName, logStreamName);
         logger.info("----------------------------------------------------");
 
-        AWSLogs logsClient = AWSLogsClientBuilder.defaultClient();
+        CloudWatchLogsClient logsClient = CloudWatchLogsClient.create();
 
         try {
-            logsClient.putLogEvents(new PutLogEventsRequest()
-                    .withLogGroupName(logGroupName)
-                    .withLogStreamName(logStreamName)
-                    .withLogEvents(
-                            new InputLogEvent().withTimestamp(currentTimeMillis).withMessage("Space, the final frontier."),
-                            new InputLogEvent().withTimestamp(fromTimeMillis).withMessage(logMessage),
-                            new InputLogEvent().withTimestamp(toTimeMillis + 5000)
-                                    .withMessage("To boldly go where no man has gone before!")));
+            logsClient.putLogEvents(PutLogEventsRequest.builder()
+                    .logGroupName(logGroupName)
+                    .logStreamName(logStreamName)
+                    .logEvents(
+                            InputLogEvent.builder().timestamp(currentTimeMillis).message("Space, the final frontier.").build(),
+                            InputLogEvent.builder().timestamp(fromTimeMillis).message(logMessage).build(),
+                            InputLogEvent.builder().timestamp(toTimeMillis + 5000)
+                                    .message("To boldly go where no man has gone before!").build())
+                    .build());
         }
         finally {
-            logsClient.shutdown();
+            logsClient.close();
         }
     }
 


### PR DESCRIPTION
*Issue #, if available: https://github.com/awslabs/aws-athena-query-federation/issues/2088*

*Description of changes:*
Migrate the cloudwatch connector to AWS SDK v2.
AwsLogs renamed to CloudwatchLogs from v1 to v2.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
