### PR TITLE
Oracle case insensitive search

### DIFF
--- a/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleCaseResolver.java
+++ b/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleCaseResolver.java
@@ -57,7 +57,7 @@ public class OracleCaseResolver
     {
         LOWER,      // casing mode to lower case everything (glue and trino lower case everything)
         UPPER,      // casing mode to upper case everything (oracle by default upper cases everything)
-        SEARCH      // casing mode to perform case insensitive search
+        CASE_INSENSITIVE_SEARCH     // casing mode to perform case insensitive search
     }
 
     public static TableName getAdjustedTableObjectName(final Connection connection, TableName tableName, Map<String, String> configOptions)
@@ -65,7 +65,7 @@ public class OracleCaseResolver
     {
         OracleCasingMode casingMode = getCasingMode(configOptions);
         switch (casingMode) {
-            case SEARCH:
+            case CASE_INSENSITIVE_SEARCH:
                 String schemaNameCaseInsensitively = getSchemaNameCaseInsensitively(connection, tableName.getSchemaName());
                 String tableNameCaseInsensitively = getTableNameCaseInsensitively(connection, schemaNameCaseInsensitively, tableName.getTableName());
                 TableName tableNameResult = new TableName(schemaNameCaseInsensitively, tableNameCaseInsensitively);
@@ -89,7 +89,7 @@ public class OracleCaseResolver
     {
         OracleCasingMode casingMode = getCasingMode(configOptions);
         switch (casingMode) {
-            case SEARCH:
+            case CASE_INSENSITIVE_SEARCH:
                 LOGGER.info("casing mode is SEARCH: performing case insensitive search for Schema...");
                 return getSchemaNameCaseInsensitively(connection, schemaNameInput);
             case UPPER:

--- a/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleCaseResolver.java
+++ b/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleCaseResolver.java
@@ -38,8 +38,8 @@ import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConsta
 public class OracleCaseResolver
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(OracleCaseResolver.class);
-    static final String SCHEMA_NAME_QUERY_TEMPLATE = "select distinct OWNER from all_tables where lower(OWNER) = ?";
-    static final String TABLE_NAME_QUERY_TEMPLATE = "select distinct TABLE_NAME from all_tables where OWNER = ? and lower(TABLE_NAME) = ?";
+    static final String SCHEMA_NAME_QUERY_TEMPLATE = "SELECT DISTINCT OWNER as \"OWNER\" FROM all_tables where lower(OWNER) = ?";
+    static final String TABLE_NAME_QUERY_TEMPLATE = "select distinct TABLE_NAME as \"TABLE_NAME\" from all_tables where OWNER = ? and lower(TABLE_NAME) = ?";
     static final String SCHEMA_NAME_COLUMN_KEY = "OWNER";
     static final String TABLE_NAME_COLUMN_KEY = "TABLE_NAME";
 
@@ -109,7 +109,7 @@ public class OracleCaseResolver
         try (PreparedStatement preparedStatement = new PreparedStatementBuilder()
                 .withConnection(connection)
                 .withQuery(SCHEMA_NAME_QUERY_TEMPLATE)
-                .withParameters(Arrays.asList(convertToLiteral(schemaNameInput.toLowerCase()))).build();
+                .withParameters(Arrays.asList(schemaNameInput.toLowerCase())).build();
                 ResultSet resultSet = preparedStatement.executeQuery()) {
             while (resultSet.next()) {
                 i++;
@@ -138,7 +138,7 @@ public class OracleCaseResolver
         try (PreparedStatement preparedStatement = new PreparedStatementBuilder()
                 .withConnection(connection)
                 .withQuery(TABLE_NAME_QUERY_TEMPLATE)
-                .withParameters(Arrays.asList(convertToLiteral(schemaName), convertToLiteral(tableNameInput.toLowerCase()))).build();
+                .withParameters(Arrays.asList((schemaName), tableNameInput.toLowerCase())).build();
                 ResultSet resultSet = preparedStatement.executeQuery()) {
             while (resultSet.next()) {
                 i++;

--- a/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleCaseResolver.java
+++ b/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleCaseResolver.java
@@ -1,0 +1,107 @@
+
+/*-
+ * #%L
+ * athena-oracle
+ * %%
+ * Copyright (C) 2019 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.oracle;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.DEFAULT_GLUE_CONNECTION;
+
+public class OracleCaseResolver
+{
+    private static final Logger logger = LoggerFactory.getLogger(OracleCaseResolver.class);
+
+    // the environment variable that can be set to specify which casing mode to use
+    static final String CASING_MODE = "casing_mode";
+
+    private OracleCaseResolver() {}
+
+    private enum OracleCasingMode
+    {
+        LOWER,      // casing mode to use whatever the engine returns (in trino's case, lower)
+        UPPER,      // casing mode to upper case everything (oracle by default upper cases everything)
+        SEARCH      // casing mode to perform case insensitive search
+    }
+
+    public static String getSchemaNameCaseInsensitiveMatch(Map<String, String> configOptions, MongoClient client, String unresolvedSchemaName)
+    {
+        String resolvedSchemaName = unresolvedSchemaName;
+        if (isCaseInsensitiveMatchEnable(configOptions)) {
+            logger.info("CaseInsensitiveMatch enable, SchemaName input: {}", resolvedSchemaName);
+            List<String> candidateSchemaNames = StreamSupport.stream(client.listDatabaseNames().spliterator(), false)
+                    .filter(candidateSchemaName -> candidateSchemaName.equalsIgnoreCase(unresolvedSchemaName))
+                    .collect(Collectors.toList());
+            if (candidateSchemaNames.size() != 1) {
+                throw new IllegalArgumentException(String.format("Schema name is empty or more than 1 for case insensitive match. schemaName: %s, size: %d",
+                        unresolvedSchemaName, candidateSchemaNames.size()));
+            }
+            resolvedSchemaName = candidateSchemaNames.get(0);
+            logger.info("CaseInsensitiveMatch, SchemaName resolved to: {}", resolvedSchemaName);
+        }
+
+        return resolvedSchemaName;
+    }
+
+    public static String getTableNameCaseInsensitiveMatch(Map<String, String> configOptions, MongoDatabase mongoDatabase, String unresolvedTableName)
+    {
+        String resolvedTableName = unresolvedTableName;
+        if (isCaseInsensitiveMatchEnable(configOptions)) {
+            logger.info("CaseInsensitiveMatch enable, TableName input: {}", resolvedTableName);
+            List<String> candidateTableNames = StreamSupport.stream(mongoDatabase.listCollectionNames().spliterator(), false)
+                    .filter(candidateTableName -> candidateTableName.equalsIgnoreCase(unresolvedTableName))
+                    .collect(Collectors.toList());
+            if (candidateTableNames.size() != 1) {
+                throw new IllegalArgumentException(String.format("Table name is empty or more than 1 for case insensitive match. schemaName: %s, size: %d",
+                        unresolvedTableName, candidateTableNames.size()));
+            }
+            resolvedTableName = candidateTableNames.get(0);
+            logger.info("CaseInsensitiveMatch, TableName resolved to: {}", resolvedTableName);
+        }
+        return resolvedTableName;
+    }
+
+    private static OracleCasingMode getCasingMode(Map<String, String> configOptions)
+    {
+        boolean isGlueConnection = StringUtils.isNotBlank(configOptions.get(DEFAULT_GLUE_CONNECTION));
+        if (!configOptions.containsKey(CASING_MODE)) {
+            logger.info("CASING MODE not set");
+            return isGlueConnection ? OracleCasingMode.LOWER : OracleCasingMode.UPPER;
+        }
+
+        try {
+            OracleCasingMode oracleCasingMode = OracleCasingMode.valueOf(configOptions.get(CASING_MODE).toUpperCase());
+            logger.info("CASING MODE enable: {}", oracleCasingMode.toString());
+            return oracleCasingMode;
+        }
+        catch (Exception ex) {
+            // print error log for customer along with list of input
+            logger.error("Invalid input for:{}, input value:{}, valid values:{}", CASING_MODE, configOptions.get(CASING_MODE), Arrays.asList(OracleCasingMode.values()), ex);
+            throw ex;
+        }
+    }
+}

--- a/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleCaseResolver.java
+++ b/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleCaseResolver.java
@@ -20,19 +20,18 @@
  */
 package com.amazonaws.athena.connectors.oracle;
 
+import com.amazonaws.athena.connector.lambda.domain.TableName;
+import com.amazonaws.athena.connectors.jdbc.manager.PreparedStatementBuilder;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Map;
-
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.amazonaws.athena.connector.lambda.domain.TableName;
-import com.amazonaws.athena.connectors.jdbc.manager.PreparedStatementBuilder;
 
 import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.DEFAULT_GLUE_CONNECTION;
 
@@ -179,7 +178,8 @@ public class OracleCaseResolver
         }
     }
 
-    public static TableName quoteTableName(TableName inputTable) {
+    public static TableName quoteTableName(TableName inputTable)
+    {
         String schemaName = inputTable.getSchemaName();
         String tableName = inputTable.getTableName();
         if (!schemaName.contains(ORACLE_IDENTIFIER_CHARACTER)) {
@@ -191,7 +191,8 @@ public class OracleCaseResolver
         return new TableName(schemaName, tableName);
     }
 
-    public static String convertToLiteral(String input) {
+    public static String convertToLiteral(String input)
+    {
         if (!input.contains(ORACLE_STRING_LITERAL_CHARACTER)) {
             input = String.join(ORACLE_STRING_LITERAL_CHARACTER, input, ORACLE_STRING_LITERAL_CHARACTER);
         }

--- a/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleCaseResolver.java
+++ b/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleCaseResolver.java
@@ -20,6 +20,10 @@
  */
 package com.amazonaws.athena.connectors.oracle;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -30,14 +34,19 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.amazonaws.athena.connector.lambda.domain.TableName;
+import com.amazonaws.athena.connectors.jdbc.manager.PreparedStatementBuilder;
+
 import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.DEFAULT_GLUE_CONNECTION;
 
 public class OracleCaseResolver
 {
-    private static final Logger logger = LoggerFactory.getLogger(OracleCaseResolver.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(OracleCaseResolver.class);
 
     // the environment variable that can be set to specify which casing mode to use
     static final String CASING_MODE = "casing_mode";
+
+    private static final String ORACLE_QUOTE_CHARACTER = "\"";
 
     private OracleCaseResolver() {}
 
@@ -48,59 +57,120 @@ public class OracleCaseResolver
         SEARCH      // casing mode to perform case insensitive search
     }
 
-    public static String getSchemaNameCaseInsensitiveMatch(Map<String, String> configOptions, MongoClient client, String unresolvedSchemaName)
+    public static TableName getAdjustedTableObjectName(final Connection connection, TableName tableName, Map<String, String> configOptions)
+            throws SQLException
     {
-        String resolvedSchemaName = unresolvedSchemaName;
-        if (isCaseInsensitiveMatchEnable(configOptions)) {
-            logger.info("CaseInsensitiveMatch enable, SchemaName input: {}", resolvedSchemaName);
-            List<String> candidateSchemaNames = StreamSupport.stream(client.listDatabaseNames().spliterator(), false)
-                    .filter(candidateSchemaName -> candidateSchemaName.equalsIgnoreCase(unresolvedSchemaName))
-                    .collect(Collectors.toList());
-            if (candidateSchemaNames.size() != 1) {
-                throw new IllegalArgumentException(String.format("Schema name is empty or more than 1 for case insensitive match. schemaName: %s, size: %d",
-                        unresolvedSchemaName, candidateSchemaNames.size()));
-            }
-            resolvedSchemaName = candidateSchemaNames.get(0);
-            logger.info("CaseInsensitiveMatch, SchemaName resolved to: {}", resolvedSchemaName);
+        OracleCasingMode casingMode = getCasingMode(configOptions);
+        switch (casingMode) {
+            case SEARCH:
+                String schemaNameCaseInsensitively = getSchemaNameCaseInsensitively(connection, tableName.getSchemaName(), configOptions);
+                String tableNameCaseInsensitively = getTableNameCaseInsensitively(connection, schemaNameCaseInsensitively, tableName.getTableName(), configOptions);
+                TableName tableNameResult = new TableName(schemaNameCaseInsensitively, tableNameCaseInsensitively);
+                LOGGER.info("casing mode is `SEARCH`: performing case insensitive search for TableName object. TableName:{}", tableNameResult);
+                return tableNameResult;
+            case UPPER:
+                TableName upperTableName = new TableName(tableName.getSchemaName().toUpperCase(), tableName.getTableName().toUpperCase());
+                LOGGER.info("casing mode is `UPPER`: adjusting casing from input to upper case for TableName object. TableName:{}", upperTableName);
+                return upperTableName;
+            case LOWER:
+                LOGGER.info("casing mode is `LOWER`: not adjust casing from input for TableName object. TableName:{}", tableName);
+                return tableName;
         }
-
-        return resolvedSchemaName;
+        LOGGER.warn("casing mode is empty: not adjust casing from input for TableName object. TableName:{}", tableName);
+        return tableName;
     }
 
-    public static String getTableNameCaseInsensitiveMatch(Map<String, String> configOptions, MongoDatabase mongoDatabase, String unresolvedTableName)
+    public static String getAdjustedSchemaName(final Connection connection, String schemaNameInput, Map<String, String> configOptions)
+            throws SQLException
     {
-        String resolvedTableName = unresolvedTableName;
-        if (isCaseInsensitiveMatchEnable(configOptions)) {
-            logger.info("CaseInsensitiveMatch enable, TableName input: {}", resolvedTableName);
-            List<String> candidateTableNames = StreamSupport.stream(mongoDatabase.listCollectionNames().spliterator(), false)
-                    .filter(candidateTableName -> candidateTableName.equalsIgnoreCase(unresolvedTableName))
-                    .collect(Collectors.toList());
-            if (candidateTableNames.size() != 1) {
-                throw new IllegalArgumentException(String.format("Table name is empty or more than 1 for case insensitive match. schemaName: %s, size: %d",
-                        unresolvedTableName, candidateTableNames.size()));
-            }
-            resolvedTableName = candidateTableNames.get(0);
-            logger.info("CaseInsensitiveMatch, TableName resolved to: {}", resolvedTableName);
+        OracleCasingMode casingMode = getCasingMode(configOptions);
+        switch (casingMode) {
+            case SEARCH:
+                LOGGER.info("casing mode is SEARCH: performing case insensitive search for Schema...");
+                return getSchemaNameCaseInsensitively(connection, schemaNameInput, configOptions);
+            case UPPER:
+                LOGGER.info("casing mode is `UPPER`: adjusting casing from input to upper case for Schema");
+                return schemaNameInput.toUpperCase();
+            case LOWER:
+                LOGGER.info("casing mode is `LOWER`: not adjust casing from input for Schema");
         }
-        return resolvedTableName;
+
+        return schemaNameInput;
+    }
+
+    public static String getSchemaNameCaseInsensitively(final Connection connection, String schemaNameInput, Map<String, String> configOptions)
+            throws SQLException
+    {
+        String nameFromSnowFlake = null;
+        int i = 0;
+        try (PreparedStatement preparedStatement = new PreparedStatementBuilder()
+                .withConnection(connection)
+                .withQuery(SCHEMA_NAME_QUERY_TEMPLATE)
+                .withParameters(Arrays.asList(schemaNameInput.toLowerCase())).build();
+                ResultSet resultSet = preparedStatement.executeQuery()) {
+            while (resultSet.next()) {
+                i++;
+                String schemaNameCandidate = resultSet.getString(SCHEMA_NAME_COLUMN_KEY);
+                LOGGER.debug("Case insensitive search on columLabel: {}, schema name: {}", SCHEMA_NAME_COLUMN_KEY, schemaNameCandidate);
+                nameFromSnowFlake = schemaNameCandidate;
+            }
+        }
+        catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+
+        if (i == 0 || i > 1) {
+            throw new RuntimeException(String.format("Schema name case insensitive match failed, number of match : %d", i));
+        }
+
+        return nameFromSnowFlake;
+    }
+
+    public static String getTableNameCaseInsensitively(final Connection connection, String schemaName, String tableNameInput, Map<String, String> configOptions)
+            throws SQLException
+    {
+        // schema name input should be correct case before searching tableName already
+        String nameFromSnowFlake = null;
+        int i = 0;
+        try (PreparedStatement preparedStatement = new PreparedStatementBuilder()
+                .withConnection(connection)
+                .withQuery(TABLE_NAME_QUERY_TEMPLATE)
+                .withParameters(Arrays.asList(schemaName, tableNameInput.toLowerCase())).build();
+                ResultSet resultSet = preparedStatement.executeQuery()) {
+            while (resultSet.next()) {
+                i++;
+                String schemaNameCandidate = resultSet.getString(TABLE_NAME_COLUMN_KEY);
+                LOGGER.debug("Case insensitive search on columLabel: {}, schema name: {}", TABLE_NAME_COLUMN_KEY, schemaNameCandidate);
+                nameFromSnowFlake = schemaNameCandidate;
+            }
+        }
+        catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+
+        if (i == 0 || i > 1) {
+            throw new RuntimeException(String.format("Schema name case insensitive match failed, number of match : %d", i));
+        }
+
+        return nameFromSnowFlake;
     }
 
     private static OracleCasingMode getCasingMode(Map<String, String> configOptions)
     {
         boolean isGlueConnection = StringUtils.isNotBlank(configOptions.get(DEFAULT_GLUE_CONNECTION));
         if (!configOptions.containsKey(CASING_MODE)) {
-            logger.info("CASING MODE not set");
+            LOGGER.info("CASING MODE not set");
             return isGlueConnection ? OracleCasingMode.LOWER : OracleCasingMode.UPPER;
         }
 
         try {
             OracleCasingMode oracleCasingMode = OracleCasingMode.valueOf(configOptions.get(CASING_MODE).toUpperCase());
-            logger.info("CASING MODE enable: {}", oracleCasingMode.toString());
+            LOGGER.info("CASING MODE enable: {}", oracleCasingMode.toString());
             return oracleCasingMode;
         }
         catch (Exception ex) {
             // print error log for customer along with list of input
-            logger.error("Invalid input for:{}, input value:{}, valid values:{}", CASING_MODE, configOptions.get(CASING_MODE), Arrays.asList(OracleCasingMode.values()), ex);
+            LOGGER.error("Invalid input for:{}, input value:{}, valid values:{}", CASING_MODE, configOptions.get(CASING_MODE), Arrays.asList(OracleCasingMode.values()), ex);
             throw ex;
         }
     }

--- a/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleCaseResolver.java
+++ b/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleCaseResolver.java
@@ -183,10 +183,10 @@ public class OracleCaseResolver
         String schemaName = inputTable.getSchemaName();
         String tableName = inputTable.getTableName();
         if (!schemaName.contains(ORACLE_IDENTIFIER_CHARACTER)) {
-            schemaName = String.join(ORACLE_IDENTIFIER_CHARACTER, schemaName, ORACLE_IDENTIFIER_CHARACTER);
+            schemaName = ORACLE_IDENTIFIER_CHARACTER + schemaName + ORACLE_IDENTIFIER_CHARACTER;
         }
         if (!tableName.contains(ORACLE_IDENTIFIER_CHARACTER)) {
-            tableName = String.join(ORACLE_IDENTIFIER_CHARACTER, tableName, ORACLE_IDENTIFIER_CHARACTER);
+            tableName = ORACLE_IDENTIFIER_CHARACTER + tableName + ORACLE_IDENTIFIER_CHARACTER;
         }
         return new TableName(schemaName, tableName);
     }
@@ -194,7 +194,7 @@ public class OracleCaseResolver
     public static String convertToLiteral(String input)
     {
         if (!input.contains(ORACLE_STRING_LITERAL_CHARACTER)) {
-            input = String.join(ORACLE_STRING_LITERAL_CHARACTER, input, ORACLE_STRING_LITERAL_CHARACTER);
+            input = ORACLE_STRING_LITERAL_CHARACTER + input + ORACLE_STRING_LITERAL_CHARACTER;
         }
         return input;
     }

--- a/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleCaseResolver.java
+++ b/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleCaseResolver.java
@@ -55,7 +55,7 @@ public class OracleCaseResolver
 
     private enum OracleCasingMode
     {
-        LOWER,      // casing mode to use whatever the engine returns (in trino's case, lower)
+        LOWER,      // casing mode to lower case everything (glue and trino lower case everything)
         UPPER,      // casing mode to upper case everything (oracle by default upper cases everything)
         SEARCH      // casing mode to perform case insensitive search
     }
@@ -121,7 +121,7 @@ public class OracleCaseResolver
             }
         }
         catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException(String.format("getSchemaNameCaseInsensitively query failed for %s", schemaName), e);
         }
 
         if (i != 1) {
@@ -150,7 +150,7 @@ public class OracleCaseResolver
             }
         }
         catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException(String.format("getTableNameCaseInsensitively query failed for schema: %s tableName: %s", schemaName, tableNameInput), e);
         }
 
         if (i != 1) {

--- a/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleCaseResolver.java
+++ b/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleCaseResolver.java
@@ -39,10 +39,10 @@ import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConsta
 public class OracleCaseResolver
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(OracleCaseResolver.class);
-    private static final String SCHEMA_NAME_QUERY_TEMPLATE = "select distinct OWNER from all_tables where lower(OWNER) = ?";
-    private static final String TABLE_NAME_QUERY_TEMPLATE = "select distinct TABLE_NAME from all_tables where OWNER = ? and lower(TABLE_NAME) = ?";
-    private static final String SCHEMA_NAME_COLUMN_KEY = "OWNER";
-    private static final String TABLE_NAME_COLUMN_KEY = "TABLE_NAME";
+    static final String SCHEMA_NAME_QUERY_TEMPLATE = "select distinct OWNER from all_tables where lower(OWNER) = ?";
+    static final String TABLE_NAME_QUERY_TEMPLATE = "select distinct TABLE_NAME from all_tables where OWNER = ? and lower(TABLE_NAME) = ?";
+    static final String SCHEMA_NAME_COLUMN_KEY = "OWNER";
+    static final String TABLE_NAME_COLUMN_KEY = "TABLE_NAME";
 
     // the environment variable that can be set to specify which casing mode to use
     static final String CASING_MODE = "casing_mode";
@@ -67,8 +67,8 @@ public class OracleCaseResolver
         OracleCasingMode casingMode = getCasingMode(configOptions);
         switch (casingMode) {
             case SEARCH:
-                String schemaNameCaseInsensitively = getSchemaNameCaseInsensitively(connection, tableName.getSchemaName(), configOptions);
-                String tableNameCaseInsensitively = getTableNameCaseInsensitively(connection, schemaNameCaseInsensitively, tableName.getTableName(), configOptions);
+                String schemaNameCaseInsensitively = getSchemaNameCaseInsensitively(connection, tableName.getSchemaName());
+                String tableNameCaseInsensitively = getTableNameCaseInsensitively(connection, schemaNameCaseInsensitively, tableName.getTableName());
                 TableName tableNameResult = new TableName(schemaNameCaseInsensitively, tableNameCaseInsensitively);
                 LOGGER.info("casing mode is `SEARCH`: performing case insensitive search for TableName object. TableName:{}", tableNameResult);
                 return tableNameResult;
@@ -91,7 +91,7 @@ public class OracleCaseResolver
         switch (casingMode) {
             case SEARCH:
                 LOGGER.info("casing mode is SEARCH: performing case insensitive search for Schema...");
-                return getSchemaNameCaseInsensitively(connection, schemaNameInput, configOptions);
+                return getSchemaNameCaseInsensitively(connection, schemaNameInput);
             case UPPER:
                 LOGGER.info("casing mode is `UPPER`: adjusting casing from input to upper case for Schema");
                 return schemaNameInput.toUpperCase();
@@ -102,7 +102,7 @@ public class OracleCaseResolver
         return schemaNameInput;
     }
 
-    public static String getSchemaNameCaseInsensitively(final Connection connection, String schemaNameInput, Map<String, String> configOptions)
+    public static String getSchemaNameCaseInsensitively(final Connection connection, String schemaNameInput)
             throws SQLException
     {
         String nameFromOracle = null;
@@ -130,7 +130,7 @@ public class OracleCaseResolver
         return nameFromOracle;
     }
 
-    public static String getTableNameCaseInsensitively(final Connection connection, String schemaName, String tableNameInput, Map<String, String> configOptions)
+    public static String getTableNameCaseInsensitively(final Connection connection, String schemaName, String tableNameInput)
             throws SQLException
     {
         // schema name input should be correct case before searching tableName already

--- a/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleMetadataHandler.java
+++ b/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleMetadataHandler.java
@@ -253,7 +253,8 @@ public class OracleMetadataHandler
         int t = token != null ? Integer.parseInt(token) : 0;
 
         LOGGER.info("Starting pagination at {} with page size {}", token, pageSize);
-        List<TableName> paginatedTables = getPaginatedTables(connection, listTablesRequest.getSchemaName(), t, pageSize);
+        String casedSchemaName = OracleCaseResolver.getAdjustedSchemaName(connection, listTablesRequest.getSchemaName(), configOptions);
+        List<TableName> paginatedTables = getPaginatedTables(connection, casedSchemaName, t, pageSize);
         LOGGER.info("{} tables returned. Next token is {}", paginatedTables.size(), t + pageSize);
         return new ListTablesResponse(listTablesRequest.getCatalogName(), paginatedTables, Integer.toString(t + pageSize));
     }

--- a/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleMetadataHandler.java
+++ b/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleMetadataHandler.java
@@ -95,7 +95,6 @@ public class OracleMetadataHandler
     static final String BLOCK_PARTITION_COLUMN_NAME = "PARTITION_NAME".toLowerCase();
     static final String ALL_PARTITIONS = "0";
     static final String PARTITION_COLUMN_NAME = "PARTITION_NAME".toLowerCase();
-    static final String CASING_MODE = "casing_mode";
     private static final Logger LOGGER = LoggerFactory.getLogger(OracleMetadataHandler.class);
     private static final int MAX_SPLITS_PER_REQUEST = 1000_000;
     private static final String COLUMN_NAME = "COLUMN_NAME";

--- a/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleMetadataHandler.java
+++ b/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleMetadataHandler.java
@@ -155,7 +155,7 @@ public class OracleMetadataHandler
             throws Exception
     {
         try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider())) {
-            TableName casedTableName = OracleCaseResolver.getAdjustedTableObjectName(connection, getTableLayoutRequest.getTableName(), configOptions);
+            TableName casedTableName = getTableLayoutRequest.getTableName();
             LOGGER.debug("{}: Schema {}, table {}", getTableLayoutRequest.getQueryId(), casedTableName.getSchemaName(),
                 casedTableName.getTableName());
             List<String> parameters = Arrays.asList(OracleCaseResolver.convertToLiteral(casedTableName.getTableName())); 
@@ -307,7 +307,7 @@ public class OracleMetadataHandler
     {
         try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider())) {
             Schema partitionSchema = getPartitionSchema(getTableRequest.getCatalogName());
-            TableName tableName = OracleCaseResolver.quoteTableName(OracleCaseResolver.getAdjustedTableObjectName(connection, getTableRequest.getTableName(), configOptions));
+            TableName tableName = OracleCaseResolver.getAdjustedTableObjectName(connection, getTableRequest.getTableName(), configOptions);
             return new GetTableResponse(getTableRequest.getCatalogName(), tableName, getSchema(connection, tableName, partitionSchema),
                     partitionSchema.getFields().stream().map(Field::getName).collect(Collectors.toSet()));
         }

--- a/athena-oracle/src/test/java/com/amazonaws/athena/connectors/oracle/OracleCaseResolverTest.java
+++ b/athena-oracle/src/test/java/com/amazonaws/athena/connectors/oracle/OracleCaseResolverTest.java
@@ -87,7 +87,7 @@ public class OracleCaseResolverTest
         String inputTableName = "testtable";
         String matchedTableName = "TESTTABLE";
         TableName inputTableNameObject = new TableName(inputSchemaName, inputTableName);
-        Map<String, String> config = Collections.singletonMap(OracleCaseResolver.CASING_MODE, "search");
+        Map<String, String> config = Collections.singletonMap(OracleCaseResolver.CASING_MODE, "case_insensitive_search");
 
         PreparedStatement preparedStatement = Mockito.mock(PreparedStatement.class);
         Mockito.when(this.connection.prepareStatement(OracleCaseResolver.SCHEMA_NAME_QUERY_TEMPLATE)).thenReturn(preparedStatement);
@@ -158,7 +158,7 @@ public class OracleCaseResolverTest
     {
         String inputSchemaName = "testschema";
         String matchedSchemaName = "testSchema";
-        Map<String, String> config = Collections.singletonMap(OracleCaseResolver.CASING_MODE, "search");
+        Map<String, String> config = Collections.singletonMap(OracleCaseResolver.CASING_MODE, "case_insensitive_search");
 
         PreparedStatement preparedStatement = Mockito.mock(PreparedStatement.class);
         Mockito.when(this.connection.prepareStatement(OracleCaseResolver.SCHEMA_NAME_QUERY_TEMPLATE)).thenReturn(preparedStatement);

--- a/athena-oracle/src/test/java/com/amazonaws/athena/connectors/oracle/OracleCaseResolverTest.java
+++ b/athena-oracle/src/test/java/com/amazonaws/athena/connectors/oracle/OracleCaseResolverTest.java
@@ -25,6 +25,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Types;
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -60,7 +61,7 @@ public class OracleCaseResolverTest
             throws Exception
     {
         TableName inputTableName = new TableName("testschema", "testtable");
-        Map<String, String> config = Map.of(OracleCaseResolver.CASING_MODE, "lower");
+        Map<String, String> config = Collections.singletonMap(OracleCaseResolver.CASING_MODE, "lower");
         TableName outputTableName = OracleCaseResolver.getAdjustedTableObjectName(connection, inputTableName, config);
         Assert.assertEquals(outputTableName.getSchemaName(), inputTableName.getSchemaName());
         Assert.assertEquals(outputTableName.getTableName(), inputTableName.getTableName());
@@ -71,7 +72,7 @@ public class OracleCaseResolverTest
             throws Exception
     {
         TableName inputTableName = new TableName("testschema", "testtable");
-        Map<String, String> config = Map.of(OracleCaseResolver.CASING_MODE, "upper");
+        Map<String, String> config = Collections.singletonMap(OracleCaseResolver.CASING_MODE, "upper");
         TableName outputTableName = OracleCaseResolver.getAdjustedTableObjectName(connection, inputTableName, config);
         Assert.assertEquals(outputTableName.getSchemaName(), inputTableName.getSchemaName().toUpperCase());
         Assert.assertEquals(outputTableName.getTableName(), inputTableName.getTableName().toUpperCase());
@@ -86,7 +87,7 @@ public class OracleCaseResolverTest
         String inputTableName = "testtable";
         String matchedTableName = "TESTTABLE";
         TableName inputTableNameObject = new TableName(inputSchemaName, inputTableName);
-        Map<String, String> config = Map.of(OracleCaseResolver.CASING_MODE, "search");
+        Map<String, String> config = Collections.singletonMap(OracleCaseResolver.CASING_MODE, "search");
 
         PreparedStatement preparedStatement = Mockito.mock(PreparedStatement.class);
         Mockito.when(this.connection.prepareStatement(OracleCaseResolver.SCHEMA_NAME_QUERY_TEMPLATE)).thenReturn(preparedStatement);
@@ -113,7 +114,7 @@ public class OracleCaseResolverTest
             throws Exception
     {
         TableName inputTableName = new TableName("testschema", "testtable");
-        Map<String, String> config = Map.of();
+        Map<String, String> config = Collections.emptyMap();
         TableName outputTableName = OracleCaseResolver.getAdjustedTableObjectName(connection, inputTableName, config);
         Assert.assertEquals(outputTableName.getSchemaName(), inputTableName.getSchemaName().toUpperCase());
         Assert.assertEquals(outputTableName.getTableName(), inputTableName.getTableName().toUpperCase());
@@ -124,7 +125,7 @@ public class OracleCaseResolverTest
             throws Exception
     {
         TableName inputTableName = new TableName("testschema", "testtable");
-        Map<String, String> config = Map.of(DEFAULT_GLUE_CONNECTION, "notBlank");
+        Map<String, String> config = Collections.singletonMap(DEFAULT_GLUE_CONNECTION, "notBlank");
         TableName outputTableName = OracleCaseResolver.getAdjustedTableObjectName(connection, inputTableName, config);
         Assert.assertEquals(outputTableName.getSchemaName(), inputTableName.getSchemaName());
         Assert.assertEquals(outputTableName.getTableName(), inputTableName.getTableName());
@@ -136,7 +137,7 @@ public class OracleCaseResolverTest
     {
         // the trino engine will lowercase anything
         String inputSchemaName = "testschema";
-        Map<String, String> config = Map.of(OracleCaseResolver.CASING_MODE, "lower");
+        Map<String, String> config = Collections.singletonMap(OracleCaseResolver.CASING_MODE, "lower");
         String outputSchemaName = OracleCaseResolver.getAdjustedSchemaName(connection, inputSchemaName, config);
         Assert.assertEquals(inputSchemaName, outputSchemaName);
     }
@@ -146,7 +147,7 @@ public class OracleCaseResolverTest
             throws Exception
     {
         String inputSchemaName = "testschema";
-        Map<String, String> config = Map.of(OracleCaseResolver.CASING_MODE, "upper");
+        Map<String, String> config = Collections.singletonMap(OracleCaseResolver.CASING_MODE, "upper");
         String outputSchemaName = OracleCaseResolver.getAdjustedSchemaName(connection, inputSchemaName, config);
         Assert.assertEquals(inputSchemaName.toUpperCase(), outputSchemaName);
     }
@@ -157,7 +158,7 @@ public class OracleCaseResolverTest
     {
         String inputSchemaName = "testschema";
         String matchedSchemaName = "testSchema";
-        Map<String, String> config = Map.of(OracleCaseResolver.CASING_MODE, "search");
+        Map<String, String> config = Collections.singletonMap(OracleCaseResolver.CASING_MODE, "search");
 
         PreparedStatement preparedStatement = Mockito.mock(PreparedStatement.class);
         Mockito.when(this.connection.prepareStatement(OracleCaseResolver.SCHEMA_NAME_QUERY_TEMPLATE)).thenReturn(preparedStatement);
@@ -177,7 +178,7 @@ public class OracleCaseResolverTest
             throws Exception
     {
         String inputSchemaName = "testschema";
-        Map<String, String> config = Map.of();
+        Map<String, String> config = Collections.emptyMap();
         String outputSchemaName = OracleCaseResolver.getAdjustedSchemaName(connection, inputSchemaName, config);
         Assert.assertEquals(inputSchemaName.toUpperCase(), outputSchemaName);
     }
@@ -188,7 +189,7 @@ public class OracleCaseResolverTest
     {
         // the trino engine will lowercase anything
         String inputSchemaName = "testschema";
-        Map<String, String> config = Map.of(DEFAULT_GLUE_CONNECTION, "notBlank");
+        Map<String, String> config = Collections.singletonMap(DEFAULT_GLUE_CONNECTION, "notBlank");
         String outputSchemaName = OracleCaseResolver.getAdjustedSchemaName(connection, inputSchemaName, config);
         Assert.assertEquals(inputSchemaName, outputSchemaName);
     }

--- a/athena-oracle/src/test/java/com/amazonaws/athena/connectors/oracle/OracleCaseResolverTest.java
+++ b/athena-oracle/src/test/java/com/amazonaws/athena/connectors/oracle/OracleCaseResolverTest.java
@@ -218,14 +218,13 @@ public class OracleCaseResolverTest
             throws Exception
     {
         String inputSchemaName = "tEsTsChEmA";
-        String[] matchedSchemaName = {"testSchema", "TESTSCHEMA"};
 
         PreparedStatement preparedStatement = Mockito.mock(PreparedStatement.class);
         Mockito.when(this.connection.prepareStatement(OracleCaseResolver.SCHEMA_NAME_QUERY_TEMPLATE)).thenReturn(preparedStatement);
 
         String[] columns = {OracleCaseResolver.SCHEMA_NAME_COLUMN_KEY};
         int[] types = {Types.VARCHAR};
-        Object[][] values = {matchedSchemaName};
+        Object[][] values = {{"testSchema"}, {"TESTSCHEMA"}};
         ResultSet resultSet = mockResultSet(columns, types, values, new AtomicInteger(-1));
         Mockito.when(preparedStatement.executeQuery()).thenReturn(resultSet);
 
@@ -279,13 +278,12 @@ public class OracleCaseResolverTest
     {
         String schemaName = "TestSchema";
         String inputTableName = "tEsTtAbLe";
-        String[] matchedTableName = {"testtable", "TESTTABLE"};
         PreparedStatement preparedStatement = Mockito.mock(PreparedStatement.class);
         Mockito.when(this.connection.prepareStatement(OracleCaseResolver.TABLE_NAME_QUERY_TEMPLATE)).thenReturn(preparedStatement);
 
         String[] columns = {OracleCaseResolver.TABLE_NAME_COLUMN_KEY};
         int[] types = {Types.VARCHAR};
-        Object[][] values = {matchedTableName};
+        Object[][] values = {{"testtable"}, {"TESTTABLE"}};
         ResultSet resultSet = mockResultSet(columns, types, values, new AtomicInteger(-1));
         Mockito.when(preparedStatement.executeQuery()).thenReturn(resultSet);
 
@@ -311,5 +309,14 @@ public class OracleCaseResolverTest
 
         // should throw exception because no matches found
         OracleCaseResolver.getTableNameCaseInsensitively(connection, schemaName, inputTableName);
+    }
+
+    @Test
+    public void convertToLiteral()
+    {
+        String input = "teststring";
+        String expectedOutput = "\'teststring\'";
+        Assert.assertEquals(expectedOutput, OracleCaseResolver.convertToLiteral(input));
+        Assert.assertEquals(expectedOutput, OracleCaseResolver.convertToLiteral(expectedOutput));
     }
 }

--- a/athena-oracle/src/test/java/com/amazonaws/athena/connectors/oracle/OracleCaseResolverTest.java
+++ b/athena-oracle/src/test/java/com/amazonaws/athena/connectors/oracle/OracleCaseResolverTest.java
@@ -25,6 +25,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Types;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Assert;
@@ -32,9 +33,12 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import com.amazonaws.athena.connector.lambda.domain.TableName;
 import com.amazonaws.athena.connectors.jdbc.TestBase;
 import com.amazonaws.athena.connectors.jdbc.connection.JdbcConnectionFactory;
 import com.amazonaws.athena.connectors.jdbc.connection.JdbcCredentialProvider;
+
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.DEFAULT_GLUE_CONNECTION;
 
 public class OracleCaseResolverTest
         extends TestBase
@@ -49,6 +53,144 @@ public class OracleCaseResolverTest
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class, Mockito.RETURNS_DEEP_STUBS);
         this.connection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);
         Mockito.when(this.jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(this.connection);
+    }
+
+    @Test
+    public void getAdjustedTableObjectNameLower()
+            throws Exception
+    {
+        TableName inputTableName = new TableName("testschema", "testtable");
+        Map<String, String> config = Map.of(OracleCaseResolver.CASING_MODE, "lower");
+        TableName outputTableName = OracleCaseResolver.getAdjustedTableObjectName(connection, inputTableName, config);
+        Assert.assertEquals(outputTableName.getSchemaName(), inputTableName.getSchemaName());
+        Assert.assertEquals(outputTableName.getTableName(), inputTableName.getTableName());
+    }
+
+    @Test
+    public void getAdjustedTableObjectNameUpper()
+            throws Exception
+    {
+        TableName inputTableName = new TableName("testschema", "testtable");
+        Map<String, String> config = Map.of(OracleCaseResolver.CASING_MODE, "upper");
+        TableName outputTableName = OracleCaseResolver.getAdjustedTableObjectName(connection, inputTableName, config);
+        Assert.assertEquals(outputTableName.getSchemaName(), inputTableName.getSchemaName().toUpperCase());
+        Assert.assertEquals(outputTableName.getTableName(), inputTableName.getTableName().toUpperCase());
+    }
+
+    @Test
+    public void getAdjustedTableObjectNameSearch()
+            throws Exception
+    {
+        String inputSchemaName = "testschema";
+        String matchedSchemaName = "testSchema";
+        String inputTableName = "testtable";
+        String matchedTableName = "TESTTABLE";
+        TableName inputTableNameObject = new TableName(inputSchemaName, inputTableName);
+        Map<String, String> config = Map.of(OracleCaseResolver.CASING_MODE, "search");
+
+        PreparedStatement preparedStatement = Mockito.mock(PreparedStatement.class);
+        Mockito.when(this.connection.prepareStatement(OracleCaseResolver.SCHEMA_NAME_QUERY_TEMPLATE)).thenReturn(preparedStatement);
+        Mockito.when(this.connection.prepareStatement(OracleCaseResolver.TABLE_NAME_QUERY_TEMPLATE)).thenReturn(preparedStatement);
+
+        String[] columnsSchema = {OracleCaseResolver.SCHEMA_NAME_COLUMN_KEY};
+        int[] typesSchema = {Types.VARCHAR};
+        Object[][] valuesSchema = {{matchedSchemaName}};
+        ResultSet resultSetSchema = mockResultSet(columnsSchema, typesSchema, valuesSchema, new AtomicInteger(-1));
+        String[] columnsTable = {OracleCaseResolver.TABLE_NAME_COLUMN_KEY};
+        int[] typesTable = {Types.VARCHAR};
+        Object[][] valuesTable = {{matchedTableName}};
+        ResultSet resultSetTable = mockResultSet(columnsTable, typesTable, valuesTable, new AtomicInteger(-1));
+        // schema query is first, then table name
+        Mockito.when(preparedStatement.executeQuery()).thenReturn(resultSetSchema).thenReturn(resultSetTable);
+        
+        TableName outputTableName = OracleCaseResolver.getAdjustedTableObjectName(connection, inputTableNameObject, config);
+        Assert.assertEquals(outputTableName.getSchemaName(), matchedSchemaName);
+        Assert.assertEquals(outputTableName.getTableName(), matchedTableName);
+    }
+
+    @Test
+    public void getAdjustedTableObjectNameNoConfig()
+            throws Exception
+    {
+        TableName inputTableName = new TableName("testschema", "testtable");
+        Map<String, String> config = Map.of();
+        TableName outputTableName = OracleCaseResolver.getAdjustedTableObjectName(connection, inputTableName, config);
+        Assert.assertEquals(outputTableName.getSchemaName(), inputTableName.getSchemaName().toUpperCase());
+        Assert.assertEquals(outputTableName.getTableName(), inputTableName.getTableName().toUpperCase());
+    }
+
+    @Test
+    public void getAdjustedTableObjectNameGlueConnection()
+            throws Exception
+    {
+        TableName inputTableName = new TableName("testschema", "testtable");
+        Map<String, String> config = Map.of(DEFAULT_GLUE_CONNECTION, "notBlank");
+        TableName outputTableName = OracleCaseResolver.getAdjustedTableObjectName(connection, inputTableName, config);
+        Assert.assertEquals(outputTableName.getSchemaName(), inputTableName.getSchemaName());
+        Assert.assertEquals(outputTableName.getTableName(), inputTableName.getTableName());
+    }
+
+    @Test
+    public void getAdjustedSchemaNameLower()
+            throws Exception
+    {
+        // the trino engine will lowercase anything
+        String inputSchemaName = "testschema";
+        Map<String, String> config = Map.of(OracleCaseResolver.CASING_MODE, "lower");
+        String outputSchemaName = OracleCaseResolver.getAdjustedSchemaName(connection, inputSchemaName, config);
+        Assert.assertEquals(inputSchemaName, outputSchemaName);
+    }
+
+    @Test
+    public void getAdjustedSchemaNameUpper()
+            throws Exception
+    {
+        String inputSchemaName = "testschema";
+        Map<String, String> config = Map.of(OracleCaseResolver.CASING_MODE, "upper");
+        String outputSchemaName = OracleCaseResolver.getAdjustedSchemaName(connection, inputSchemaName, config);
+        Assert.assertEquals(inputSchemaName.toUpperCase(), outputSchemaName);
+    }
+
+    @Test
+    public void getAdjustedSchemaNameSearch()
+            throws Exception
+    {
+        String inputSchemaName = "testschema";
+        String matchedSchemaName = "testSchema";
+        Map<String, String> config = Map.of(OracleCaseResolver.CASING_MODE, "search");
+
+        PreparedStatement preparedStatement = Mockito.mock(PreparedStatement.class);
+        Mockito.when(this.connection.prepareStatement(OracleCaseResolver.SCHEMA_NAME_QUERY_TEMPLATE)).thenReturn(preparedStatement);
+
+        String[] columns = {OracleCaseResolver.SCHEMA_NAME_COLUMN_KEY};
+        int[] types = {Types.VARCHAR};
+        Object[][] values = {{matchedSchemaName}};
+        ResultSet resultSet = mockResultSet(columns, types, values, new AtomicInteger(-1));
+        Mockito.when(preparedStatement.executeQuery()).thenReturn(resultSet);
+        
+        String outputSchemaName = OracleCaseResolver.getAdjustedSchemaName(connection, inputSchemaName, config);
+        Assert.assertEquals(matchedSchemaName, outputSchemaName);
+    }
+
+    @Test
+    public void getAdjustedSchemaNameNoConfig()
+            throws Exception
+    {
+        String inputSchemaName = "testschema";
+        Map<String, String> config = Map.of();
+        String outputSchemaName = OracleCaseResolver.getAdjustedSchemaName(connection, inputSchemaName, config);
+        Assert.assertEquals(inputSchemaName.toUpperCase(), outputSchemaName);
+    }
+
+    @Test
+    public void getAdjustedSchemaNameGlueConnection()
+            throws Exception
+    {
+        // the trino engine will lowercase anything
+        String inputSchemaName = "testschema";
+        Map<String, String> config = Map.of(DEFAULT_GLUE_CONNECTION, "notBlank");
+        String outputSchemaName = OracleCaseResolver.getAdjustedSchemaName(connection, inputSchemaName, config);
+        Assert.assertEquals(inputSchemaName, outputSchemaName);
     }
 
     @Test

--- a/athena-oracle/src/test/java/com/amazonaws/athena/connectors/oracle/OracleCaseResolverTest.java
+++ b/athena-oracle/src/test/java/com/amazonaws/athena/connectors/oracle/OracleCaseResolverTest.java
@@ -1,0 +1,173 @@
+/*-
+ * #%L
+ * athena-oracle
+ * %%
+ * Copyright (C) 2019 - 2022 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.oracle;
+
+import static org.mockito.ArgumentMatchers.nullable;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Types;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.amazonaws.athena.connectors.jdbc.TestBase;
+import com.amazonaws.athena.connectors.jdbc.connection.JdbcConnectionFactory;
+import com.amazonaws.athena.connectors.jdbc.connection.JdbcCredentialProvider;
+
+public class OracleCaseResolverTest
+        extends TestBase
+{
+    private JdbcConnectionFactory jdbcConnectionFactory;
+    private Connection connection;
+
+    @Before
+    public void setup()
+            throws Exception
+    {
+        this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class, Mockito.RETURNS_DEEP_STUBS);
+        this.connection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);
+        Mockito.when(this.jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(this.connection);
+    }
+
+    @Test
+    public void getSchemaNameCaseInsensitively()
+            throws Exception
+    {
+        String inputSchemaName = "tEsTsChEmA";
+        String matchedSchemaName = "testSchema";
+
+        PreparedStatement preparedStatement = Mockito.mock(PreparedStatement.class);
+        Mockito.when(this.connection.prepareStatement(OracleCaseResolver.SCHEMA_NAME_QUERY_TEMPLATE)).thenReturn(preparedStatement);
+
+        String[] columns = {OracleCaseResolver.SCHEMA_NAME_COLUMN_KEY};
+        int[] types = {Types.VARCHAR};
+        Object[][] values = {{matchedSchemaName}};
+        ResultSet resultSet = mockResultSet(columns, types, values, new AtomicInteger(-1));
+        Mockito.when(preparedStatement.executeQuery()).thenReturn(resultSet);
+
+        String outputSchemaName = OracleCaseResolver.getSchemaNameCaseInsensitively(connection, inputSchemaName);
+        Assert.assertEquals(outputSchemaName, matchedSchemaName);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void getSchemaNameCaseInsensitivelyFailMultipleMatches()
+            throws Exception
+    {
+        String inputSchemaName = "tEsTsChEmA";
+        String[] matchedSchemaName = {"testSchema", "TESTSCHEMA"};
+
+        PreparedStatement preparedStatement = Mockito.mock(PreparedStatement.class);
+        Mockito.when(this.connection.prepareStatement(OracleCaseResolver.SCHEMA_NAME_QUERY_TEMPLATE)).thenReturn(preparedStatement);
+
+        String[] columns = {OracleCaseResolver.SCHEMA_NAME_COLUMN_KEY};
+        int[] types = {Types.VARCHAR};
+        Object[][] values = {matchedSchemaName};
+        ResultSet resultSet = mockResultSet(columns, types, values, new AtomicInteger(-1));
+        Mockito.when(preparedStatement.executeQuery()).thenReturn(resultSet);
+
+        // should throw exception because 2 matches found
+        OracleCaseResolver.getSchemaNameCaseInsensitively(connection, inputSchemaName);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void getSchemaNameCaseInsensitivelyFailNoMatches()
+            throws Exception
+    {
+        String inputSchemaName = "tEsTsChEmA";
+        String[] matchedSchemaName = {};
+
+        PreparedStatement preparedStatement = Mockito.mock(PreparedStatement.class);
+        Mockito.when(this.connection.prepareStatement(OracleCaseResolver.SCHEMA_NAME_QUERY_TEMPLATE)).thenReturn(preparedStatement);
+
+        String[] columns = {OracleCaseResolver.SCHEMA_NAME_COLUMN_KEY};
+        int[] types = {Types.VARCHAR};
+        Object[][] values = {matchedSchemaName};
+        ResultSet resultSet = mockResultSet(columns, types, values, new AtomicInteger(-1));
+        Mockito.when(preparedStatement.executeQuery()).thenReturn(resultSet);
+
+        // should throw exception because no matches found
+        OracleCaseResolver.getSchemaNameCaseInsensitively(connection, inputSchemaName);
+    }
+
+    @Test
+    public void getTableNameCaseInsensitively()
+            throws Exception
+    {
+        String schemaName = "TestSchema";
+        String inputTableName = "tEsTtAbLe";
+        String matchedTableName = "TestTable";
+        PreparedStatement preparedStatement = Mockito.mock(PreparedStatement.class);
+        Mockito.when(this.connection.prepareStatement(OracleCaseResolver.TABLE_NAME_QUERY_TEMPLATE)).thenReturn(preparedStatement);
+
+        String[] columns = {OracleCaseResolver.TABLE_NAME_COLUMN_KEY};
+        int[] types = {Types.VARCHAR};
+        Object[][] values = {{matchedTableName}};
+        ResultSet resultSet = mockResultSet(columns, types, values, new AtomicInteger(-1));
+        Mockito.when(preparedStatement.executeQuery()).thenReturn(resultSet);
+
+        String outputTableName = OracleCaseResolver.getTableNameCaseInsensitively(connection, schemaName, inputTableName);
+        Assert.assertEquals(outputTableName, matchedTableName);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void getTableNameCaseInsensitivelyFailMultipleMatches()
+            throws Exception
+    {
+        String schemaName = "TestSchema";
+        String inputTableName = "tEsTtAbLe";
+        String[] matchedTableName = {"testtable", "TESTTABLE"};
+        PreparedStatement preparedStatement = Mockito.mock(PreparedStatement.class);
+        Mockito.when(this.connection.prepareStatement(OracleCaseResolver.TABLE_NAME_QUERY_TEMPLATE)).thenReturn(preparedStatement);
+
+        String[] columns = {OracleCaseResolver.TABLE_NAME_COLUMN_KEY};
+        int[] types = {Types.VARCHAR};
+        Object[][] values = {matchedTableName};
+        ResultSet resultSet = mockResultSet(columns, types, values, new AtomicInteger(-1));
+        Mockito.when(preparedStatement.executeQuery()).thenReturn(resultSet);
+
+        // should throw exception because 2 matches found
+        OracleCaseResolver.getTableNameCaseInsensitively(connection, schemaName, inputTableName);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void getTableNameCaseInsensitivelyFailNoMatches()
+            throws Exception
+    {
+        String schemaName = "TestSchema";
+        String inputTableName = "tEsTtAbLe";
+        String[] matchedTableName = {};
+        PreparedStatement preparedStatement = Mockito.mock(PreparedStatement.class);
+        Mockito.when(this.connection.prepareStatement(OracleCaseResolver.TABLE_NAME_QUERY_TEMPLATE)).thenReturn(preparedStatement);
+
+        String[] columns = {OracleCaseResolver.TABLE_NAME_COLUMN_KEY};
+        int[] types = {Types.VARCHAR};
+        Object[][] values = {matchedTableName};
+        ResultSet resultSet = mockResultSet(columns, types, values, new AtomicInteger(-1));
+        Mockito.when(preparedStatement.executeQuery()).thenReturn(resultSet);
+
+        // should throw exception because no matches found
+        OracleCaseResolver.getTableNameCaseInsensitively(connection, schemaName, inputTableName);
+    }
+}

--- a/athena-oracle/src/test/java/com/amazonaws/athena/connectors/oracle/OracleMetadataHandlerTest.java
+++ b/athena-oracle/src/test/java/com/amazonaws/athena/connectors/oracle/OracleMetadataHandlerTest.java
@@ -104,7 +104,7 @@ public class OracleMetadataHandlerTest
     {
         BlockAllocator blockAllocator = new BlockAllocatorImpl();
         Constraints constraints = Mockito.mock(Constraints.class);
-        TableName tableName = new TableName("testSchema", "\"TESTTABLE\"");
+        TableName tableName = new TableName("testSchema", "\'TESTTABLE\'");
         Schema partitionSchema = this.oracleMetadataHandler.getPartitionSchema("testCatalogName");
         Set<String> partitionCols = partitionSchema.getFields().stream().map(Field::getName).collect(Collectors.toSet());
         GetTableLayoutRequest getTableLayoutRequest = new GetTableLayoutRequest(this.federatedIdentity, "testQueryId", "testCatalogName", tableName, constraints, partitionSchema, partitionCols);
@@ -145,7 +145,7 @@ public class OracleMetadataHandlerTest
     {
         BlockAllocator blockAllocator = new BlockAllocatorImpl();
         Constraints constraints = Mockito.mock(Constraints.class);
-        TableName tableName = new TableName("testSchema", "\"TESTTABLE\"");
+        TableName tableName = new TableName("testSchema", "\'TESTTABLE\'");
         Schema partitionSchema = this.oracleMetadataHandler.getPartitionSchema("testCatalogName");
         Set<String> partitionCols = partitionSchema.getFields().stream().map(Field::getName).collect(Collectors.toSet());
         GetTableLayoutRequest getTableLayoutRequest = new GetTableLayoutRequest(this.federatedIdentity, "testQueryId", "testCatalogName", tableName, constraints, partitionSchema, partitionCols);
@@ -327,7 +327,7 @@ public class OracleMetadataHandlerTest
         PARTITION_SCHEMA.getFields().forEach(expectedSchemaBuilder::addField);
         Schema expected = expectedSchemaBuilder.build();
 
-        TableName inputTableName = new TableName("TESTSCHEMA", "TESTTABLE");
+        TableName inputTableName = OracleCaseResolver.quoteTableName(new TableName("TESTSCHEMA", "TESTTABLE"));
         Mockito.when(connection.getMetaData().getColumns("testCatalog", inputTableName.getSchemaName(), inputTableName.getTableName(), null)).thenReturn(resultSet);
         Mockito.when(connection.getCatalog()).thenReturn("testCatalog");
 


### PR DESCRIPTION
*Description of changes:*
Oracle by default upper cases everything. Glue does not support anything aside from lowercase. Originally, we were casing everything to upper case to match oracle. Now to support glue connections, we need to not do this. So we have three casing modes now, upper (default for legacy connectors), lower (default for connectors using glue connections), and now search, which will perform a case insensitive search.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
