### PR TITLE
Ecr deployment

### DIFF
--- a/athena-aws-cmdb/Dockerfile
+++ b/athena-aws-cmdb/Dockerfile
@@ -1,0 +1,9 @@
+FROM public.ecr.aws/lambda/java:11
+
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-aws-cmdb-2022.47.1.jar ${LAMBDA_TASK_ROOT}
+# Unpack the jar
+RUN jar xf athena-aws-cmdb-2022.47.1.jar
+
+# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
+CMD [ "com.amazonaws.athena.connectors.aws.cmdb.AwsCmdbCompositeHandler" ]

--- a/athena-aws-cmdb/athena-aws-cmdb.yaml
+++ b/athena-aws-cmdb/athena-aws-cmdb.yaml
@@ -53,7 +53,7 @@ Resources:
           spill_prefix: !Ref SpillPrefix
       FunctionName: !Ref AthenaCatalogName
       PackageType: "Image"
-      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-aws-cmdb:2022.47.1'
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-aws-cmdb:2022.47.1'
       Description: "Enables Amazon Athena to communicate with various AWS Services, making your resource inventories accessible via SQL."
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory

--- a/athena-aws-cmdb/athena-aws-cmdb.yaml
+++ b/athena-aws-cmdb/athena-aws-cmdb.yaml
@@ -52,10 +52,9 @@ Resources:
           spill_bucket: !Ref SpillBucket
           spill_prefix: !Ref SpillPrefix
       FunctionName: !Ref AthenaCatalogName
-      Handler: "com.amazonaws.athena.connectors.aws.cmdb.AwsCmdbCompositeHandler"
-      CodeUri: "./target/athena-aws-cmdb-2022.47.1.jar"
+      PackageType: "Image"
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-aws-cmdb:2022.47.1'
       Description: "Enables Amazon Athena to communicate with various AWS Services, making your resource inventories accessible via SQL."
-      Runtime: java11
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       PermissionsBoundary: !If [ HasPermissionsBoundary, !Ref PermissionsBoundaryARN, !Ref "AWS::NoValue" ]

--- a/athena-clickhouse/Dockerfile
+++ b/athena-clickhouse/Dockerfile
@@ -1,0 +1,9 @@
+FROM public.ecr.aws/lambda/java:11
+
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-clickhouse-2022.47.1.jar ${LAMBDA_TASK_ROOT}
+# Unpack the jar
+RUN jar xf athena-clickhouse-2022.47.1.jar
+
+# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
+CMD [ "com.amazonaws.athena.connectors.clickhouse.ClickHouseMuxCompositeHandler" ]

--- a/athena-clickhouse/athena-clickhouse.yaml
+++ b/athena-clickhouse/athena-clickhouse.yaml
@@ -71,7 +71,7 @@ Resources:
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
       PackageType: "Image"
-      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-clickhouse:2022.47.1'
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-clickhouse:2022.47.1'
       Description: "Enables Amazon Athena to communicate with ClickHouse using JDBC"
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory

--- a/athena-clickhouse/athena-clickhouse.yaml
+++ b/athena-clickhouse/athena-clickhouse.yaml
@@ -70,10 +70,9 @@ Resources:
           spill_prefix: !Ref SpillPrefix
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
-      Handler: "com.amazonaws.athena.connectors.clickhouse.ClickHouseMuxCompositeHandler"
-      CodeUri: "./target/athena-clickhouse-2022.47.1.jar"
+      PackageType: "Image"
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-clickhouse:2022.47.1'
       Description: "Enables Amazon Athena to communicate with ClickHouse using JDBC"
-      Runtime: java11
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       PermissionsBoundary: !If [ HasPermissionsBoundary, !Ref PermissionsBoundaryARN, !Ref "AWS::NoValue" ]

--- a/athena-cloudera-hive/Dockerfile
+++ b/athena-cloudera-hive/Dockerfile
@@ -1,0 +1,9 @@
+FROM public.ecr.aws/lambda/java:11
+
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-cloudera-hive-2022.47.1.jar ${LAMBDA_TASK_ROOT}
+# Unpack the jar
+RUN jar xf athena-cloudera-hive-2022.47.1.jar
+
+# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
+CMD [ "com.amazonaws.athena.connectors.cloudera.HiveMuxCompositeHandler" ]

--- a/athena-cloudera-hive/athena-cloudera-hive.yaml
+++ b/athena-cloudera-hive/athena-cloudera-hive.yaml
@@ -66,7 +66,7 @@ Resources:
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
       PackageType: "Image"
-      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-cloudera-hive:2022.47.1'
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-cloudera-hive:2022.47.1'
       Description: "Enables Amazon Athena to communicate with Coludera Hive using JDBC"
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory

--- a/athena-cloudera-hive/athena-cloudera-hive.yaml
+++ b/athena-cloudera-hive/athena-cloudera-hive.yaml
@@ -65,10 +65,9 @@ Resources:
           spill_prefix: !Ref SpillPrefix
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
-      Handler: "com.amazonaws.athena.connectors.cloudera.HiveMuxCompositeHandler"
-      CodeUri: "./target/athena-cloudera-hive-2022.47.1.jar"
+      PackageType: "Image"
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-cloudera-hive:2022.47.1'
       Description: "Enables Amazon Athena to communicate with Coludera Hive using JDBC"
-      Runtime: java11
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       PermissionsBoundary: !If [ HasPermissionsBoundary, !Ref PermissionsBoundaryARN, !Ref "AWS::NoValue" ]

--- a/athena-cloudera-impala/Dockerfile
+++ b/athena-cloudera-impala/Dockerfile
@@ -1,0 +1,9 @@
+FROM public.ecr.aws/lambda/java:11
+
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-cloudera-impala-2022.47.1.jar ${LAMBDA_TASK_ROOT}
+# Unpack the jar
+RUN jar xf athena-cloudera-impala-2022.47.1.jar
+
+# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
+CMD [ "com.amazonaws.athena.connectors.cloudera.ImpalaMuxCompositeHandler" ]

--- a/athena-cloudera-impala/athena-cloudera-impala.yaml
+++ b/athena-cloudera-impala/athena-cloudera-impala.yaml
@@ -71,7 +71,7 @@ Resources:
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
       PackageType: "Image"
-      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-cloudera-impala:2022.47.1'
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-cloudera-impala:2022.47.1'
       Description: "Enables Amazon Athena to communicate with Cloudera Impala using JDBC"
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory

--- a/athena-cloudera-impala/athena-cloudera-impala.yaml
+++ b/athena-cloudera-impala/athena-cloudera-impala.yaml
@@ -70,10 +70,9 @@ Resources:
           spill_prefix: !Ref SpillPrefix
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
-      Handler: "com.amazonaws.athena.connectors.cloudera.ImpalaMuxCompositeHandler"
-      CodeUri: "./target/athena-cloudera-impala-2022.47.1.jar"
+      PackageType: "Image"
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-cloudera-impala:2022.47.1'
       Description: "Enables Amazon Athena to communicate with Cloudera Impala using JDBC"
-      Runtime: java11
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       PermissionsBoundary: !If [ HasPermissionsBoundary, !Ref PermissionsBoundaryARN, !Ref "AWS::NoValue" ]

--- a/athena-cloudwatch-metrics/Dockerfile
+++ b/athena-cloudwatch-metrics/Dockerfile
@@ -1,0 +1,9 @@
+FROM public.ecr.aws/lambda/java:11
+
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-cloudwatch-metrics-2022.47.1.jar ${LAMBDA_TASK_ROOT}
+# Unpack the jar
+RUN jar xf athena-cloudwatch-metrics-2022.47.1.jar
+
+# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
+CMD [ "com.amazonaws.athena.connectors.cloudwatch.metrics.MetricsCompositeHandler" ]

