### PR TITLE
Upgraded Arrow to 18

### DIFF
--- a/athena-clickhouse/src/test/java/com/amazonaws/athena/connectors/clickhouse/ClickHouseMuxJdbcMetadataHandlerTest.java
+++ b/athena-clickhouse/src/test/java/com/amazonaws/athena/connectors/clickhouse/ClickHouseMuxJdbcMetadataHandlerTest.java
@@ -57,6 +57,9 @@ public class ClickHouseMuxJdbcMetadataHandlerTest
     @Before
     public void setup()
     {
+        System.setProperty("arrow.memory.debug.allocator", "false");
+        System.setProperty("arrow.memory.debug.logging", "false");
+        
         //this.allocator = Mockito.mock(BlockAllocator.class);
         this.allocator = new BlockAllocatorImpl();
         //Mockito.when(this.allocator.createBlock(nullable(Schema.class))).thenReturn(Mockito.mock(Block.class));

--- a/athena-clickhouse/src/test/java/com/amazonaws/athena/connectors/clickhouse/ClickHouseMuxJdbcMetadataHandlerTest.java
+++ b/athena-clickhouse/src/test/java/com/amazonaws/athena/connectors/clickhouse/ClickHouseMuxJdbcMetadataHandlerTest.java
@@ -57,9 +57,6 @@ public class ClickHouseMuxJdbcMetadataHandlerTest
     @Before
     public void setup()
     {
-        System.setProperty("arrow.memory.debug.allocator", "false");
-        System.setProperty("arrow.memory.debug.logging", "false");
-        
         //this.allocator = Mockito.mock(BlockAllocator.class);
         this.allocator = new BlockAllocatorImpl();
         //Mockito.when(this.allocator.createBlock(nullable(Schema.class))).thenReturn(Mockito.mock(Block.class));

--- a/athena-cloudera-hive/src/main/java/com/amazonaws/athena/connectors/cloudera/HiveMetadataHandler.java
+++ b/athena-cloudera-hive/src/main/java/com/amazonaws/athena/connectors/cloudera/HiveMetadataHandler.java
@@ -74,6 +74,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -328,7 +329,7 @@ public class HiveMetadataHandler extends JdbcMetadataHandler
             try (PreparedStatement psmt = connection.prepareStatement(GET_METADATA_QUERY + tableName.getQualifiedTableName().toUpperCase())) {
                 Map<String, String> meteHashMap = getMetadataForGivenTable(psmt);
                 while (resultSet.next()) {
-                    ArrowType columnType = JdbcArrowTypeConverter.toArrowType(resultSet.getInt("DATA_TYPE"),
+                    Optional<ArrowType> columnType = JdbcArrowTypeConverter.toArrowType(resultSet.getInt("DATA_TYPE"),
                             resultSet.getInt("COLUMN_SIZE"), resultSet.getInt("DECIMAL_DIGITS"), configOptions);
                     String columnName = resultSet.getString(HiveConstants.COLUMN_NAME);
                     String dataType = meteHashMap.get(columnName);
@@ -338,46 +339,46 @@ public class HiveMetadataHandler extends JdbcMetadataHandler
                      * Converting date data type into DATEDAY MinorType
                      */
                     if (dataType != null && (dataType.toUpperCase().contains("DATE"))) {
-                        columnType = Types.MinorType.DATEDAY.getType();
+                        columnType = Optional.of(Types.MinorType.DATEDAY.getType());
                     }
                     /**
                      * Converting binary data type into VARBINARY MinorType
                      */
 
                     if (dataType != null && (dataType.toUpperCase().contains("BINARY"))) {
-                        columnType = Types.MinorType.VARBINARY.getType();
+                        columnType = Optional.of(Types.MinorType.VARBINARY.getType());
                     }
                     /**
                      * Converting double data type into FLOAT8 MinorType
                      */
                     if (dataType != null && dataType.toUpperCase().contains("DOUBLE")) {
-                        columnType = Types.MinorType.FLOAT8.getType();
+                        columnType = Optional.of(Types.MinorType.FLOAT8.getType());
                     }
                     /**
                      * Converting boolean data type into BIT MinorType
                      */
                     if (dataType != null && dataType.toUpperCase().contains("BOOLEAN")) {
-                        columnType = Types.MinorType.BIT.getType();
+                        columnType = Optional.of(Types.MinorType.BIT.getType());
                     }
                     /**
                      * Converting float data type into FLOAT4 MinorType
                      */
                     if (dataType != null && dataType.contains("FLOAT")) {
-                        columnType = Types.MinorType.FLOAT4.getType();
+                        columnType = Optional.of(Types.MinorType.FLOAT4.getType());
                     }
                     /**
-                     * Converting  TIMESTAMP data type into DATEMILLI MinorType
+                     * Converting TIMESTAMP data type into DATEMILLI MinorType
                      */
                     if (dataType != null && (dataType.toUpperCase().contains("TIMESTAMP"))) {
-                        columnType = Types.MinorType.DATEMILLI.getType();
+                        columnType = Optional.of(Types.MinorType.DATEMILLI.getType());
                     }
                     /**
                      * Converting other data type into VARCHAR MinorType
                      */
-                    if ((columnType == null) || (columnType != null && !SupportedTypes.isSupported(columnType))) {
-                        columnType = Types.MinorType.VARCHAR.getType();
+                    if (columnType.isEmpty() || !SupportedTypes.isSupported(columnType.get())) {
+                        columnType = Optional.of(Types.MinorType.VARCHAR.getType());
                     }
-                    schemaBuilder.addField(FieldBuilder.newBuilder(columnName, columnType).build());
+                    schemaBuilder.addField(FieldBuilder.newBuilder(columnName, columnType.get()).build());
                 }
             }
             partitionSchema.getFields().forEach(schemaBuilder::addField);

--- a/athena-db2/src/main/java/com/amazonaws/athena/connectors/db2/Db2MetadataHandler.java
+++ b/athena-db2/src/main/java/com/amazonaws/athena/connectors/db2/Db2MetadataHandler.java
@@ -78,6 +78,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -471,7 +472,7 @@ public class Db2MetadataHandler extends JdbcMetadataHandler
                 }
 
                 while (resultSet.next()) {
-                    ArrowType columnType = JdbcArrowTypeConverter.toArrowType(
+                    Optional<ArrowType> columnType = JdbcArrowTypeConverter.toArrowType(
                             resultSet.getInt("DATA_TYPE"),
                             resultSet.getInt("COLUMN_SIZE"),
                             resultSet.getInt("DECIMAL_DIGITS"),
@@ -484,27 +485,27 @@ public class Db2MetadataHandler extends JdbcMetadataHandler
                     If arrow type is struct then convert to VARCHAR, because struct is
                     considered as Unhandled type by JdbcRecordHandler's makeExtractor method.
                      */
-                    if (columnType != null && columnType.getTypeID().name().equalsIgnoreCase("Struct")) {
-                        columnType = Types.MinorType.VARCHAR.getType();
+                    if (columnType.isPresent() && columnType.get().getTypeID().name().equalsIgnoreCase("Struct")) {
+                        columnType = Optional.of(Types.MinorType.VARCHAR.getType());
                     }
 
                     /*
                      * Converting REAL, DOUBLE, DECFLOAT data types into FLOAT8 since framework is unable to map it by default
                      */
                     if ("real".equalsIgnoreCase(typeName) || "double".equalsIgnoreCase(typeName) || "decfloat".equalsIgnoreCase(typeName)) {
-                        columnType = Types.MinorType.FLOAT8.getType();
+                        columnType = Optional.of(Types.MinorType.FLOAT8.getType());
                     }
 
                     /*
                      * converting into VARCHAR for non supported data types.
                      */
-                    if ((columnType == null) || !SupportedTypes.isSupported(columnType)) {
-                        columnType = Types.MinorType.VARCHAR.getType();
+                    if (columnType.isEmpty() || !SupportedTypes.isSupported(columnType.get())) {
+                        columnType = Optional.of(Types.MinorType.VARCHAR.getType());
                     }
 
                     LOGGER.debug("columnType: " + columnType);
-                    if (columnType != null && SupportedTypes.isSupported(columnType)) {
-                        schemaBuilder.addField(FieldBuilder.newBuilder(columnName, columnType).build());
+                    if (columnType.isPresent() && SupportedTypes.isSupported(columnType.get())) {
+                        schemaBuilder.addField(FieldBuilder.newBuilder(columnName, columnType.get()).build());
                         found = true;
                     }
                     else {

--- a/athena-google-bigquery/pom.xml
+++ b/athena-google-bigquery/pom.xml
@@ -51,6 +51,22 @@
                     <groupId>com.google.api.grpc</groupId>
                     <artifactId>grpc-google-cloud-bigquerystorage-v1beta2</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.arrow</groupId>
+                    <artifactId>arrow-vector</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.arrow</groupId>
+                    <artifactId>arrow-format</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.arrow</groupId>
+                    <artifactId>arrow-memory-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.arrow</groupId>
+                    <artifactId>arrow-memory-netty</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/athena-jdbc/pom.xml
+++ b/athena-jdbc/pom.xml
@@ -164,7 +164,7 @@
                 <version>${mvn.shade.plugin.version}</version>
                 <configuration>
                     <createDependencyReducedPom>true</createDependencyReducedPom>
-                    <shadeTestJar>true</shadeTestJar>
+                    <shadeTestJar>false</shadeTestJar>
                     <filters>
                         <filter>
                             <artifact>*:*</artifact>

--- a/athena-jdbc/pom.xml
+++ b/athena-jdbc/pom.xml
@@ -164,6 +164,9 @@
                 <version>${mvn.shade.plugin.version}</version>
                 <configuration>
                     <createDependencyReducedPom>true</createDependencyReducedPom>
+                    <!--This should never be set to true
+                    It will cause all sorts of class-path issue with Arrow RootAllocator
+                    due to it being shaded | If changed; test from CLI and NOT IntelliJ -->
                     <shadeTestJar>false</shadeTestJar>
                     <filters>
                         <filter>

--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcArrowTypeConverter.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcArrowTypeConverter.java
@@ -23,8 +23,11 @@ import org.apache.arrow.adapter.jdbc.JdbcFieldInfo;
 import org.apache.arrow.adapter.jdbc.JdbcToArrowUtils;
 import org.apache.arrow.vector.types.DateUnit;
 import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.sql.Types;
+import java.util.Optional;
 
 /**
  * Utility abstracts Jdbc to Arrow type conversions.
@@ -32,6 +35,7 @@ import java.sql.Types;
 public final class JdbcArrowTypeConverter
 {
     private static final int DEFAULT_PRECISION = 38;
+    private static final Logger LOGGER = LoggerFactory.getLogger(JdbcArrowTypeConverter.class);
 
     private JdbcArrowTypeConverter() {}
 
@@ -43,7 +47,7 @@ public final class JdbcArrowTypeConverter
      * @param scale Decimal scale.
      * @return Arrow type. See {@link ArrowType}.
      */
-    public static ArrowType toArrowType(final int jdbcType, final int precision, final int scale, java.util.Map<String, String> configOptions)
+    public static Optional<ArrowType> toArrowType(final int jdbcType, final int precision, final int scale, java.util.Map<String, String> configOptions)
     {
         int defaultScale = Integer.parseInt(configOptions.getOrDefault("default_scale", "0"));
         int resolvedPrecision = precision;
@@ -59,19 +63,26 @@ public final class JdbcArrowTypeConverter
             resolvedPrecision = DEFAULT_PRECISION;
         }
 
-        ArrowType arrowType = JdbcToArrowUtils.getArrowTypeFromJdbcType(
-                new JdbcFieldInfo(jdbcType, resolvedPrecision, resolvedScale),
-                null);
+        Optional<ArrowType> arrowTypeOptional = Optional.empty();
 
-        if (arrowType instanceof ArrowType.Date) {
+        try {
+            arrowTypeOptional = Optional.of(JdbcToArrowUtils.getArrowTypeFromJdbcType(
+                    new JdbcFieldInfo(jdbcType, resolvedPrecision, resolvedScale), null));
+        }
+        catch (UnsupportedOperationException e) {
+            LOGGER.warn("Error converting JDBC Type [{}] to arrow: {}", jdbcType, e.getMessage());
+            return arrowTypeOptional;
+        }
+
+        if (arrowTypeOptional.isPresent() && arrowTypeOptional.get() instanceof ArrowType.Date) {
             // Convert from DateMilli to DateDay
-            return new ArrowType.Date(DateUnit.DAY);
+            return Optional.of(new ArrowType.Date(DateUnit.DAY));
         }
-        else if (arrowType instanceof ArrowType.Timestamp) {
+        else if (arrowTypeOptional.isPresent() && arrowTypeOptional.get() instanceof ArrowType.Timestamp) {
             // Convert from Timestamp to DateMilli
-            return new ArrowType.Date(DateUnit.MILLISECOND);
+            return Optional.of(new ArrowType.Date(DateUnit.MILLISECOND));
         }
 
-        return arrowType;
+        return arrowTypeOptional;
     }
 }

--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcArrowTypeConverter.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcArrowTypeConverter.java
@@ -34,7 +34,7 @@ import java.util.Optional;
  */
 public final class JdbcArrowTypeConverter
 {
-    private static final int DEFAULT_PRECISION = 38;
+    public static final int DEFAULT_PRECISION = 38;
     private static final Logger LOGGER = LoggerFactory.getLogger(JdbcArrowTypeConverter.class);
 
     private JdbcArrowTypeConverter() {}

--- a/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcArrowTypeConverterTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcArrowTypeConverterTest.java
@@ -24,8 +24,11 @@ import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Optional;
+
 public class JdbcArrowTypeConverterTest
 {
+
     @Test
     public void toArrowType()
     {
@@ -53,5 +56,12 @@ public class JdbcArrowTypeConverterTest
         Assert.assertEquals(Types.MinorType.TIMEMILLI.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.TIME, 0, 0, com.google.common.collect.ImmutableMap.of()).get());
         Assert.assertEquals(Types.MinorType.DATEMILLI.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.TIMESTAMP, 0, 0, com.google.common.collect.ImmutableMap.of()).get());
         Assert.assertEquals(Types.MinorType.LIST.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.ARRAY, 0, 0, com.google.common.collect.ImmutableMap.of()).get());
+
+        //As of 18.1.0 Arrow does not support TIMESTAMP_WITH_TIMEZONE! Hence the arrow type returns an empty optional
+        Assert.assertTrue(JdbcArrowTypeConverter.toArrowType(java.sql.Types.TIMESTAMP_WITH_TIMEZONE, 0, 0, com.google.common.collect.ImmutableMap.of()).isEmpty());
+        //Test if precision is more than the default
+        Assert.assertEquals(new ArrowType.Decimal(JdbcArrowTypeConverter.DEFAULT_PRECISION , 3), JdbcArrowTypeConverter.toArrowType(java.sql.Types.DECIMAL, JdbcArrowTypeConverter.DEFAULT_PRECISION + 1, 3, com.google.common.collect.ImmutableMap.of()).get());
+        //test for negative scale
+        Assert.assertEquals(new ArrowType.Decimal(JdbcArrowTypeConverter.DEFAULT_PRECISION, 0), JdbcArrowTypeConverter.toArrowType(java.sql.Types.NUMERIC, 0, -1, com.google.common.collect.ImmutableMap.of()).get());
     }
 }

--- a/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcArrowTypeConverterTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcArrowTypeConverterTest.java
@@ -29,29 +29,29 @@ public class JdbcArrowTypeConverterTest
     @Test
     public void toArrowType()
     {
-        Assert.assertEquals(Types.MinorType.BIT.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.BIT, 0, 0, com.google.common.collect.ImmutableMap.of()));
-        Assert.assertEquals(Types.MinorType.BIT.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.BOOLEAN, 0, 0, com.google.common.collect.ImmutableMap.of()));
-        Assert.assertEquals(Types.MinorType.TINYINT.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.TINYINT, 0, 0, com.google.common.collect.ImmutableMap.of()));
-        Assert.assertEquals(Types.MinorType.SMALLINT.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.SMALLINT, 0, 0, com.google.common.collect.ImmutableMap.of()));
-        Assert.assertEquals(Types.MinorType.INT.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.INTEGER, 0, 0, com.google.common.collect.ImmutableMap.of()));
-        Assert.assertEquals(Types.MinorType.BIGINT.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.BIGINT, 0, 0, com.google.common.collect.ImmutableMap.of()));
-        Assert.assertEquals(Types.MinorType.FLOAT4.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.REAL, 0, 0, com.google.common.collect.ImmutableMap.of()));
-        Assert.assertEquals(Types.MinorType.FLOAT4.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.FLOAT, 0, 0, com.google.common.collect.ImmutableMap.of()));
-        Assert.assertEquals(Types.MinorType.FLOAT8.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.DOUBLE, 0, 0, com.google.common.collect.ImmutableMap.of()));
-        Assert.assertEquals(new ArrowType.Decimal(5, 3), JdbcArrowTypeConverter.toArrowType(java.sql.Types.DECIMAL, 5, 3, com.google.common.collect.ImmutableMap.of()));
-        Assert.assertEquals(new ArrowType.Decimal(38, 0), JdbcArrowTypeConverter.toArrowType(java.sql.Types.NUMERIC, 0, 0, com.google.common.collect.ImmutableMap.of()));
-        Assert.assertEquals(Types.MinorType.VARCHAR.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.CHAR, 0, 0, com.google.common.collect.ImmutableMap.of()));
-        Assert.assertEquals(Types.MinorType.VARCHAR.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.NCHAR, 0, 0, com.google.common.collect.ImmutableMap.of()));
-        Assert.assertEquals(Types.MinorType.VARCHAR.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.VARCHAR, 0, 0, com.google.common.collect.ImmutableMap.of()));
-        Assert.assertEquals(Types.MinorType.VARCHAR.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.NVARCHAR, 0, 0, com.google.common.collect.ImmutableMap.of()));
-        Assert.assertEquals(Types.MinorType.VARCHAR.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.LONGVARCHAR, 0, 0, com.google.common.collect.ImmutableMap.of()));
-        Assert.assertEquals(Types.MinorType.VARCHAR.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.LONGNVARCHAR, 0, 0, com.google.common.collect.ImmutableMap.of()));
-        Assert.assertEquals(Types.MinorType.VARBINARY.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.BINARY, 0, 0, com.google.common.collect.ImmutableMap.of()));
-        Assert.assertEquals(Types.MinorType.VARBINARY.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.VARBINARY, 0, 0, com.google.common.collect.ImmutableMap.of()));
-        Assert.assertEquals(Types.MinorType.VARBINARY.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.LONGVARBINARY, 0, 0, com.google.common.collect.ImmutableMap.of()));
-        Assert.assertEquals(Types.MinorType.DATEDAY.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.DATE, 0, 0, com.google.common.collect.ImmutableMap.of()));
-        Assert.assertEquals(Types.MinorType.TIMEMILLI.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.TIME, 0, 0, com.google.common.collect.ImmutableMap.of()));
-        Assert.assertEquals(Types.MinorType.DATEMILLI.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.TIMESTAMP, 0, 0, com.google.common.collect.ImmutableMap.of()));
-        Assert.assertEquals(Types.MinorType.LIST.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.ARRAY, 0, 0, com.google.common.collect.ImmutableMap.of()));
+        Assert.assertEquals(Types.MinorType.BIT.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.BIT, 0, 0, com.google.common.collect.ImmutableMap.of()).get());
+        Assert.assertEquals(Types.MinorType.BIT.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.BOOLEAN, 0, 0, com.google.common.collect.ImmutableMap.of()).get());
+        Assert.assertEquals(Types.MinorType.TINYINT.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.TINYINT, 0, 0, com.google.common.collect.ImmutableMap.of()).get());
+        Assert.assertEquals(Types.MinorType.SMALLINT.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.SMALLINT, 0, 0, com.google.common.collect.ImmutableMap.of()).get());
+        Assert.assertEquals(Types.MinorType.INT.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.INTEGER, 0, 0, com.google.common.collect.ImmutableMap.of()).get());
+        Assert.assertEquals(Types.MinorType.BIGINT.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.BIGINT, 0, 0, com.google.common.collect.ImmutableMap.of()).get());
+        Assert.assertEquals(Types.MinorType.FLOAT4.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.REAL, 0, 0, com.google.common.collect.ImmutableMap.of()).get());
+        Assert.assertEquals(Types.MinorType.FLOAT4.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.FLOAT, 0, 0, com.google.common.collect.ImmutableMap.of()).get());
+        Assert.assertEquals(Types.MinorType.FLOAT8.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.DOUBLE, 0, 0, com.google.common.collect.ImmutableMap.of()).get());
+        Assert.assertEquals(new ArrowType.Decimal(5, 3), JdbcArrowTypeConverter.toArrowType(java.sql.Types.DECIMAL, 5, 3, com.google.common.collect.ImmutableMap.of()).get());
+        Assert.assertEquals(new ArrowType.Decimal(38, 0), JdbcArrowTypeConverter.toArrowType(java.sql.Types.NUMERIC, 0, 0, com.google.common.collect.ImmutableMap.of()).get());
+        Assert.assertEquals(Types.MinorType.VARCHAR.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.CHAR, 0, 0, com.google.common.collect.ImmutableMap.of()).get());
+        Assert.assertEquals(Types.MinorType.VARCHAR.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.NCHAR, 0, 0, com.google.common.collect.ImmutableMap.of()).get());
+        Assert.assertEquals(Types.MinorType.VARCHAR.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.VARCHAR, 0, 0, com.google.common.collect.ImmutableMap.of()).get());
+        Assert.assertEquals(Types.MinorType.VARCHAR.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.NVARCHAR, 0, 0, com.google.common.collect.ImmutableMap.of()).get());
+        Assert.assertEquals(Types.MinorType.VARCHAR.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.LONGVARCHAR, 0, 0, com.google.common.collect.ImmutableMap.of()).get());
+        Assert.assertEquals(Types.MinorType.VARCHAR.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.LONGNVARCHAR, 0, 0, com.google.common.collect.ImmutableMap.of()).get());
+        Assert.assertEquals(Types.MinorType.VARBINARY.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.BINARY, 0, 0, com.google.common.collect.ImmutableMap.of()).get());
+        Assert.assertEquals(Types.MinorType.VARBINARY.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.VARBINARY, 0, 0, com.google.common.collect.ImmutableMap.of()).get());
+        Assert.assertEquals(Types.MinorType.VARBINARY.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.LONGVARBINARY, 0, 0, com.google.common.collect.ImmutableMap.of()).get());
+        Assert.assertEquals(Types.MinorType.DATEDAY.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.DATE, 0, 0, com.google.common.collect.ImmutableMap.of()).get());
+        Assert.assertEquals(Types.MinorType.TIMEMILLI.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.TIME, 0, 0, com.google.common.collect.ImmutableMap.of()).get());
+        Assert.assertEquals(Types.MinorType.DATEMILLI.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.TIMESTAMP, 0, 0, com.google.common.collect.ImmutableMap.of()).get());
+        Assert.assertEquals(Types.MinorType.LIST.getType(), JdbcArrowTypeConverter.toArrowType(java.sql.Types.ARRAY, 0, 0, com.google.common.collect.ImmutableMap.of()).get());
     }
 }

