### PR TITLE
CLOUDERA-IMPALA Connection String Fix

### DIFF
--- a/athena-cloudera-impala/src/main/java/com/amazonaws/athena/connectors/cloudera/ImpalaEnvironmentProperties.java
+++ b/athena-cloudera-impala/src/main/java/com/amazonaws/athena/connectors/cloudera/ImpalaEnvironmentProperties.java
@@ -32,8 +32,8 @@ public class ImpalaEnvironmentProperties extends JdbcEnvironmentProperties
     }
 
     @Override
-    protected String getDatabase(Map<String, String> connectionProperties)
+    protected String getJdbcParametersSeparator()
     {
-        return "/";
+        return ";";
     }
 }

--- a/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaEnvironmentPropertiesTest.java
+++ b/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaEnvironmentPropertiesTest.java
@@ -1,0 +1,57 @@
+/*-
+ * #%L
+ * athena-cloudera-impala
+ * %%
+ * Copyright (C) 2019 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.cloudera;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.DATABASE;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.DEFAULT;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.HOST;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.PORT;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.SECRET_NAME;
+import static org.junit.Assert.assertEquals;
+
+public class ImpalaEnvironmentPropertiesTest {
+    Map<String, String> connectionProperties;
+    ImpalaEnvironmentProperties impalaEnvironmentProperties;
+
+    @Before
+    public void setUp() {
+        connectionProperties = new HashMap<>();
+        connectionProperties.put(HOST, "50.100.00.10");
+        connectionProperties.put(DATABASE, "default");
+        connectionProperties.put(SECRET_NAME, "testSecret");
+        connectionProperties.put(PORT, "49172");
+        impalaEnvironmentProperties = new ImpalaEnvironmentProperties();
+    }
+
+    @Test
+    public void impalaConnectionPropertiesTest() {
+
+        Map<String, String> impalaConnectionProperties = impalaEnvironmentProperties.connectionPropertiesToEnvironment(connectionProperties);
+
+        String expectedConnectionString = "impala://jdbc:impala://50.100.00.10:49172/default;${testSecret}";
+        assertEquals(expectedConnectionString, impalaConnectionProperties.get(DEFAULT));
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
The connection string was not forming correctly, which caused an error. 

Expected Connection string should be in "jdbc:impala://50.100.00.00:49172/default;UID=username;PWD=pass"  format but we were getting in "jdbc:impala://50.000.00.00:49172/?UID=username;PWD=pass".

After making these code changes, it is now successful. PFA test doc for LF testing with glue.
[CLOUDERA_IMPALA_PHASE2.xlsx](https://github.com/user-attachments/files/18520945/CLOUDERA_IMPALA_PHASE2.xlsx)





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
