### PR TITLE
Add Support for Case-Insensitive Search in DataLake Gen2 Connector

### DIFF
--- a/athena-datalakegen2/src/main/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2CaseInsensitiveResolver.java
+++ b/athena-datalakegen2/src/main/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2CaseInsensitiveResolver.java
@@ -1,0 +1,169 @@
+/*-
+ * #%L
+ * athena-datalakegen2
+ * %%
+ * Copyright (C) 2019 - 2024 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.datalakegen2;
+
+import com.amazonaws.athena.connector.lambda.domain.TableName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Map;
+
+public class DataLakeGen2CaseInsensitiveResolver
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(DataLakeGen2CaseInsensitiveResolver.class);
+    private static final String OBJECT_NAME_QUERY_TEMPLATE = "SELECT TABLE_SCHEMA, TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE LOWER(TABLE_SCHEMA) = ? AND LOWER(TABLE_NAME) = ?";
+    private static final String SCHEMA_NAME_QUERY_TEMPLATE = "SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE LOWER(SCHEMA_NAME) = ?";
+    private static final String CASING_MODE = "casing_mode";
+
+    private DataLakeGen2CaseInsensitiveResolver()
+    {
+    }
+
+    private enum DataLakeGen2CasingMode
+    {
+        NONE,
+        CASE_INSENSITIVE_SEARCH
+    }
+
+    public static TableName getAdjustedTableObjectNameBasedOnConfig(final Connection connection,  TableName tableName, Map<String, String> configOptions)
+            throws SQLException
+    {
+        DataLakeGen2CasingMode casingMode = getCasingMode(configOptions);
+        switch (casingMode) {
+            case CASE_INSENSITIVE_SEARCH:
+                TableName tableNameResult = getObjectNameCaseInsensitively(connection, tableName);
+                LOGGER.info("casing mode is `CASE_INSENSITIVE_SEARCH`: adjusting casing from DataLake Gen2 case insensitive search for TableName object. TableName:{}", tableNameResult);
+                return tableNameResult;
+            case NONE:
+                LOGGER.info("casing mode is `NONE`: not adjust casing from input for TableName object. TableName:{}", tableName);
+                return tableName;
+        }
+        LOGGER.warn("casing mode is empty: not adjust casing from input for TableName object. TableName:{}", tableName);
+        return tableName;
+    }
+
+    /**
+     * Retrieves the exact schema and table name from DataLake Gen2.
+     *
+     * @param connection The database connection.
+     * @param tableName TableName to validate and convert.
+     * @return The exact case-sensitive TableName.
+     * @throws SQLException If a database connection failures.
+     */
+    public static TableName getObjectNameCaseInsensitively(Connection connection, TableName tableName) throws SQLException
+    {
+        try (PreparedStatement stmt = connection.prepareStatement(OBJECT_NAME_QUERY_TEMPLATE)) {
+            stmt.setString(1, tableName.getSchemaName().toLowerCase());
+            stmt.setString(2, tableName.getTableName().toLowerCase());
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) {
+                    TableName matchedTable = new TableName(rs.getString("TABLE_SCHEMA"), rs.getString("TABLE_NAME"));
+
+                    // Check if another match found
+                    if (rs.next()) {
+                        throw new RuntimeException(String.format("Multiple matches found for object %s.%s",
+                                tableName.getSchemaName(), tableName.getTableName()));
+                    }
+                    // Return the exact case-sensitive schema and table name.
+                    return matchedTable;
+                }
+            }
+        }
+        // Throw an exception if no matching schema and table name is found.
+        throw new RuntimeException(String.format("Object %s.%s not found", tableName.getSchemaName(), tableName.getTableName()));
+    }
+
+    public static String getAdjustedSchemaNameBasedOnConfig(final Connection connection, String schemaNameInput, Map<String, String> configOptions)
+            throws SQLException
+    {
+        DataLakeGen2CasingMode casingMode = getCasingMode(configOptions);
+        switch (casingMode) {
+            case CASE_INSENSITIVE_SEARCH:
+                LOGGER.info("casing mode is `CASE_INSENSITIVE_SEARCH`: adjusting casing from DataLake Gen2 case insensitive search for Schema...");
+                return getSchemaNameCaseInsensitively(connection, schemaNameInput);
+            case NONE:
+                LOGGER.info("casing mode is `NONE`: not adjust casing from input for Schema");
+                return schemaNameInput;
+        }
+
+        return schemaNameInput;
+    }
+
+    /**
+     * Retrieves the exact schema name from the DataLake Gen2.
+     *
+     * @param connection The database connection.
+     * @param schemaNameInput SchemaName to validate and convert.
+     * @return The exact case-sensitive SchemaName.
+     * @throws SQLException If a database connection failures.
+     */
+    public static String getSchemaNameCaseInsensitively(Connection connection, String schemaNameInput) throws SQLException
+    {
+        try (PreparedStatement stmt = connection.prepareStatement(SCHEMA_NAME_QUERY_TEMPLATE)) {
+            stmt.setString(1, schemaNameInput.toLowerCase());
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) {
+                    String matchedSchema = rs.getString("SCHEMA_NAME");
+
+                    // Check if another match found
+                    if (rs.next()) {
+                        throw new RuntimeException(String.format("Multiple matches found for schema %s", schemaNameInput));
+                    }
+                    // Return the exact case-sensitive schema name.
+                    return matchedSchema;
+                }
+            }
+        }
+        // Throw an exception if no matching schema found.
+        throw new RuntimeException(String.format("Schema %s not found", schemaNameInput));
+    }
+
+    /**
+     * Retrieves the casing mode from the provided options.
+     * If the casing mode is not specified, it defaults to NONE. This applies to both Glue and non-Glue connections.
+     *
+     * @param configOptions Config options where the casing mode may be present.
+     * @return CasingMode corresponding to the config value, or NONE if not specified.
+     * @throws IllegalArgumentException If the provided casing mode value is invalid.
+     */
+    private static DataLakeGen2CasingMode getCasingMode(Map<String, String> configOptions)
+    {
+        if (!configOptions.containsKey(CASING_MODE)) {
+            LOGGER.info("CASING MODE disable");
+            return DataLakeGen2CasingMode.NONE;
+        }
+
+        try {
+            DataLakeGen2CasingMode dataLakeGen2CasingMode = DataLakeGen2CasingMode.valueOf(configOptions.get(CASING_MODE).toUpperCase());
+            LOGGER.info("CASING MODE enable: {}", dataLakeGen2CasingMode.toString());
+            return dataLakeGen2CasingMode;
+        }
+        catch (Exception ex) {
+            // print error log for customer along with list of input
+            LOGGER.error("Invalid input for:{}, input value:{}, valid values:{}", CASING_MODE, configOptions.get(CASING_MODE), Arrays.asList(DataLakeGen2CasingMode.values()), ex);
+            throw ex;
+        }
+    }
+}

