### PR TITLE
[Fix] athena-sqlserver: Add null check for partition function and partitioning column in getPartitionWhereClauses method

### DIFF
--- a/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerQueryStringBuilder.java
+++ b/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerQueryStringBuilder.java
@@ -61,14 +61,17 @@ public class SqlServerQueryStringBuilder extends JdbcSplitQueryBuilder
     @Override
     protected List<String> getPartitionWhereClauses(Split split)
     {
-        //example query: select * from MyPartitionTable where $PARTITION.myRangePF(col1) =2
-        LOGGER.debug("PARTITION_FUNCTION: {}", split.getProperty(SqlServerMetadataHandler.PARTITION_FUNCTION));
-        LOGGER.debug("PARTITIONING_COLUMN: {}", split.getProperty(SqlServerMetadataHandler.PARTITIONING_COLUMN));
+        String partitionFunction = split.getProperty(SqlServerMetadataHandler.PARTITION_FUNCTION);
+        String partitioningColumn = split.getProperty(SqlServerMetadataHandler.PARTITIONING_COLUMN);
+        String partitionNumber = split.getProperty(SqlServerMetadataHandler.PARTITION_NUMBER);
 
-        if (split.getProperty(SqlServerMetadataHandler.PARTITION_NUMBER) != null && !split.getProperty(SqlServerMetadataHandler.PARTITION_NUMBER).equals("0")) {
+        //example query: select * from MyPartitionTable where $PARTITION.myRangePF(col1) =2
+        LOGGER.debug("PARTITION_FUNCTION: {}", partitionFunction);
+        LOGGER.debug("PARTITIONING_COLUMN: {}", partitioningColumn);
+
+        if (partitionFunction != null && partitioningColumn != null && partitionNumber != null && !partitionNumber.equals("0")) {
             LOGGER.info("Fetching data using Partition");
-            return Collections.singletonList(" $PARTITION." + split.getProperty(SqlServerMetadataHandler.PARTITION_FUNCTION)
-                    + "(" + split.getProperty(SqlServerMetadataHandler.PARTITIONING_COLUMN) + ") = " + split.getProperty(SqlServerMetadataHandler.PARTITION_NUMBER));
+            return Collections.singletonList(" $PARTITION." + partitionFunction + "(" + partitioningColumn + ") = " + partitionNumber);
         }
         else {
             LOGGER.info("Fetching data without Partition");

--- a/athena-sqlserver/src/test/java/com/amazonaws/athena/connectors/sqlserver/SqlServerQueryStringBuilderTest.java
+++ b/athena-sqlserver/src/test/java/com/amazonaws/athena/connectors/sqlserver/SqlServerQueryStringBuilderTest.java
@@ -27,6 +27,7 @@ import org.testng.Assert;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 import static com.amazonaws.athena.connectors.sqlserver.SqlServerConstants.SQLSERVER_QUOTE_CHARACTER;
 
@@ -63,6 +64,45 @@ public class SqlServerQueryStringBuilderTest
         Mockito.when(split1.getProperty(SqlServerMetadataHandler.PARTITION_NUMBER)).thenReturn("1");
         Assert.assertEquals(Collections.singletonList(" $PARTITION.pf(col) = 1"), builder.getPartitionWhereClauses(split1));
 
+    }
+
+    @Test
+    public void getPartitionWhereClausesWhenPartitionFunctionIsNull()
+    {
+        SqlServerQueryStringBuilder builder = new SqlServerQueryStringBuilder(SQLSERVER_QUOTE_CHARACTER, new SqlServerFederationExpressionParser(SQLSERVER_QUOTE_CHARACTER));
+        Split split = Mockito.mock(Split.class);
+        Mockito.when(split.getProperty(SqlServerMetadataHandler.PARTITION_FUNCTION)).thenReturn(null);
+        Mockito.when(split.getProperty(SqlServerMetadataHandler.PARTITIONING_COLUMN)).thenReturn("col");
+        Mockito.when(split.getProperty(SqlServerMetadataHandler.PARTITION_NUMBER)).thenReturn("74");
+        List<String> result = builder.getPartitionWhereClauses(split);
+        // Should return empty list if partition function is null.
+        Assert.assertEquals(0, result.size());
+    }
+
+    @Test
+    public void getPartitionWhereClausesWhenPartitioningColumnIsNull()
+    {
+        SqlServerQueryStringBuilder builder = new SqlServerQueryStringBuilder(SQLSERVER_QUOTE_CHARACTER, new SqlServerFederationExpressionParser(SQLSERVER_QUOTE_CHARACTER));
+        Split split = Mockito.mock(Split.class);
+        Mockito.when(split.getProperty(SqlServerMetadataHandler.PARTITION_FUNCTION)).thenReturn("pf");
+        Mockito.when(split.getProperty(SqlServerMetadataHandler.PARTITIONING_COLUMN)).thenReturn(null);
+        Mockito.when(split.getProperty(SqlServerMetadataHandler.PARTITION_NUMBER)).thenReturn("74");
+        List<String> result = builder.getPartitionWhereClauses(split);
+        // Should return empty list if partitioning column is null.
+        Assert.assertEquals(0, result.size());
+    }
+
+    @Test
+    public void getPartitionWhereClausesWhenPartitionFunctionAndColumnAreNull()
+    {
+        SqlServerQueryStringBuilder builder = new SqlServerQueryStringBuilder(SQLSERVER_QUOTE_CHARACTER, new SqlServerFederationExpressionParser(SQLSERVER_QUOTE_CHARACTER));
+        Split split = Mockito.mock(Split.class);
+        Mockito.when(split.getProperty(SqlServerMetadataHandler.PARTITION_FUNCTION)).thenReturn(null);
+        Mockito.when(split.getProperty(SqlServerMetadataHandler.PARTITIONING_COLUMN)).thenReturn(null);
+        Mockito.when(split.getProperty(SqlServerMetadataHandler.PARTITION_NUMBER)).thenReturn("74");
+        List<String> result = builder.getPartitionWhereClauses(split);
+        // Should return empty list if both partition function and partitioning column are null.
+        Assert.assertEquals(0, result.size());
     }
 
     @Test


### PR DESCRIPTION
This change adds a null check for the partition function and partitioning column in Athena SQL Server connector. It ensures that data will be fetched using specific partition when the necessary partition information is available.

Note: customer's schema has not yet been verified.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
