### PR TITLE
Converting Oracle unhandled datatypes to Arrow types

### DIFF
--- a/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleMetadataHandler.java
+++ b/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleMetadataHandler.java
@@ -380,27 +380,22 @@ public class OracleMetadataHandler
                 /** Handling TIMESTAMP, DATE, 0 Precision **/
                 if (arrowColumnType != null && arrowColumnType.getTypeID().equals(ArrowType.ArrowTypeID.Decimal)) {
                     String[] data = arrowColumnType.toString().split(",");
-                    if (scale == 0) {
+                    if (scale == 0 || Integer.parseInt(data[1].trim()) < 0) {
                         arrowColumnType = Types.MinorType.BIGINT.getType();
-                    }
-
-                    /** Handling negative scale issue */
-                    if (Integer.parseInt(data[1].trim().replace(")", "")) < 0.0) {
-                        arrowColumnType = Types.MinorType.VARCHAR.getType();
                     }
                 }
 
                 /**
                  * Converting an Oracle date data type into DATEDAY MinorType
                  */
-                if (jdbcColumnType == java.sql.Types.DATE) {
+                if (jdbcColumnType == java.sql.Types.TIMESTAMP && scale == 7) {
                     arrowColumnType = Types.MinorType.DATEDAY.getType();
                 }
 
                 /**
-                 * Converting an Oracle TIMESTAMP data type into DATEMILLI MinorType
+                 * Converting an Oracle TIMESTAMP_WITH_TZ & TIMESTAMP_WITH_LOCAL_TZ data type into DATEMILLI MinorType
                  */
-                if (jdbcColumnType == java.sql.Types.TIMESTAMP) {
+                if (jdbcColumnType == -101 || jdbcColumnType == -102) {
                     arrowColumnType = Types.MinorType.DATEMILLI.getType();
                 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- date: getting jdbc column type as date(millisecond) with scale 7, updated condition check.
- TIMESTAMP_WITH_TZ, TIMESTAMP_WITH_LOCAL_TZ: updated the condition check with jdbc column type.
- negative scale datatype :  added condition on negative scale. but not sure earlier implemented condition was used as converted datatype was BIGINT. so removed the code.

attached doc with screenshots and functional test document.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
[ORACLE_FUNCTIONAL_TEST.xlsx](https://github.com/user-attachments/files/18061525/ORACLE_FUNCTIONAL_TEST.xlsx)
[Oracle_datatype_fix_test.docx](https://github.com/user-attachments/files/18061530/Oracle_datatype_fix_test.docx)