--- a/athena-datalakegen2/src/main/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2MetadataHandler.java
+++ b/athena-datalakegen2/src/main/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2MetadataHandler.java
@@ -36,6 +36,8 @@ import com.amazonaws.athena.connector.lambda.metadata.GetSplitsResponse;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableLayoutRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableResponse;
+import com.amazonaws.athena.connector.lambda.metadata.ListTablesRequest;
+import com.amazonaws.athena.connector.lambda.metadata.ListTablesResponse;
 import com.amazonaws.athena.connector.lambda.metadata.optimizations.DataSourceOptimizations;
 import com.amazonaws.athena.connector.lambda.metadata.optimizations.OptimizationSubType;
 import com.amazonaws.athena.connector.lambda.metadata.optimizations.pushdown.ComplexExpressionPushdownSubType;
@@ -48,6 +50,7 @@ import com.amazonaws.athena.connectors.jdbc.manager.JDBCUtil;
 import com.amazonaws.athena.connectors.jdbc.manager.JdbcArrowTypeConverter;
 import com.amazonaws.athena.connectors.jdbc.manager.JdbcMetadataHandler;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.apache.arrow.vector.types.Types;
@@ -81,7 +84,7 @@ public class DataLakeGen2MetadataHandler extends JdbcMetadataHandler
     private static final Logger LOGGER = LoggerFactory.getLogger(DataLakeGen2MetadataHandler.class);
 
     static final Map<String, String> JDBC_PROPERTIES = ImmutableMap.of("databaseTerm", "SCHEMA");
