### PR TITLE
Upgrade to Java 17: GitHub Actions workflows and prepare_dev_env.sh

### DIFF
--- a/.github/workflows/cut_release.yml
+++ b/.github/workflows/cut_release.yml
@@ -13,11 +13,11 @@ jobs:
           sudo apt-get install -y libxml2-utils python3
           pip3 install lxml beautifulsoup4
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           distribution: 'corretto'
-          java-version: '11'
+          java-version: '17'
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -62,22 +62,22 @@ jobs:
           git log --format='  - %s' $PREVIOUS_RELEASE_TAG..HEAD >> /tmp/RELEASE_MESSAGE
           git commit -a -F /tmp/RELEASE_MESSAGE
 
-      - name: Build Java 11 jars
+      - name: Build Java 17 jars
         run: |
           mvn clean package -T 1C -DskipTests -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN --no-transfer-progress
 
           # Copy over the sdk jars
-          mkdir -p /tmp/java11_sdk_jars/
-          cp ./athena-federation-sdk/target/aws-athena-federation-sdk-${NEW_RELEASE_VERSION}.jar /tmp/java11_sdk_jars/
-          cp ./athena-federation-sdk/target/aws-athena-federation-sdk-${NEW_RELEASE_VERSION}-withdep.jar /tmp/java11_sdk_jars/
+          mkdir -p /tmp/java17_sdk_jars/
+          cp ./athena-federation-sdk/target/aws-athena-federation-sdk-${NEW_RELEASE_VERSION}.jar /tmp/java17_sdk_jars/
+          cp ./athena-federation-sdk/target/aws-athena-federation-sdk-${NEW_RELEASE_VERSION}-withdep.jar /tmp/java17_sdk_jars/
 
           # Copy over the connector jars
-          mkdir -p /tmp/java11_connector_jars/
-          find athena-*/target -name "*.jar" -type f | grep -v "test" | grep -v "arrow" | grep -v "/original" | grep -v "example" | grep -v "\-sdk-" | grep -v "\-dsv2/" | grep -v "athena-jdbc" | xargs -I{} cp {} /tmp/java11_connector_jars/
+          mkdir -p /tmp/java17_connector_jars/
+          find athena-*/target -name "*.jar" -type f | grep -v "test" | grep -v "arrow" | grep -v "/original" | grep -v "example" | grep -v "\-sdk-" | grep -v "\-dsv2/" | grep -v "athena-jdbc" | xargs -I{} cp {} /tmp/java17_connector_jars/
 
           # Copy over the connector zips
-          mkdir -p /tmp/java11_connector_zips/
-          find athena-*/target/ -name "*.zip" -type f | grep -v "test" | grep -v "arrow" | grep -v "/original" | grep -v "example" | grep -v "\-sdk-" | grep -v "\-dsv2/" | xargs -I{} cp {} /tmp/java11_connector_zips/
+          mkdir -p /tmp/java17_connector_zips/
+          find athena-*/target/ -name "*.zip" -type f | grep -v "test" | grep -v "arrow" | grep -v "/original" | grep -v "example" | grep -v "\-sdk-" | grep -v "\-dsv2/" | xargs -I{} cp {} /tmp/java17_connector_zips/
 
       - name: Push the release branch
         run: |
@@ -107,17 +107,17 @@ jobs:
           Athena Federation SDK jars
           |CheckSum|File|
           |----------|----|
-          $(cd /tmp/java11_sdk_jars && ls | xargs -I{} cksum {} | sed 's/\([0-9]\) \([a-zA-Z]\)/\1|\2/g' | sed 's/^/|/g' | sed 's/$/|/g')
+          $(cd /tmp/java17_sdk_jars && ls | xargs -I{} cksum {} | sed 's/\([0-9]\) \([a-zA-Z]\)/\1|\2/g' | sed 's/^/|/g' | sed 's/$/|/g')
 
           Athena Federation Connector Lambda jars
           |CheckSum|File|
           |----------|----|
