### PR TITLE
Fix teradata

### DIFF
--- a/athena-teradata/athena-teradata.yaml
+++ b/athena-teradata/athena-teradata.yaml
@@ -30,9 +30,6 @@ Parameters:
     Description: 'The prefix within SpillBucket where this function can spill data.'
     Type: String
     Default: athena-spill
-  LambdaJDBCLayername:
-    Description: 'Lambda JDBC layer Name. Must be ARN of layer'
-    Type: String
   LambdaTimeout:
     Description: 'Maximum Lambda invocation runtime in seconds. (min 1 - 900 max)'
     Default: 900
@@ -77,8 +74,6 @@ Resources:
           default: !Ref DefaultConnectionString
           partitioncount: !Ref PartitionCount
       FunctionName: !Ref LambdaFunctionName
-      Layers:
-        - !Ref LambdaJDBCLayername
       PackageType: "Image"
       ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-teradata:2022.47.1'
       Description: "Enables Amazon Athena to communicate with Teradata using JDBC"

--- a/athena-teradata/pom.xml
+++ b/athena-teradata/pom.xml
@@ -59,6 +59,11 @@
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.teradata.jdbc</groupId>
+            <artifactId>terajdbc</artifactId>
+            <version>20.00.00.34</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Image-based lambda cannot have layer properties. Remove the need for the teradata layer by adding teradata jdbc as a dependency instead. Now with ECR, jar/dependency size is not an issue so this can be done.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
