### PR TITLE
Oracle metadata decimal bug & Clean up

### DIFF
--- a/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleMetadataHandler.java
+++ b/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleMetadataHandler.java
@@ -378,27 +378,22 @@ public class OracleMetadataHandler
                 /** Handling TIMESTAMP, DATE, 0 Precision **/
                 if (arrowColumnType != null && arrowColumnType.getTypeID().equals(ArrowType.ArrowTypeID.Decimal)) {
                     String[] data = arrowColumnType.toString().split(",");
-                    if (scale == 0) {
+                    if (scale == 0 || Integer.parseInt(data[1].trim()) < 0) {
                         arrowColumnType = Types.MinorType.BIGINT.getType();
-                    }
-
-                    /** Handling negative scale issue */
-                    if (Integer.parseInt(data[1].trim().replace(")", "")) < 0.0) {
-                        arrowColumnType = Types.MinorType.VARCHAR.getType();
                     }
                 }
 
                 /**
                  * Converting an Oracle date data type into DATEDAY MinorType
                  */
-                if (jdbcColumnType == java.sql.Types.DATE) {
+                if (jdbcColumnType == java.sql.Types.TIMESTAMP && scale == 7) {
                     arrowColumnType = Types.MinorType.DATEDAY.getType();
                 }
 
                 /**
-                 * Converting an Oracle TIMESTAMP data type into DATEMILLI MinorType
+                 * Converting an Oracle TIMESTAMP_WITH_TZ & TIMESTAMP_WITH_LOCAL_TZ data type into DATEMILLI MinorType
                  */
-                if (jdbcColumnType == java.sql.Types.TIMESTAMP) {
+                if (jdbcColumnType == -101 || jdbcColumnType == -102) {
                     arrowColumnType = Types.MinorType.DATEMILLI.getType();
                 }
 

--- a/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleMetadataHandler.java
+++ b/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleMetadataHandler.java
@@ -73,7 +73,6 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -353,82 +352,69 @@ public class OracleMetadataHandler
     {
         SchemaBuilder schemaBuilder = SchemaBuilder.newBuilder();
 
-        try (ResultSet resultSet = getColumns(jdbcConnection.getCatalog(), tableName, jdbcConnection.getMetaData());
-             Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider())) {
+        try (ResultSet resultSet = getColumns(jdbcConnection.getCatalog(), tableName, jdbcConnection.getMetaData())) {
             boolean found = false;
-            HashMap<String, String> hashMap = new HashMap<String, String>();
-            /**
-             * Getting original data type from oracle table for conversion
-             */
-            try
-                    (PreparedStatement stmt = connection.prepareStatement("select COLUMN_NAME ,DATA_TYPE from USER_TAB_COLS where  table_name =?")) {
-                stmt.setString(1, transformString(tableName.getTableName(), true));
-                ResultSet dataTypeResultSet = stmt.executeQuery();
-                while (dataTypeResultSet.next()) {
-                    hashMap.put(dataTypeResultSet.getString(COLUMN_NAME).trim(), dataTypeResultSet.getString("DATA_TYPE").trim());
+
+            while (resultSet.next()) {
+                ArrowType arrowColumnType = JdbcArrowTypeConverter.toArrowType(
+                        resultSet.getInt("DATA_TYPE"),
+                        resultSet.getInt("COLUMN_SIZE"),
+                        resultSet.getInt("DECIMAL_DIGITS"),
+                        configOptions);
+
+                String columnName = resultSet.getString(COLUMN_NAME);
+                int jdbcColumnType = resultSet.getInt("DATA_TYPE");
+                int scale = resultSet.getInt("COLUMN_SIZE");
+
+                LOGGER.debug("columnName: {}", columnName);
+                LOGGER.debug("arrowColumnType: {}", arrowColumnType);
+                LOGGER.debug("jdbcColumnType: {}", jdbcColumnType);
+
+                /**
+                 * below data type conversion doing since a framework not giving appropriate
+                 * data types for oracle data types.
+                 */
+
+                /** Handling TIMESTAMP, DATE, 0 Precision **/
+                if (arrowColumnType != null && arrowColumnType.getTypeID().equals(ArrowType.ArrowTypeID.Decimal)) {
+                    String[] data = arrowColumnType.toString().split(",");
+                    if (scale == 0) {
+                        arrowColumnType = Types.MinorType.BIGINT.getType();
+                    }
+
+                    /** Handling negative scale issue */
+                    if (Integer.parseInt(data[1].trim().replace(")", "")) < 0.0) {
+                        arrowColumnType = Types.MinorType.VARCHAR.getType();
+                    }
                 }
-                LOGGER.debug("hashMap", hashMap.toString());
-                while (resultSet.next()) {
-                    ArrowType columnType = JdbcArrowTypeConverter.toArrowType(
-                            resultSet.getInt("DATA_TYPE"),
-                            resultSet.getInt("COLUMN_SIZE"),
-                            resultSet.getInt("DECIMAL_DIGITS"),
-                            configOptions);
-                    String columnName = resultSet.getString(COLUMN_NAME);
-                    /** Handling TIMESTAMP,DATE, 0 Precesion**/
-                    if (columnType != null && columnType.getTypeID().equals(ArrowType.ArrowTypeID.Decimal)) {
-                        String[] data = columnType.toString().split(",");
-                        if (data[0].contains("0") || data[1].contains("0")) {
-                            columnType = Types.MinorType.BIGINT.getType();
-                        }
 
-                        /** Handling negative scale issue */
-                        if (Integer.parseInt(data[1].trim().replace(")", "")) < 0.0) {
-                            columnType = Types.MinorType.VARCHAR.getType();
-                        }
-                    }
+                /**
+                 * Converting an Oracle date data type into DATEDAY MinorType
+                 */
+                if (jdbcColumnType == java.sql.Types.DATE) {
+                    arrowColumnType = Types.MinorType.DATEDAY.getType();
+                }
 
-                    String dataType = hashMap.get(columnName);
-                    LOGGER.debug("columnName: " + columnName);
-                    LOGGER.debug("dataType: " + dataType);
-                    /**
-                     * below data type conversion  doing since framework not giving appropriate
-                     * data types for oracle data types..
-                     */
-                    /**
-                     * Converting oracle date data type into DATEDAY MinorType
-                     */
-                    if (dataType != null && (dataType.contains("date") || dataType.contains("DATE"))) {
-                        columnType = Types.MinorType.DATEDAY.getType();
-                    }
-                    /**
-                     * Converting oracle NUMBER data type into BIGINT  MinorType
-                     */
-                    if (dataType != null && (dataType.contains("NUMBER")) && columnType.getTypeID().toString().equalsIgnoreCase("Utf8")) {
-                        columnType = Types.MinorType.BIGINT.getType();
-                    }
+                /**
+                 * Converting an Oracle TIMESTAMP data type into DATEMILLI MinorType
+                 */
+                if (jdbcColumnType == java.sql.Types.TIMESTAMP) {
+                    arrowColumnType = Types.MinorType.DATEMILLI.getType();
+                }
 
-                    /**
-                     * Converting oracle TIMESTAMP data type into DATEMILLI  MinorType
-                     */
-                    if (dataType != null && (dataType.contains("TIMESTAMP"))
-                    ) {
-                        columnType = Types.MinorType.DATEMILLI.getType();
-                    }
-                    if (columnType == null) {
-                        columnType = Types.MinorType.VARCHAR.getType();
-                    }
-                    if (columnType != null && !SupportedTypes.isSupported(columnType)) {
-                        columnType = Types.MinorType.VARCHAR.getType();
-                    }
+                if (arrowColumnType == null) {
+                    arrowColumnType = Types.MinorType.VARCHAR.getType();
+                }
+                if (arrowColumnType != null && !SupportedTypes.isSupported(arrowColumnType)) {
+                    arrowColumnType = Types.MinorType.VARCHAR.getType();
+                }
 
-                    if (columnType != null && SupportedTypes.isSupported(columnType)) {
-                        schemaBuilder.addField(FieldBuilder.newBuilder(columnName, columnType).build());
-                        found = true;
-                    }
-                    else {
-                        LOGGER.error("getSchema: Unable to map type for column[" + columnName + "] to a supported type, attempted " + columnType);
-                    }
+                if (arrowColumnType != null && SupportedTypes.isSupported(arrowColumnType)) {
+                    schemaBuilder.addField(FieldBuilder.newBuilder(columnName, arrowColumnType).build());
+                    found = true;
+                }
+                else {
+                    LOGGER.error("getSchema: Unable to map type for column[" + columnName + "] to a supported type, attempted " + arrowColumnType);
                 }
             }
             if (!found) {

--- a/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleMetadataHandler.java
+++ b/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleMetadataHandler.java
@@ -394,7 +394,7 @@ public class OracleMetadataHandler
                 /**
                  * Converting an Oracle TIMESTAMP_WITH_TZ & TIMESTAMP_WITH_LOCAL_TZ data type into DATEMILLI MinorType
                  */
-                if(jdbcColumnType == OracleTypes.TIMESTAMPLTZ || jdbcColumnType == OracleTypes.TIMESTAMPTZ ) {
+                if (jdbcColumnType == OracleTypes.TIMESTAMPLTZ || jdbcColumnType == OracleTypes.TIMESTAMPTZ) {
                     arrowColumnType = Types.MinorType.DATEMILLI.getType();
                 }
 

--- a/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleMetadataHandler.java
+++ b/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleMetadataHandler.java
@@ -56,6 +56,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import oracle.jdbc.OracleTypes;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.ArrowType;
@@ -393,7 +394,7 @@ public class OracleMetadataHandler
                 /**
                  * Converting an Oracle TIMESTAMP_WITH_TZ & TIMESTAMP_WITH_LOCAL_TZ data type into DATEMILLI MinorType
                  */
-                if (jdbcColumnType == -101 || jdbcColumnType == -102) {
+                if(jdbcColumnType == OracleTypes.TIMESTAMPLTZ || jdbcColumnType == OracleTypes.TIMESTAMPTZ ) {
                     arrowColumnType = Types.MinorType.DATEMILLI.getType();
                 }
 

--- a/athena-oracle/src/test/java/com/amazonaws/athena/connectors/oracle/OracleMetadataHandlerTest.java
+++ b/athena-oracle/src/test/java/com/amazonaws/athena/connectors/oracle/OracleMetadataHandlerTest.java
@@ -33,6 +33,7 @@ import com.amazonaws.athena.connectors.jdbc.TestBase;
 import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionConfig;
 import com.amazonaws.athena.connectors.jdbc.connection.JdbcConnectionFactory;
 import com.amazonaws.athena.connectors.jdbc.connection.JdbcCredentialProvider;
+import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.junit.Assert;
@@ -312,7 +313,7 @@ public class OracleMetadataHandlerTest
         BlockAllocator blockAllocator = new BlockAllocatorImpl();
         String[] schema = {"DATA_TYPE", "COLUMN_SIZE", "COLUMN_NAME", "DECIMAL_DIGITS", "NUM_PREC_RADIX"};
         Object[][] values = {{Types.INTEGER, 12, "testCol1", 0, 0}, {Types.VARCHAR, 25, "testCol2", 0, 0},
-                {Types.TIMESTAMP, 93, "testCol3", 0, 0},  {Types.TIMESTAMP_WITH_TIMEZONE, 93, "testCol4", 0, 0}};
+                {Types.TIMESTAMP, 93, "testCol3", 0, 0},  {Types.TIMESTAMP_WITH_TIMEZONE, 93, "testCol4", 0, 0}, {Types.NUMERIC, 10, "testCol5", 2, 0}};
         AtomicInteger rowNumber = new AtomicInteger(-1);
         ResultSet resultSet = mockResultSet(schema, values, rowNumber);
 
@@ -321,6 +322,8 @@ public class OracleMetadataHandlerTest
         expectedSchemaBuilder.addField(FieldBuilder.newBuilder("testCol2", org.apache.arrow.vector.types.Types.MinorType.VARCHAR.getType()).build());
         expectedSchemaBuilder.addField(FieldBuilder.newBuilder("testCol3", org.apache.arrow.vector.types.Types.MinorType.DATEMILLI.getType()).build());
         expectedSchemaBuilder.addField(FieldBuilder.newBuilder("testCol4", org.apache.arrow.vector.types.Types.MinorType.VARCHAR.getType()).build());
+        ArrowType.Decimal testCol5ArrowType = ArrowType.Decimal.createDecimal(10, 2, 128);
+        expectedSchemaBuilder.addField(FieldBuilder.newBuilder("testCol5", testCol5ArrowType).build());
         PARTITION_SCHEMA.getFields().forEach(expectedSchemaBuilder::addField);
         Schema expected = expectedSchemaBuilder.build();
 


### PR DESCRIPTION
*Issue #, if available:*
Oracle handle was misahndling classifications of decimal types; there were also other unneeded loop to get the column fields in order to reclassify some types; which now is used through the column metadata handler.  

*Description of changes:*

![image](https://github.com/user-attachments/assets/7b519096-a718-4d81-87eb-ecddbdd28795)




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
