### PR TITLE
V2 rds

### DIFF
--- a/athena-aws-cmdb/pom.xml
+++ b/athena-aws-cmdb/pom.xml
@@ -33,9 +33,15 @@
             <version>${aws-sdk.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-rds</artifactId>
-            <version>${aws-sdk.version}</version>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>rds</artifactId>
+            <version>${aws-sdk-v2.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>netty-nio-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/athena-aws-cmdb/src/main/java/com/amazonaws/athena/connectors/aws/cmdb/TableProviderFactory.java
+++ b/athena-aws-cmdb/src/main/java/com/amazonaws/athena/connectors/aws/cmdb/TableProviderFactory.java
@@ -36,9 +36,8 @@ import com.amazonaws.services.ec2.AmazonEC2;
 import com.amazonaws.services.ec2.AmazonEC2ClientBuilder;
 import com.amazonaws.services.elasticmapreduce.AmazonElasticMapReduce;
 import com.amazonaws.services.elasticmapreduce.AmazonElasticMapReduceClientBuilder;
-import com.amazonaws.services.rds.AmazonRDS;
-import com.amazonaws.services.rds.AmazonRDSClientBuilder;
 import org.apache.arrow.util.VisibleForTesting;
+import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.s3.S3Client;
 
 import java.util.ArrayList;
@@ -60,13 +59,13 @@ public class TableProviderFactory
         this(
             AmazonEC2ClientBuilder.standard().build(),
             AmazonElasticMapReduceClientBuilder.standard().build(),
-            AmazonRDSClientBuilder.standard().build(),
+            RdsClient.create(),
             S3Client.create(),
             configOptions);
     }
 
     @VisibleForTesting
-    protected TableProviderFactory(AmazonEC2 ec2, AmazonElasticMapReduce emr, AmazonRDS rds, S3Client amazonS3, java.util.Map<String, String> configOptions)
+    protected TableProviderFactory(AmazonEC2 ec2, AmazonElasticMapReduce emr, RdsClient rds, S3Client amazonS3, java.util.Map<String, String> configOptions)
     {
         addProvider(new Ec2TableProvider(ec2));
         addProvider(new EbsTableProvider(ec2));

--- a/athena-aws-cmdb/src/main/java/com/amazonaws/athena/connectors/aws/cmdb/TableProviderFactory.java
+++ b/athena-aws-cmdb/src/main/java/com/amazonaws/athena/connectors/aws/cmdb/TableProviderFactory.java
@@ -57,8 +57,8 @@ public class TableProviderFactory
     {
         this(
             AmazonEC2ClientBuilder.standard().build(),
-            RdsClient.create(),
             EmrClient.create(),
+            RdsClient.create(),
             S3Client.create(),
             configOptions);
     }

--- a/athena-aws-cmdb/src/main/java/com/amazonaws/athena/connectors/aws/cmdb/tables/RdsTableProvider.java
+++ b/athena-aws-cmdb/src/main/java/com/amazonaws/athena/connectors/aws/cmdb/tables/RdsTableProvider.java
@@ -30,22 +30,22 @@ import com.amazonaws.athena.connector.lambda.domain.predicate.ValueSet;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableResponse;
 import com.amazonaws.athena.connector.lambda.records.ReadRecordsRequest;
-import com.amazonaws.services.rds.AmazonRDS;
-import com.amazonaws.services.rds.model.DBInstance;
-import com.amazonaws.services.rds.model.DBInstanceStatusInfo;
-import com.amazonaws.services.rds.model.DBParameterGroupStatus;
-import com.amazonaws.services.rds.model.DBSecurityGroupMembership;
-import com.amazonaws.services.rds.model.DBSubnetGroup;
-import com.amazonaws.services.rds.model.DescribeDBInstancesRequest;
-import com.amazonaws.services.rds.model.DescribeDBInstancesResult;
-import com.amazonaws.services.rds.model.DomainMembership;
-import com.amazonaws.services.rds.model.Endpoint;
-import com.amazonaws.services.rds.model.Subnet;
-import com.amazonaws.services.rds.model.Tag;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
+import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.DBInstance;
+import software.amazon.awssdk.services.rds.model.DBInstanceStatusInfo;
+import software.amazon.awssdk.services.rds.model.DBParameterGroupStatus;
+import software.amazon.awssdk.services.rds.model.DBSecurityGroupMembership;
+import software.amazon.awssdk.services.rds.model.DBSubnetGroup;
+import software.amazon.awssdk.services.rds.model.DescribeDbInstancesRequest;
+import software.amazon.awssdk.services.rds.model.DescribeDbInstancesResponse;
+import software.amazon.awssdk.services.rds.model.DomainMembership;
+import software.amazon.awssdk.services.rds.model.Endpoint;
+import software.amazon.awssdk.services.rds.model.Subnet;
+import software.amazon.awssdk.services.rds.model.Tag;
 
 import java.util.stream.Collectors;
 
@@ -56,9 +56,9 @@ public class RdsTableProvider
         implements TableProvider
 {
     private static final Schema SCHEMA;
-    private AmazonRDS rds;
+    private RdsClient rds;
 
-    public RdsTableProvider(AmazonRDS rds)
+    public RdsTableProvider(RdsClient rds)
     {
         this.rds = rds;
     }
@@ -99,27 +99,24 @@ public class RdsTableProvider
     @Override
     public void readWithConstraint(BlockSpiller spiller, ReadRecordsRequest recordsRequest, QueryStatusChecker queryStatusChecker)
     {
-        boolean done = false;
-        DescribeDBInstancesRequest request = new DescribeDBInstancesRequest();
+        DescribeDbInstancesRequest.Builder requestBuilder = DescribeDbInstancesRequest.builder();
 
         ValueSet idConstraint = recordsRequest.getConstraints().getSummary().get("instance_id");
         if (idConstraint != null && idConstraint.isSingleValue()) {
-            request.setDBInstanceIdentifier(idConstraint.getSingleValue().toString());
+            requestBuilder.dbInstanceIdentifier(idConstraint.getSingleValue().toString());
         }
 
-        while (!done) {
-            DescribeDBInstancesResult response = rds.describeDBInstances(request);
+        DescribeDbInstancesResponse response;
+        do {
+            response = rds.describeDBInstances(requestBuilder.build());
 
-            for (DBInstance instance : response.getDBInstances()) {
+            for (DBInstance instance : response.dbInstances()) {
                 instanceToRow(instance, spiller);
             }
 
-            request.setMarker(response.getMarker());
-
-            if (response.getMarker() == null || !queryStatusChecker.isQueryRunning()) {
-                done = true;
-            }
+            requestBuilder.marker(response.marker());
         }
+        while (response.marker() == null || !queryStatusChecker.isQueryRunning());
     }
 
     /**
@@ -136,145 +133,145 @@ public class RdsTableProvider
         spiller.writeRows((Block block, int row) -> {
             boolean matched = true;
 
-            matched &= block.offerValue("instance_id", row, instance.getDBInstanceIdentifier());
-            matched &= block.offerValue("primary_az", row, instance.getAvailabilityZone());
-            matched &= block.offerValue("storage_gb", row, instance.getAllocatedStorage());
-            matched &= block.offerValue("is_encrypted", row, instance.getStorageEncrypted());
-            matched &= block.offerValue("storage_type", row, instance.getStorageType());
-            matched &= block.offerValue("backup_retention_days", row, instance.getBackupRetentionPeriod());
-            matched &= block.offerValue("auto_upgrade", row, instance.getAutoMinorVersionUpgrade());
-            matched &= block.offerValue("instance_class", row, instance.getDBInstanceClass());
-            matched &= block.offerValue("port", row, instance.getDbInstancePort());
-            matched &= block.offerValue("status", row, instance.getDBInstanceStatus());
-            matched &= block.offerValue("dbi_resource_id", row, instance.getDbiResourceId());
-            matched &= block.offerValue("name", row, instance.getDBName());
-            matched &= block.offerValue("engine", row, instance.getEngine());
-            matched &= block.offerValue("engine_version", row, instance.getEngineVersion());
-            matched &= block.offerValue("license_model", row, instance.getLicenseModel());
-            matched &= block.offerValue("secondary_az", row, instance.getSecondaryAvailabilityZone());
-            matched &= block.offerValue("backup_window", row, instance.getPreferredBackupWindow());
-            matched &= block.offerValue("maint_window", row, instance.getPreferredMaintenanceWindow());
-            matched &= block.offerValue("read_replica_source_id", row, instance.getReadReplicaSourceDBInstanceIdentifier());
-            matched &= block.offerValue("create_time", row, instance.getInstanceCreateTime());
-            matched &= block.offerValue("public_access", row, instance.getPubliclyAccessible());
-            matched &= block.offerValue("iops", row, instance.getIops());
-            matched &= block.offerValue("is_multi_az", row, instance.getMultiAZ());
+            matched &= block.offerValue("instance_id", row, instance.dbInstanceIdentifier());
+            matched &= block.offerValue("primary_az", row, instance.availabilityZone());
+            matched &= block.offerValue("storage_gb", row, instance.allocatedStorage());
+            matched &= block.offerValue("is_encrypted", row, instance.storageEncrypted());
+            matched &= block.offerValue("storage_type", row, instance.storageType());
+            matched &= block.offerValue("backup_retention_days", row, instance.backupRetentionPeriod());
+            matched &= block.offerValue("auto_upgrade", row, instance.autoMinorVersionUpgrade());
+            matched &= block.offerValue("instance_class", row, instance.dbInstanceClass());
+            matched &= block.offerValue("port", row, instance.dbInstancePort());
+            matched &= block.offerValue("status", row, instance.dbInstanceStatus());
+            matched &= block.offerValue("dbi_resource_id", row, instance.dbiResourceId());
+            matched &= block.offerValue("name", row, instance.dbName());
+            matched &= block.offerValue("engine", row, instance.engine());
+            matched &= block.offerValue("engine_version", row, instance.engineVersion());
+            matched &= block.offerValue("license_model", row, instance.licenseModel());
+            matched &= block.offerValue("secondary_az", row, instance.secondaryAvailabilityZone());
+            matched &= block.offerValue("backup_window", row, instance.preferredBackupWindow());
+            matched &= block.offerValue("maint_window", row, instance.preferredMaintenanceWindow());
+            matched &= block.offerValue("read_replica_source_id", row, instance.readReplicaSourceDBInstanceIdentifier());
+            matched &= block.offerValue("create_time", row, instance.instanceCreateTime());
+            matched &= block.offerValue("public_access", row, instance.publiclyAccessible());
+            matched &= block.offerValue("iops", row, instance.iops());
+            matched &= block.offerValue("is_multi_az", row, instance.multiAZ());
 
             matched &= block.offerComplexValue("domains", row, (Field field, Object val) -> {
                         if (field.getName().equals("domain")) {
-                            return ((DomainMembership) val).getDomain();
+                            return ((DomainMembership) val).domain();
                         }
                         else if (field.getName().equals("fqdn")) {
-                            return ((DomainMembership) val).getFQDN();
+                            return ((DomainMembership) val).fqdn();
                         }
                         else if (field.getName().equals("iam_role")) {
-                            return ((DomainMembership) val).getIAMRoleName();
+                            return ((DomainMembership) val).iamRoleName();
                         }
                         else if (field.getName().equals("status")) {
-                            return ((DomainMembership) val).getStatus();
+                            return ((DomainMembership) val).status();
                         }
 
                         throw new RuntimeException("Unexpected field " + field.getName());
                     },
-                    instance.getDomainMemberships());
+                    instance.domainMemberships());
 
             matched &= block.offerComplexValue("param_groups", row, (Field field, Object val) -> {
                         if (field.getName().equals("name")) {
-                            return ((DBParameterGroupStatus) val).getDBParameterGroupName();
+                            return ((DBParameterGroupStatus) val).dbParameterGroupName();
                         }
                         else if (field.getName().equals("status")) {
-                            return ((DBParameterGroupStatus) val).getParameterApplyStatus();
+                            return ((DBParameterGroupStatus) val).parameterApplyStatus();
                         }
                         throw new RuntimeException("Unexpected field " + field.getName());
                     },
-                    instance.getDBParameterGroups());
+                    instance.dbParameterGroups());
 
             matched &= block.offerComplexValue("db_security_groups",
                     row,
                     (Field field, Object val) -> {
                         if (field.getName().equals("name")) {
-                            return ((DBSecurityGroupMembership) val).getDBSecurityGroupName();
+                            return ((DBSecurityGroupMembership) val).dbSecurityGroupName();
                         }
                         else if (field.getName().equals("status")) {
-                            return ((DBSecurityGroupMembership) val).getStatus();
+                            return ((DBSecurityGroupMembership) val).status();
                         }
                         throw new RuntimeException("Unexpected field " + field.getName());
                     },
-                    instance.getDBSecurityGroups());
+                    instance.dbSecurityGroups());
 
             matched &= block.offerComplexValue("subnet_group",
                     row,
                     (Field field, Object val) -> {
                         if (field.getName().equals("description")) {
-                            return ((DBSubnetGroup) val).getDBSubnetGroupDescription();
+                            return ((DBSubnetGroup) val).dbSubnetGroupDescription();
                         }
                         else if (field.getName().equals("name")) {
-                            return ((DBSubnetGroup) val).getDBSubnetGroupName();
+                            return ((DBSubnetGroup) val).dbSubnetGroupName();
                         }
                         else if (field.getName().equals("status")) {
-                            return ((DBSubnetGroup) val).getSubnetGroupStatus();
+                            return ((DBSubnetGroup) val).subnetGroupStatus();
                         }
                         else if (field.getName().equals("vpc")) {
-                            return ((DBSubnetGroup) val).getVpcId();
+                            return ((DBSubnetGroup) val).vpcId();
                         }
                         else if (field.getName().equals("subnets")) {
-                            return ((DBSubnetGroup) val).getSubnets().stream()
-                                    .map(next -> next.getSubnetIdentifier()).collect(Collectors.toList());
+                            return ((DBSubnetGroup) val).subnets().stream()
+                                    .map(next -> next.subnetIdentifier()).collect(Collectors.toList());
                         }
                         else if (val instanceof Subnet) {
-                            return ((Subnet) val).getSubnetIdentifier();
+                            return ((Subnet) val).subnetIdentifier();
                         }
                         throw new RuntimeException("Unexpected field " + field.getName());
                     },
-                    instance.getDBSubnetGroup());
+                    instance.dbSubnetGroup());
 
             matched &= block.offerComplexValue("endpoint",
                     row,
                     (Field field, Object val) -> {
                         if (field.getName().equals("address")) {
-                            return ((Endpoint) val).getAddress();
+                            return ((Endpoint) val).address();
                         }
                         else if (field.getName().equals("port")) {
-                            return ((Endpoint) val).getPort();
+                            return ((Endpoint) val).port();
                         }
                         else if (field.getName().equals("zone")) {
-                            return ((Endpoint) val).getHostedZoneId();
+                            return ((Endpoint) val).hostedZoneId();
                         }
                         throw new RuntimeException("Unexpected field " + field.getName());
                     },
-                    instance.getEndpoint());
+                    instance.endpoint());
 
             matched &= block.offerComplexValue("status_infos",
                     row,
                     (Field field, Object val) -> {
                         if (field.getName().equals("message")) {
-                            return ((DBInstanceStatusInfo) val).getMessage();
+                            return ((DBInstanceStatusInfo) val).message();
                         }
                         else if (field.getName().equals("is_normal")) {
-                            return ((DBInstanceStatusInfo) val).getNormal();
+                            return ((DBInstanceStatusInfo) val).normal();
                         }
                         else if (field.getName().equals("status")) {
-                            return ((DBInstanceStatusInfo) val).getStatus();
+                            return ((DBInstanceStatusInfo) val).status();
                         }
                         else if (field.getName().equals("type")) {
-                            return ((DBInstanceStatusInfo) val).getStatusType();
+                            return ((DBInstanceStatusInfo) val).statusType();
                         }
                         throw new RuntimeException("Unexpected field " + field.getName());
                     },
-                    instance.getStatusInfos());
+                    instance.statusInfos());
 
             matched &= block.offerComplexValue("tags", row,
                     (Field field, Object val) -> {
                         if (field.getName().equals("key")) {
-                            return ((Tag) val).getKey();
+                            return ((Tag) val).key();
                         }
                         else if (field.getName().equals("value")) {
-                            return ((Tag) val).getValue();
+                            return ((Tag) val).value();
                         }
 
                         throw new RuntimeException("Unexpected field " + field.getName());
                     },
-                    instance.getTagList());
+                    instance.tagList());
 
             return matched ? 1 : 0;
         });

--- a/athena-aws-cmdb/src/main/java/com/amazonaws/athena/connectors/aws/cmdb/tables/RdsTableProvider.java
+++ b/athena-aws-cmdb/src/main/java/com/amazonaws/athena/connectors/aws/cmdb/tables/RdsTableProvider.java
@@ -116,7 +116,7 @@ public class RdsTableProvider
 
             requestBuilder.marker(response.marker());
         }
-        while (response.marker() == null || !queryStatusChecker.isQueryRunning());
+        while (response.marker() != null && queryStatusChecker.isQueryRunning());
     }
 
     /**

--- a/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/TableProviderFactoryTest.java
+++ b/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/TableProviderFactoryTest.java
@@ -23,11 +23,11 @@ import com.amazonaws.athena.connector.lambda.domain.TableName;
 import com.amazonaws.athena.connectors.aws.cmdb.tables.TableProvider;
 import com.amazonaws.services.ec2.AmazonEC2;
 import com.amazonaws.services.elasticmapreduce.AmazonElasticMapReduce;
-import com.amazonaws.services.rds.AmazonRDS;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.s3.S3Client;
 
 import java.util.List;
@@ -48,7 +48,7 @@ public class TableProviderFactoryTest
     private AmazonElasticMapReduce mockEmr;
 
     @Mock
-    private AmazonRDS mockRds;
+    private RdsClient mockRds;
 
     @Mock
     private S3Client amazonS3;

--- a/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/RdsTableProviderTest.java
+++ b/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/RdsTableProviderTest.java
@@ -31,20 +31,6 @@ import com.amazonaws.services.elasticmapreduce.model.DescribeClusterRequest;
 import com.amazonaws.services.elasticmapreduce.model.DescribeClusterResult;
 import com.amazonaws.services.elasticmapreduce.model.ListClustersRequest;
 import com.amazonaws.services.elasticmapreduce.model.ListClustersResult;
-import com.amazonaws.services.rds.AmazonRDS;
-import com.amazonaws.services.rds.model.DBInstance;
-import com.amazonaws.services.rds.model.DBInstanceStatusInfo;
-import com.amazonaws.services.rds.model.DBParameterGroup;
-import com.amazonaws.services.rds.model.DBParameterGroupStatus;
-import com.amazonaws.services.rds.model.DBSecurityGroupMembership;
-import com.amazonaws.services.rds.model.DBSubnetGroup;
-import com.amazonaws.services.rds.model.DescribeDBInstancesRequest;
-import com.amazonaws.services.rds.model.DescribeDBInstancesResult;
-import com.amazonaws.services.rds.model.DomainMembership;
-import com.amazonaws.services.rds.model.Endpoint;
-import com.amazonaws.services.rds.model.Subnet;
-import com.amazonaws.services.rds.model.Tag;
-
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.Field;
@@ -54,6 +40,18 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.DBInstance;
+import software.amazon.awssdk.services.rds.model.DBInstanceStatusInfo;
+import software.amazon.awssdk.services.rds.model.DBParameterGroupStatus;
+import software.amazon.awssdk.services.rds.model.DBSecurityGroupMembership;
+import software.amazon.awssdk.services.rds.model.DBSubnetGroup;
+import software.amazon.awssdk.services.rds.model.DescribeDbInstancesRequest;
+import software.amazon.awssdk.services.rds.model.DescribeDbInstancesResponse;
+import software.amazon.awssdk.services.rds.model.DomainMembership;
+import software.amazon.awssdk.services.rds.model.Endpoint;
+import software.amazon.awssdk.services.rds.model.Subnet;
+import software.amazon.awssdk.services.rds.model.Tag;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -74,7 +72,7 @@ public class RdsTableProviderTest
     private static final Logger logger = LoggerFactory.getLogger(RdsTableProviderTest.class);
 
     @Mock
-    private AmazonRDS mockRds;
+    private RdsClient mockRds;
 
     protected String getIdField()
     {
@@ -110,17 +108,17 @@ public class RdsTableProviderTest
     protected void setUpRead()
     {
         final AtomicLong requestCount = new AtomicLong(0);
-        when(mockRds.describeDBInstances(nullable(DescribeDBInstancesRequest.class)))
+        when(mockRds.describeDBInstances(nullable(DescribeDbInstancesRequest.class)))
                 .thenAnswer((InvocationOnMock invocation) -> {
-                    DescribeDBInstancesResult mockResult = mock(DescribeDBInstancesResult.class);
+                    DescribeDbInstancesResponse mockResult = mock(DescribeDbInstancesResponse.class);
                     List<DBInstance> values = new ArrayList<>();
                     values.add(makeValue(getIdValue()));
                     values.add(makeValue(getIdValue()));
                     values.add(makeValue("fake-id"));
-                    when(mockResult.getDBInstances()).thenReturn(values);
+                    when(mockResult.dbInstances()).thenReturn(values);
 
                     if (requestCount.incrementAndGet() < 3) {
-                        when(mockResult.getMarker()).thenReturn(String.valueOf(requestCount.get()));
+                        when(mockResult.marker()).thenReturn(String.valueOf(requestCount.get()));
                     }
                     return mockResult;
                 });
@@ -184,56 +182,61 @@ public class RdsTableProviderTest
 
     private DBInstance makeValue(String id)
     {
-        return new DBInstance()
-                .withDBInstanceIdentifier(id)
-                .withAvailabilityZone("primary_az")
-                .withAllocatedStorage(100)
-                .withStorageEncrypted(true)
-                .withBackupRetentionPeriod(100)
-                .withAutoMinorVersionUpgrade(true)
-                .withDBInstanceClass("instance_class")
-                .withDbInstancePort(100)
-                .withDBInstanceStatus("status")
-                .withStorageType("storage_type")
-                .withDbiResourceId("dbi_resource_id")
-                .withDBName("name")
-                .withDomainMemberships(new DomainMembership()
-                        .withDomain("domain")
-                        .withFQDN("fqdn")
-                        .withIAMRoleName("iam_role")
-                        .withStatus("status"))
-                .withEngine("engine")
-                .withEngineVersion("engine_version")
-                .withLicenseModel("license_model")
-                .withSecondaryAvailabilityZone("secondary_az")
-                .withPreferredBackupWindow("backup_window")
-                .withPreferredMaintenanceWindow("maint_window")
-                .withReadReplicaSourceDBInstanceIdentifier("read_replica_source_id")
-                .withDBParameterGroups(new DBParameterGroupStatus()
-                        .withDBParameterGroupName("name")
-                        .withParameterApplyStatus("status"))
-                .withDBSecurityGroups(new DBSecurityGroupMembership()
-                        .withDBSecurityGroupName("name")
-                        .withStatus("status"))
-                .withDBSubnetGroup(new DBSubnetGroup()
-                        .withDBSubnetGroupName("name")
-                        .withSubnetGroupStatus("status")
-                        .withVpcId("vpc")
-                        .withSubnets(new Subnet()
-                                .withSubnetIdentifier("subnet")))
-                .withStatusInfos(new DBInstanceStatusInfo()
-                        .withStatus("status")
-                        .withMessage("message")
-                        .withNormal(true)
-                        .withStatusType("type"))
-                .withEndpoint(new Endpoint()
-                        .withAddress("address")
-                        .withPort(100)
-                        .withHostedZoneId("zone"))
-                .withInstanceCreateTime(new Date(100000))
-                .withIops(100)
-                .withMultiAZ(true)
-                .withPubliclyAccessible(true)
-                .withTagList(new Tag().withKey("key").withValue("value"));
+        return DBInstance.builder()
+                .dbInstanceIdentifier(id)
+                .availabilityZone("primary_az")
+                .allocatedStorage(100)
+                .storageEncrypted(true)
+                .backupRetentionPeriod(100)
+                .autoMinorVersionUpgrade(true)
+                .dbInstanceClass("instance_class")
+                .dbInstancePort(100)
+                .dbInstanceStatus("status")
+                .storageType("storage_type")
+                .dbiResourceId("dbi_resource_id")
+                .dbName("name")
+                .domainMemberships(DomainMembership.builder()
+                        .domain("domain")
+                        .fqdn("fqdn")
+                        .iamRoleName("iam_role")
+                        .status("status")
+                        .build())
+                .engine("engine")
+                .engineVersion("engine_version")
+                .licenseModel("license_model")
+                .secondaryAvailabilityZone("secondary_az")
+                .preferredBackupWindow("backup_window")
+                .preferredMaintenanceWindow("maint_window")
+                .readReplicaSourceDBInstanceIdentifier("read_replica_source_id")
+                .dbParameterGroups(DBParameterGroupStatus.builder()
+                        .dbParameterGroupName("name")
+                        .parameterApplyStatus("status")
+                        .build())
+                .dbSecurityGroups(DBSecurityGroupMembership.builder()
+                        .dbSecurityGroupName("name")
+                        .status("status").build())
+                .dbSubnetGroup(DBSubnetGroup.builder()
+                        .dbSubnetGroupName("name")
+                        .subnetGroupStatus("status")
+                        .vpcId("vpc")
+                        .subnets(Subnet.builder().subnetIdentifier("subnet").build())
+                        .build())
+                .statusInfos(DBInstanceStatusInfo.builder()
+                        .status("status")
+                        .message("message")
+                        .normal(true)
+                        .statusType("type")
+                        .build())
+                .endpoint(Endpoint.builder()
+                        .address("address")
+                        .port(100)
+                        .hostedZoneId("zone")
+                        .build())
+                .instanceCreateTime(new Date(100000).toInstant())
+                .iops(100)
+                .multiAZ(true)
+                .publiclyAccessible(true)
+                .tagList(Tag.builder().key("key").value("value").build())
+                .build();
     }
 }

--- a/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/RdsTableProviderTest.java
+++ b/athena-aws-cmdb/src/test/java/com/amazonaws/athena/connectors/aws/cmdb/tables/RdsTableProviderTest.java
@@ -110,17 +110,17 @@ public class RdsTableProviderTest
         final AtomicLong requestCount = new AtomicLong(0);
         when(mockRds.describeDBInstances(nullable(DescribeDbInstancesRequest.class)))
                 .thenAnswer((InvocationOnMock invocation) -> {
-                    DescribeDbInstancesResponse mockResult = mock(DescribeDbInstancesResponse.class);
                     List<DBInstance> values = new ArrayList<>();
                     values.add(makeValue(getIdValue()));
                     values.add(makeValue(getIdValue()));
                     values.add(makeValue("fake-id"));
-                    when(mockResult.dbInstances()).thenReturn(values);
+                    DescribeDbInstancesResponse.Builder resultBuilder = DescribeDbInstancesResponse.builder();
+                    resultBuilder.dbInstances(values);
 
                     if (requestCount.incrementAndGet() < 3) {
-                        when(mockResult.marker()).thenReturn(String.valueOf(requestCount.get()));
+                        resultBuilder.marker(String.valueOf(requestCount.get()));
                     }
-                    return mockResult;
+                    return resultBuilder.build();
                 });
     }
 

--- a/athena-cloudera-hive/pom.xml
+++ b/athena-cloudera-hive/pom.xml
@@ -52,12 +52,18 @@
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-rds -->
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/rds -->
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-rds</artifactId>
-            <version>${aws-sdk.version}</version>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>rds</artifactId>
+            <version>${aws-sdk-v2.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>netty-nio-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awscdk/rds -->
         <dependency>

--- a/athena-cloudera-impala/pom.xml
+++ b/athena-cloudera-impala/pom.xml
@@ -48,12 +48,18 @@
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-rds -->
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/rds -->
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-rds</artifactId>
-            <version>${aws-sdk.version}</version>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>rds</artifactId>
+            <version>${aws-sdk-v2.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>netty-nio-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awscdk/rds -->
         <dependency>

--- a/athena-datalakegen2/pom.xml
+++ b/athena-datalakegen2/pom.xml
@@ -32,12 +32,18 @@
             <artifactId>mssql-jdbc</artifactId>
             <version>${mssql.jdbc.version}</version>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-rds -->
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/rds -->
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-rds</artifactId>
-            <version>${aws-sdk.version}</version>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>rds</artifactId>
+            <version>${aws-sdk-v2.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>netty-nio-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awscdk/rds -->
         <dependency>

--- a/athena-db2-as400/pom.xml
+++ b/athena-db2-as400/pom.xml
@@ -33,12 +33,18 @@
             <artifactId>jt400</artifactId>
             <version>20.0.7</version>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-rds -->
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/rds -->
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-rds</artifactId>
-            <version>${aws-sdk.version}</version>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>rds</artifactId>
+            <version>${aws-sdk-v2.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>netty-nio-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awscdk/rds -->
         <dependency>

--- a/athena-db2/pom.xml
+++ b/athena-db2/pom.xml
@@ -33,12 +33,18 @@
             <artifactId>jcc</artifactId>
             <version>11.5.9.0</version>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-rds -->
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/rds -->
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-rds</artifactId>
-            <version>${aws-sdk.version}</version>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>rds</artifactId>
+            <version>${aws-sdk-v2.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>netty-nio-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awscdk/rds -->
         <dependency>

--- a/athena-google-bigquery/pom.xml
+++ b/athena-google-bigquery/pom.xml
@@ -27,10 +27,16 @@
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awscdk/rds -->
         <dependency>
-            <groupId>software.amazon.awscdk</groupId>
+            <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>${aws-cdk.version}</version>
+            <version>${aws-sdk-v2.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>netty-nio-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- Google Bigquery SDK Dependencies-->
         <dependency>

--- a/athena-hortonworks-hive/pom.xml
+++ b/athena-hortonworks-hive/pom.xml
@@ -48,12 +48,18 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-rds -->
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/rds -->
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-rds</artifactId>
-            <version>${aws-sdk.version}</version>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>rds</artifactId>
+            <version>${aws-sdk-v2.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>netty-nio-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awscdk/rds -->
         <dependency>

--- a/athena-jdbc/pom.xml
+++ b/athena-jdbc/pom.xml
@@ -113,12 +113,18 @@
             <version>${aws-cdk.version}</version>
             <scope>test</scope>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-rds -->
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/rds -->
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-rds</artifactId>
-            <version>${aws-sdk.version}</version>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>rds</artifactId>
+            <version>${aws-sdk-v2.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>netty-nio-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awscdk/rds -->
         <dependency>

--- a/athena-mysql/pom.xml
+++ b/athena-mysql/pom.xml
@@ -43,12 +43,18 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-rds -->
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/rds -->
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-rds</artifactId>
-            <version>${aws-sdk.version}</version>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>rds</artifactId>
+            <version>${aws-sdk-v2.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>netty-nio-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awscdk/rds -->
         <dependency>

--- a/athena-oracle/pom.xml
+++ b/athena-oracle/pom.xml
@@ -32,12 +32,18 @@
             <artifactId>ojdbc8</artifactId>
             <version>23.5.0.24.07</version>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-rds -->
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/rds -->
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-rds</artifactId>
-            <version>${aws-sdk.version}</version>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>rds</artifactId>
+            <version>${aws-sdk-v2.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>netty-nio-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awscdk/rds -->
         <dependency>

--- a/athena-postgresql/pom.xml
+++ b/athena-postgresql/pom.xml
@@ -39,12 +39,18 @@
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-rds -->
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/rds -->
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-rds</artifactId>
-            <version>${aws-sdk.version}</version>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>rds</artifactId>
+            <version>${aws-sdk-v2.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>netty-nio-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awscdk/rds -->
         <dependency>

--- a/athena-postgresql/src/test/java/com/amazonaws/athena/connectors/postgresql/integ/PostGreSqlIntegTest.java
+++ b/athena-postgresql/src/test/java/com/amazonaws/athena/connectors/postgresql/integ/PostGreSqlIntegTest.java
@@ -26,11 +26,6 @@ import com.amazonaws.athena.connector.integ.data.SecretsManagerCredentials;
 import com.amazonaws.athena.connector.lambda.domain.TableName;
 import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionInfo;
 import com.amazonaws.athena.connectors.jdbc.integ.JdbcTableUtils;
-import com.amazonaws.services.rds.AmazonRDS;
-import com.amazonaws.services.rds.AmazonRDSClientBuilder;
-import com.amazonaws.services.rds.model.DescribeDBInstancesRequest;
-import com.amazonaws.services.rds.model.DescribeDBInstancesResult;
-import com.amazonaws.services.rds.model.Endpoint;
 import com.google.common.collect.ImmutableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,6 +48,10 @@ import software.amazon.awscdk.services.rds.PostgresInstanceEngineProps;
 import software.amazon.awscdk.services.rds.StorageType;
 import software.amazon.awscdk.services.secretsmanager.Secret;
 import software.amazon.awssdk.services.athena.model.Row;
+import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.DescribeDbInstancesRequest;
+import software.amazon.awssdk.services.rds.model.DescribeDbInstancesResponse;
+import software.amazon.awssdk.services.rds.model.Endpoint;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -195,14 +194,15 @@ public class PostGreSqlIntegTest extends IntegrationTestBase
      */
     private Endpoint getInstanceData()
     {
-        AmazonRDS rdsClient = AmazonRDSClientBuilder.defaultClient();
+        RdsClient rdsClient = RdsClient.create();
         try {
-            DescribeDBInstancesResult instancesResult = rdsClient.describeDBInstances(new DescribeDBInstancesRequest()
-                    .withDBInstanceIdentifier(dbInstanceName));
-            return instancesResult.getDBInstances().get(0).getEndpoint();
+            DescribeDbInstancesResponse instancesResponse = rdsClient.describeDBInstances(DescribeDbInstancesRequest.builder()
+                    .dbInstanceIdentifier(dbInstanceName)
+                    .build());
+            return instancesResponse.dbInstances().get(0).endpoint();
         }
         finally {
-            rdsClient.shutdown();
+            rdsClient.close();
         }
     }
 
@@ -213,7 +213,7 @@ public class PostGreSqlIntegTest extends IntegrationTestBase
     private void setEnvironmentVars(Endpoint endpoint)
     {
         String connectionString = String.format("postgres://jdbc:postgresql://%s:%s/postgres?user=%s&password=%s",
-                endpoint.getAddress(), endpoint.getPort(), username, password);
+                endpoint.address(), endpoint.port(), username, password);
         String connectionStringTag = lambdaFunctionName + "_connection_string";
         environmentVars.put("default", connectionString);
         environmentVars.put(connectionStringTag, connectionString);

--- a/athena-redshift/pom.xml
+++ b/athena-redshift/pom.xml
@@ -56,12 +56,18 @@
             <version>${aws-cdk.version}</version>
             <scope>test</scope>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-rds -->
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/rds -->
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-rds</artifactId>
-            <version>${aws-sdk.version}</version>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>rds</artifactId>
+            <version>${aws-sdk-v2.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>netty-nio-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awscdk/rds -->
         <dependency>

--- a/athena-saphana/pom.xml
+++ b/athena-saphana/pom.xml
@@ -27,12 +27,18 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-rds -->
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/rds -->
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-rds</artifactId>
-            <version>${aws-sdk.version}</version>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>rds</artifactId>
+            <version>${aws-sdk-v2.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>netty-nio-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awscdk/rds -->
         <dependency>

--- a/athena-snowflake/pom.xml
+++ b/athena-snowflake/pom.xml
@@ -32,12 +32,18 @@
             <artifactId>snowflake-jdbc</artifactId>
             <version>3.19.0</version>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-rds -->
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/rds -->
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-rds</artifactId>
-            <version>${aws-sdk.version}</version>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>rds</artifactId>
+            <version>${aws-sdk-v2.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>netty-nio-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awscdk/rds -->
         <dependency>

--- a/athena-sqlserver/pom.xml
+++ b/athena-sqlserver/pom.xml
@@ -32,12 +32,18 @@
             <artifactId>mssql-jdbc</artifactId>
             <version>${mssql.jdbc.version}</version>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-rds -->
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/rds -->
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-rds</artifactId>
-            <version>${aws-sdk.version}</version>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>rds</artifactId>
+            <version>${aws-sdk-v2.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>netty-nio-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awscdk/rds -->
         <dependency>

--- a/athena-synapse/pom.xml
+++ b/athena-synapse/pom.xml
@@ -59,12 +59,18 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-rds -->
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/rds -->
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-rds</artifactId>
-            <version>${aws-sdk.version}</version>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>rds</artifactId>
+            <version>${aws-sdk-v2.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>netty-nio-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awscdk/rds -->
         <dependency>

--- a/athena-teradata/pom.xml
+++ b/athena-teradata/pom.xml
@@ -27,12 +27,18 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-rds -->
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/rds -->
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-rds</artifactId>
-            <version>${aws-sdk.version}</version>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>rds</artifactId>
+            <version>${aws-sdk-v2.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>netty-nio-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awscdk/rds -->
         <dependency>


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-athena-query-federation/issues/2087

*Description of changes:*
Migrate the RDS service to AWS SDK v2.
Only true migration was in aws-cmdb. All others were only a test dependency, with only 2 actually having changes need to be made.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