--- a/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandlerTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandlerTest.java
@@ -181,9 +181,14 @@ public class JdbcMetadataHandlerTest
     public void doGetTable()
             throws Exception
     {
-        String[] schema = {"DATA_TYPE", "COLUMN_SIZE", "COLUMN_NAME", "DECIMAL_DIGITS", "NUM_PREC_RADIX"};
-        Object[][] values = {{Types.INTEGER, 12, "testCol1", 0, 0}, {Types.VARCHAR, 25, "testCol2", 0, 0},
-                {Types.TIMESTAMP, 93, "testCol3", 0, 0},  {Types.TIMESTAMP_WITH_TIMEZONE, 93, "testCol4", 0, 0}};
+        String[] schema = {"DATA_TYPE", "COLUMN_SIZE", "COLUMN_NAME", "DECIMAL_DIGITS", "NUM_PREC_RADIX", "TYPE_NAME"};
+        Object[][] values = {
+                {Types.INTEGER, 12, "testCol1", 0, 0, "_int4"},
+                {Types.VARCHAR, 25, "testCol2", 0, 0, "VARCHAR"},
+                {Types.TIMESTAMP, 93, "testCol3", 0, 0, "_timestamp"},
+                {Types.TIMESTAMP_WITH_TIMEZONE, 93, "testCol4", 0, 0, "_timestamp"},
+                {Types.ARRAY, 0, "testCol5", 0, 0, "_array"}
+        };
         AtomicInteger rowNumber = new AtomicInteger(-1);
         ResultSet resultSet = mockResultSet(schema, values, rowNumber);
 
@@ -192,6 +197,7 @@ public class JdbcMetadataHandlerTest
         expectedSchemaBuilder.addField(FieldBuilder.newBuilder("testCol2", org.apache.arrow.vector.types.Types.MinorType.VARCHAR.getType()).build());
         expectedSchemaBuilder.addField(FieldBuilder.newBuilder("testCol3", org.apache.arrow.vector.types.Types.MinorType.DATEMILLI.getType()).build());
         expectedSchemaBuilder.addField(FieldBuilder.newBuilder("testCol4", org.apache.arrow.vector.types.Types.MinorType.VARCHAR.getType()).build());
+        expectedSchemaBuilder.addListField("testCol5", org.apache.arrow.vector.types.Types.MinorType.VARCHAR.getType());
         PARTITION_SCHEMA.getFields().forEach(expectedSchemaBuilder::addField);
         Schema expected = expectedSchemaBuilder.build();
 

--- a/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandlerTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandlerTest.java
@@ -50,15 +50,24 @@ import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueReques
 import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
 
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.Collections;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.amazonaws.athena.connector.lambda.metadata.ListTablesRequest.UNLIMITED_PAGE_SIZE_VALUE;
+import static com.amazonaws.athena.connector.lambda.metadata.optimizations.querypassthrough.QueryPassthroughSignature.ENABLE_QUERY_PASSTHROUGH;
+import static com.amazonaws.athena.connector.lambda.metadata.optimizations.querypassthrough.QueryPassthroughSignature.SCHEMA_FUNCTION_NAME;
+import static com.amazonaws.athena.connectors.jdbc.qpt.JdbcQueryPassthrough.NAME;
+import static com.amazonaws.athena.connectors.jdbc.qpt.JdbcQueryPassthrough.QUERY;
+import static com.amazonaws.athena.connectors.jdbc.qpt.JdbcQueryPassthrough.SCHEMA_NAME;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.mock;
 
 public class JdbcMetadataHandlerTest
         extends TestBase
@@ -78,12 +87,12 @@ public class JdbcMetadataHandlerTest
     public void setup()
             throws Exception
     {
-        this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
-        this.connection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);
+        this.jdbcConnectionFactory = mock(JdbcConnectionFactory.class);
+        this.connection = mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);
         Mockito.when(connection.getCatalog()).thenReturn("testCatalog");
         Mockito.when(this.jdbcConnectionFactory.getConnection(nullable(JdbcCredentialProvider.class))).thenReturn(this.connection);
