### PR TITLE
Oracle date issue fix

### DIFF
--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcRecordHandler.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcRecordHandler.java
@@ -82,11 +82,11 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Abstracts JDBC record handler and provides common reusable split records handling.
@@ -273,8 +273,9 @@ public abstract class JdbcRecordHandler
             case DATEDAY:
                 return (DateDayExtractor) (Object context, NullableDateDayHolder dst) ->
                 {
+                    //Issue fix for getting different date (offset by 1) for any dates prior to 1/1/1970.
                     if (resultSet.getDate(fieldName) != null) {
-                        dst.value = (int) TimeUnit.MILLISECONDS.toDays(resultSet.getDate(fieldName).getTime());
+                        dst.value = (int) LocalDate.parse(resultSet.getDate(fieldName).toString()).toEpochDay();
                     }
                     dst.isSet = resultSet.wasNull() ? 0 : 1;
                 };


### PR DESCRIPTION
*Issue #, if available:*
Customer has complained that in Oracle DB RDS they are seeing different date (offset by 1) for any dates prior to 1/1/1970. 
**Example**: 
• Database stores 7/20/1967 
o SQL*Plus query: 7/20/1967 
o Athena query: 7/21/1967 
• Database stores 7/20/1972 
o SQL*Plus query: 7/20/1972 
o Athena query: 7/20/1972

*Description of changes:*
This code changes resolves the issue and now we will see correct dates. Please refer attached doc for more details and testing results.

[Oracle Date Type Issue Testin2.docx](https://github.com/user-attachments/files/17115900/Oracle.Date.Type.Issue.Testin2.docx)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
