### PR TITLE
add quotes around oracle password

### DIFF
--- a/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleJdbcConnectionFactory.java
+++ b/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleJdbcConnectionFactory.java
@@ -79,6 +79,10 @@ public class OracleJdbcConnectionFactory extends GenericJdbcConnectionFactory
                     LOGGER.info("Establishing normal connection..");
                 }
                 Matcher secretMatcher = SECRET_NAME_PATTERN.matcher(databaseConnectionConfig.getJdbcConnectionString());
+                String password = jdbcCredentialProvider.getCredential().getPassword();
+                if (!password.contains("\"")) {
+                    password = String.format("\"%s\"", password);
+                }
                 final String secretReplacement = String.format("%s/%s", jdbcCredentialProvider.getCredential().getUser(),
                         jdbcCredentialProvider.getCredential().getPassword());
                 derivedJdbcString = secretMatcher.replaceAll(Matcher.quoteReplacement(secretReplacement));


### PR DESCRIPTION
Currently if a secret is used for username and password, if the password is not encased in double quotes, it will cause an error (this is documented in the oracle DB documentation). This change checks to make sure the password is not already inside of double quotes (to not break existing customers using double quotes). If it is not, it adds the double quotes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
