### PR TITLE
reverting PR #2273 for gbq connector as it's not required for cdk.

### DIFF
--- a/athena-google-bigquery/pom.xml
+++ b/athena-google-bigquery/pom.xml
@@ -27,16 +27,10 @@
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awscdk/rds -->
         <dependency>
-            <groupId>software.amazon.awssdk</groupId>
+            <groupId>software.amazon.awscdk</groupId>
             <artifactId>rds</artifactId>
-            <version>${aws-sdk-v2.version}</version>
+            <version>${aws-cdk.version}</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>software.amazon.awssdk</groupId>
-                    <artifactId>netty-nio-client</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <!-- Google Bigquery SDK Dependencies-->
         <dependency>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
While migrating RDS service to AWS SDK V2, accidentally updated for cdk as well. So, reverting back to original code. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
