### PR TITLE
Upgraded RDS Postgresql Version Used In Integ Tests

### DIFF
--- a/validation_testing/cdk_federation_infra_provisioning/app/lib/stacks/rds-generic-stack.ts
+++ b/validation_testing/cdk_federation_infra_provisioning/app/lib/stacks/rds-generic-stack.ts
@@ -161,7 +161,7 @@ export class RdsGenericStack extends cdk.Stack {
     if (db_type == 'mysql') {
       return rds.DatabaseClusterEngine.auroraMysql({version:rds.AuroraMysqlEngineVersion.VER_3_04_1});
     } else if (db_type == 'postgresql') {
-      return rds.DatabaseClusterEngine.auroraPostgres({version:rds.AuroraPostgresEngineVersion.VER_13_7});
+      return rds.DatabaseClusterEngine.auroraPostgres({version:rds.AuroraPostgresEngineVersion.VER_15_4});
     } else {
       throw new Error("unsupported rds engine version");
     }


### PR DESCRIPTION
*Issue #, if available:*

Current tests are failing due to not being able to support version 13.7 for aurora-postgresql ; upgrading the cluster to use the latest version. 

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