-        this.secretsManager = Mockito.mock(SecretsManagerClient.class);
-        this.athena = Mockito.mock(AthenaClient.class);
+        this.secretsManager = mock(SecretsManagerClient.class);
+        this.athena = mock(AthenaClient.class);
         Mockito.when(this.secretsManager.getSecretValue(Mockito.eq(GetSecretValueRequest.builder().secretId("testSecret").build()))).thenReturn(GetSecretValueResponse.builder().secretString("{\"username\": \"testUser\", \"password\": \"testPassword\"}").build());
         DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", "fakedatabase",
                 "fakedatabase://jdbc:fakedatabase://hostname/${testSecret}", "testSecret");
@@ -106,8 +115,8 @@ public class JdbcMetadataHandlerTest
                 return null;
             }
         };
-        this.federatedIdentity = Mockito.mock(FederatedIdentity.class);
-        this.blockAllocator = Mockito.mock(BlockAllocator.class);
+        this.federatedIdentity = mock(FederatedIdentity.class);
+        this.blockAllocator = mock(BlockAllocator.class);
         String[] columnNames = new String[] {"TABLE_SCHEM", "TABLE_NAME"};
         String[][] tableNameValues = new String[][]{new String[] {"testSchema", "testTable"}};
         this.resultSetName = mockResultSet(columnNames, tableNameValues, new AtomicInteger(-1));
