### PR TITLE
athena-synapse: Fix Partition Number and Table name for Glue Table API compatibility

### DIFF
--- a/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseMetadataHandler.java
+++ b/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseMetadataHandler.java
@@ -87,7 +87,7 @@ public class SynapseMetadataHandler extends JdbcMetadataHandler
 
     static final Map<String, String> JDBC_PROPERTIES = ImmutableMap.of("databaseTerm", "SCHEMA");
     static final String ALL_PARTITIONS = "0";
-    static final String PARTITION_NUMBER = "PARTITION_NUMBER";
+    static final String PARTITION_NUMBER = "partition_number";
     static final String PARTITION_BOUNDARY_FROM = "PARTITION_BOUNDARY_FROM";
     static final String PARTITION_BOUNDARY_TO = "PARTITION_BOUNDARY_TO";
     static final String PARTITION_COLUMN = "PARTITION_COLUMN";
@@ -320,7 +320,7 @@ public class SynapseMetadataHandler extends JdbcMetadataHandler
     {
         try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider())) {
             Schema partitionSchema = getPartitionSchema(getTableRequest.getCatalogName());
-            TableName tableName = new TableName(getTableRequest.getTableName().getSchemaName().toUpperCase(), getTableRequest.getTableName().getTableName().toUpperCase());
+            TableName tableName = new TableName(getTableRequest.getTableName().getSchemaName().toUpperCase(), getTableRequest.getTableName().getTableName());
             return new GetTableResponse(getTableRequest.getCatalogName(), tableName, getSchema(connection, tableName, partitionSchema),
                     partitionSchema.getFields().stream().map(Field::getName).collect(Collectors.toSet()));
         }


### PR DESCRIPTION
*Issue #, if available:*
Unable to fetch the table list through the Synapse Glue Federated Catalog.
*Description of changes:*
Lowercased the partition number and removed the toUpperCase() conversion from the table name in the doGetTable method.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
