### PR TITLE
Feature/postgresql disable predicate pushdown

### DIFF
--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcSplitQueryBuilder.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcSplitQueryBuilder.java
@@ -336,7 +336,7 @@ public abstract class JdbcSplitQueryBuilder
         return "(" + Joiner.on(" OR ").join(disjuncts) + ")";
     }
 
-    protected String toPredicate(String columnName, String operator, Object value, ArrowType type,
+    private String toPredicate(String columnName, String operator, Object value, ArrowType type,
             List<TypeAndValue> accumulator)
     {
         accumulator.add(new TypeAndValue(type, value));

--- a/athena-postgresql/src/main/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlMetadataHandler.java
+++ b/athena-postgresql/src/main/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlMetadataHandler.java
@@ -98,8 +98,8 @@ public class PostGreSqlMetadataHandler
 
     static final String LIST_PAGINATED_TABLES_QUERY = "SELECT a.\"TABLE_NAME\", a.\"TABLE_SCHEM\" FROM ((SELECT table_name as \"TABLE_NAME\", table_schema as \"TABLE_SCHEM\" FROM information_schema.tables WHERE table_schema = ?) UNION (SELECT matviewname as \"TABLE_NAME\", schemaname as \"TABLE_SCHEM\" from pg_catalog.pg_matviews mv where has_table_privilege(format('%I.%I', mv.schemaname, mv.matviewname), 'select') and schemaname = ?)) AS a ORDER BY a.\"TABLE_NAME\" LIMIT ? OFFSET ?";
 
-    //Session Property Flag that hints to the engine that the data source is using default collation
-    protected static final String USING_DEFAULT_COLLATE = "using_default_collate";
+    //Session Property Flag that hints to the engine that the data source is using none default collation
+    protected static final String NON_DEFAULT_COLLATE = "non_default_collate";
 
     /**
      * Instantiates handler to be used by Lambda function directly.
@@ -150,8 +150,8 @@ public class PostGreSqlMetadataHandler
 
         //Provide a hint to the engine that postgresql is using default collate settings
         //Which doesn't match Athena's Engine Collation; this disabling Predicate pushdown
-        boolean usingDefaultCollate = Boolean.valueOf(this.configOptions.getOrDefault(USING_DEFAULT_COLLATE, "false"));
-        if (usingDefaultCollate) {
+        boolean nonDefaultCollate = Boolean.valueOf(this.configOptions.getOrDefault(NON_DEFAULT_COLLATE, "false"));
+        if (nonDefaultCollate) {
             capabilities.put(DataSourceOptimizations.DATA_SOURCE_HINTS.withSupportedSubTypes(HintsSubtype.NON_DEFAULT_COLLATE));
         }
 

--- a/athena-postgresql/src/main/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlQueryStringBuilder.java
+++ b/athena-postgresql/src/main/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlQueryStringBuilder.java
@@ -1,7 +1,4 @@
-/*-
- * #%L
- * athena-postgresql
- * %%
+/*- #%L athena-postgresql %%
  * Copyright (C) 2019 Amazon Web Services
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,10 +20,7 @@ import com.amazonaws.athena.connector.lambda.domain.Split;
 import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
 import com.amazonaws.athena.connectors.jdbc.manager.FederationExpressionParser;
 import com.amazonaws.athena.connectors.jdbc.manager.JdbcSplitQueryBuilder;
-import com.amazonaws.athena.connectors.jdbc.manager.TypeAndValue;
 import com.google.common.base.Strings;
-import org.apache.arrow.vector.types.Types;
-import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Schema;
 
 import java.sql.Connection;
@@ -37,8 +31,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import static java.lang.String.format;
-
 /**
  * Extends {@link JdbcSplitQueryBuilder} and implements PostGreSql specific SQL clauses for split.
  *
@@ -47,13 +39,9 @@ import static java.lang.String.format;
 public class PostGreSqlQueryStringBuilder
         extends JdbcSplitQueryBuilder
 {
-    private final java.util.Map<String, String> configOptions;
-    private final String postgresqlCollateExperimentalFlag = "postgresql_collate_experimental_flag";
-
-    public PostGreSqlQueryStringBuilder(final String quoteCharacters, final FederationExpressionParser federationExpressionParser, final java.util.Map<String, String> configOptions)
+    public PostGreSqlQueryStringBuilder(final String quoteCharacters, final FederationExpressionParser federationExpressionParser)
     {
         super(quoteCharacters, federationExpressionParser);
-        this.configOptions = configOptions;
     }
 
     @Override
@@ -106,10 +94,10 @@ public class PostGreSqlQueryStringBuilder
 
         if (PostGreSqlMetadataHandler.ALL_PARTITIONS.equals(partitionSchemaName) || PostGreSqlMetadataHandler.ALL_PARTITIONS.equals(partitionName)) {
             // No partitions
-            return format(" FROM %s ", tableName);
+            return String.format(" FROM %s ", tableName);
         }
 
-        return format(" FROM %s.%s ", quote(partitionSchemaName), quote(partitionName));
+        return String.format(" FROM %s.%s ", quote(partitionSchemaName), quote(partitionName));
     }
 
     @Override
@@ -121,44 +109,5 @@ public class PostGreSqlQueryStringBuilder
         }
 
         return Collections.emptyList();
-    }
-
-    protected String toPredicate(String columnName, String operator, Object value, ArrowType type,
-                                 List<TypeAndValue> accumulator)
-    {
-        if (isPostgresqlCollateExperimentalFlagEnabled()) {
-            Types.MinorType minorType = Types.getMinorTypeForArrowType(type);
-            //Only check for varchar; as it's the only collate-able type
-            //Only a range that is applicable
-            if (minorType.equals(Types.MinorType.VARCHAR) && isOperatorARange(operator)) {
-                accumulator.add(new TypeAndValue(type, value));
-                return format("%s %s ? COLLATE \"C\"", quote(columnName), operator);
-            }
-        }
-        // Default to parent's behavior
-        return super.toPredicate(columnName, operator, value, type, accumulator);
-    }
-
-    /**
-     * Flags to check if experimental flag to allow different collate for postgresql
-     * @return true if a flag is set; default otherwise to false;
-     */
-    private boolean isPostgresqlCollateExperimentalFlagEnabled()
-    {
-        String flag = configOptions.getOrDefault(postgresqlCollateExperimentalFlag, "false");
-        return flag.equalsIgnoreCase("true");
-    }
-
-    private boolean isOperatorARange(String operator)
-    {
-        switch (operator) {
-            case ">":
-            case "<":
-            case ">=":
-            case "<=":
-                return true;
-            default:
-                return false;
-        }
     }
 }

--- a/athena-postgresql/src/main/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlRecordHandler.java
+++ b/athena-postgresql/src/main/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlRecordHandler.java
@@ -72,8 +72,7 @@ public class PostGreSqlRecordHandler
     public PostGreSqlRecordHandler(DatabaseConnectionConfig databaseConnectionConfig, java.util.Map<String, String> configOptions)
     {
         this(databaseConnectionConfig, AmazonS3ClientBuilder.defaultClient(), AWSSecretsManagerClientBuilder.defaultClient(), AmazonAthenaClientBuilder.defaultClient(),
-                new GenericJdbcConnectionFactory(databaseConnectionConfig, PostGreSqlMetadataHandler.JDBC_PROPERTIES, new DatabaseConnectionInfo(POSTGRESQL_DRIVER_CLASS, POSTGRESQL_DEFAULT_PORT)),
-                new PostGreSqlQueryStringBuilder(POSTGRES_QUOTE_CHARACTER, new PostgreSqlFederationExpressionParser(POSTGRES_QUOTE_CHARACTER), configOptions), configOptions);
+                new GenericJdbcConnectionFactory(databaseConnectionConfig, PostGreSqlMetadataHandler.JDBC_PROPERTIES, new DatabaseConnectionInfo(POSTGRESQL_DRIVER_CLASS, POSTGRESQL_DEFAULT_PORT)), new PostGreSqlQueryStringBuilder(POSTGRES_QUOTE_CHARACTER, new PostgreSqlFederationExpressionParser(POSTGRES_QUOTE_CHARACTER)), configOptions);
     }
 
     @VisibleForTesting

