### PR TITLE
V2 final changes

### DIFF
--- a/athena-cloudwatch-metrics/src/main/java/com/amazonaws/athena/connectors/cloudwatch/metrics/MetricsMetadataHandler.java
+++ b/athena-cloudwatch-metrics/src/main/java/com/amazonaws/athena/connectors/cloudwatch/metrics/MetricsMetadataHandler.java
@@ -42,7 +42,6 @@ import com.amazonaws.athena.connector.lambda.security.EncryptionKeyFactory;
 import com.amazonaws.athena.connectors.cloudwatch.metrics.tables.MetricSamplesTable;
 import com.amazonaws.athena.connectors.cloudwatch.metrics.tables.MetricsTable;
 import com.amazonaws.athena.connectors.cloudwatch.metrics.tables.Table;
-import com.amazonaws.util.CollectionUtils;
 import com.google.common.collect.Lists;
 import org.apache.arrow.util.VisibleForTesting;
 import org.slf4j.Logger;
@@ -54,6 +53,7 @@ import software.amazon.awssdk.services.cloudwatch.model.ListMetricsResponse;
 import software.amazon.awssdk.services.cloudwatch.model.Metric;
 import software.amazon.awssdk.services.cloudwatch.model.MetricStat;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.utils.CollectionUtils;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBMetadataHandler.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBMetadataHandler.java
@@ -56,7 +56,7 @@ import com.amazonaws.athena.connectors.dynamodb.util.DDBRecordMetadata;
 import com.amazonaws.athena.connectors.dynamodb.util.DDBTableUtils;
 import com.amazonaws.athena.connectors.dynamodb.util.DDBTypeUtils;
 import com.amazonaws.athena.connectors.dynamodb.util.IncrementingValueNameProducer;
-import com.amazonaws.util.json.Jackson;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import org.apache.arrow.vector.complex.reader.FieldReader;
@@ -446,7 +446,14 @@ public class DynamoDBMetadataHandler
                 expressionValueMapping.put(valueNameProducer2.getNext(), value);
             }
 
-            partitionsSchemaBuilder.addMetadata(EXPRESSION_NAMES_METADATA, Jackson.toJsonString(aliasedColumns));
+            try {
+                ObjectMapper objectMapper = new ObjectMapper();
+                partitionsSchemaBuilder.addMetadata(EXPRESSION_NAMES_METADATA, objectMapper.writeValueAsString(aliasedColumns));
+            }
+            catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+            
             partitionsSchemaBuilder.addMetadata(EXPRESSION_VALUES_METADATA, EnhancedDocument.fromAttributeValueMap(expressionValueMapping).toJson());
         }
     }

--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBRecordHandler.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBRecordHandler.java
@@ -35,8 +35,8 @@ import com.amazonaws.athena.connectors.dynamodb.resolver.DynamoDBFieldResolver;
 import com.amazonaws.athena.connectors.dynamodb.util.DDBPredicateUtils;
 import com.amazonaws.athena.connectors.dynamodb.util.DDBRecordMetadata;
 import com.amazonaws.athena.connectors.dynamodb.util.DDBTypeUtils;