-    static final String PARTITION_NUMBER = "PARTITION_NUMBER";
+    static final String PARTITION_NUMBER = "partition_number";
 
     /**
      * Instantiates handler to be used by Lambda function directly.
@@ -197,7 +200,7 @@ public class DataLakeGen2MetadataHandler extends JdbcMetadataHandler
     {
         try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider())) {
             Schema partitionSchema = getPartitionSchema(getTableRequest.getCatalogName());
-            TableName tableName = new TableName(getTableRequest.getTableName().getSchemaName().toUpperCase(), getTableRequest.getTableName().getTableName().toUpperCase());
+            TableName tableName = DataLakeGen2CaseInsensitiveResolver.getAdjustedTableObjectNameBasedOnConfig(connection, getTableRequest.getTableName(), configOptions);
             return new GetTableResponse(getTableRequest.getCatalogName(), tableName, getSchema(connection, tableName, partitionSchema),
                     partitionSchema.getFields().stream().map(Field::getName).collect(Collectors.toSet()));
         }
@@ -229,8 +232,8 @@ public class DataLakeGen2MetadataHandler extends JdbcMetadataHandler
         LOGGER.info("Inside getSchema");
 
         String dataTypeQuery = "SELECT C.NAME AS COLUMN_NAME, TYPE_NAME(C.USER_TYPE_ID) AS DATA_TYPE " +
-                "FROM SYS.COLUMNS C " +
-                "JOIN SYS.TYPES T " +
+                "FROM sys.columns C " +
+                "JOIN sys.types T " +
                 "ON C.USER_TYPE_ID=T.USER_TYPE_ID " +
                 "WHERE C.OBJECT_ID=OBJECT_ID(?)";
 
@@ -244,7 +247,7 @@ public class DataLakeGen2MetadataHandler extends JdbcMetadataHandler
              Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider());
              PreparedStatement stmt = connection.prepareStatement(dataTypeQuery)) {
             // fetch data types of columns and prepare map with column name and datatype.
-            stmt.setString(1, tableName.getSchemaName().toUpperCase() + "." + tableName.getTableName().toUpperCase());
+            stmt.setString(1, tableName.getSchemaName() + "." + tableName.getTableName());
             try (ResultSet dataTypeResultSet = stmt.executeQuery()) {
                 while (dataTypeResultSet.next()) {
                     dataType = dataTypeResultSet.getString("DATA_TYPE");
@@ -303,5 +306,36 @@ public class DataLakeGen2MetadataHandler extends JdbcMetadataHandler
                 escapeNamePattern(tableHandle.getSchemaName(), escape),
                 escapeNamePattern(tableHandle.getTableName(), escape),
                 null);
+    }
+
+    @Override
+    public ListTablesResponse doListTables(final BlockAllocator blockAllocator, final ListTablesRequest listTablesRequest)
+            throws Exception
+    {
+        try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider())) {
+            LOGGER.info("{}: List table names for Catalog {}, Schema {}", listTablesRequest.getQueryId(),
+                    listTablesRequest.getCatalogName(), listTablesRequest.getSchemaName());
+            String adjustedSchemaName = DataLakeGen2CaseInsensitiveResolver.getAdjustedSchemaNameBasedOnConfig(connection, listTablesRequest.getSchemaName(), configOptions);
+            // TODO: Implement pagination if supported by DataLake Gen2
+            LOGGER.info("doListTables - NO pagination");
+            return new ListTablesResponse(listTablesRequest.getCatalogName(), listTablesNoPagination(connection, adjustedSchemaName), null);
+        }
+    }
+
+    private List<TableName> listTablesNoPagination(final Connection jdbcConnection, final String databaseName)
+            throws SQLException
+    {
+        LOGGER.debug("listTables, databaseName:" + databaseName);
+        try (ResultSet resultSet = jdbcConnection.getMetaData().getTables(
+                jdbcConnection.getCatalog(),
+                databaseName,
+                null,
+                new String[] {"TABLE", "VIEW", "EXTERNAL TABLE", "MATERIALIZED VIEW"})) {
+            ImmutableList.Builder<TableName> list = ImmutableList.builder();
+            while (resultSet.next()) {
+                list.add(JDBCUtil.getSchemaTableName(resultSet));
+            }
+            return list.build();
+        }
     }
 }

--- a/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2CaseInsensitiveResolverTest.java
+++ b/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2CaseInsensitiveResolverTest.java
@@ -1,0 +1,146 @@
+/*-
+ * #%L
+ * athena-datalakegen2
+ * %%
+ * Copyright (C) 2019 - 2022 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.datalakegen2;
+
+import com.amazonaws.athena.connector.lambda.domain.TableName;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class DataLakeGen2CaseInsensitiveResolverTest {
+
+    private Connection mockConnection;
+    private ResultSet mockResultSet;
+
+    @Before
+    public void setUp() throws SQLException {
+        mockConnection = mock(Connection.class);
+        PreparedStatement mockStmt = mock(PreparedStatement.class);
+        mockResultSet = mock(ResultSet.class);
+
+        when(mockConnection.prepareStatement(anyString())).thenReturn(mockStmt);
+        when(mockStmt.executeQuery()).thenReturn(mockResultSet);
+    }
+
+    @Test
+    public void getAdjustedTableObjectNameCaseInsensitively() throws SQLException {
+        TableName inputTableName = new TableName("schema", "table");
+        TableName expectedTableName = new TableName("SCHEMA", "TABLE");
+
+        when(mockResultSet.next()).thenReturn(true, false);
+        when(mockResultSet.getString("TABLE_SCHEMA")).thenReturn("SCHEMA");
+        when(mockResultSet.getString("TABLE_NAME")).thenReturn("TABLE");
+
+        Map<String, String> config = new HashMap<>();
+        config.put("casing_mode", "CASE_INSENSITIVE_SEARCH");
+
+        TableName result = DataLakeGen2CaseInsensitiveResolver.getAdjustedTableObjectNameBasedOnConfig(mockConnection, inputTableName, config);
+        Assert.assertEquals(expectedTableName, result);
+    }
+
+    @Test
+    public void getAdjustedTableObjectNameNoConfig() throws SQLException {
+        TableName inputTableName = new TableName("schema", "table");
+        TableName result = DataLakeGen2CaseInsensitiveResolver.getAdjustedTableObjectNameBasedOnConfig(mockConnection, inputTableName, Collections.emptyMap());
+        Assert.assertEquals(inputTableName, result);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void getAdjustedTableObjectNameInvalidCasingMode() throws SQLException {
+        TableName inputTableName = new TableName("schema", "table");
+        Map<String, String> config = new HashMap<>();
+        config.put("casing_mode", "INVALID_MODE");
+
+        DataLakeGen2CaseInsensitiveResolver.getAdjustedTableObjectNameBasedOnConfig(mockConnection, inputTableName, config);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void getObjectNameCaseInsensitivelyMultiMatches() throws SQLException {
+        TableName inputTableName = new TableName("schema", "table");
+
+        when(mockResultSet.next()).thenReturn(true, true, false);
+        when(mockResultSet.getString("TABLE_SCHEMA")).thenReturn("SCHEMA");
+        when(mockResultSet.getString("TABLE_NAME")).thenReturn("TABLE");
+
+        DataLakeGen2CaseInsensitiveResolver.getObjectNameCaseInsensitively(mockConnection, inputTableName);
+    }
+
+    @Test
+    public void getAdjustedSchemaNameCaseInsensitively() throws SQLException {
+        String inputSchemaName = "schema";
+        String expectedSchemaName = "SCHEMA";
+
+        when(mockResultSet.next()).thenReturn(true, false);
+        when(mockResultSet.getString("SCHEMA_NAME")).thenReturn("SCHEMA");
+
+        Map<String, String> config = new HashMap<>();
+        config.put("casing_mode", "CASE_INSENSITIVE_SEARCH");
+
+        String result = DataLakeGen2CaseInsensitiveResolver.getAdjustedSchemaNameBasedOnConfig(mockConnection, inputSchemaName, config);
+        Assert.assertEquals(expectedSchemaName, result);
+    }
+
+    @Test
+    public void getAdjustedSchemaNameNoConfig() throws SQLException {
+        String inputSchemaName = "schema";
+        String result = DataLakeGen2CaseInsensitiveResolver.getAdjustedSchemaNameBasedOnConfig(mockConnection, inputSchemaName, Collections.emptyMap());
+        Assert.assertEquals(inputSchemaName, result);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void getAdjustedSchemaNameInvalidCasingMode() throws SQLException {
+        String inputSchemaName = "schema";
+        Map<String, String> config = new HashMap<>();
+        config.put("casing_mode", "INVALID_MODE");
+
+        DataLakeGen2CaseInsensitiveResolver.getAdjustedSchemaNameBasedOnConfig(mockConnection, inputSchemaName, config);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void getSchemaNameCaseInsensitivelyMultiMatches() throws SQLException {
+        String inputSchemaName = "schema";
+
+        when(mockResultSet.next()).thenReturn(true, true, false);
+        when(mockResultSet.getString("SCHEMA_NAME")).thenReturn("SCHEMA");
+
+        DataLakeGen2CaseInsensitiveResolver.getSchemaNameCaseInsensitively(mockConnection, inputSchemaName);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void getSchemaNameNotFound() throws SQLException {
+        String inputSchemaName = "nonexistent_schema";
+
+        when(mockResultSet.next()).thenReturn(false);
+        when(mockResultSet.getString("SCHEMA_NAME")).thenReturn(null);
+
+        DataLakeGen2CaseInsensitiveResolver.getSchemaNameCaseInsensitively(mockConnection, inputSchemaName);
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
Unable to query external tables stored on ADLS Gen2 when case-sensitive collation is enabled.
*Description of changes:*
1) Lowercased the partition number, as Glue supports only lowercase.
2) Added a new class Gen2CaseInsensitiveResolver to handle case sensitivity in schema/table lookups.
3) Added a configurable environment variable 'casing_mode', with the following options:
    i) NONE (default):Uses the schema and table names provided by Athena Request without modification.
    ii) CASE_INSENSITIVE_SEARCH: Adjusts schema and table names to match their actual stored values in the database.
Please find the attached test results.
[gen2-cs-collation-issue.odt](https://github.com/user-attachments/files/18905022/gen2-cs-collation-issue.odt)
[DATALAKEGEN2_FUNCTIONAL_TEST_2025-02-21_15_45_38.099143.csv](https://github.com/user-attachments/files/18905050/DATALAKEGEN2_FUNCTIONAL_TEST_2025-02-21_15_45_38.099143.csv)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