--- a/athena-redshift/src/main/java/com/amazonaws/athena/connectors/redshift/RedshiftRecordHandler.java
+++ b/athena-redshift/src/main/java/com/amazonaws/athena/connectors/redshift/RedshiftRecordHandler.java
@@ -63,9 +63,7 @@ public class RedshiftRecordHandler
     public RedshiftRecordHandler(DatabaseConnectionConfig databaseConnectionConfig, java.util.Map<String, String> configOptions)
     {
         super(databaseConnectionConfig, AmazonS3ClientBuilder.defaultClient(), AWSSecretsManagerClientBuilder.defaultClient(), AmazonAthenaClientBuilder.defaultClient(),
-                new GenericJdbcConnectionFactory(databaseConnectionConfig, PostGreSqlMetadataHandler.JDBC_PROPERTIES,
-                        new DatabaseConnectionInfo(REDSHIFT_DRIVER_CLASS, REDSHIFT_DEFAULT_PORT)),
-                        new PostGreSqlQueryStringBuilder(POSTGRES_QUOTE_CHARACTER, new PostgreSqlFederationExpressionParser(POSTGRES_QUOTE_CHARACTER), configOptions), configOptions);
+                new GenericJdbcConnectionFactory(databaseConnectionConfig, PostGreSqlMetadataHandler.JDBC_PROPERTIES, new DatabaseConnectionInfo(REDSHIFT_DRIVER_CLASS, REDSHIFT_DEFAULT_PORT)), new PostGreSqlQueryStringBuilder(POSTGRES_QUOTE_CHARACTER, new PostgreSqlFederationExpressionParser(POSTGRES_QUOTE_CHARACTER)), configOptions);
     }
 
     @VisibleForTesting