-          $(cd /tmp/java11_connector_jars && ls | xargs -I{} cksum {} | sed 's/\([0-9]\) \([a-zA-Z]\)/\1|\2/g' | sed 's/^/|/g' | sed 's/$/|/g')
+          $(cd /tmp/java17_connector_jars && ls | xargs -I{} cksum {} | sed 's/\([0-9]\) \([a-zA-Z]\)/\1|\2/g' | sed 's/^/|/g' | sed 's/$/|/g')
 
           Athena Federation Connector Lambda zips
           |CheckSum|File|
           |----------|----|
-          $(cd /tmp/java11_connector_zips && ls | xargs -I{} cksum {} | sed 's/\([0-9]\) \([a-zA-Z]\)/\1|\2/g' | sed 's/^/|/g' | sed 's/$/|/g')
+          $(cd /tmp/java17_connector_zips && ls | xargs -I{} cksum {} | sed 's/\([0-9]\) \([a-zA-Z]\)/\1|\2/g' | sed 's/^/|/g' | sed 's/$/|/g')
 
           ## What's Changed
           $(git log --format='- %s' v$PREVIOUS_RELEASE_VERSION..HEAD~1)
@@ -133,7 +133,7 @@ jobs:
             --notes-file /tmp/RELEASE_NOTES
           # Upload the jar attachments
           gh release upload "v$NEW_RELEASE_VERSION" \
-            $(find /tmp/java11_sdk_jars -type f) \
-            $(find /tmp/java11_connector_jars -type f) \
-            $(find /tmp/java11_connector_zips -type f) \
+            $(find /tmp/java17_sdk_jars -type f) \
+            $(find /tmp/java17_connector_jars -type f) \
+            $(find /tmp/java17_connector_zips -type f) \
             --clobber

--- a/.github/workflows/javadoc_sync.yaml
+++ b/.github/workflows/javadoc_sync.yaml
@@ -10,11 +10,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           distribution: 'corretto'
-          java-version: '11'
+          java-version: '17'
 
       - name: Build Javadoc with Maven
         run: mvn -B javadoc:aggregate --file pom.xml -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN --no-transfer-progress

--- a/.github/workflows/maven_push.yml
+++ b/.github/workflows/maven_push.yml
@@ -22,11 +22,11 @@ jobs:
     runs-on: aws-athena-query-federation_ubuntu-latest_16-core
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           distribution: 'corretto'
-          java-version: '11'
+          java-version: '17'
       # Target java 8 to ensure that the source is compatible with java 8
       - name: Build with Maven
         env:

--- a/.github/workflows/publish_to_maven_central.yml
+++ b/.github/workflows/publish_to_maven_central.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Maven Central Repository
         uses: actions/setup-java@v4
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'adopt'
           server-id: ossrh
           server-username: MAVEN_USERNAME

--- a/.github/workflows/run_release_tests.yml
+++ b/.github/workflows/run_release_tests.yml
@@ -21,11 +21,11 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 18
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           distribution: 'corretto'
-          java-version: '11'
+          java-version: '17'
       - name: Checkout repository
         uses: actions/checkout@v4
         with:

--- a/tools/prepare_dev_env.sh
+++ b/tools/prepare_dev_env.sh
@@ -45,13 +45,13 @@ echo "export PATH=\${M2_HOME}/bin:\${PATH}" >> ~/.profile
 echo "export M2_HOME=/opt/apache-maven-3.9.6" >> ~/.bash_profile
 echo "export PATH=\${M2_HOME}/bin:\${PATH}" >> ~/.bash_profile
 
-sudo yum -y install java-11-openjdk-devel
+sudo yum -y install java-17-openjdk-devel
 # If using amazon linux 2 and the above doesn't work, you can try this line instead
-# sudo amazon-linux-extras install -y java-openjdk11
+# sudo amazon-linux-extras install -y java-openjdk17
 # For amazon linux 2023, use the following line instead
-# sudo dnf install java-11-amazon-corretto
+# sudo dnf install java-17-amazon-corretto
 
-echo "Set the default to the Java 11 installation"
+echo "Set the default to the Java 17 installation"
 sudo update-alternatives --config java
 
 sh -c "$(curl -fsSL https://raw.githubusercontent.com/Linuxbrew/install/master/install.sh)"


### PR DESCRIPTION
*Description of changes:*
Updated Github Actions to java 17.
Updated prepare_dev_env.sh to java 17.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
