### PR TITLE
check legacy IS_FIPS_ENABLED

### DIFF
--- a/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleJdbcConnectionFactory.java
+++ b/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleJdbcConnectionFactory.java
@@ -38,6 +38,7 @@ import java.util.regex.Pattern;
 public class OracleJdbcConnectionFactory extends GenericJdbcConnectionFactory
 {
     public static final String IS_FIPS_ENABLED = "is_fips_enabled";
+    public static final String IS_FIPS_ENABLED_LEGACY = "is_FIPS_Enabled";
     private final DatabaseConnectionInfo databaseConnectionInfo;
     private final DatabaseConnectionConfig databaseConnectionConfig;
     private static final Logger LOGGER = LoggerFactory.getLogger(OracleJdbcConnectionFactory.class);
@@ -46,8 +47,8 @@ public class OracleJdbcConnectionFactory extends GenericJdbcConnectionFactory
 
     /**
      * @param databaseConnectionConfig database connection configuration {@link DatabaseConnectionConfig}
-     * @param databaseConnectionInfo
-     */
+    * @param databaseConnectionInfo
+    */
     public OracleJdbcConnectionFactory(DatabaseConnectionConfig databaseConnectionConfig, DatabaseConnectionInfo databaseConnectionInfo)
     {
         super(databaseConnectionConfig, null, databaseConnectionInfo);
@@ -68,7 +69,7 @@ public class OracleJdbcConnectionFactory extends GenericJdbcConnectionFactory
                     properties.put("javax.net.ssl.trustStoreType", "JKS");
                     properties.put("javax.net.ssl.trustStorePassword", "changeit");
                     properties.put("oracle.net.ssl_server_dn_match", "true");
-                    if (System.getenv().getOrDefault(IS_FIPS_ENABLED, "false").equalsIgnoreCase("true")) {
+                    if (System.getenv().getOrDefault(IS_FIPS_ENABLED, "false").equalsIgnoreCase("true") || System.getenv().getOrDefault(IS_FIPS_ENABLED_LEGACY, "false").equalsIgnoreCase("true")) {
                         properties.put("oracle.net.ssl_cipher_suites", "(TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256, TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA)");
                     }
                 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
For some reason the `IS_FIPS_ENABLED` field was changed. In order to support both the old or new, we now check for either.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
