### PR TITLE
Java Docs were github action was pointing to wrong directory

### DIFF
--- a/.github/workflows/javadoc_sync.yaml
+++ b/.github/workflows/javadoc_sync.yaml
@@ -28,7 +28,7 @@ jobs:
         run: rm -rf com
 
       - name: Copy new files
-        run: cp -r target/site/apidocs/* .
+        run: cp -r target/reports/apidocs/* .
 
       - name: Commit files
         run: |


### PR DESCRIPTION
The original script was pointing to the wrong path;

according to documentations: https://maven.apache.org/plugins/maven-javadoc-plugin/aggregate-mojo.html

the Default location is ${project.build.directory}/reports
