### PR TITLE
Remove endpoint

### DIFF
--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/connection/EnvironmentProperties.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/connection/EnvironmentProperties.java
@@ -29,7 +29,6 @@ import software.amazon.awssdk.services.glue.model.Connection;
 import software.amazon.awssdk.services.glue.model.GetConnectionRequest;
 import software.amazon.awssdk.services.glue.model.GetConnectionResponse;
 
-import java.net.URI;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -68,20 +67,11 @@ public class EnvironmentProperties
     public Connection getGlueConnection(String glueConnectionName) throws RuntimeException
     {
         try {
-            HashMap<String, String> lambdaEnvironment = new HashMap<>(System.getenv());
             GlueClient awsGlue = GlueClient.builder()
                     .httpClientBuilder(ApacheHttpClient
                             .builder()
                             .connectionTimeout(Duration.ofMillis(CONNECT_TIMEOUT)))
                     .build();
-            if (lambdaEnvironment.getOrDefault("USE_GAMMA_GLUE", "false").equals("true")) {
-                awsGlue = GlueClient.builder()
-                        .endpointOverride(new URI(String.format("https://glue-gamma.%s.amazonaws.com", lambdaEnvironment.get("AWS_REGION"))))
-                        .httpClientBuilder(ApacheHttpClient
-                                .builder()
-                                .connectionTimeout(Duration.ofMillis(CONNECT_TIMEOUT)))
-                        .build();
-            }
             GetConnectionResponse glueConnection = awsGlue.getConnection(GetConnectionRequest.builder().name(glueConnectionName).build());
             logger.debug("Successfully retrieved connection {}", glueConnectionName);
             return glueConnection.connection();


### PR DESCRIPTION
Cleanup and remove endpoint that is not in use - This was part of initial development with connectors working with Glue Connection; currently all tests are by default pointing to production and this is was purely for internal development; 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
