### PR TITLE
add default to oracle connection kmskeyid

### DIFF
--- a/athena-oracle/athena-oracle-connection.yaml
+++ b/athena-oracle/athena-oracle-connection.yaml
@@ -37,6 +37,7 @@ Parameters:
   KmsKeyId:
     Description: "(Optional) By default any data that is spilled to S3 is encrypted using AES-GCM and a randomly generated key. Setting a KMS Key ID allows your Lambda function to use KMS for key generation for a stronger source of encryption keys."
     Type: String
+    Default: ""
   LambdaRoleArn:
     Description: "(Optional) A custom role to be used by the Connector lambda"
     Type: String


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Oracle create data catalog failing due to kmskeyid being required by cloud formation. This is because it doesn't have a default.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
