### PR TITLE
Update update_dockerfile to catch all version numbers used by jar

### DIFF
--- a/tools/bump_versions/common.py
+++ b/tools/bump_versions/common.py
@@ -41,8 +41,7 @@ def update_yaml(yaml_files, new_version):
 
 def update_dockerfile(dockerfiles, new_version):
     for file in dockerfiles:
-        subprocess.run(["sed", "-i", f"s|\(target\/.*-\)[0-9]*\.[0-9]*\.[0-9]*|\\1{new_version}|", file])
-        subprocess.run(["sed", "-i", f"s|\(xf\s*.*-\)[0-9]*\.[0-9]*\.[0-9]*|\\1{new_version}|", file])
+        subprocess.run(["sed", "-i", f"s|\(athena-.*\)-[0-9]*\.[0-9]*\.[0-9]*\.jar|\\1-{new_version}.jar|g", file])
 
 
 def update_project_version(soup, new_version):


### PR DESCRIPTION
*Description of changes:*
The oracle Dockerfile had a new line added where the version number needs to be updated from 2022.47.1 to the version of the release. This was not added before to the update_dockerfile command, causing the building of the image to fail.

Update the update_dockerfile to now change all instances of `athena-*-2022.47.1.jar` to the correct version. This will make it so any changes made to any of the dockerfiles in the future will work and not cause a fail.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