--- a/athena-redshift/src/test/java/com/amazonaws/athena/connectors/redshift/RedshiftRecordHandlerTest.java
+++ b/athena-redshift/src/test/java/com/amazonaws/athena/connectors/redshift/RedshiftRecordHandlerTest.java
@@ -90,7 +90,7 @@ public class RedshiftRecordHandlerTest
         this.connection = Mockito.mock(Connection.class);
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         Mockito.when(this.jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(this.connection);
-        jdbcSplitQueryBuilder = new PostGreSqlQueryStringBuilder("\"", new PostgreSqlFederationExpressionParser("\""), Collections.emptyMap());
+        jdbcSplitQueryBuilder = new PostGreSqlQueryStringBuilder("\"", new PostgreSqlFederationExpressionParser("\""));
         final DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", REDSHIFT_NAME,
                 "redshift://jdbc:redshift://hostname/user=A&password=B");
 

--- a/athena-saphana/src/main/java/com/amazonaws/athena/connectors/saphana/SaphanaQueryStringBuilder.java
+++ b/athena-saphana/src/main/java/com/amazonaws/athena/connectors/saphana/SaphanaQueryStringBuilder.java
@@ -349,4 +349,11 @@ public class SaphanaQueryStringBuilder extends JdbcSplitQueryBuilder
 
         return "(" + Joiner.on(" OR ").join(disjuncts) + ")";
     }
+
+    private String toPredicate(String columnName, String operator, Object value, ArrowType type,
+                               List<TypeAndValue> accumulator)
+    {
+        accumulator.add(new TypeAndValue(type, value));
+        return quote(columnName) + " " + operator + " ?";
+    }
 }


### PR DESCRIPTION
*Description of changes:*

Two changes; 

1. Revert https://github.com/awslabs/aws-athena-query-federation/pull/2216
2. Enable Engine hint for postgresql -- to allow the Cx to tell the engine that postgresql is using default collate setting. This will in turn disable predicate pushdown. 
