### PR TITLE
Fix issue with secret being not populated for default EnvironmentProp…

### DIFF
--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/connection/EnvironmentProperties.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/connection/EnvironmentProperties.java
@@ -53,10 +53,10 @@ public class EnvironmentProperties
         HashMap<String, String> connectionEnvironment = new HashMap<>();
         if (StringUtils.isNotBlank(glueConnectionName)) {
             Connection connection = getGlueConnection(glueConnectionName);
-            Map<String, String> connectionProperties = new HashMap<>(connection.connectionPropertiesAsStrings());
-            connectionProperties.putAll(authenticationConfigurationToMap(connection.authenticationConfiguration()));
+            Map<String, String> connectionPropertiesWithSecret = new HashMap<>(connection.connectionPropertiesAsStrings());
+            connectionPropertiesWithSecret.putAll(authenticationConfigurationToMap(connection.authenticationConfiguration()));
 
-            connectionEnvironment.putAll(connectionPropertiesToEnvironment(connectionProperties));
+            connectionEnvironment.putAll(connectionPropertiesToEnvironment(connectionPropertiesWithSecret));
             connectionEnvironment.putAll(athenaPropertiesToEnvironment(connection.athenaProperties()));
         }
 
@@ -120,13 +120,14 @@ public class EnvironmentProperties
     }
 
     /**
-     * Maps glue connection properties to environment properties like 'default' and 'secret_manager_gcp_creds_name'
-     * Default behavior is to not populate environment with these properties
+     * Maps glue connection properties and authentication configuration
+     * to Athena federation environment properties like 'default' and 'secret_manager_gcp_creds_name'
+     * Default behavior is to not map to Athena federation environment variables
      *
      * @param connectionProperties contains secret_name and connection properties
      */
     public Map<String, String> connectionPropertiesToEnvironment(Map<String, String> connectionProperties)
     {
-        return new HashMap<>();
+        return connectionProperties;
     }
 }


### PR DESCRIPTION
…erties behavior

*Issue #, if available:*
Previously, authenticationConfigurationToMap would correctly populate secret_name. However, the output gets passed to connectionPropertiesToEnvironment(...) which returned an empty hashmap. This empty hashmap would mean secret_name did not exist in config map.

*Description of changes:*
connectionPropertiesToEnvironment default behavior is now to keep all glue ConnectionProperties + authentication configuration fields in environment unless connectionPropertiesToEnvironment is overriden (It is commonly overriden by jdbc connectors and bigquery for example).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
