### PR TITLE
Revert redshift version bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,7 @@ updates:
       - dependency-name: "com.google.api.grpc:grpc-google-cloud-bigquerystorage-v1"
       - dependency-name: "io.grpc:grpc-api"
       - dependency-name: "software.amazon.msk:aws-msk-iam-auth"
+      # bumping redshift version causes release tests to fail
       - dependency-name: "com.amazon.redshift:redshift-jdbc42"
 
   - package-ecosystem: "github-actions"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,7 @@ updates:
       - dependency-name: "com.google.api.grpc:grpc-google-cloud-bigquerystorage-v1"
       - dependency-name: "io.grpc:grpc-api"
       - dependency-name: "software.amazon.msk:aws-msk-iam-auth"
+      - dependency-name: "com.amazon.redshift:redshift-jdbc42"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/athena-redshift/pom.xml
+++ b/athena-redshift/pom.xml
@@ -24,7 +24,7 @@
             <groupId>com.amazon.redshift</groupId>
             <artifactId>redshift-jdbc42</artifactId>
             <!-- Increasing to 2.1.0.31 caused a casing issue in release tests -->
-            <version>2.1.0.32</version>
+            <version>2.1.0.30</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>


### PR DESCRIPTION
Dependabot automatically bumped the redshift version, which caused release tests to fail. Why is unknown. This has been reverted before (https://github.com/awslabs/aws-athena-query-federation/pull/2469), but now is added to dependabot ignore list.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
