### PR TITLE
Enabled Auto Merge for minor version exluding preview/beta

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -19,6 +19,16 @@ jobs:
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Approve patch and minor updates
+        if: ${{ (steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch' || steps.dependabot-metadata.outputs.update-type == 'version-update:semver-minor') &&
+            !contains(steps.dependabot-metadata.outputs.new-version, 'preview') &&
+            !contains(steps.dependabot-metadata.outputs.new-version, 'alpha') &&
+            !contains(steps.dependabot-metadata.outputs.new-version, 'beta') &&
+            !contains(steps.dependabot-metadata.outputs.new-version, 'rc') }}
+        run: gh pr review $PR_URL --approve -b "I'm **approving** this pull request because **it includes a patch or minor update**"
+        env:
+            PR_URL: ${{github.event.pull_request.html_url}}
+            GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Comment on major updates of non-development dependencies
         if: ${{steps.dependabot-metadata.outputs.update-type == 'version-update:semver-major'}}
         run: |


### PR DESCRIPTION
*Description of changes:*
1. re-enable dependabot to auto merge minor versions (this was stopped when we were merging a large feature into master)
2. Make sure that the auto merge ignores preview/beta versions that are not supposed to be production ready. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