-import com.amazonaws.util.json.Jackson;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -321,7 +321,8 @@ public class DynamoDBRecordHandler
         Map<String, AttributeValue> expressionAttributeValues = new HashMap<>();
         if (rangeKeyFilter != null || nonKeyFilter != null) {
             try {
-                expressionAttributeNames.putAll(Jackson.getObjectMapper().readValue(split.getProperty(EXPRESSION_NAMES_METADATA), STRING_MAP_TYPE_REFERENCE));
+                ObjectMapper objectMapper = new ObjectMapper();
+                expressionAttributeNames.putAll(objectMapper.readValue(split.getProperty(EXPRESSION_NAMES_METADATA), STRING_MAP_TYPE_REFERENCE));
                 expressionAttributeValues.putAll(EnhancedDocument.fromJson(split.getProperty(EXPRESSION_VALUES_METADATA)).toMap());
             }
             catch (IOException e) {
@@ -388,7 +389,8 @@ public class DynamoDBRecordHandler
         Map<String, AttributeValue> expressionAttributeValues = new HashMap<>();
         if (rangeKeyFilter != null || nonKeyFilter != null) {
             try {
-                expressionAttributeNames.putAll(Jackson.getObjectMapper().readValue(split.getProperty(EXPRESSION_NAMES_METADATA), STRING_MAP_TYPE_REFERENCE));
+                ObjectMapper objectMapper = new ObjectMapper();
+                expressionAttributeNames.putAll(objectMapper.readValue(split.getProperty(EXPRESSION_NAMES_METADATA), STRING_MAP_TYPE_REFERENCE));
                 expressionAttributeValues.putAll(EnhancedDocument.fromJson(split.getProperty(EXPRESSION_VALUES_METADATA)).toMap());
             }
             catch (IOException e) {

--- a/athena-elasticsearch/src/main/java/com/amazonaws/athena/connectors/elasticsearch/AwsRestHighLevelClientFactory.java
+++ b/athena-elasticsearch/src/main/java/com/amazonaws/athena/connectors/elasticsearch/AwsRestHighLevelClientFactory.java
@@ -19,9 +19,9 @@
  */
 package com.amazonaws.athena.connectors.elasticsearch;
 
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -100,7 +100,7 @@ public class AwsRestHighLevelClientFactory
     {
         if (useAwsCredentials) {
             return new AwsRestHighLevelClient.Builder(endpoint)
-                    .withCredentials(new DefaultAWSCredentialsProviderChain()).build();
+                    .withCredentials(DefaultCredentialsProvider.create()).build();
         }
         else {
             Matcher credentials = credentialsPattern.matcher(endpoint);

--- a/athena-federation-sdk/pom.xml
+++ b/athena-federation-sdk/pom.xml
@@ -27,33 +27,6 @@
     </licenses>
     <dependencies>
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-core</artifactId>
-            <version>${aws-sdk.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.datatype</groupId>
-                    <artifactId>jackson-datatype-jsr310</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.dataformat</groupId>
-                    <artifactId>jackson-dataformat-cbor</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-annotations</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>apache-client</artifactId>
             <version>${aws-sdk-v2.version}</version>

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/credentials/CrossAccountCredentialsProvider.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/credentials/CrossAccountCredentialsProvider.java
@@ -19,12 +19,12 @@
  */
 package com.amazonaws.athena.connector.credentials;
 
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicSessionCredentials;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 import software.amazon.awssdk.services.sts.model.AssumeRoleResponse;
@@ -39,7 +39,7 @@ public class CrossAccountCredentialsProvider
 
     private CrossAccountCredentialsProvider() {}
 
-    public static AWSCredentialsProvider getCrossAccountCredentialsIfPresent(Map<String, String> configOptions, String roleSessionName)
+    public static AwsCredentialsProvider getCrossAccountCredentialsIfPresent(Map<String, String> configOptions, String roleSessionName)
     {
         if (configOptions.containsKey(CROSS_ACCOUNT_ROLE_ARN_CONFIG)) {
             logger.debug("Found cross-account role arn to assume.");
@@ -50,9 +50,9 @@ public class CrossAccountCredentialsProvider
                 .build();
             AssumeRoleResponse assumeRoleResponse = stsClient.assumeRole(assumeRoleRequest);
             Credentials credentials = assumeRoleResponse.credentials();
-            BasicSessionCredentials basicSessionCredentials = new BasicSessionCredentials(credentials.accessKeyId(), credentials.secretAccessKey(), credentials.sessionToken());
-            return new AWSStaticCredentialsProvider(basicSessionCredentials);
+            AwsSessionCredentials awsSessionCredentials = AwsSessionCredentials.builder().accessKeyId(credentials.accessKeyId()).secretAccessKey(credentials.secretAccessKey()).sessionToken(credentials.sessionToken()).build();
+            return StaticCredentialsProvider.create(awsSessionCredentials);
         }
-        return DefaultAWSCredentialsProviderChain.getInstance();
+        return DefaultCredentialsProvider.create();
     }
 }

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/DateTimeFormatterUtil.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/DateTimeFormatterUtil.java
@@ -19,13 +19,13 @@
  */
 package com.amazonaws.athena.connector.lambda.data;
 
-import com.amazonaws.util.StringUtils;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.commons.lang3.time.DateFormatUtils;
 import org.apache.commons.lang3.time.DateUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.utils.StringUtils;
 
 import java.math.BigDecimal;
 import java.text.ParseException;
@@ -98,7 +98,7 @@ public class DateTimeFormatterUtil
     public static LocalDate stringToLocalDate(String value, String dateFormat,
                                               ZoneId defaultTimeZone)
     {
-        if (StringUtils.isNullOrEmpty(dateFormat)) {
+        if (StringUtils.isEmpty(dateFormat)) {
             logger.info("Unable to parse {} as Date type due to invalid dateformat", value);
             return null;
         }
@@ -143,7 +143,7 @@ public class DateTimeFormatterUtil
      */
     public static Object stringToDateTime(String value, String dateFormat, ZoneId defaultTimeZone)
     {
-        if (StringUtils.isNullOrEmpty(dateFormat)) {
+        if (StringUtils.isEmpty(dateFormat)) {
             logger.warn("Unable to parse {} as DateTime type due to invalid date format", value);
             return null;
         }

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/QueryStatusCheckerTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/QueryStatusCheckerTest.java
@@ -19,9 +19,9 @@
  */
 package com.amazonaws.athena.connector.lambda;
 
-import com.amazonaws.AmazonServiceException;
 import com.google.common.collect.ImmutableList;
 
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.services.athena.AthenaClient;
 import software.amazon.awssdk.services.athena.model.GetQueryExecutionRequest;
 import software.amazon.awssdk.services.athena.model.GetQueryExecutionResponse;
@@ -111,7 +111,7 @@ public class QueryStatusCheckerTest
     {
         String queryId = "query3";
         GetQueryExecutionRequest request = GetQueryExecutionRequest.builder().queryExecutionId(queryId).build();
-        when(athena.getQueryExecution(request)).thenThrow(new AmazonServiceException(""));
+        when(athena.getQueryExecution(request)).thenThrow(AwsServiceException.builder().message("").build());
         try (QueryStatusChecker queryStatusChecker = new QueryStatusChecker(athena, athenaInvoker, queryId)) {
             assertTrue(queryStatusChecker.isQueryRunning());
             Thread.sleep(3000);

--- a/athena-jdbc/pom.xml
+++ b/athena-jdbc/pom.xml
@@ -101,9 +101,9 @@
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-redshift -->
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-redshift</artifactId>
-            <version>${aws-sdk.version}</version>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>redshift</artifactId>
+            <version>${aws-sdk-v2.version}</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awscdk/redshift -->

--- a/athena-kafka/src/test/java/com/amazonaws/athena/connectors/kafka/KafkaUtilsTest.java
+++ b/athena-kafka/src/test/java/com/amazonaws/athena/connectors/kafka/KafkaUtilsTest.java
@@ -21,9 +21,6 @@ package com.amazonaws.athena.connectors.kafka;
 
 import com.amazonaws.athena.connectors.kafka.dto.SplitParameters;
 import com.amazonaws.athena.connectors.kafka.dto.TopicResultSet;
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.arrow.vector.types.Types;
@@ -42,6 +39,10 @@ import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
+
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
@@ -81,13 +82,13 @@ public class KafkaUtilsTest {
     GetSecretValueResponse secretValueResponse;
 
     @Mock
-    DefaultAWSCredentialsProviderChain chain;
+    DefaultCredentialsProvider chain;
 
     @Mock
-    AWSStaticCredentialsProvider credentialsProvider;
+    StaticCredentialsProvider credentialsProvider;
 
     @Mock
-    BasicAWSCredentials credentials;
+    AwsBasicCredentials credentials;
 
     @Mock
     S3Client amazonS3Client;
@@ -100,7 +101,7 @@ public class KafkaUtilsTest {
         "certificates_s3_reference", "s3://kafka-connector-test-bucket/kafkafiles/",
         "secrets_manager_secret", "Kafka_afq");
 
-    private MockedConstruction<DefaultAWSCredentialsProviderChain> mockedDefaultCredentials;
+    private MockedConstruction<DefaultCredentialsProvider> mockedDefaultCredentials;
     private MockedStatic<S3Client> mockedS3ClientBuilder;
     private MockedStatic<SecretsManagerClient> mockedSecretsManagerClient;
 
@@ -126,9 +127,9 @@ public class KafkaUtilsTest {
         Mockito.when(secretValueResponse.secretString()).thenReturn(creds);
         Mockito.when(awsSecretsManager.getSecretValue(Mockito.isA(GetSecretValueRequest.class))).thenReturn(secretValueResponse);
 
-        mockedDefaultCredentials = Mockito.mockConstruction(DefaultAWSCredentialsProviderChain.class,
+        mockedDefaultCredentials = Mockito.mockConstruction(DefaultCredentialsProvider.class,
                 (mock, context) -> {
-                    Mockito.when(mock.getCredentials()).thenReturn(credentials);
+                    Mockito.when(mock.resolveCredentials()).thenReturn(credentials);
                 });
         mockedS3ClientBuilder = Mockito.mockStatic(S3Client.class);
         mockedS3ClientBuilder.when(()-> S3Client.create()).thenReturn(amazonS3Client);

--- a/athena-msk/pom.xml
+++ b/athena-msk/pom.xml
@@ -16,6 +16,13 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom</artifactId>
+                <version>${aws-sdk-v2.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-stdlib</artifactId>
                 <version>2.0.20</version>

--- a/athena-msk/pom.xml
+++ b/athena-msk/pom.xml
@@ -59,11 +59,6 @@
                 <scope>runtime</scope>
             </dependency>
             <dependency>
-                <groupId>com.amazonaws</groupId>
-                <artifactId>aws-java-sdk-sts</artifactId>
-                <version>1.12.772</version>
-            </dependency>
-            <dependency>
                 <groupId>software.amazon.msk</groupId>
                 <artifactId>aws-msk-iam-auth</artifactId>
                 <version>2.1.1</version>

--- a/athena-vertica/src/main/java/com/amazonaws/athena/connectors/vertica/VerticaMetadataHandler.java
+++ b/athena-vertica/src/main/java/com/amazonaws/athena/connectors/vertica/VerticaMetadataHandler.java
@@ -20,7 +20,6 @@
 
 package com.amazonaws.athena.connectors.vertica;
 
-import com.amazonaws.SdkClientException;
 import com.amazonaws.athena.connector.lambda.QueryStatusChecker;
 import com.amazonaws.athena.connector.lambda.data.Block;
 import com.amazonaws.athena.connector.lambda.data.BlockAllocator;
@@ -57,6 +56,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.stringtemplate.v4.ST;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.ListObjectsRequest;

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,6 @@
         <maven.compiler.release>11</maven.compiler.release>
         <maven.compiler.plugin.version>3.13.0</maven.compiler.plugin.version>
         <!--- to meet engine version 1.12.533-->
-        <aws-sdk.version>1.12.772</aws-sdk.version>
         <aws-sdk-v2.version>2.28.9</aws-sdk-v2.version>
         <aws.lambda-java-core.version>1.2.2</aws.lambda-java-core.version>
         <aws.lambda-java-log4j2.version>1.6.0</aws.lambda-java-log4j2.version>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <maven.compiler.plugin.version>3.13.0</maven.compiler.plugin.version>
         <!--- to meet engine version 1.12.533-->
         <aws-sdk.version>1.12.772</aws-sdk.version>
-        <aws-sdk-v2.version>2.25.56</aws-sdk-v2.version>
+        <aws-sdk-v2.version>2.28.9</aws-sdk-v2.version>
         <aws.lambda-java-core.version>1.2.2</aws.lambda-java-core.version>
         <aws.lambda-java-log4j2.version>1.6.0</aws.lambda-java-log4j2.version>
         <aws-cdk.version>1.204.0</aws-cdk.version>


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-athena-query-federation/issues/1960

*Description of changes:*
Final few changes to fully remove the dependency on AWS SDK v1.

Key changes:
* com.amazonaws.util.json.Jackson was removed in v2, so ObjectMappers were used instead.
* AWSRequestSigningApacheInterceptor.java used many features no longer in v2. It was updated to use the new v2 features.
* CredentialsProviders updated to v2.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
