### PR TITLE
Fix data mismatch issue in Vertica Connector

### DIFF
--- a/athena-vertica/src/main/java/com/amazonaws/athena/connectors/vertica/VerticaMetadataHandler.java
+++ b/athena-vertica/src/main/java/com/amazonaws/athena/connectors/vertica/VerticaMetadataHandler.java
@@ -369,16 +369,17 @@ public class VerticaMetadataHandler
         FieldReader fieldReaderAwsRegion = request.getPartitions().getFieldReader("awsRegionSql");
         String awsRegionSql  = fieldReaderAwsRegion.readText().toString();
 
-
-        //execute the queries on Vertica
-        executeQueriesOnVertica(connection, sqlStatement, awsRegionSql);
-
-        /*
-         * For each generated S3 object, create a split and add data to the split.
-         */
-        Split split;
         List<S3Object> s3ObjectsList = getlistExportedObjects(exportBucket, queryId);
+        if (s3ObjectsList.isEmpty()) {
+            // Execute queries on Vertica if S3 export bucket does not contain objects for given queryId
+            executeQueriesOnVertica(connection, sqlStatement, awsRegionSql);
+            // Retrieve the S3 objects list for given queryId
+            s3ObjectsList = getlistExportedObjects(exportBucket, queryId);
+        }
 
+        Split split;
+
+        // Create a split for each s3 object
         if(!s3ObjectsList.isEmpty())
         {
             for (S3Object s3Object : s3ObjectsList)


### PR DESCRIPTION
Issue #, if available:
Records mismatch for large datasets, such as 10M records.
The executeQueriesOnVertica method was being triggered multiple times due to multiple requests, leading to duplication issues.

Description of changes:
Added a conditional check to ensure that the executeQueriesOnVertica method is invoked only once per queryId. Tested with large datasets to confirm records match. Please find attached document.
[vertica-data-mismatch.odt](https://github.com/user-attachments/files/17900509/vertica-data-mismatch.odt)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
