### PR TITLE
update to use SSL oracle url

### DIFF
--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/connection/EnvironmentConstants.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/connection/EnvironmentConstants.java
@@ -51,4 +51,5 @@ public final class EnvironmentConstants
     public static final String ZOOKEEPER_PORT = "ZOOKEEPER_PORT";
     public static final String CUSTOM_AUTH_TYPE = "CUSTOM_AUTH_TYPE";
     public static final String GLUE_CERTIFICATES_S3_REFERENCE = "CERTIFICATE_S3_REFERENCE";
+    public static final String ENFORCE_SSL = "ENFORCE_SSL";
 }

--- a/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleEnvironmentProperties.java
+++ b/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleEnvironmentProperties.java
@@ -24,6 +24,7 @@ import com.amazonaws.athena.connectors.jdbc.JdbcEnvironmentProperties;
 import java.util.Map;
 
 import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.DATABASE;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.ENFORCE_SSL;
 import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.SECRET_NAME;
 
 public class OracleEnvironmentProperties extends JdbcEnvironmentProperties
@@ -35,7 +36,12 @@ public class OracleEnvironmentProperties extends JdbcEnvironmentProperties
         if (connectionProperties.containsKey(SECRET_NAME)) {
             prefix = prefix + "${" + connectionProperties.get(SECRET_NAME) + "}";
         }
-        prefix = prefix + "@//";
+        if (connectionProperties.containsKey(ENFORCE_SSL)) {
+            prefix = prefix + "@tcps://";
+        }
+        else {
+            prefix = prefix + "@//";
+        }
 
         return prefix;
     }

--- a/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleJdbcConnectionFactory.java
+++ b/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleJdbcConnectionFactory.java
@@ -41,10 +41,7 @@ public class OracleJdbcConnectionFactory extends GenericJdbcConnectionFactory
     private final DatabaseConnectionInfo databaseConnectionInfo;
     private final DatabaseConnectionConfig databaseConnectionConfig;
     private static final Logger LOGGER = LoggerFactory.getLogger(OracleJdbcConnectionFactory.class);
-    private static final String SSL_CONNECTION_STRING_REGEX = "jdbc:oracle:thin:\\$\\{([a-zA-Z0-9:_/+=.@-]+)\\}@" +
-            "\\((?i)description=\\(address=\\(protocol=tcps\\)\\(host=[a-zA-Z0-9-.]+\\)" +
-            "\\(port=([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])\\)\\)" +
-            "\\(connect_data=\\(sid=[a-zA-Z_]+\\)\\)\\(security=\\(ssl_server_cert_dn=\"[=a-zA-Z,0-9-.,]+\"\\)\\)\\)";
+    private static final String SSL_CONNECTION_STRING_REGEX = "jdbc:oracle:thin:\\$\\{([a-zA-Z0-9:_/+=.@-]+)\\}@tcps://";
     private static final Pattern SSL_CONNECTION_STRING_PATTERN = Pattern.compile(SSL_CONNECTION_STRING_REGEX);
 
     /**


### PR DESCRIPTION
Previously, no matter what, the same jdbc oracle url would be used. For SSL, a different oracle url is required, so SSL was not possible with a glue connection. Now, a check is added to see if the ENFORCE_SSL property is set.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
