### PR TITLE
Addressing CVE-2021-42392,CVE-2022-23221,CVE-2022-23305,CVE-2019-17571

### DIFF
--- a/athena-jdbc/pom.xml
+++ b/athena-jdbc/pom.xml
@@ -63,6 +63,10 @@
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-annotations</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.h2database</groupId>
+                    <artifactId>h2</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/athena-postgresql/src/main/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlQueryStringBuilder.java
+++ b/athena-postgresql/src/main/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlQueryStringBuilder.java
@@ -1,4 +1,7 @@
-/*- #%L athena-postgresql %%
+/*- 
+ * #%L 
+ * athena-postgresql 
+ * %%
  * Copyright (C) 2019 Amazon Web Services
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,13 @@
         <module>athena-clickhouse</module>
     </modules>
     <dependencies>
+         <dependency>
+             <!-- Setting this dependency to provided with the range version will ensure to exclude it from all transitive depndencies -->
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+            <version>[1.2,)</version>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>


### PR DESCRIPTION
*Issue #, if available:*
Fixing `commons-logging` that brings in vulnerable `log4j` version 1; as well as excluding H2 database from `arrow-jdbc`. 

Please note that AWS Inspector will still show risk for the h2 database; this is due to how the service actually search for vulnerability using the pom; which as of now we can't upgrade above from arrow-jdbc 13; without upgrading everything else. However this should remove the H2 Jar all together from the final package. Moreover; it is a test dependency; so even then it shouldn't have brought it in.