--- a/athena-cloudwatch-metrics/athena-cloudwatch-metrics.yaml
+++ b/athena-cloudwatch-metrics/athena-cloudwatch-metrics.yaml
@@ -53,7 +53,7 @@ Resources:
           spill_prefix: !Ref SpillPrefix
       FunctionName: !Ref AthenaCatalogName
       PackageType: "Image"
-      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-cloudwatch-metrics:2022.47.1'
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-cloudwatch-metrics:2022.47.1'
       Description: "Enables Amazon Athena to communicate with Cloudwatch Metrics, making your metrics data accessible via SQL"
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory

--- a/athena-cloudwatch-metrics/athena-cloudwatch-metrics.yaml
+++ b/athena-cloudwatch-metrics/athena-cloudwatch-metrics.yaml
@@ -52,10 +52,9 @@ Resources:
           spill_bucket: !Ref SpillBucket
           spill_prefix: !Ref SpillPrefix
       FunctionName: !Ref AthenaCatalogName
-      Handler: "com.amazonaws.athena.connectors.cloudwatch.metrics.MetricsCompositeHandler"
-      CodeUri: "./target/athena-cloudwatch-metrics-2022.47.1.jar"
+      PackageType: "Image"
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-cloudwatch-metrics:2022.47.1'
       Description: "Enables Amazon Athena to communicate with Cloudwatch Metrics, making your metrics data accessible via SQL"
-      Runtime: java11
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       PermissionsBoundary: !If [ HasPermissionsBoundary, !Ref PermissionsBoundaryARN, !Ref "AWS::NoValue" ]

--- a/athena-cloudwatch/Dockerfile
+++ b/athena-cloudwatch/Dockerfile
@@ -1,0 +1,9 @@
+FROM public.ecr.aws/lambda/java:11
+
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-cloudwatch-2022.47.1.jar ${LAMBDA_TASK_ROOT}
+# Unpack the jar
+RUN jar xf athena-cloudwatch-2022.47.1.jar
+
+# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
+CMD [ "com.amazonaws.athena.connectors.cloudwatch.CloudwatchCompositeHandler" ]

--- a/athena-cloudwatch/athena-cloudwatch.yaml
+++ b/athena-cloudwatch/athena-cloudwatch.yaml
@@ -67,7 +67,7 @@ Resources:
           kms_key_id: !If [HasKMSKeyId, !Ref KMSKeyId, !Ref "AWS::NoValue"]
       FunctionName: !Ref AthenaCatalogName
       PackageType: "Image"
-      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-cloudwatch:2022.47.1'
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-cloudwatch:2022.47.1'
       Description: "Enables Amazon Athena to communicate with Cloudwatch, making your log accessible via SQL"
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory

--- a/athena-cloudwatch/athena-cloudwatch.yaml
+++ b/athena-cloudwatch/athena-cloudwatch.yaml
@@ -66,10 +66,9 @@ Resources:
           spill_prefix: !Ref SpillPrefix
           kms_key_id: !If [HasKMSKeyId, !Ref KMSKeyId, !Ref "AWS::NoValue"]
       FunctionName: !Ref AthenaCatalogName
-      Handler: "com.amazonaws.athena.connectors.cloudwatch.CloudwatchCompositeHandler"
-      CodeUri: "./target/athena-cloudwatch-2022.47.1.jar"
+      PackageType: "Image"
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-cloudwatch:2022.47.1'
       Description: "Enables Amazon Athena to communicate with Cloudwatch, making your log accessible via SQL"
-      Runtime: java11
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       Role: !If [NotHasLambdaRole, !GetAtt FunctionRole.Arn, !Ref LambdaRole]

--- a/athena-datalakegen2/Dockerfile
+++ b/athena-datalakegen2/Dockerfile
@@ -1,0 +1,9 @@
+FROM public.ecr.aws/lambda/java:11
+
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-datalakegen2-2022.47.1.jar ${LAMBDA_TASK_ROOT}
+# Unpack the jar
+RUN jar xf athena-datalakegen2-2022.47.1.jar
+
+# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
+CMD [ "com.amazonaws.athena.connectors.datalakegen2.DataLakeGen2MuxCompositeHandler" ]

--- a/athena-datalakegen2/athena-datalakegen2.yaml
+++ b/athena-datalakegen2/athena-datalakegen2.yaml
@@ -72,7 +72,7 @@ Resources:
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
       PackageType: "Image"
-      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-datalakegen2:2022.47.1'
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-datalakegen2:2022.47.1'
       Description: "Enables Amazon Athena to communicate with DataLake Gen2 using JDBC"
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory

--- a/athena-datalakegen2/athena-datalakegen2.yaml
+++ b/athena-datalakegen2/athena-datalakegen2.yaml
@@ -71,10 +71,9 @@ Resources:
           spill_prefix: !Ref SpillPrefix
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
-      Handler: "com.amazonaws.athena.connectors.datalakegen2.DataLakeGen2MuxCompositeHandler"
-      CodeUri: "./target/athena-datalakegen2-2022.47.1.jar"
+      PackageType: "Image"
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-datalakegen2:2022.47.1'
       Description: "Enables Amazon Athena to communicate with DataLake Gen2 using JDBC"
-      Runtime: java11
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       PermissionsBoundary: !If [ HasPermissionsBoundary, !Ref PermissionsBoundaryARN, !Ref "AWS::NoValue" ]

--- a/athena-db2-as400/Dockerfile
+++ b/athena-db2-as400/Dockerfile
@@ -1,0 +1,9 @@
+FROM public.ecr.aws/lambda/java:11
+
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-db2-as400-2022.47.1.jar ${LAMBDA_TASK_ROOT}
+# Unpack the jar
+RUN jar xf athena-db2-as400-2022.47.1.jar
+
+# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
+CMD [ "com.amazonaws.athena.connectors.db2as400.Db2As400MuxCompositeHandler" ]

--- a/athena-db2-as400/athena-db2-as400.yaml
+++ b/athena-db2-as400/athena-db2-as400.yaml
@@ -73,7 +73,7 @@ Resources:
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
       PackageType: "Image"
-      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-db2-as400:2022.47.1'
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-db2-as400:2022.47.1'
       Description: "Enables Amazon Athena to communicate with DB2 on iSeries (AS400) using JDBC"
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory

--- a/athena-db2-as400/athena-db2-as400.yaml
+++ b/athena-db2-as400/athena-db2-as400.yaml
@@ -72,10 +72,9 @@ Resources:
           spill_prefix: !Ref SpillPrefix
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
-      Handler: "com.amazonaws.athena.connectors.db2as400.Db2As400MuxCompositeHandler"
-      CodeUri: "./target/athena-db2-as400-2022.47.1.jar"
+      PackageType: "Image"
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-db2-as400:2022.47.1'
       Description: "Enables Amazon Athena to communicate with DB2 on iSeries (AS400) using JDBC"
-      Runtime: java11
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       PermissionsBoundary: !If [ HasPermissionsBoundary, !Ref PermissionsBoundaryARN, !Ref "AWS::NoValue" ]

--- a/athena-db2/Dockerfile
+++ b/athena-db2/Dockerfile
@@ -1,0 +1,9 @@
+FROM public.ecr.aws/lambda/java:11
+
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-db2-2022.47.1.jar ${LAMBDA_TASK_ROOT}
+# Unpack the jar
+RUN jar xf athena-db2-2022.47.1.jar
+
+# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
+CMD [ "com.amazonaws.athena.connectors.db2.Db2MuxCompositeHandler" ]

--- a/athena-db2/athena-db2.yaml
+++ b/athena-db2/athena-db2.yaml
@@ -73,7 +73,7 @@ Resources:
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
       PackageType: "Image"
-      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-db2:2022.47.1'
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-db2:2022.47.1'
       Description: "Enables Amazon Athena to communicate with DB2 using JDBC"
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory

