### PR TITLE
Adding rds certs to docker image

### DIFF
--- a/athena-oracle/Dockerfile
+++ b/athena-oracle/Dockerfile
@@ -1,9 +1,42 @@
 FROM public.ecr.aws/lambda/java:11
 
+# Install necessary tools
+RUN yum update -y && yum install -y curl perl openssl
+
 # Copy function code and runtime dependencies from Maven layout
 COPY target/athena-oracle-2022.47.1.jar ${LAMBDA_TASK_ROOT}
+
 # Unpack the jar
 RUN jar xf athena-oracle-2022.47.1.jar
+
+# Set up environment variables
+ENV truststore=/var/lang/lib/security/cacerts
+ENV storepassword=changeit
+
+# Download and process the RDS certificate
+RUN curl -sS "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem" > ${LAMBDA_TASK_ROOT}/global-bundle.pem && \
+    awk 'split_after == 1 {n++;split_after=0} /-----END CERTIFICATE-----/ {split_after=1}{print > "rds-ca-" n ".pem"}' < ${LAMBDA_TASK_ROOT}/global-bundle.pem
+
+# Import certificates into the truststore
+RUN for CERT in rds-ca-*; do \
+        alias=$(openssl x509 -noout -text -in $CERT | perl -ne 'next unless /Subject:/; s/.*(CN=|CN = )//; print') && \
+        echo "Importing $alias" && \
+        keytool -import -file ${CERT} -alias "${alias}" -storepass ${storepassword} -keystore ${truststore} -noprompt && \
+        rm $CERT; \
+    done
+
+# Clean up
+RUN rm ${LAMBDA_TASK_ROOT}/global-bundle.pem
+
+# Optional: List the content of the trust store (for verification)
+RUN echo "Trust store content is: " && \
+    keytool -list -v -keystore "$truststore" -storepass ${storepassword} | grep Alias | cut -d " " -f3- | while read alias; do \
+        expiry=$(keytool -list -v -keystore "$truststore" -storepass ${storepassword} -alias "${alias}" | grep Valid | perl -ne 'if(/until: (.*?)\n/) { print "$1\n"; }'); \
+        echo " Certificate ${alias} expires in '$expiry'"; \
+    done
+
+#setting system variables
+ENV JAVA_TOOL_OPTIONS="-Djavax.net.ssl.trustStore=/var/lang/lib/security/cacerts -Djavax.net.ssl.trustStorePassword=changeit"
 
 # Command can be overwritten by providing a different command in the template directly.
 # No need to specify here (already defined in .yaml file because legacy and connections use different)


### PR DESCRIPTION
*Issue #, if available:*
SSL issue in Oracle connector
*Description of changes:*

Following the changes implemented in the DocumentDB PR raised by Abdul, similar updates have been made for importing global RDS certificates. For Oracle, as the custom trust store approach is not functioning as expected, the RDS certificates are being imported into the default trust store.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
