### PR TITLE
Enabled RDS Certs for Oracle DB

### DIFF
--- a/athena-oracle/Dockerfile
+++ b/athena-oracle/Dockerfile
@@ -1,9 +1,42 @@
 FROM public.ecr.aws/lambda/java:11
 
+# Install necessary tools
+RUN yum update -y && yum install -y curl perl openssl
+
+ENV truststore=${LAMBDA_TASK_ROOT}/rds-truststore.jks
+ENV storepassword=federationStorePass
+
+# Download and process the RDS certificate
+RUN curl -sS "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem" > ${LAMBDA_TASK_ROOT}/global-bundle.pem && \
+    awk 'split_after == 1 {n++;split_after=0} /-----END CERTIFICATE-----/ {split_after=1}{print > "rds-ca-" n ".pem"}' < ${LAMBDA_TASK_ROOT}/global-bundle.pem
+
+# Import certificates into the truststore
+RUN for CERT in rds-ca-*; do \
+        alias=$(openssl x509 -noout -text -in $CERT | perl -ne 'next unless /Subject:/; s/.*(CN=|CN = )//; print') && \
+        echo "Importing $alias" && \
+        keytool -import -file ${CERT} -alias "${alias}" -storepass ${storepassword} -keystore ${truststore} -noprompt && \
+        rm $CERT; \
+    done
+
+# Clean up
+RUN rm ${LAMBDA_TASK_ROOT}/global-bundle.pem
+
+# Optional: List the content of the trust store (for verification)
+RUN echo "Trust store content is: " && \
+    keytool -list -v -keystore "$truststore" -storepass ${storepassword} | grep Alias | cut -d " " -f3- | while read alias; do \
+        expiry=$(keytool -list -v -keystore "$truststore" -storepass ${storepassword} -alias "${alias}" | grep Valid | perl -ne 'if(/until: (.*?)\n/) { print "$1\n"; }'); \
+        echo " Certificate ${alias} expires in '$expiry'"; \
+    done
+
 # Copy function code and runtime dependencies from Maven layout
 COPY target/athena-oracle-2022.47.1.jar ${LAMBDA_TASK_ROOT}
 # Unpack the jar
 RUN jar xf athena-oracle-2022.47.1.jar
 
+# Clean up JAR
+RUN rm ${LAMBDA_TASK_ROOT}/athena-oracle-2022.47.1.jar
+
 # Command can be overwritten by providing a different command in the template directly.
 # No need to specify here (already defined in .yaml file because legacy and connections use different)
+# Set the CMD to your handler by removing the following comment for manual testing
+# CMD [ "com.amazonaws.athena.connectors.oracle.OracleCompositeHandler" ]


### PR DESCRIPTION

*Description of changes:*
Enabling RDS Certs for ECR based image; tested this on RDS Oracle with FIPS and SSL enabled: 

![image](https://github.com/user-attachments/assets/2aba5168-5c58-402c-bb56-fbf3ebbc5e21)

I've also simplified the logic to check if the connection string is using TCPS (Secure Transport) protocol instead of (TCP). 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