--- a/athena-db2/athena-db2.yaml
+++ b/athena-db2/athena-db2.yaml
@@ -72,10 +72,9 @@ Resources:
           spill_prefix: !Ref SpillPrefix
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
-      Handler: "com.amazonaws.athena.connectors.db2.Db2MuxCompositeHandler"
-      CodeUri: "./target/athena-db2-2022.47.1.jar"
+      PackageType: "Image"
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-db2:2022.47.1'
       Description: "Enables Amazon Athena to communicate with DB2 using JDBC"
-      Runtime: java11
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       PermissionsBoundary: !If [ HasPermissionsBoundary, !Ref PermissionsBoundaryARN, !Ref "AWS::NoValue" ]

--- a/athena-docdb/Dockerfile
+++ b/athena-docdb/Dockerfile
@@ -1,0 +1,9 @@
+FROM public.ecr.aws/lambda/java:11
+
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-docdb-2022.47.1.jar ${LAMBDA_TASK_ROOT}
+# Unpack the jar
+RUN jar xf athena-docdb-2022.47.1.jar
+
+# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
+CMD [ "com.amazonaws.athena.connectors.docdb.DocDBCompositeHandler" ]

--- a/athena-docdb/athena-docdb.yaml
+++ b/athena-docdb/athena-docdb.yaml
@@ -67,7 +67,7 @@ Resources:
           default_docdb: !Ref DocDBConnectionString
       FunctionName: !Ref AthenaCatalogName
       PackageType: "Image"
-      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-docdb:2022.47.1'
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-docdb:2022.47.1'
       Description: "Enables Amazon Athena to communicate with DocumentDB, making your DocumentDB data accessible via SQL."
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory

--- a/athena-docdb/athena-docdb.yaml
+++ b/athena-docdb/athena-docdb.yaml
@@ -66,10 +66,9 @@ Resources:
           spill_prefix: !Ref SpillPrefix
           default_docdb: !Ref DocDBConnectionString
       FunctionName: !Ref AthenaCatalogName
-      Handler: "com.amazonaws.athena.connectors.docdb.DocDBCompositeHandler"
-      CodeUri: "./target/athena-docdb-2022.47.1.jar"
+      PackageType: "Image"
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-docdb:2022.47.1'
       Description: "Enables Amazon Athena to communicate with DocumentDB, making your DocumentDB data accessible via SQL."
-      Runtime: java11
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       PermissionsBoundary: !If [ HasPermissionsBoundary, !Ref PermissionsBoundaryARN, !Ref "AWS::NoValue" ]

--- a/athena-dynamodb/Dockerfile
+++ b/athena-dynamodb/Dockerfile
@@ -1,0 +1,9 @@
+FROM public.ecr.aws/lambda/java:11
+
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-dynamodb-2022.47.1.jar ${LAMBDA_TASK_ROOT}
+# Unpack the jar
+RUN jar xf athena-dynamodb-2022.47.1.jar
+
+# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
+CMD [ "com.amazonaws.athena.connectors.dynamodb.DynamoDBCompositeHandler" ]

--- a/athena-dynamodb/athena-dynamodb.yaml
+++ b/athena-dynamodb/athena-dynamodb.yaml
@@ -67,7 +67,7 @@ Resources:
           kms_key_id: !If [HasKMSKeyId, !Ref KMSKeyId, !Ref "AWS::NoValue"]
       FunctionName: !Ref AthenaCatalogName
       PackageType: "Image"
-      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-dynamodb:2022.47.1'
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-dynamodb:2022.47.1'
       Description: "Enables Amazon Athena to communicate with DynamoDB, making your tables accessible via SQL"
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory

--- a/athena-dynamodb/athena-dynamodb.yaml
+++ b/athena-dynamodb/athena-dynamodb.yaml
@@ -66,10 +66,9 @@ Resources:
           spill_prefix: !Ref SpillPrefix
           kms_key_id: !If [HasKMSKeyId, !Ref KMSKeyId, !Ref "AWS::NoValue"]
       FunctionName: !Ref AthenaCatalogName
-      Handler: "com.amazonaws.athena.connectors.dynamodb.DynamoDBCompositeHandler"
-      CodeUri: "./target/athena-dynamodb-2022.47.1.jar"
+      PackageType: "Image"
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-dynamodb:2022.47.1'
       Description: "Enables Amazon Athena to communicate with DynamoDB, making your tables accessible via SQL"
-      Runtime: java11
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       Role: !If [NotHasLambdaRole, !GetAtt FunctionRole.Arn, !Ref LambdaRole]

--- a/athena-elasticsearch/Dockerfile
+++ b/athena-elasticsearch/Dockerfile
@@ -1,0 +1,9 @@
+FROM public.ecr.aws/lambda/java:11
+
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-elasticsearch-2022.47.1.jar ${LAMBDA_TASK_ROOT}
+# Unpack the jar
+RUN jar xf athena-elasticsearch-2022.47.1.jar
+
+# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
+CMD [ "com.amazonaws.athena.connectors.elasticsearch.ElasticsearchCompositeHandler" ]

--- a/athena-elasticsearch/athena-elasticsearch.yaml
+++ b/athena-elasticsearch/athena-elasticsearch.yaml
@@ -103,7 +103,7 @@ Resources:
           query_scroll_timeout: !Ref QueryScrollTimeout
       FunctionName: !Sub "${AthenaCatalogName}"
       PackageType: "Image"
-      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-elasticsearch:2022.47.1'
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-elasticsearch:2022.47.1'
       Description: "The Elasticsearch Lambda Connector provides Athena users the ability to query data stored on Elasticsearch clusters."
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory

--- a/athena-elasticsearch/athena-elasticsearch.yaml
+++ b/athena-elasticsearch/athena-elasticsearch.yaml
@@ -102,10 +102,9 @@ Resources:
           query_timeout_search: !Ref QueryTimeoutSearch
           query_scroll_timeout: !Ref QueryScrollTimeout
       FunctionName: !Sub "${AthenaCatalogName}"
-      Handler: "com.amazonaws.athena.connectors.elasticsearch.ElasticsearchCompositeHandler"
-      CodeUri: "./target/athena-elasticsearch-2022.47.1.jar"
+      PackageType: "Image"
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-elasticsearch:2022.47.1'
       Description: "The Elasticsearch Lambda Connector provides Athena users the ability to query data stored on Elasticsearch clusters."
-      Runtime: java11
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       PermissionsBoundary: !If [ HasPermissionsBoundary, !Ref PermissionsBoundaryARN, !Ref "AWS::NoValue" ]

--- a/athena-gcs/Dockerfile
+++ b/athena-gcs/Dockerfile
@@ -1,0 +1,9 @@
+FROM public.ecr.aws/lambda/java:11
+
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-gcs.zip ${LAMBDA_TASK_ROOT}
+# Unpack the jar
+RUN jar xf athena-gcs.zip
+
+# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
+CMD [ "com.amazonaws.athena.connectors.gcs.GcsCompositeHandler" ]

--- a/athena-gcs/athena-gcs.yaml
+++ b/athena-gcs/athena-gcs.yaml
@@ -60,7 +60,7 @@ Resources:
           secret_manager_gcp_creds_name: !Ref GCSSecretName
       FunctionName: !Ref LambdaFunctionName
       PackageType: "Image"
-      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-gcs:2022.47.1'
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-gcs:2022.47.1'
       Description: "Amazon Athena GCS Connector"
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory

--- a/athena-gcs/athena-gcs.yaml
+++ b/athena-gcs/athena-gcs.yaml
@@ -59,10 +59,9 @@ Resources:
           spill_prefix: !Ref SpillPrefix
           secret_manager_gcp_creds_name: !Ref GCSSecretName
       FunctionName: !Ref LambdaFunctionName
