### PR TITLE
Revert "bump com.microsoft.sqlserver:mssql-jdbc from 12.8.1.jre11 to 12.9.0.jre11-preview"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <antlr.st4.version>4.3.4</antlr.st4.version>
         <log4j2.cachefile.transformer.version>2.15</log4j2.cachefile.transformer.version>
         <apache.httpclient.version>4.5.14</apache.httpclient.version>
-        <mssql.jdbc.version>12.9.0.jre11-preview</mssql.jdbc.version>
+        <mssql.jdbc.version>12.8.1.jre11</mssql.jdbc.version>
         <commons.cli.version>1.9.0</commons.cli.version>
         <spark.version>3.2.1</spark.version>
         <test.system.rules.version>1.19.0</test.system.rules.version>


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-athena-query-federation/issues/2510.

SQL Server, Synapse and Gen2 connectors are failing with the following error:

java.lang.StringIndexOutOfBoundsException: begin 0, end -6, length 10
at java.lang.String.checkBoundsBeginEnd(Unknown Source) ~[?:?]
at java.lang.String.substring(Unknown Source) ~[?:?]
at com.microsoft.sqlserver.jdbc.ConfigurableRetryLogic.getCurrentClassPath(ConfigurableRetryLogic.java:290) ~[task/:?]

This issue is caused by version upgrade of mssql-jdbc dependency which is in preview state.

*Description of changes:*
Reverted to the previous version of the dependency.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
