### PR TITLE
Update aws-cdk cli version to match aws-cdk-lib 2.177.0

### DIFF
--- a/validation_testing/cdk_federation_infra_provisioning/app/package.json
+++ b/validation_testing/cdk_federation_infra_provisioning/app/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@types/jest": "^29.4.0",
     "@types/node": "18.11.18",
-    "aws-cdk": "2.130.0",
+    "aws-cdk": "2.177.0",
     "jest": "^29.4.1",
     "ts-jest": "^29.0.5",
     "ts-node": "^10.9.1"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update CDK CLI version to match aws-cdk-lib to resolve `This CDK CLI is not compatible with the CDK library used by your application. Please upgrade the CLI to the latest version.
(Cloud assembly schema version mismatch: Maximum schema version supported is 36.0.0, but found 39.0.0)`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