-      Handler: "com.amazonaws.athena.connectors.gcs.GcsCompositeHandler"
-      CodeUri: "./target/athena-gcs.zip"
+      PackageType: "Image"
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-gcs:2022.47.1'
       Description: "Amazon Athena GCS Connector"
-      Runtime: java11
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       PermissionsBoundary: !If [ HasPermissionsBoundary, !Ref PermissionsBoundaryARN, !Ref "AWS::NoValue" ]

--- a/athena-google-bigquery/Dockerfile
+++ b/athena-google-bigquery/Dockerfile
@@ -1,0 +1,9 @@
+FROM public.ecr.aws/lambda/java:11
+
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-google-bigquery-2022.47.1.jar ${LAMBDA_TASK_ROOT}
+# Unpack the jar
+RUN jar xf athena-google-bigquery-2022.47.1.jar
+
+# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
+CMD [ "com.amazonaws.athena.connectors.google.bigquery.BigQueryCompositeHandler" ]

--- a/athena-google-bigquery/athena-google-bigquery.yaml
+++ b/athena-google-bigquery/athena-google-bigquery.yaml
@@ -80,7 +80,7 @@ Resources:
           GOOGLE_APPLICATION_CREDENTIALS: '/tmp/service-account.json'
       FunctionName: !Ref LambdaFunctionName
       PackageType: "Image"
-      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-google-bigquery:2022.47.1'
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-google-bigquery:2022.47.1'
       Description: "Enables Amazon Athena to communicate with BigQuery using Google SDK"
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory

--- a/athena-google-bigquery/athena-google-bigquery.yaml
+++ b/athena-google-bigquery/athena-google-bigquery.yaml
@@ -79,10 +79,9 @@ Resources:
           big_query_endpoint: !Ref BigQueryEndpoint
           GOOGLE_APPLICATION_CREDENTIALS: '/tmp/service-account.json'
       FunctionName: !Ref LambdaFunctionName
-      Handler: "com.amazonaws.athena.connectors.google.bigquery.BigQueryCompositeHandler"
-      CodeUri: "./target/athena-google-bigquery-2022.47.1.jar"
+      PackageType: "Image"
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-google-bigquery:2022.47.1'
       Description: "Enables Amazon Athena to communicate with BigQuery using Google SDK"
-      Runtime: java11
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       PermissionsBoundary: !If [ HasPermissionsBoundary, !Ref PermissionsBoundaryARN, !Ref "AWS::NoValue" ]

--- a/athena-hbase/Dockerfile
+++ b/athena-hbase/Dockerfile
@@ -1,0 +1,9 @@
+FROM public.ecr.aws/lambda/java:11
+
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-hbase-2022.47.1.jar ${LAMBDA_TASK_ROOT}
+# Unpack the jar
+RUN jar xf athena-hbase-2022.47.1.jar
+
+# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
+CMD [ "com.amazonaws.athena.connectors.hbase.HbaseCompositeHandler" ]

--- a/athena-hbase/athena-hbase.yaml
+++ b/athena-hbase/athena-hbase.yaml
@@ -86,7 +86,7 @@ Resources:
           hbase_rpc_protection: !Ref HbaseRpcProtection
       FunctionName: !Ref AthenaCatalogName
       PackageType: "Image"
-      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-hbase:2022.47.1'
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-hbase:2022.47.1'
       Description: "Enables Amazon Athena to communicate with HBase, making your HBase data accessible via SQL"
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory

--- a/athena-hbase/athena-hbase.yaml
+++ b/athena-hbase/athena-hbase.yaml
@@ -85,10 +85,9 @@ Resources:
           principal_name: !Ref PrincipalName
           hbase_rpc_protection: !Ref HbaseRpcProtection
       FunctionName: !Ref AthenaCatalogName
-      Handler: "com.amazonaws.athena.connectors.hbase.HbaseCompositeHandler"
-      CodeUri: "./target/athena-hbase-2022.47.1.jar"
+      PackageType: "Image"
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-hbase:2022.47.1'
       Description: "Enables Amazon Athena to communicate with HBase, making your HBase data accessible via SQL"
-      Runtime: java11
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       PermissionsBoundary: !If [ HasPermissionsBoundary, !Ref PermissionsBoundaryARN, !Ref "AWS::NoValue" ]

--- a/athena-hortonworks-hive/Dockerfile
+++ b/athena-hortonworks-hive/Dockerfile
@@ -1,0 +1,9 @@
+FROM public.ecr.aws/lambda/java:11
+
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-hortonworks-hive-2022.47.1.jar ${LAMBDA_TASK_ROOT}
+# Unpack the jar
+RUN jar xf athena-hortonworks-hive-2022.47.1.jar
+
+# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
+CMD [ "com.amazonaws.athena.connectors.hortonworks.HiveMuxCompositeHandler" ]

--- a/athena-hortonworks-hive/athena-hortonworks-hive.yaml
+++ b/athena-hortonworks-hive/athena-hortonworks-hive.yaml
@@ -70,7 +70,7 @@ Resources:
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
       PackageType: "Image"
-      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-hortonworks-hive:2022.47.1'
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-hortonworks-hive:2022.47.1'
       Description: "Enables Amazon Athena to communicate with Hortonworks Hive using JDBC"
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory

--- a/athena-hortonworks-hive/athena-hortonworks-hive.yaml
+++ b/athena-hortonworks-hive/athena-hortonworks-hive.yaml
@@ -69,10 +69,9 @@ Resources:
           spill_prefix: !Ref SpillPrefix
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
-      Handler: "com.amazonaws.athena.connectors.hortonworks.HiveMuxCompositeHandler"
-      CodeUri: "./target/athena-hortonworks-hive-2022.47.1.jar"
+      PackageType: "Image"
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-hortonworks-hive:2022.47.1'
       Description: "Enables Amazon Athena to communicate with Hortonworks Hive using JDBC"
-      Runtime: java11
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       PermissionsBoundary: !If [ HasPermissionsBoundary, !Ref PermissionsBoundaryARN, !Ref "AWS::NoValue" ]

--- a/athena-kafka/Dockerfile
+++ b/athena-kafka/Dockerfile
@@ -1,0 +1,9 @@
+FROM public.ecr.aws/lambda/java:11
+
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-kafka-2022.47.1.jar ${LAMBDA_TASK_ROOT}
+# Unpack the jar
+RUN jar xf athena-kafka-2022.47.1.jar
+
+# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
+CMD [ "com.amazonaws.athena.connectors.kafka.KafkaCompositeHandler" ]

--- a/athena-kafka/athena-kafka.yaml
+++ b/athena-kafka/athena-kafka.yaml
@@ -102,7 +102,7 @@ Resources:
           auth_type: !Ref AuthType
       FunctionName: !Ref LambdaFunctionName
       PackageType: "Image"
-      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-kafka:2022.47.1'
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-kafka:2022.47.1'
       Description: "Enables Amazon Athena to communicate with Kafka clusters"
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory

--- a/athena-kafka/athena-kafka.yaml
+++ b/athena-kafka/athena-kafka.yaml
@@ -101,10 +101,9 @@ Resources:
           schema_registry_url: !Ref SchemaRegistryUrl
           auth_type: !Ref AuthType
       FunctionName: !Ref LambdaFunctionName
-      Handler: "com.amazonaws.athena.connectors.kafka.KafkaCompositeHandler"
-      CodeUri: "./target/athena-kafka-2022.47.1.jar"
+      PackageType: "Image"
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-kafka:2022.47.1'
       Description: "Enables Amazon Athena to communicate with Kafka clusters"
-      Runtime: java11
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       Role: !If [NotHasLambdaRole, !GetAtt FunctionRole.Arn, !Ref LambdaRoleARN]

