### PR TITLE
v2 sdk changes redshift

### DIFF
--- a/athena-jdbc/pom.xml
+++ b/athena-jdbc/pom.xml
@@ -99,20 +99,6 @@
             <version>${log4j2Version}</version>
             <scope>runtime</scope>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-redshift -->
-        <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-redshift</artifactId>
-            <version>${aws-sdk.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <!-- https://mvnrepository.com/artifact/software.amazon.awscdk/redshift -->
-        <dependency>
-            <groupId>software.amazon.awscdk</groupId>
-            <artifactId>redshift</artifactId>
-            <version>${aws-cdk.version}</version>
-            <scope>test</scope>
-        </dependency>
         <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-rds -->
         <dependency>
             <groupId>com.amazonaws</groupId>

--- a/athena-redshift/pom.xml
+++ b/athena-redshift/pom.xml
@@ -38,16 +38,11 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-redshift -->
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/redshift -->
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-redshift</artifactId>
-            <version>${aws-sdk.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-redshiftserverless</artifactId>
-            <version>${aws-sdk.version}</version>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>redshift</artifactId>
+            <version>${aws-sdk-v2.version}</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awscdk/redshift -->
         <dependency>

--- a/athena-redshift/pom.xml
+++ b/athena-redshift/pom.xml
@@ -44,6 +44,11 @@
             <artifactId>redshift</artifactId>
             <version>${aws-sdk-v2.version}</version>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>redshiftserverless</artifactId>
+            <version>${aws-sdk-v2.version}</version>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awscdk/redshift -->
         <dependency>
             <groupId>software.amazon.awscdk</groupId>

--- a/athena-redshift/src/test/java/com/amazonaws/athena/connectors/redshift/integ/RedshiftIntegTest.java
+++ b/athena-redshift/src/test/java/com/amazonaws/athena/connectors/redshift/integ/RedshiftIntegTest.java
@@ -26,14 +26,8 @@ import com.amazonaws.athena.connector.integ.data.SecretsManagerCredentials;
 import com.amazonaws.athena.connector.lambda.domain.TableName;
 import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionInfo;
 import com.amazonaws.athena.connectors.jdbc.integ.JdbcTableUtils;
-import com.amazonaws.services.redshift.AmazonRedshift;
-import com.amazonaws.services.redshift.AmazonRedshiftClientBuilder;
-import com.amazonaws.services.redshift.model.DescribeClustersRequest;
-import com.amazonaws.services.redshift.model.DescribeClustersResult;
-import com.amazonaws.services.redshift.model.Endpoint;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testng.AssertJUnit;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -49,7 +43,12 @@ import software.amazon.awscdk.services.redshift.Cluster;
 import software.amazon.awscdk.services.redshift.ClusterType;
 import software.amazon.awscdk.services.redshift.Login;
 import software.amazon.awscdk.services.redshift.NodeType;
+import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 import software.amazon.awssdk.services.athena.model.Row;
+import software.amazon.awssdk.services.redshift.RedshiftClient;
+import software.amazon.awssdk.services.redshift.model.DescribeClustersRequest;
+import software.amazon.awssdk.services.redshift.model.DescribeClustersResponse;
+import software.amazon.awssdk.services.redshift.model.Endpoint;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -189,14 +188,16 @@ public class RedshiftIntegTest extends IntegrationTestBase
      */
     private Endpoint getClusterData()
     {
-        AmazonRedshift redshiftClient = AmazonRedshiftClientBuilder.defaultClient();
+        RedshiftClient redshiftClient = RedshiftClient.builder()
+                .region(DefaultAwsRegionProviderChain.builder().build().getRegion())
+                .build();;
         try {
-            DescribeClustersResult clustersResult = redshiftClient.describeClusters(new DescribeClustersRequest()
-                    .withClusterIdentifier(clusterName));
-            return clustersResult.getClusters().get(0).getEndpoint();
+            DescribeClustersResponse clustersResult = redshiftClient.describeClusters(DescribeClustersRequest.builder()
+                    .clusterIdentifier(clusterName).build());
+            return clustersResult.clusters().get(0).endpoint();
         }
         finally {
-            redshiftClient.shutdown();
+            redshiftClient.close();
         }
     }
 
@@ -207,7 +208,7 @@ public class RedshiftIntegTest extends IntegrationTestBase
     private void setEnvironmentVars(Endpoint endpoint)
     {
         String connectionString = String.format("redshift://jdbc:redshift://%s:%s/public?user=%s&password=%s",
-                endpoint.getAddress(), endpoint.getPort(), username, password);
+                endpoint.address(), endpoint.port(), username, password);
         String connectionStringTag = lambdaFunctionName + "_connection_string";
         environmentVars.put("default", connectionString);
         environmentVars.put(connectionStringTag, connectionString);

--- a/athena-redshift/src/test/java/com/amazonaws/athena/connectors/redshift/integ/RedshiftIntegTest.java
+++ b/athena-redshift/src/test/java/com/amazonaws/athena/connectors/redshift/integ/RedshiftIntegTest.java
@@ -43,7 +43,6 @@ import software.amazon.awscdk.services.redshift.Cluster;
 import software.amazon.awscdk.services.redshift.ClusterType;
 import software.amazon.awscdk.services.redshift.Login;
 import software.amazon.awscdk.services.redshift.NodeType;
-import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 import software.amazon.awssdk.services.athena.model.Row;
 import software.amazon.awssdk.services.redshift.RedshiftClient;
 import software.amazon.awssdk.services.redshift.model.DescribeClustersRequest;
@@ -188,9 +187,7 @@ public class RedshiftIntegTest extends IntegrationTestBase
      */
     private Endpoint getClusterData()
     {
-        RedshiftClient redshiftClient = RedshiftClient.builder()
-                .region(DefaultAwsRegionProviderChain.builder().build().getRegion())
-                .build();;
+        RedshiftClient redshiftClient = RedshiftClient.create();
         try {
             DescribeClustersResponse clustersResult = redshiftClient.describeClusters(DescribeClustersRequest.builder()
                     .clusterIdentifier(clusterName).build());


### PR DESCRIPTION
*Issue #, if available:*
#2089 SDK V2 changes for redshift
*Description of changes:*
SDK V2 changes for redshift
removed redshift serverless dependency from redshift pom as it is not in use.
removed redshift dependency from Athena-jdbc as it is not in use.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
