### PR TITLE
Fixed Encoding Warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,8 @@
     <description>The Amazon Athena Query Federation SDK allows you to customize Amazon Athena with your own code.</description>
     <url>https://github.com/awslabs/aws-athena-query-federation</url>
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.release>11</maven.compiler.release>
         <maven.compiler.plugin.version>3.13.0</maven.compiler.plugin.version>
         <!--- to meet engine version 1.12.533-->


### PR DESCRIPTION
*Issue #, if available:*
All our current build have thousands of line of encoding warning making any github action that has a maven build extremely hard to read; this should fix it. 

*Description of changes:*
Enforce encoding setting on the parent project properties; this is following [stack overflow suggestion](https://stackoverflow.com/questions/3017695/how-can-i-configure-encoding-in-maven/3018152#3018152)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