--- a/athena-msk/Dockerfile
+++ b/athena-msk/Dockerfile
@@ -1,0 +1,9 @@
+FROM public.ecr.aws/lambda/java:11
+
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-msk-2022.47.1.jar ${LAMBDA_TASK_ROOT}
+# Unpack the jar
+RUN jar xf athena-msk-2022.47.1.jar
+
+# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
+CMD [ "com.amazonaws.athena.connectors.msk.AmazonMskCompositeHandler" ]

--- a/athena-msk/athena-msk.yaml
+++ b/athena-msk/athena-msk.yaml
@@ -97,7 +97,7 @@ Resources:
           auth_type: !Ref AuthType
       FunctionName: !Ref LambdaFunctionName
       PackageType: "Image"
-      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-msk:2022.47.1'
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-msk:2022.47.1'
       Description: "Enables Amazon Athena to communicate with MSK clusters"
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory

--- a/athena-msk/athena-msk.yaml
+++ b/athena-msk/athena-msk.yaml
@@ -96,10 +96,9 @@ Resources:
           kafka_endpoint: !Ref KafkaEndpoint
           auth_type: !Ref AuthType
       FunctionName: !Ref LambdaFunctionName
-      Handler: "com.amazonaws.athena.connectors.msk.AmazonMskCompositeHandler"
-      CodeUri: "./target/athena-msk-2022.47.1.jar"
+      PackageType: "Image"
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-msk:2022.47.1'
       Description: "Enables Amazon Athena to communicate with MSK clusters"
-      Runtime: java11
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       Role: !If [NotHasLambdaRole, !GetAtt FunctionRole.Arn, !Ref LambdaRoleARN]

--- a/athena-mysql/Dockerfile
+++ b/athena-mysql/Dockerfile
@@ -1,0 +1,9 @@
+FROM public.ecr.aws/lambda/java:11
+
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-mysql-2022.47.1.jar ${LAMBDA_TASK_ROOT}
+# Unpack the jar
+RUN jar xf athena-mysql-2022.47.1.jar
+
+# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
+CMD [ "com.amazonaws.athena.connectors.mysql.MySqlMuxCompositeHandler" ]

--- a/athena-mysql/athena-mysql.yaml
+++ b/athena-mysql/athena-mysql.yaml
@@ -71,7 +71,7 @@ Resources:
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
       PackageType: "Image"
-      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-mysql:2022.47.1'
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-mysql:2022.47.1'
       Description: "Enables Amazon Athena to communicate with MySQL using JDBC"
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory

--- a/athena-mysql/athena-mysql.yaml
+++ b/athena-mysql/athena-mysql.yaml
@@ -70,10 +70,9 @@ Resources:
           spill_prefix: !Ref SpillPrefix
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
-      Handler: "com.amazonaws.athena.connectors.mysql.MySqlMuxCompositeHandler"
-      CodeUri: "./target/athena-mysql-2022.47.1.jar"
+      PackageType: "Image"
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-mysql:2022.47.1'
       Description: "Enables Amazon Athena to communicate with MySQL using JDBC"
-      Runtime: java11
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       PermissionsBoundary: !If [ HasPermissionsBoundary, !Ref PermissionsBoundaryARN, !Ref "AWS::NoValue" ]

--- a/athena-neptune/Dockerfile
+++ b/athena-neptune/Dockerfile
@@ -1,0 +1,9 @@
+FROM public.ecr.aws/lambda/java:11
+
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-neptune-2022.47.1.jar ${LAMBDA_TASK_ROOT}
+# Unpack the jar
+RUN jar xf athena-neptune-2022.47.1.jar
+
+# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
+CMD [ "com.amazonaws.athena.connectors.neptune.NeptuneCompositeHandler" ]

--- a/athena-neptune/athena-neptune.yaml
+++ b/athena-neptune/athena-neptune.yaml
@@ -97,7 +97,7 @@ Resources:
           enable_caseinsensitivematch: !Ref EnableCaseInsensitiveMatch
       FunctionName: !Ref AthenaCatalogName
       PackageType: "Image"
-      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-neptune:2022.47.1'
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-neptune:2022.47.1'
       Description: "Enables Amazon Athena to communicate with Neptune, making your Neptune graph data accessible via SQL."
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory

--- a/athena-neptune/athena-neptune.yaml
+++ b/athena-neptune/athena-neptune.yaml
@@ -96,10 +96,9 @@ Resources:
           SERVICE_REGION: !Ref AWS::Region
           enable_caseinsensitivematch: !Ref EnableCaseInsensitiveMatch
       FunctionName: !Ref AthenaCatalogName
-      Handler: "com.amazonaws.athena.connectors.neptune.NeptuneCompositeHandler"
-      CodeUri: "./target/athena-neptune-2022.47.1.jar"
+      PackageType: "Image"
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-neptune:2022.47.1'
       Description: "Enables Amazon Athena to communicate with Neptune, making your Neptune graph data accessible via SQL."
-      Runtime: java11
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       PermissionsBoundary: !If [ HasPermissionsBoundary, !Ref PermissionsBoundaryARN, !Ref "AWS::NoValue" ]

--- a/athena-oracle/Dockerfile
+++ b/athena-oracle/Dockerfile
@@ -1,0 +1,9 @@
+FROM public.ecr.aws/lambda/java:11
+
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-oracle-2022.47.1.jar ${LAMBDA_TASK_ROOT}
+# Unpack the jar
+RUN jar xf athena-oracle-2022.47.1.jar
+
+# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
+CMD [ "com.amazonaws.athena.connectors.oracle.OracleMuxCompositeHandler" ]

--- a/athena-oracle/athena-oracle.yaml
+++ b/athena-oracle/athena-oracle.yaml
@@ -83,7 +83,7 @@ Resources:
           is_FIPS_Enabled: !Ref IsFIPSEnabled
       FunctionName: !Ref LambdaFunctionName
       PackageType: "Image"
-      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-oracle:2022.47.1'
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-oracle:2022.47.1'
       Description: "Enables Amazon Athena to communicate with ORACLE using JDBC"
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory

--- a/athena-oracle/athena-oracle.yaml
+++ b/athena-oracle/athena-oracle.yaml
@@ -82,10 +82,9 @@ Resources:
           default: !Ref DefaultConnectionString
           is_FIPS_Enabled: !Ref IsFIPSEnabled
       FunctionName: !Ref LambdaFunctionName
-      Handler: "com.amazonaws.athena.connectors.oracle.OracleMuxCompositeHandler"
-      CodeUri: "./target/athena-oracle-2022.47.1.jar"
+      PackageType: "Image"
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-oracle:2022.47.1'
       Description: "Enables Amazon Athena to communicate with ORACLE using JDBC"
-      Runtime: java11
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       PermissionsBoundary: !If [ HasPermissionsBoundary, !Ref PermissionsBoundaryARN, !Ref "AWS::NoValue" ]

--- a/athena-postgresql/Dockerfile
+++ b/athena-postgresql/Dockerfile
@@ -1,0 +1,9 @@
+FROM public.ecr.aws/lambda/java:11
+
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-postgresql-2022.47.1.jar ${LAMBDA_TASK_ROOT}
+# Unpack the jar
+RUN jar xf athena-postgresql-2022.47.1.jar
+
+# Command can be overwritten by providing a different command in the template directly.
+# No need to specify here (already defined in athena-postgresql.yaml because has two different handlers)

--- a/athena-postgresql/athena-postgresql.yaml
+++ b/athena-postgresql/athena-postgresql.yaml
@@ -82,7 +82,7 @@ Resources:
           default_scale: !Ref DefaultScale
       FunctionName: !Ref LambdaFunctionName
       PackageType: "Image"
-      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-postgresql:2022.47.1'
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-postgresql:2022.47.1'
       ImageConfig:
         Command: [ !Sub "com.amazonaws.athena.connectors.postgresql.${CompositeHandler}" ]
       Description: "Enables Amazon Athena to communicate with PostgreSQL using JDBC"

