### PR TITLE
Add port  number as a DBS_PORT parameter in Teradata JDBC Connection String

### DIFF
--- a/athena-teradata/src/main/java/com/amazonaws/athena/connectors/teradata/TeradataEnvironmentProperties.java
+++ b/athena-teradata/src/main/java/com/amazonaws/athena/connectors/teradata/TeradataEnvironmentProperties.java
@@ -35,12 +35,10 @@ public class TeradataEnvironmentProperties extends JdbcEnvironmentProperties
     public Map<String, String> connectionPropertiesToEnvironment(Map<String, String> connectionProperties)
     {
         HashMap<String, String> environment = new HashMap<>();
-        // Default port for teradata is 1025
-        String port = connectionProperties.getOrDefault(PORT, "1025");
 
         // Construct the JDBC connection string and include the port as a DBS_PORT parameter
         String connectionString = getConnectionStringPrefix(connectionProperties) + connectionProperties.get(HOST)
-                + getDatabase(connectionProperties)  + ",DBS_PORT=" + port + getJdbcParameters(connectionProperties);
+                + getDatabase(connectionProperties)  + ",DBS_PORT=" + connectionProperties.getOrDefault(PORT, String.valueOf(TeradataConstants.TERADATA_DEFAULT_PORT)) + getJdbcParameters(connectionProperties);
 
         environment.put(DEFAULT, connectionString);
         return environment;

--- a/athena-teradata/src/main/java/com/amazonaws/athena/connectors/teradata/TeradataEnvironmentProperties.java
+++ b/athena-teradata/src/main/java/com/amazonaws/athena/connectors/teradata/TeradataEnvironmentProperties.java
@@ -21,12 +21,31 @@ package com.amazonaws.athena.connectors.teradata;
 
 import com.amazonaws.athena.connectors.jdbc.JdbcEnvironmentProperties;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.DATABASE;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.DEFAULT;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.HOST;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.PORT;
 
 public class TeradataEnvironmentProperties extends JdbcEnvironmentProperties
 {
+    @Override
+    public Map<String, String> connectionPropertiesToEnvironment(Map<String, String> connectionProperties)
+    {
+        HashMap<String, String> environment = new HashMap<>();
+        // Default port for teradata is 1025
+        String port = connectionProperties.getOrDefault(PORT, "1025");
+
+        // Construct the JDBC connection string and include the port as a DBS_PORT parameter
+        String connectionString = getConnectionStringPrefix(connectionProperties) + connectionProperties.get(HOST)
+                + getDatabase(connectionProperties)  + ",DBS_PORT=" + port + getJdbcParameters(connectionProperties);
+
+        environment.put(DEFAULT, connectionString);
+        return environment;
+    }
+
     @Override
     protected String getConnectionStringPrefix(Map<String, String> connectionProperties)
     {

--- a/athena-teradata/src/test/java/com/amazonaws/athena/connectors/teradata/TeradataEnvironmentPropertiesTest.java
+++ b/athena-teradata/src/test/java/com/amazonaws/athena/connectors/teradata/TeradataEnvironmentPropertiesTest.java
@@ -1,0 +1,70 @@
+/*-
+ * #%L
+ * athena-teradata
+ * %%
+ * Copyright (C) 2019 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.teradata;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.DATABASE;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.DEFAULT;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.HOST;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.PORT;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.SECRET_NAME;
+import static org.junit.Assert.assertEquals;
+
+public class TeradataEnvironmentPropertiesTest
+{
+    Map<String, String> connectionProperties;
+    TeradataEnvironmentProperties teradataEnvironmentProperties;
+
+    @Before
+    public void setUp()
+    {
+        connectionProperties = new HashMap<>();
+        connectionProperties.put(HOST, "test.teradata.com");
+        connectionProperties.put(DATABASE, "testdb");
+        connectionProperties.put(SECRET_NAME, "testSecret");
+        teradataEnvironmentProperties = new TeradataEnvironmentProperties();
+    }
+
+    @Test
+    public void connectionPropertiesWithCustomPort()
+    {
+        // adding custom port
+        connectionProperties.put(PORT, "1234");
+
+        Map<String, String> teradataConnectionProperties = teradataEnvironmentProperties.connectionPropertiesToEnvironment(connectionProperties);
+
+        String expectedConnectionString = "teradata://jdbc:teradata://test.teradata.com/TMODE=ANSI,CHARSET=UTF8,DATABASE=testdb,DBS_PORT=1234,${testSecret}";
+        assertEquals(expectedConnectionString, teradataConnectionProperties.get(DEFAULT));
+    }
+
+    @Test
+    public void connectionPropertiesWithDefaultPort()
+    {
+        Map<String, String> teradataConnectionProperties = teradataEnvironmentProperties.connectionPropertiesToEnvironment(connectionProperties);
+
+        String expectedConnectionString = "teradata://jdbc:teradata://test.teradata.com/TMODE=ANSI,CHARSET=UTF8,DATABASE=testdb,DBS_PORT=1025,${testSecret}";
+        assertEquals(expectedConnectionString, teradataConnectionProperties.get(DEFAULT));
+    }
+}


### PR DESCRIPTION
Issue #, if available:
The Teradata JDBC connection string requires a specific format to include the port number.
Example URL:
jdbc:teradata://host/TMODE=ANSI,CHARSET=UTF8,DATABASE=TEST,**DBS_PORT=1025**,user=dummy,password=dummy

Previously, the port was included in the connection string as host:port, which was not compatible with the Teradata JDBC driver

Description of changes:
Overridden the connectionPropertiesToEnvironment method to include the port number as a DBS_PORT parameter.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