@@ -206,6 +215,49 @@ public class JdbcMetadataHandlerTest
 
         GetTableResponse getTableResponse = this.jdbcMetadataHandler.doGetTable(
                 this.blockAllocator, new GetTableRequest(this.federatedIdentity, "testQueryId", "testCatalog", inputTableName, Collections.emptyMap()));
+
+        Assert.assertEquals(expected, getTableResponse.getSchema());
+        Assert.assertEquals(inputTableName, getTableResponse.getTableName());
+        Assert.assertEquals("testCatalog", getTableResponse.getCatalogName());
+    }
+
+    @Test
+    public void doGetQueryPassthroughSchema()
+            throws Exception
+    {
+        String query = "select testCol1 from testTable";
+
+        String[] schema = {"DATA_TYPE", "COLUMN_SIZE", "COLUMN_NAME", "DECIMAL_DIGITS", "NUM_PREC_RADIX", "TYPE_NAME"};
+        Object[][] values = {
+                {Types.INTEGER, 12, "testCol1", 0, 0, "_int4"}
+        };
+        SchemaBuilder expectedSchemaBuilder = SchemaBuilder.newBuilder();
+        expectedSchemaBuilder.addField(FieldBuilder.newBuilder("testCol1", org.apache.arrow.vector.types.Types.MinorType.INT.getType()).build());
+        Schema expected = expectedSchemaBuilder.build();
+
+        TableName inputTableName = new TableName("testSchema", "testTable");
+
+        ResultSetMetaData resultSetMetadata = Mockito.mock(ResultSetMetaData.class);
+        Mockito.when(resultSetMetadata.getColumnCount()).thenReturn(values.length);
+        Mockito.when(resultSetMetadata.getColumnName(1)).thenReturn((String) values[0][2]);
+        Mockito.when(resultSetMetadata.getColumnLabel(1)).thenReturn((String) values[0][2]);
+        Mockito.when(resultSetMetadata.getPrecision(1)).thenReturn((Integer) values[0][3]);
+        Mockito.when(resultSetMetadata.getColumnDisplaySize(1)).thenReturn((Integer) values[0][4]);
+        Mockito.when(resultSetMetadata.getColumnType(1)).thenReturn(Types.INTEGER);
+
+        PreparedStatement preparedStatement = mock(PreparedStatement.class);
+        Mockito.when(preparedStatement.getMetaData()).thenReturn(resultSetMetadata);
+        Mockito.when(connection.prepareStatement(query)).thenReturn(preparedStatement);
+
+        Map<String, String> queryPassthroughParameters = Map.of(
+                SCHEMA_FUNCTION_NAME, "system.query",
+                ENABLE_QUERY_PASSTHROUGH, "true",
+                NAME, "query",
+                SCHEMA_NAME, "system",
+                QUERY, query);
+
+        GetTableResponse getTableResponse = this.jdbcMetadataHandler.doGetQueryPassthroughSchema(
+                this.blockAllocator, new GetTableRequest(this.federatedIdentity, "testQueryId", "testCatalog", inputTableName, queryPassthroughParameters));
 
         Assert.assertEquals(expected, getTableResponse.getSchema());
         Assert.assertEquals(inputTableName, getTableResponse.getTableName());

--- a/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerMetadataHandler.java
+++ b/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerMetadataHandler.java
@@ -81,6 +81,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -411,13 +412,13 @@ public class SqlServerMetadataHandler extends JdbcMetadataHandler
     }
 
     @Override