--- a/athena-postgresql/athena-postgresql.yaml
+++ b/athena-postgresql/athena-postgresql.yaml
@@ -81,10 +81,11 @@ Resources:
           default: !Ref DefaultConnectionString
           default_scale: !Ref DefaultScale
       FunctionName: !Ref LambdaFunctionName
-      Handler: !Sub "com.amazonaws.athena.connectors.postgresql.${CompositeHandler}"
-      CodeUri: "./target/athena-postgresql-2022.47.1.jar"
+      PackageType: "Image"
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-postgresql:2022.47.1'
+      ImageConfig:
+        Command: [ !Sub "com.amazonaws.athena.connectors.postgresql.${CompositeHandler}" ]
       Description: "Enables Amazon Athena to communicate with PostgreSQL using JDBC"
-      Runtime: java11
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       PermissionsBoundary: !If [ HasPermissionsBoundary, !Ref PermissionsBoundaryARN, !Ref "AWS::NoValue" ]

--- a/athena-redis/Dockerfile
+++ b/athena-redis/Dockerfile
@@ -1,0 +1,9 @@
+FROM public.ecr.aws/lambda/java:11
+
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-redis-2022.47.1.jar ${LAMBDA_TASK_ROOT}
+# Unpack the jar
+RUN jar xf athena-redis-2022.47.1.jar
+
+# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
+CMD [ "com.amazonaws.athena.connectors.redis.RedisCompositeHandler" ]

--- a/athena-redis/athena-redis.yaml
+++ b/athena-redis/athena-redis.yaml
@@ -82,7 +82,7 @@ Resources:
           qpt_db_number: !Ref QPTConnectionDBNumber
       FunctionName: !Ref AthenaCatalogName
       PackageType: "Image"
-      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-redis:2022.47.1'
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-redis:2022.47.1'
       Description: "Enables Amazon Athena to communicate with Redis, making your Redis data accessible via SQL"
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory

--- a/athena-redis/athena-redis.yaml
+++ b/athena-redis/athena-redis.yaml
@@ -81,10 +81,9 @@ Resources:
           qpt_cluster: !Ref QPTConnectionCluster
           qpt_db_number: !Ref QPTConnectionDBNumber
       FunctionName: !Ref AthenaCatalogName
-      Handler: "com.amazonaws.athena.connectors.redis.RedisCompositeHandler"
-      CodeUri: "./target/athena-redis-2022.47.1.jar"
+      PackageType: "Image"
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-redis:2022.47.1'
       Description: "Enables Amazon Athena to communicate with Redis, making your Redis data accessible via SQL"
-      Runtime: java11
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       PermissionsBoundary: !If [ HasPermissionsBoundary, !Ref PermissionsBoundaryARN, !Ref "AWS::NoValue" ]

--- a/athena-redshift/Dockerfile
+++ b/athena-redshift/Dockerfile
@@ -1,0 +1,9 @@
+FROM public.ecr.aws/lambda/java:11
+
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-redshift-2022.47.1.jar ${LAMBDA_TASK_ROOT}
+# Unpack the jar
+RUN jar xf athena-redshift-2022.47.1.jar
+
+# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
+CMD [ "com.amazonaws.athena.connectors.redshift.RedshiftMuxCompositeHandler" ]

--- a/athena-redshift/athena-redshift.yaml
+++ b/athena-redshift/athena-redshift.yaml
@@ -80,7 +80,7 @@ Resources:
           kms_key_id: !If [HasKMSKeyId, !Ref KMSKeyId, !Ref "AWS::NoValue"]
       FunctionName: !Ref LambdaFunctionName
       PackageType: "Image"
-      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-redshift:2022.47.1'
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-redshift:2022.47.1'
       Description: "Enables Amazon Athena to communicate with Redshift using JDBC"
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory

--- a/athena-redshift/athena-redshift.yaml
+++ b/athena-redshift/athena-redshift.yaml
@@ -79,10 +79,9 @@ Resources:
           default: !Ref DefaultConnectionString
           kms_key_id: !If [HasKMSKeyId, !Ref KMSKeyId, !Ref "AWS::NoValue"]
       FunctionName: !Ref LambdaFunctionName
-      Handler: "com.amazonaws.athena.connectors.redshift.RedshiftMuxCompositeHandler"
-      CodeUri: "./target/athena-redshift-2022.47.1.jar"
+      PackageType: "Image"
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-redshift:2022.47.1'
       Description: "Enables Amazon Athena to communicate with Redshift using JDBC"
-      Runtime: java11
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       Role: !If [NotHasLambdaRole, !GetAtt FunctionRole.Arn, !Ref LambdaRole]

--- a/athena-saphana/Dockerfile
+++ b/athena-saphana/Dockerfile
@@ -1,0 +1,9 @@
+FROM public.ecr.aws/lambda/java:11
+
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-saphana.zip ${LAMBDA_TASK_ROOT}
+# Unpack the jar
+RUN jar xf athena-saphana.zip
+
+# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
+CMD [ "com.amazonaws.athena.connectors.saphana.SaphanaMuxCompositeHandler" ]

--- a/athena-saphana/athena-saphana.yaml
+++ b/athena-saphana/athena-saphana.yaml
@@ -70,7 +70,7 @@ Resources:
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
       PackageType: "Image"
-      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-saphana:2022.47.1'
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-saphana:2022.47.1'
       Description: "Enables Amazon Athena to communicate with Teradata using JDBC"
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory

--- a/athena-saphana/athena-saphana.yaml
+++ b/athena-saphana/athena-saphana.yaml
@@ -69,10 +69,9 @@ Resources:
           spill_prefix: !Ref SpillPrefix
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
-      Handler: "com.amazonaws.athena.connectors.saphana.SaphanaMuxCompositeHandler"
-      CodeUri: "./target/athena-saphana.zip"
+      PackageType: "Image"
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-saphana:2022.47.1'
       Description: "Enables Amazon Athena to communicate with Teradata using JDBC"
-      Runtime: java11
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       PermissionsBoundary: !If [ HasPermissionsBoundary, !Ref PermissionsBoundaryARN, !Ref "AWS::NoValue" ]

--- a/athena-snowflake/Dockerfile
+++ b/athena-snowflake/Dockerfile
@@ -1,0 +1,9 @@
+FROM public.ecr.aws/lambda/java:11
+
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-snowflake.zip ${LAMBDA_TASK_ROOT}
+# Unpack the jar
+RUN jar xf athena-snowflake.zip
+
+# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
+CMD [ "com.amazonaws.athena.connectors.snowflake.SnowflakeMuxCompositeHandler" ]

--- a/athena-snowflake/athena-snowflake.yaml
+++ b/athena-snowflake/athena-snowflake.yaml
@@ -70,7 +70,7 @@ Resources:
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
       PackageType: "Image"
-      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-snowflake:2022.47.1'
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-snowflake:2022.47.1'
       Description: "Enables Amazon Athena to communicate with Snowflake using JDBC"
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory

--- a/athena-snowflake/athena-snowflake.yaml
+++ b/athena-snowflake/athena-snowflake.yaml
@@ -69,10 +69,9 @@ Resources:
           spill_prefix: !Ref SpillPrefix
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
-      Handler: "com.amazonaws.athena.connectors.snowflake.SnowflakeMuxCompositeHandler"
-      CodeUri: "./target/athena-snowflake.zip"
+      PackageType: "Image"
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-snowflake:2022.47.1'
       Description: "Enables Amazon Athena to communicate with Snowflake using JDBC"
-      Runtime: java11
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       PermissionsBoundary: !If [ HasPermissionsBoundary, !Ref PermissionsBoundaryARN, !Ref "AWS::NoValue" ]

