### PR TITLE
fixing to use quoted password

### DIFF
--- a/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleJdbcConnectionFactory.java
+++ b/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleJdbcConnectionFactory.java
@@ -81,7 +81,7 @@ public class OracleJdbcConnectionFactory extends GenericJdbcConnectionFactory
                     password = String.format("\"%s\"", password);
                 }
                 final String secretReplacement = String.format("%s/%s", jdbcCredentialProvider.getCredential().getUser(),
-                        jdbcCredentialProvider.getCredential().getPassword());
+                        password);
                 derivedJdbcString = secretMatcher.replaceAll(Matcher.quoteReplacement(secretReplacement));
                 LOGGER.info("derivedJdbcString: " + derivedJdbcString);
                 return DriverManager.getConnection(derivedJdbcString, properties);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Due to a merge conflict likely, it wasn't using the `password` variable that encases the password in double quotes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