-    protected ArrowType convertDatasourceTypeToArrow(int columnIndex, int precision, Map<String, String> configOptions, ResultSetMetaData metadata) throws SQLException
+    protected Optional<ArrowType> convertDatasourceTypeToArrow(int columnIndex, int precision, Map<String, String> configOptions, ResultSetMetaData metadata) throws SQLException
     {
         String dataType = metadata.getColumnTypeName(columnIndex);
         LOGGER.info("In convertDatasourceTypeToArrow: converting {}", dataType);
         if (dataType != null && SqlServerDataType.isSupported(dataType)) {
             LOGGER.debug("Sql Server  Datatype is support: {}", dataType);
-            return SqlServerDataType.fromType(dataType); 
+            return Optional.of(SqlServerDataType.fromType(dataType));
         }
         return super.convertDatasourceTypeToArrow(columnIndex, precision, configOptions, metadata);
     }
@@ -459,7 +460,7 @@ public class SqlServerMetadataHandler extends JdbcMetadataHandler
             }
 
             while (resultSet.next()) {
-                ArrowType columnType = JdbcArrowTypeConverter.toArrowType(
+                Optional<ArrowType> columnType = JdbcArrowTypeConverter.toArrowType(
                         resultSet.getInt("DATA_TYPE"),
                         resultSet.getInt("COLUMN_SIZE"),
                         resultSet.getInt("DECIMAL_DIGITS"),
@@ -471,18 +472,18 @@ public class SqlServerMetadataHandler extends JdbcMetadataHandler
                 LOGGER.debug("dataType: " + dataType);
 
                 if (dataType != null && SqlServerDataType.isSupported(dataType)) {
-                    columnType = SqlServerDataType.fromType(dataType);
+                    columnType = Optional.of(SqlServerDataType.fromType(dataType));
                 }
                 /**
                  * converting into VARCHAR for non supported data types.
                  */
-                if ((columnType == null) || !SupportedTypes.isSupported(columnType)) {
-                    columnType = Types.MinorType.VARCHAR.getType();
+                if (columnType.isEmpty() || !SupportedTypes.isSupported(columnType.get())) {
+                    columnType = Optional.of(Types.MinorType.VARCHAR.getType());
                 }
 
                 LOGGER.debug("columnType: " + columnType);
-                if (columnType != null && SupportedTypes.isSupported(columnType)) {
-                    schemaBuilder.addField(FieldBuilder.newBuilder(columnName, columnType).build());
+                if (columnType.isPresent() && SupportedTypes.isSupported(columnType.get())) {
+                    schemaBuilder.addField(FieldBuilder.newBuilder(columnName, columnType.get()).build());
                     found = true;
                 }
                 else {

--- a/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseMetadataHandler.java
+++ b/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseMetadataHandler.java
@@ -76,6 +76,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -327,13 +328,13 @@ public class SynapseMetadataHandler extends JdbcMetadataHandler
     }
 
     @Override
-    protected ArrowType convertDatasourceTypeToArrow(int columnIndex, int precision, Map<String, String> configOptions, ResultSetMetaData metadata) throws SQLException
+    protected Optional<ArrowType> convertDatasourceTypeToArrow(int columnIndex, int precision, Map<String, String> configOptions, ResultSetMetaData metadata) throws SQLException
     {
         String dataType = metadata.getColumnTypeName(columnIndex);
         LOGGER.info("In convertDatasourceTypeToArrow: converting {}", dataType);
         if (dataType != null && SynapseDataType.isSupported(dataType)) {
             LOGGER.debug("Synapse  Datatype is support: {}", dataType);
-            return SynapseDataType.fromType(dataType); 
+            return Optional.of(SynapseDataType.fromType(dataType));
         }
         return super.convertDatasourceTypeToArrow(columnIndex, precision, configOptions, metadata);
     }
@@ -458,7 +459,7 @@ public class SynapseMetadataHandler extends JdbcMetadataHandler
         try (ResultSet resultSet = getColumns(jdbcConnection.getCatalog(), tableName, jdbcConnection.getMetaData())) {
             boolean found = false;
             while (resultSet.next()) {
-                ArrowType columnType = JdbcArrowTypeConverter.toArrowType(
+                Optional<ArrowType> columnType = JdbcArrowTypeConverter.toArrowType(
                         resultSet.getInt("DATA_TYPE"),
                         resultSet.getInt("COLUMN_SIZE"),
                         resultSet.getInt("DECIMAL_DIGITS"),
@@ -470,19 +471,19 @@ public class SynapseMetadataHandler extends JdbcMetadataHandler
                 LOGGER.debug("dataType: " + dataType);
 
                 if (dataType != null && SynapseDataType.isSupported(dataType)) {
-                    columnType = SynapseDataType.fromType(dataType);
+                    columnType = Optional.of(SynapseDataType.fromType(dataType));
                 }
 
                 /**
                  * converting into VARCHAR for non supported data types.
                  */
-                if ((columnType == null) || !SupportedTypes.isSupported(columnType)) {
-                    columnType = Types.MinorType.VARCHAR.getType();
+                if (columnType.isEmpty() || !SupportedTypes.isSupported(columnType.get())) {
+                    columnType = Optional.of(Types.MinorType.VARCHAR.getType());
                 }
 
                 LOGGER.debug("columnType: " + columnType);
-                if (columnType != null && SupportedTypes.isSupported(columnType)) {
-                    schemaBuilder.addField(FieldBuilder.newBuilder(columnName, columnType).build());
+                if (columnType.isPresent() && SupportedTypes.isSupported(columnType.get())) {
+                    schemaBuilder.addField(FieldBuilder.newBuilder(columnName, columnType.get()).build());
                     found = true;
                 }
                 else {

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <fasterxml.jackson.version>2.18.2</fasterxml.jackson.version>
         <surefire.failsafe.version>3.5.2</surefire.failsafe.version>
         <log4j2Version>2.24.2</log4j2Version>
-        <apache.arrow.version>13.0.0</apache.arrow.version>
+        <apache.arrow.version>18.1.0</apache.arrow.version>
         <guava.version>33.4.0-jre</guava.version>
         <protobuf3.version>3.25.3</protobuf3.version>
         <antlr.st4.version>4.3.4</antlr.st4.version>


### PR DESCRIPTION
*Issue #, if available:*
Upgrading to Arrow 18; this will move of from few CVEs as well as bring us closer to the latest version of arrow. requires further testing; release testing, etc. 

*Description of changes:*

Most notable changes are:
* JdbcArrowTypeConverter returns an `Optional`; this helps readability and better than null checking 
* Excluding arrow packages that were conflicting from `google-big-query`; version 15 was coming instead of 18. This requires manual testing of `google-big-query`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