--- a/athena-sqlserver/Dockerfile
+++ b/athena-sqlserver/Dockerfile
@@ -1,0 +1,9 @@
+FROM public.ecr.aws/lambda/java:11
+
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-sqlserver-2022.47.1.jar ${LAMBDA_TASK_ROOT}
+# Unpack the jar
+RUN jar xf athena-sqlserver-2022.47.1.jar
+
+# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
+CMD [ "com.amazonaws.athena.connectors.sqlserver.SqlServerMuxCompositeHandler" ]

--- a/athena-sqlserver/athena-sqlserver.yaml
+++ b/athena-sqlserver/athena-sqlserver.yaml
@@ -77,7 +77,7 @@ Resources:
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
       PackageType: "Image"
-      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-sqlserver:2022.47.1'
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-sqlserver:2022.47.1'
       Description: "Enables Amazon Athena to communicate with SQLSERVER using JDBC"
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory

--- a/athena-sqlserver/athena-sqlserver.yaml
+++ b/athena-sqlserver/athena-sqlserver.yaml
@@ -76,10 +76,9 @@ Resources:
           spill_prefix: !Ref SpillPrefix
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
-      Handler: "com.amazonaws.athena.connectors.sqlserver.SqlServerMuxCompositeHandler"
-      CodeUri: "./target/athena-sqlserver-2022.47.1.jar"
+      PackageType: "Image"
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-sqlserver:2022.47.1'
       Description: "Enables Amazon Athena to communicate with SQLSERVER using JDBC"
-      Runtime: java11
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       PermissionsBoundary: !If [ HasPermissionsBoundary, !Ref PermissionsBoundaryARN, !Ref "AWS::NoValue" ]

--- a/athena-synapse/Dockerfile
+++ b/athena-synapse/Dockerfile
@@ -1,0 +1,9 @@
+FROM public.ecr.aws/lambda/java:11
+
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-synapse-2022.47.1.jar ${LAMBDA_TASK_ROOT}
+# Unpack the jar
+RUN jar xf athena-synapse-2022.47.1.jar
+
+# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
+CMD [ "com.amazonaws.athena.connectors.synapse.SynapseMuxCompositeHandler" ]

--- a/athena-synapse/athena-synapse.yaml
+++ b/athena-synapse/athena-synapse.yaml
@@ -79,7 +79,7 @@ Resources:
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
       PackageType: "Image"
-      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-synapse:2022.47.1'
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-synapse:2022.47.1'
       Description: "Enables Amazon Athena to communicate with SYNPASE using JDBC"
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory

--- a/athena-synapse/athena-synapse.yaml
+++ b/athena-synapse/athena-synapse.yaml
@@ -78,10 +78,9 @@ Resources:
           spill_prefix: !Ref SpillPrefix
           default: !Ref DefaultConnectionString
       FunctionName: !Ref LambdaFunctionName
-      Handler: "com.amazonaws.athena.connectors.synapse.SynapseMuxCompositeHandler"
-      CodeUri: "./target/athena-synapse-2022.47.1.jar"
+      PackageType: "Image"
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-synapse:2022.47.1'
       Description: "Enables Amazon Athena to communicate with SYNPASE using JDBC"
-      Runtime: java11
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       Role: !If [NotHasLambdaRole, !GetAtt FunctionRole.Arn, !Ref LambdaRoleARN]

--- a/athena-teradata/Dockerfile
+++ b/athena-teradata/Dockerfile
@@ -1,0 +1,9 @@
+FROM public.ecr.aws/lambda/java:11
+
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-teradata-2022.47.1.jar ${LAMBDA_TASK_ROOT}
+# Unpack the jar
+RUN jar xf athena-teradata-2022.47.1.jar
+
+# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
+CMD [ "com.amazonaws.athena.connectors.teradata.TeradataMuxCompositeHandler" ]

--- a/athena-teradata/athena-teradata.yaml
+++ b/athena-teradata/athena-teradata.yaml
@@ -80,7 +80,7 @@ Resources:
       Layers:
         - !Ref LambdaJDBCLayername
       PackageType: "Image"
-      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-teradata:2022.47.1'
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-teradata:2022.47.1'
       Description: "Enables Amazon Athena to communicate with Teradata using JDBC"
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory

--- a/athena-teradata/athena-teradata.yaml
+++ b/athena-teradata/athena-teradata.yaml
@@ -77,12 +77,11 @@ Resources:
           default: !Ref DefaultConnectionString
           partitioncount: !Ref PartitionCount
       FunctionName: !Ref LambdaFunctionName
-      Handler: "com.amazonaws.athena.connectors.teradata.TeradataMuxCompositeHandler"
       Layers:
         - !Ref LambdaJDBCLayername
-      CodeUri: "./target/athena-teradata-2022.47.1.jar"
+      PackageType: "Image"
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-teradata:2022.47.1'
       Description: "Enables Amazon Athena to communicate with Teradata using JDBC"
-      Runtime: java11
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       PermissionsBoundary: !If [ HasPermissionsBoundary, !Ref PermissionsBoundaryARN, !Ref "AWS::NoValue" ]

--- a/athena-teradata/athena-teradata.yaml
+++ b/athena-teradata/athena-teradata.yaml
@@ -30,9 +30,6 @@ Parameters:
     Description: 'The prefix within SpillBucket where this function can spill data.'
     Type: String
     Default: athena-spill
-  LambdaJDBCLayername:
-    Description: 'Lambda JDBC layer Name. Must be ARN of layer'
-    Type: String
   LambdaTimeout:
     Description: 'Maximum Lambda invocation runtime in seconds. (min 1 - 900 max)'
     Default: 900
@@ -77,8 +74,6 @@ Resources:
           default: !Ref DefaultConnectionString
           partitioncount: !Ref PartitionCount
       FunctionName: !Ref LambdaFunctionName
-      Layers:
-        - !Ref LambdaJDBCLayername
       PackageType: "Image"
       ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-teradata:2022.47.1'
       Description: "Enables Amazon Athena to communicate with Teradata using JDBC"

--- a/athena-teradata/pom.xml
+++ b/athena-teradata/pom.xml
@@ -53,6 +53,11 @@
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.teradata.jdbc</groupId>
+            <artifactId>terajdbc</artifactId>
+            <version>20.00.00.34</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/athena-timestream/Dockerfile
+++ b/athena-timestream/Dockerfile
@@ -1,0 +1,9 @@
+FROM public.ecr.aws/lambda/java:11
+
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-timestream-2022.47.1.jar ${LAMBDA_TASK_ROOT}
+# Unpack the jar
+RUN jar xf athena-timestream-2022.47.1.jar
+
+# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
+CMD [ "com.amazonaws.athena.connectors.timestream.TimestreamCompositeHandler" ]

--- a/athena-timestream/athena-timestream.yaml
+++ b/athena-timestream/athena-timestream.yaml
@@ -53,7 +53,7 @@ Resources:
           spill_prefix: !Ref SpillPrefix
       FunctionName: !Ref AthenaCatalogName
       PackageType: "Image"
-      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-timestream:2022.47.1'
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-timestream:2022.47.1'
       Description: "Enables Amazon Athena to communicate with Amazon Timestream, making your time series data accessible from Athena."
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory

--- a/athena-timestream/athena-timestream.yaml
+++ b/athena-timestream/athena-timestream.yaml
@@ -52,10 +52,9 @@ Resources:
           spill_bucket: !Ref SpillBucket
           spill_prefix: !Ref SpillPrefix
       FunctionName: !Ref AthenaCatalogName
-      Handler: "com.amazonaws.athena.connectors.timestream.TimestreamCompositeHandler"
-      CodeUri: "./target/athena-timestream-2022.47.1.jar"
+      PackageType: "Image"
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-timestream:2022.47.1'
       Description: "Enables Amazon Athena to communicate with Amazon Timestream, making your time series data accessible from Athena."
-      Runtime: java11
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       PermissionsBoundary: !If [ HasPermissionsBoundary, !Ref PermissionsBoundaryARN, !Ref "AWS::NoValue" ]

--- a/athena-tpcds/Dockerfile
+++ b/athena-tpcds/Dockerfile
@@ -1,0 +1,9 @@
+FROM public.ecr.aws/lambda/java:11
+
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-tpcds-2022.47.1.jar ${LAMBDA_TASK_ROOT}
+# Unpack the jar
+RUN jar xf athena-tpcds-2022.47.1.jar
+
+# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
+CMD [ "com.amazonaws.athena.connectors.tpcds.TPCDSCompositeHandler" ]

--- a/athena-tpcds/athena-tpcds.yaml
+++ b/athena-tpcds/athena-tpcds.yaml
@@ -53,7 +53,7 @@ Resources:
           spill_prefix: !Ref SpillPrefix
       FunctionName: !Ref AthenaCatalogName
       PackageType: "Image"
-      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-tpcds:2022.47.1'
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-tpcds:2022.47.1'
       Description: "This connector enables Amazon Athena to communicate with a randomly generated TPC-DS data source."
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory

--- a/athena-tpcds/athena-tpcds.yaml
+++ b/athena-tpcds/athena-tpcds.yaml
@@ -52,10 +52,9 @@ Resources:
           spill_bucket: !Ref SpillBucket
           spill_prefix: !Ref SpillPrefix
       FunctionName: !Ref AthenaCatalogName
-      Handler: "com.amazonaws.athena.connectors.tpcds.TPCDSCompositeHandler"
-      CodeUri: "./target/athena-tpcds-2022.47.1.jar"
+      PackageType: "Image"
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-tpcds:2022.47.1'
       Description: "This connector enables Amazon Athena to communicate with a randomly generated TPC-DS data source."
-      Runtime: java11
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       PermissionsBoundary: !If [ HasPermissionsBoundary, !Ref PermissionsBoundaryARN, !Ref "AWS::NoValue" ]

--- a/athena-udfs/Dockerfile
+++ b/athena-udfs/Dockerfile
@@ -1,0 +1,9 @@
+FROM public.ecr.aws/lambda/java:11
+
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-udfs-2022.47.1.jar ${LAMBDA_TASK_ROOT}
+# Unpack the jar
+RUN jar xf athena-udfs-2022.47.1.jar
+
+# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
+CMD [ "com.amazonaws.athena.connectors.udfs.AthenaUDFHandler" ]

--- a/athena-udfs/athena-udfs.yaml
+++ b/athena-udfs/athena-udfs.yaml
@@ -40,7 +40,7 @@ Resources:
     Properties:
       FunctionName: !Ref LambdaFunctionName
       PackageType: "Image"
-      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-udfs:2022.47.1'
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-udfs:2022.47.1'
       Description: "This connector enables Amazon Athena to leverage common UDFs made available via Lambda."
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory

--- a/athena-udfs/athena-udfs.yaml
+++ b/athena-udfs/athena-udfs.yaml
@@ -39,10 +39,9 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       FunctionName: !Ref LambdaFunctionName
-      Handler: "com.amazonaws.athena.connectors.udfs.AthenaUDFHandler"
-      CodeUri: "./target/athena-udfs-2022.47.1.jar"
+      PackageType: "Image"
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-udfs:2022.47.1'
       Description: "This connector enables Amazon Athena to leverage common UDFs made available via Lambda."
-      Runtime: java11
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       PermissionsBoundary: !If [ HasPermissionsBoundary, !Ref PermissionsBoundaryARN, !Ref "AWS::NoValue" ]

--- a/athena-vertica/Dockerfile
+++ b/athena-vertica/Dockerfile
@@ -1,0 +1,9 @@
+FROM public.ecr.aws/lambda/java:11
+
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-vertica-2022.47.1.jar ${LAMBDA_TASK_ROOT}
+# Unpack the jar
+RUN jar xf athena-vertica-2022.47.1.jar
+
+# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
+CMD [ "com.amazonaws.athena.connectors.vertica.VerticaCompositeHandler" ]

--- a/athena-vertica/athena-vertica.yaml
+++ b/athena-vertica/athena-vertica.yaml
@@ -83,7 +83,7 @@ Resources:
 
       FunctionName: !Sub "${AthenaCatalogName}"
       PackageType: "Image"
-      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-vertica:2022.47.1'
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/athena-federation-repository-vertica:2022.47.1'
       Description: "Amazon Athena Vertica Connector"
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory

--- a/athena-vertica/athena-vertica.yaml
+++ b/athena-vertica/athena-vertica.yaml
@@ -82,10 +82,9 @@ Resources:
           default: !Ref VerticaConnectionString
 
       FunctionName: !Sub "${AthenaCatalogName}"
-      Handler: "com.amazonaws.athena.connectors.vertica.VerticaCompositeHandler"
-      CodeUri: "./target/athena-vertica-2022.47.1.jar"
+      PackageType: "Image"
+      ImageUri: !Sub '292517598671.dkr.ecr.${AWS::Region}.amazonaws.com/prod-athena-federation-repository-vertica:2022.47.1'
       Description: "Amazon Athena Vertica Connector"
-      Runtime: java11
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       PermissionsBoundary: !If [ HasPermissionsBoundary, !Ref PermissionsBoundaryARN, !Ref "AWS::NoValue" ]

--- a/tools/bump_versions/bump_connectors_version.py
+++ b/tools/bump_versions/bump_connectors_version.py
@@ -49,3 +49,7 @@ if __name__ == "__main__":
         # Bump the versions in the yaml files
         yaml_files = glob.glob(f"{connector}/*.yaml") + glob.glob(f"{connector}/*.yml")
         common.update_yaml(yaml_files, new_version)
+
+        # Bump the versions in the Dockerfiles
+        dockerfiles = glob.glob("Dockerfile")
+        common.update_dockerfile(dockerfiles, new_version)

--- a/tools/bump_versions/common.py
+++ b/tools/bump_versions/common.py
@@ -36,6 +36,13 @@ def update_yaml(yaml_files, new_version):
     for yml in yaml_files:
         subprocess.run(["sed", "-i", f"s/\(SemanticVersion:\s*\).*/\\1{new_version}/", yml])
         subprocess.run(["sed", "-i", f"s/\(CodeUri:.*-\)[0-9]*\.[0-9]*\.[0-9]*\(-\?.*\.jar\)/\\1{new_version}\\2/", yml])
+        subprocess.run(["sed", "-i", f"s/\(ImageUri:.*:\)[0-9]*\.[0-9]*\.[0-9]*\(\'\)/\\1{new_version}\\2/", yml])
+
+
+def update_dockerfile(dockerfiles, new_version):
+    for file in dockerfiles:
+        subprocess.run(["sed", "-i", f"s/\(COPY\s.*-\)[0-9]*\.[0-9]*\.[0-9]*\(\.jar.*\)/\\1{new_version}\\2/", file])
+        subprocess.run(["sed", "-i", f"s/\(RUN\sjar\sxf.*-\)[0-9]*\.[0-9]*\.[0-9]*\(\.jar\)/\\1{new_version}\\2/", file])
 
 
 def update_project_version(soup, new_version):


### PR DESCRIPTION
*Description of changes:*
This PR adds Dockerfiles to each connector that take the produced jar/zip file and unpack it. The yaml files are then updated to deploy image-based lambdas instead of package based lambdas. This is done by:
* Removing the `Handler`, `CodeUri`, and `Runtime` properties.
* Adding the `PackageType`: `"Image"` property.
* Adding the `ImageUri` property with the uri pointing to the production ECR repository.
This currently works only for non-opt-in regions. An update will be made for opt-in regions to fetch the image from the correct accounts.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
