### PR TITLE
Fix Synapse Connector to Support Case-Sensitive Collation

### DIFF
--- a/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseCaseInsensitiveResolver.java
+++ b/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseCaseInsensitiveResolver.java
@@ -1,0 +1,123 @@
+/*-
+ * #%L
+ * athena-Synapse
+ * %%
+ * Copyright (C) 2019 - 2024 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.synapse;
+
+import com.amazonaws.athena.connector.lambda.domain.TableName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Map;
+
+public class SynapseCaseInsensitiveResolver
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(SynapseCaseInsensitiveResolver.class);
+    private static final String OBJECT_NAME_QUERY_TEMPLATE = "SELECT TABLE_SCHEMA, TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE LOWER(TABLE_SCHEMA) = ? AND LOWER(TABLE_NAME) = ?";
+    private static final String CASING_MODE = "casing_mode";
+
+    private SynapseCaseInsensitiveResolver()
+    {
+    }
+
+    private enum SynapseCasingMode
+    {
+        NONE,
+        CASE_INSENSITIVE_SEARCH
+    }
+
+    public static TableName getAdjustedTableObjectNameBasedOnConfig(final Connection connection,  TableName tableName, Map<String, String> configOptions)
+            throws SQLException
+    {
+        SynapseCasingMode casingMode = getCasingMode(configOptions);
+        switch (casingMode) {
+            case CASE_INSENSITIVE_SEARCH:
+                TableName tableNameResult = getObjectNameCaseInsensitively(connection, tableName);
+                LOGGER.info("casing mode is `CASE_INSENSITIVE_SEARCH`: adjusting casing from Synapse case insensitive search for TableName object. TableName:{}", tableNameResult);
+                return tableNameResult;
+            case NONE:
+                LOGGER.info("casing mode is `NONE`: not adjust casing from input for TableName object. TableName:{}", tableName);
+                return tableName;
+        }
+        LOGGER.warn("casing mode is empty: not adjust casing from input for TableName object. TableName:{}", tableName);
+        return tableName;
+    }
+
+    /**
+     * Retrieves the exact schema and table name from the synapse database.
+     *
+     * @param connection The database connection.
+     * @param tableName TableName to validate and convert.
+     * @return The exact case-sensitive TableName.
+     * @throws SQLException If a database connection failures.
+     */
+    public static TableName getObjectNameCaseInsensitively(Connection connection, TableName tableName) throws SQLException
+    {
+        try (PreparedStatement stmt = connection.prepareStatement(OBJECT_NAME_QUERY_TEMPLATE)) {
+            stmt.setString(1, tableName.getSchemaName().toLowerCase());
+            stmt.setString(2, tableName.getTableName().toLowerCase());
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) {
+                    TableName matchedTable = new TableName(rs.getString("TABLE_SCHEMA"), rs.getString("TABLE_NAME"));
+
+                    // Check if another match found
+                    if (rs.next()) {
+                        throw new RuntimeException(String.format("Multiple matches found for object %s.%s",
+                                tableName.getSchemaName(), tableName.getTableName()));
+                    }
+                    // Return the exact case-sensitive schema and table name.
+                    return matchedTable;
+                }
+            }
+        }
+        // Throw an exception if no matching schema and table name is found.
+        throw new RuntimeException(String.format("Object %s.%s not found", tableName.getSchemaName(), tableName.getTableName()));
+    }
+
+    /**
+     * Retrieves the casing mode from the provided options.
+     * If the casing mode is not specified, it defaults to NONE. This applies to both Glue and non-Glue connections.
+     *
+     * @param configOptions Config options where the casing mode may be present.
+     * @return CasingMode corresponding to the config value, or NONE if not specified.
+     * @throws IllegalArgumentException If the provided casing mode value is invalid.
+     */
+    private static SynapseCasingMode getCasingMode(Map<String, String> configOptions)
+    {
+        if (!configOptions.containsKey(CASING_MODE)) {
+            LOGGER.info("CASING MODE disable");
+            return SynapseCasingMode.NONE;
+        }
+
+        try {
+            SynapseCasingMode synapseCasingMode = SynapseCasingMode.valueOf(configOptions.get(CASING_MODE).toUpperCase());
+            LOGGER.info("CASING MODE enable: {}", synapseCasingMode.toString());
+            return synapseCasingMode;
+        }
+        catch (Exception ex) {
+            // print error log for customer along with list of input
+            LOGGER.error("Invalid input for:{}, input value:{}, valid values:{}", CASING_MODE, configOptions.get(CASING_MODE), Arrays.asList(SynapseCasingMode.values()), ex);
+            throw ex;
+        }
+    }
+}

--- a/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseMetadataHandler.java
+++ b/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseMetadataHandler.java
@@ -321,8 +321,8 @@ public class SynapseMetadataHandler extends JdbcMetadataHandler
     {
         try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider())) {
             Schema partitionSchema = getPartitionSchema(getTableRequest.getCatalogName());
-            TableName tableName = new TableName(getTableRequest.getTableName().getSchemaName().toUpperCase(), getTableRequest.getTableName().getTableName());
-            return new GetTableResponse(getTableRequest.getCatalogName(), tableName, getSchema(connection, tableName, partitionSchema),
+            TableName exactObjectName = getExactCaseObjectName(connection, getTableRequest.getTableName());
+            return new GetTableResponse(getTableRequest.getCatalogName(), exactObjectName, getSchema(connection, exactObjectName, partitionSchema),
                     partitionSchema.getFields().stream().map(Field::getName).collect(Collectors.toSet()));
         }
     }
@@ -354,8 +354,8 @@ public class SynapseMetadataHandler extends JdbcMetadataHandler
 
         String dataTypeQuery = "SELECT C.NAME AS COLUMN_NAME, TYPE_NAME(C.USER_TYPE_ID) AS DATA_TYPE, " +
                 "C.PRECISION, C.SCALE " +
-                "FROM SYS.COLUMNS C " +
-                "JOIN SYS.TYPES T " +
+                "FROM sys.columns C " +
+                "JOIN sys.types T " +
                 "ON C.USER_TYPE_ID=T.USER_TYPE_ID " +
                 "WHERE C.OBJECT_ID=OBJECT_ID(?)";
 
@@ -506,5 +506,32 @@ public class SynapseMetadataHandler extends JdbcMetadataHandler
                 escapeNamePattern(tableHandle.getSchemaName(), escape),
                 escapeNamePattern(tableHandle.getTableName(), escape),
                 null);
+    }
+
+    /**
+     * Retrieves the exact schema and table name from the synapse database.
+     *
+     * @param connection The database connection.
+     * @param tableName  TableName to  validate and convert.
+     * @return The exact case-sensitive TableName.
+     * @throws SQLException If a database connection failures.
+     */
+    private TableName getExactCaseObjectName(Connection connection, TableName tableName) throws SQLException
+    {
+        // SQL query to fetch the exact case-sensitive schema and table name.
+        String query = "SELECT TABLE_SCHEMA, TABLE_NAME FROM INFORMATION_SCHEMA.TABLES " +
+                "WHERE LOWER(TABLE_SCHEMA) = ? AND LOWER(TABLE_NAME) = ?";
+        try (PreparedStatement stmt = connection.prepareStatement(query)) {
+            stmt.setString(1, tableName.getSchemaName().toLowerCase());
+            stmt.setString(2, tableName.getTableName().toLowerCase());
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) {
+                    // If a matching record is found, return the exact case-sensitive schema and table name.
+                    return new TableName(rs.getString("TABLE_SCHEMA"), rs.getString("TABLE_NAME"));
+                }
+            }
+        }
+        // Throw an exception if no matching schema and table name is found.
+        throw new RuntimeException(String.format("Object %s.%s not found", tableName.getSchemaName(), tableName.getTableName()));
     }
 }

--- a/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseMetadataHandler.java
+++ b/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseMetadataHandler.java
@@ -37,6 +37,8 @@ import com.amazonaws.athena.connector.lambda.metadata.GetSplitsResponse;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableLayoutRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableResponse;
+import com.amazonaws.athena.connector.lambda.metadata.ListTablesRequest;
+import com.amazonaws.athena.connector.lambda.metadata.ListTablesResponse;
 import com.amazonaws.athena.connector.lambda.metadata.optimizations.DataSourceOptimizations;
 import com.amazonaws.athena.connector.lambda.metadata.optimizations.OptimizationSubType;
 import com.amazonaws.athena.connector.lambda.metadata.optimizations.pushdown.ComplexExpressionPushdownSubType;
@@ -49,6 +51,7 @@ import com.amazonaws.athena.connectors.jdbc.manager.JDBCUtil;
 import com.amazonaws.athena.connectors.jdbc.manager.JdbcArrowTypeConverter;
 import com.amazonaws.athena.connectors.jdbc.manager.JdbcMetadataHandler;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.apache.arrow.vector.complex.reader.FieldReader;
@@ -506,5 +509,36 @@ public class SynapseMetadataHandler extends JdbcMetadataHandler
                 escapeNamePattern(tableHandle.getSchemaName(), escape),
                 escapeNamePattern(tableHandle.getTableName(), escape),
                 null);
+    }
+
+    @Override
+    public ListTablesResponse doListTables(final BlockAllocator blockAllocator, final ListTablesRequest listTablesRequest)
+            throws Exception
+    {
+        try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider())) {
+            LOGGER.info("{}: List table names for Catalog {}, Schema {}", listTablesRequest.getQueryId(),
+                    listTablesRequest.getCatalogName(), listTablesRequest.getSchemaName());
+            String adjustedSchemaName = SynapseCaseInsensitiveResolver.getAdjustedSchemaNameBasedOnConfig(connection, listTablesRequest.getSchemaName(), configOptions);
+            // TODO: Implement pagination if supported by azure synapse
+            LOGGER.info("doListTables - NO pagination");
+            return new ListTablesResponse(listTablesRequest.getCatalogName(), listTablesNoPagination(connection, adjustedSchemaName), null);
+        }
+    }
+
+    private List<TableName> listTablesNoPagination(final Connection jdbcConnection, final String databaseName)
+            throws SQLException
+    {
+        LOGGER.debug("listTables, databaseName:" + databaseName);
+        try (ResultSet resultSet = jdbcConnection.getMetaData().getTables(
+                jdbcConnection.getCatalog(),
+                databaseName,
+                null,
+                new String[] {"TABLE", "VIEW", "EXTERNAL TABLE", "MATERIALIZED VIEW"})) {
+            ImmutableList.Builder<TableName> list = ImmutableList.builder();
+            while (resultSet.next()) {
+                list.add(JDBCUtil.getSchemaTableName(resultSet));
+            }
+            return list.build();
+        }
     }
 }

--- a/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/SynapseCaseInsensitiveResolverTest.java
+++ b/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/SynapseCaseInsensitiveResolverTest.java
@@ -1,0 +1,95 @@
+/*-
+ * #%L
+ * athena-synapse
+ * %%
+ * Copyright (C) 2019 - 2022 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.synapse;
+
+import com.amazonaws.athena.connector.lambda.domain.TableName;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SynapseCaseInsensitiveResolverTest {
+
+    private Connection mockConnection;
+    private ResultSet mockResultSet;
+
+    @Before
+    public void setUp() throws SQLException {
+        mockConnection = mock(Connection.class);
+        PreparedStatement mockStmt = mock(PreparedStatement.class);
+        mockResultSet = mock(ResultSet.class);
+
+        when(mockConnection.prepareStatement(anyString())).thenReturn(mockStmt);
+        when(mockStmt.executeQuery()).thenReturn(mockResultSet);
+    }
+
+    @Test
+    public void getAdjustedTableObjectNameCaseInsensitively() throws SQLException {
+        TableName inputTableName = new TableName("schema", "table");
+        TableName expectedTableName = new TableName("SCHEMA", "TABLE");
+
+        when(mockResultSet.next()).thenReturn(true, false);
+        when(mockResultSet.getString("TABLE_SCHEMA")).thenReturn("SCHEMA");
+        when(mockResultSet.getString("TABLE_NAME")).thenReturn("TABLE");
+
+        Map<String, String> config = new HashMap<>();
+        config.put("casing_mode", "CASE_INSENSITIVE_SEARCH");
+
+        TableName result = SynapseCaseInsensitiveResolver.getAdjustedTableObjectNameBasedOnConfig(mockConnection, inputTableName, config);
+        Assert.assertEquals(expectedTableName, result);
+    }
+
+    @Test
+    public void getAdjustedTableObjectNameNoConfig() throws SQLException {
+        TableName inputTableName = new TableName("schema", "table");
+        TableName result = SynapseCaseInsensitiveResolver.getAdjustedTableObjectNameBasedOnConfig(mockConnection, inputTableName, Collections.emptyMap());
+        Assert.assertEquals(inputTableName, result);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void getAdjustedTableObjectNameInvalidCasingMode() throws SQLException {
+        TableName inputTableName = new TableName("schema", "table");
+        Map<String, String> config = new HashMap<>();
+        config.put("casing_mode", "INVALID_MODE");
+
+        SynapseCaseInsensitiveResolver.getAdjustedTableObjectNameBasedOnConfig(mockConnection, inputTableName, config);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void getObjectNameCaseInsensitivelyMultiMatches() throws SQLException {
+        TableName inputTableName = new TableName("schema", "table");
+
+        when(mockResultSet.next()).thenReturn(true, true, false);
+        when(mockResultSet.getString("TABLE_SCHEMA")).thenReturn("SCHEMA");
+        when(mockResultSet.getString("TABLE_NAME")).thenReturn("TABLE");
+
+        SynapseCaseInsensitiveResolver.getObjectNameCaseInsensitively(mockConnection, inputTableName);
+    }
+}

--- a/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/SynapseMetadataHandlerTest.java
+++ b/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/SynapseMetadataHandlerTest.java
@@ -33,24 +33,27 @@ import com.amazonaws.athena.connector.lambda.metadata.GetTableLayoutRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableLayoutResponse;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableResponse;
+import com.amazonaws.athena.connector.lambda.metadata.ListTablesRequest;
+import com.amazonaws.athena.connector.lambda.metadata.ListTablesResponse;
 import com.amazonaws.athena.connector.lambda.security.FederatedIdentity;
 import com.amazonaws.athena.connectors.jdbc.TestBase;
 import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionConfig;
 import com.amazonaws.athena.connectors.jdbc.connection.JdbcConnectionFactory;
 import com.amazonaws.athena.connector.credentials.CredentialsProvider;
+import com.amazonaws.athena.connectors.jdbc.manager.JDBCUtil;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.athena.AthenaClient;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
 import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
+
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -70,14 +73,21 @@ import static com.amazonaws.athena.connectors.synapse.SynapseMetadataHandler.PAR
 import static com.amazonaws.athena.connectors.synapse.SynapseMetadataHandler.PARTITION_BOUNDARY_TO;
 import static com.amazonaws.athena.connectors.synapse.SynapseMetadataHandler.PARTITION_COLUMN;
 import static com.amazonaws.athena.connectors.synapse.SynapseMetadataHandler.PARTITION_NUMBER;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 
 public class SynapseMetadataHandlerTest
         extends TestBase
 {
     private static final Logger logger = LoggerFactory.getLogger(SynapseMetadataHandlerTest.class);
     private DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", SynapseConstants.NAME,
-    		  "synapse://jdbc:sqlserver://hostname;databaseName=fakedatabase");
+            "synapse://jdbc:sqlserver://hostname;databaseName=fakedatabase");
     private SynapseMetadataHandler synapseMetadataHandler;
     private JdbcConnectionFactory jdbcConnectionFactory;
     private Connection connection;
@@ -90,21 +100,20 @@ public class SynapseMetadataHandlerTest
             throws Exception
     {
         System.setProperty("aws.region", "us-east-1");
-        this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class, Mockito.RETURNS_DEEP_STUBS);
-        this.connection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);
-        logger.info(" this.connection.."+ this.connection);
-        Mockito.when(this.jdbcConnectionFactory.getConnection(nullable(CredentialsProvider.class))).thenReturn(this.connection);
-        this.secretsManager = Mockito.mock(SecretsManagerClient.class);
-        this.athena = Mockito.mock(AthenaClient.class);
-        Mockito.when(this.secretsManager.getSecretValue(Mockito.eq(GetSecretValueRequest.builder().secretId("testSecret").build()))).thenReturn(GetSecretValueResponse.builder().secretString("{\"user\": \"testUser\", \"password\": \"testPassword\"}").build());
+        this.jdbcConnectionFactory = mock(JdbcConnectionFactory.class, RETURNS_DEEP_STUBS);
+        this.connection = mock(Connection.class, RETURNS_DEEP_STUBS);
+        logger.info(" this.connection.." + this.connection);
+        when(this.jdbcConnectionFactory.getConnection(nullable(CredentialsProvider.class))).thenReturn(this.connection);
+        this.secretsManager = mock(SecretsManagerClient.class);
+        this.athena = mock(AthenaClient.class);
+        when(this.secretsManager.getSecretValue(eq(GetSecretValueRequest.builder().secretId("testSecret").build()))).thenReturn(GetSecretValueResponse.builder().secretString("{\"user\": \"testUser\", \"password\": \"testPassword\"}").build());
         this.synapseMetadataHandler = new SynapseMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, this.jdbcConnectionFactory, com.google.common.collect.ImmutableMap.of());
-        this.federatedIdentity = Mockito.mock(FederatedIdentity.class);
+        this.federatedIdentity = mock(FederatedIdentity.class);
     }
 
     @Test
-    public void getPartitionSchema()
-    {
-        Assert.assertEquals(SchemaBuilder.newBuilder()
+    public void getPartitionSchema() {
+        assertEquals(SchemaBuilder.newBuilder()
                         .addField(PARTITION_NUMBER, org.apache.arrow.vector.types.Types.MinorType.VARCHAR.getType()).build(),
                 this.synapseMetadataHandler.getPartitionSchema("testCatalogName"));
     }
@@ -114,7 +123,7 @@ public class SynapseMetadataHandlerTest
             throws Exception
     {
         BlockAllocator blockAllocator = new BlockAllocatorImpl();
-        Constraints constraints = Mockito.mock(Constraints.class);
+        Constraints constraints = mock(Constraints.class);
         TableName tableName = new TableName("testSchema", "testTable");
 
         Schema partitionSchema = this.synapseMetadataHandler.getPartitionSchema("testCatalogName");
@@ -123,12 +132,12 @@ public class SynapseMetadataHandlerTest
 
         String[] columns = {"ROW_COUNT", PARTITION_NUMBER, PARTITION_COLUMN, "PARTITION_BOUNDARY_VALUE"};
         int[] types = {Types.INTEGER, Types.VARCHAR, Types.VARCHAR, Types.VARCHAR};
-        Object[][] values = {{2, null, null, null}, {0, "1", "id", "100000" }, {0, "2", "id", "300000"}};
+        Object[][] values = {{2, null, null, null}, {0, "1", "id", "100000"}, {0, "2", "id", "300000"}};
         ResultSet resultSet = mockResultSet(columns, types, values, new AtomicInteger(-1));
 
-        Statement st = Mockito.mock(Statement.class);
-        Mockito.when(this.connection.createStatement()).thenReturn(st);
-        Mockito.when(st.executeQuery(nullable(String.class))).thenReturn(resultSet);
+        Statement st = mock(Statement.class);
+        when(this.connection.createStatement()).thenReturn(st);
+        when(st.executeQuery(nullable(String.class))).thenReturn(resultSet);
 
         GetTableLayoutResponse getTableLayoutResponse = this.synapseMetadataHandler.doGetTableLayout(blockAllocator, getTableLayoutRequest);
 
@@ -136,13 +145,13 @@ public class SynapseMetadataHandlerTest
         for (int i = 0; i < getTableLayoutResponse.getPartitions().getRowCount(); i++) {
             actualValues.add(BlockUtils.rowToString(getTableLayoutResponse.getPartitions(), i));
         }
-        Assert.assertEquals(Arrays.asList("[partition_number : 1::: :::100000:::id]","[partition_number : 2:::100000:::300000:::id]"), actualValues);
+        assertEquals(Arrays.asList("[partition_number : 1::: :::100000:::id]", "[partition_number : 2:::100000:::300000:::id]"), actualValues);
 
         SchemaBuilder expectedSchemaBuilder = SchemaBuilder.newBuilder();
         expectedSchemaBuilder.addField(FieldBuilder.newBuilder(PARTITION_NUMBER, org.apache.arrow.vector.types.Types.MinorType.VARCHAR.getType()).build());
         Schema expectedSchema = expectedSchemaBuilder.build();
-        Assert.assertEquals(expectedSchema, getTableLayoutResponse.getPartitions().getSchema());
-        Assert.assertEquals(tableName, getTableLayoutResponse.getTableName());
+        assertEquals(expectedSchema, getTableLayoutResponse.getPartitions().getSchema());
+        assertEquals(tableName, getTableLayoutResponse.getTableName());
     }
 
     @Test
@@ -150,54 +159,54 @@ public class SynapseMetadataHandlerTest
             throws Exception
     {
         BlockAllocator blockAllocator = new BlockAllocatorImpl();
-        Constraints constraints = Mockito.mock(Constraints.class);
+        Constraints constraints = mock(Constraints.class);
         TableName tableName = new TableName("testSchema", "testTable");
         Schema partitionSchema = this.synapseMetadataHandler.getPartitionSchema("testCatalogName");
         Set<String> partitionCols = partitionSchema.getFields().stream().map(Field::getName).collect(Collectors.toSet());
         GetTableLayoutRequest getTableLayoutRequest = new GetTableLayoutRequest(this.federatedIdentity, "testQueryId", "testCatalogName", tableName, constraints, partitionSchema, partitionCols);
 
         Object[][] values = {{}};
-        ResultSet resultSet = mockResultSet(new String[] {"ROW_COUNT"}, new int[] {Types.INTEGER}, values, new AtomicInteger(-1));
+        ResultSet resultSet = mockResultSet(new String[]{"ROW_COUNT"}, new int[]{Types.INTEGER}, values, new AtomicInteger(-1));
 
-        Statement st = Mockito.mock(Statement.class);
-        Mockito.when(this.connection.createStatement()).thenReturn(st);
-        Mockito.when(st.executeQuery(nullable(String.class))).thenReturn(resultSet);
+        Statement st = mock(Statement.class);
+        when(this.connection.createStatement()).thenReturn(st);
+        when(st.executeQuery(nullable(String.class))).thenReturn(resultSet);
 
         GetTableLayoutResponse getTableLayoutResponse = this.synapseMetadataHandler.doGetTableLayout(blockAllocator, getTableLayoutRequest);
 
-        Assert.assertEquals(values.length, getTableLayoutResponse.getPartitions().getRowCount());
+        assertEquals(values.length, getTableLayoutResponse.getPartitions().getRowCount());
 
         List<String> actualValues = new ArrayList<>();
         for (int i = 0; i < getTableLayoutResponse.getPartitions().getRowCount(); i++) {
             actualValues.add(BlockUtils.rowToString(getTableLayoutResponse.getPartitions(), i));
         }
 
-        Assert.assertEquals(Collections.singletonList("[partition_number : 0]"), actualValues);
+        assertEquals(Collections.singletonList("[partition_number : 0]"), actualValues);
 
         SchemaBuilder expectedSchemaBuilder = SchemaBuilder.newBuilder();
         expectedSchemaBuilder.addField(FieldBuilder.newBuilder(PARTITION_NUMBER, org.apache.arrow.vector.types.Types.MinorType.VARCHAR.getType()).build());
         Schema expectedSchema = expectedSchemaBuilder.build();
-        Assert.assertEquals(expectedSchema, getTableLayoutResponse.getPartitions().getSchema());
-        Assert.assertEquals(tableName, getTableLayoutResponse.getTableName());
+        assertEquals(expectedSchema, getTableLayoutResponse.getPartitions().getSchema());
+        assertEquals(tableName, getTableLayoutResponse.getTableName());
     }
 
     @Test(expected = RuntimeException.class)
     public void doGetTableLayoutWithSQLException()
             throws Exception
     {
-        Constraints constraints = Mockito.mock(Constraints.class);
+        Constraints constraints = mock(Constraints.class);
         TableName tableName = new TableName("testSchema", "testTable");
         Schema partitionSchema = this.synapseMetadataHandler.getPartitionSchema("testCatalogName");
         Set<String> partitionCols = partitionSchema.getFields().stream().map(Field::getName).collect(Collectors.toSet());
         GetTableLayoutRequest getTableLayoutRequest = new GetTableLayoutRequest(this.federatedIdentity, "testQueryId", "testCatalogName", tableName, constraints, partitionSchema, partitionCols);
 
-        Connection connection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);
-        JdbcConnectionFactory jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
-        Mockito.when(jdbcConnectionFactory.getConnection(nullable(CredentialsProvider.class))).thenReturn(connection);
-        Mockito.when(connection.getMetaData().getSearchStringEscape()).thenThrow(new SQLException());
+        Connection connection = mock(Connection.class, RETURNS_DEEP_STUBS);
+        JdbcConnectionFactory jdbcConnectionFactory = mock(JdbcConnectionFactory.class);
+        when(jdbcConnectionFactory.getConnection(nullable(CredentialsProvider.class))).thenReturn(connection);
+        when(connection.getMetaData().getSearchStringEscape()).thenThrow(new SQLException());
         SynapseMetadataHandler synapseMetadataHandler = new SynapseMetadataHandler(databaseConnectionConfig, this.secretsManager, this.athena, jdbcConnectionFactory, com.google.common.collect.ImmutableMap.of());
 
-        synapseMetadataHandler.doGetTableLayout(Mockito.mock(BlockAllocator.class), getTableLayoutRequest);
+        synapseMetadataHandler.doGetTableLayout(mock(BlockAllocator.class), getTableLayoutRequest);
     }
 
     @Test
@@ -205,7 +214,7 @@ public class SynapseMetadataHandlerTest
             throws Exception
     {
         BlockAllocator blockAllocator = new BlockAllocatorImpl();
-        Constraints constraints = Mockito.mock(Constraints.class);
+        Constraints constraints = mock(Constraints.class);
         TableName tableName = new TableName("testSchema", "testTable");
 
         String[] columns = {"ROW_COUNT", PARTITION_NUMBER, PARTITION_COLUMN, "PARTITION_BOUNDARY_VALUE"};
@@ -214,9 +223,9 @@ public class SynapseMetadataHandlerTest
 
         ResultSet resultSet = mockResultSet(columns, types, values, new AtomicInteger(-1));
 
-        Statement st = Mockito.mock(Statement.class);
-        Mockito.when(this.connection.createStatement()).thenReturn(st);
-        Mockito.when(st.executeQuery(nullable(String.class))).thenReturn(resultSet);
+        Statement st = mock(Statement.class);
+        when(this.connection.createStatement()).thenReturn(st);
+        when(st.executeQuery(nullable(String.class))).thenReturn(resultSet);
 
         Schema partitionSchema = this.synapseMetadataHandler.getPartitionSchema("testCatalogName");
         Set<String> partitionCols = partitionSchema.getFields().stream().map(Field::getName).collect(Collectors.toSet());
@@ -253,9 +262,9 @@ public class SynapseMetadataHandlerTest
                 PARTITION_BOUNDARY_TO, "null")
         );
 
-        Assert.assertEquals(expectedSplits.size(), getSplitsResponse.getSplits().size());
+        assertEquals(expectedSplits.size(), getSplitsResponse.getSplits().size());
         Set<Map<String, String>> actualSplits = getSplitsResponse.getSplits().stream().map(Split::getProperties).collect(Collectors.toSet());
-        Assert.assertEquals(expectedSplits, actualSplits);
+        assertEquals(expectedSplits, actualSplits);
     }
 
     @Test
@@ -263,15 +272,15 @@ public class SynapseMetadataHandlerTest
             throws Exception
     {
         BlockAllocator blockAllocator = new BlockAllocatorImpl();
-        Constraints constraints = Mockito.mock(Constraints.class);
+        Constraints constraints = mock(Constraints.class);
         TableName tableName = new TableName("testSchema", "testTable");
 
         Object[][] values = {{}};
-        ResultSet resultSet = mockResultSet(new String[] {"ROW_COUNT"}, new int[] {Types.INTEGER}, values, new AtomicInteger(-1));
+        ResultSet resultSet = mockResultSet(new String[]{"ROW_COUNT"}, new int[]{Types.INTEGER}, values, new AtomicInteger(-1));
 
-        Statement st = Mockito.mock(Statement.class);
-        Mockito.when(this.connection.createStatement()).thenReturn(st);
-        Mockito.when(st.executeQuery(nullable(String.class))).thenReturn(resultSet);
+        Statement st = mock(Statement.class);
+        when(this.connection.createStatement()).thenReturn(st);
+        when(st.executeQuery(nullable(String.class))).thenReturn(resultSet);
 
         Schema partitionSchema = this.synapseMetadataHandler.getPartitionSchema("testCatalogName");
         Set<String> partitionCols = partitionSchema.getFields().stream().map(Field::getName).collect(Collectors.toSet());
@@ -285,9 +294,9 @@ public class SynapseMetadataHandlerTest
 
         Set<Map<String, String>> expectedSplits = new HashSet<>();
         expectedSplits.add(Collections.singletonMap(PARTITION_NUMBER, "0"));
-        Assert.assertEquals(expectedSplits.size(), getSplitsResponse.getSplits().size());
+        assertEquals(expectedSplits.size(), getSplitsResponse.getSplits().size());
         Set<Map<String, String>> actualSplits = getSplitsResponse.getSplits().stream().map(Split::getProperties).collect(Collectors.toSet());
-        Assert.assertEquals(expectedSplits, actualSplits);
+        assertEquals(expectedSplits, actualSplits);
     }
 
     @Test
@@ -295,7 +304,7 @@ public class SynapseMetadataHandlerTest
             throws Exception
     {
         BlockAllocator blockAllocator = new BlockAllocatorImpl();
-        Constraints constraints = Mockito.mock(Constraints.class);
+        Constraints constraints = mock(Constraints.class);
         TableName tableName = new TableName("testSchema", "testTable");
         Schema partitionSchema = this.synapseMetadataHandler.getPartitionSchema("testCatalogName");
         Set<String> partitionCols = partitionSchema.getFields().stream().map(Field::getName).collect(Collectors.toSet());
@@ -307,9 +316,9 @@ public class SynapseMetadataHandlerTest
 
         ResultSet resultSet = mockResultSet(columns, types, values, new AtomicInteger(-1));
 
-        Statement st = Mockito.mock(Statement.class);
-        Mockito.when(this.connection.createStatement()).thenReturn(st);
-        Mockito.when(st.executeQuery(nullable(String.class))).thenReturn(resultSet);
+        Statement st = mock(Statement.class);
+        when(this.connection.createStatement()).thenReturn(st);
+        when(st.executeQuery(nullable(String.class))).thenReturn(resultSet);
 
         GetTableLayoutResponse getTableLayoutResponse = this.synapseMetadataHandler.doGetTableLayout(blockAllocator, getTableLayoutRequest);
 
@@ -329,7 +338,7 @@ public class SynapseMetadataHandlerTest
                 PARTITION_COLUMN, "id",
                 PARTITION_BOUNDARY_TO, "null"));
         Set<Map<String, String>> actualSplits = getSplitsResponse.getSplits().stream().map(Split::getProperties).collect(Collectors.toSet());
-        Assert.assertEquals(expectedSplits, actualSplits);
+        assertEquals(expectedSplits, actualSplits);
     }
 
     @Test
@@ -359,21 +368,21 @@ public class SynapseMetadataHandlerTest
         PARTITION_SCHEMA.getFields().forEach(expectedSchemaBuilder::addField);
         Schema expected = expectedSchemaBuilder.build();
 
-        PreparedStatement stmt = Mockito.mock(PreparedStatement.class);
-        Mockito.when(connection.prepareStatement(nullable(String.class))).thenReturn(stmt);
-        Mockito.when(stmt.executeQuery()).thenReturn(resultSet);
+        PreparedStatement stmt = mock(PreparedStatement.class);
+        when(connection.prepareStatement(nullable(String.class))).thenReturn(stmt);
+        when(stmt.executeQuery()).thenReturn(resultSet);
 
-        Mockito.when(connection.getMetaData().getURL()).thenReturn("jdbc:sqlserver://hostname;databaseName=fakedatabase");
+        when(connection.getMetaData().getURL()).thenReturn("jdbc:sqlserver://hostname;databaseName=fakedatabase");
 
         TableName inputTableName = new TableName("TESTSCHEMA", "TESTTABLE");
-        Mockito.when(connection.getCatalog()).thenReturn("testCatalog");
-        Mockito.when(connection.getMetaData().getColumns("testCatalog", inputTableName.getSchemaName(), inputTableName.getTableName(), null)).thenReturn(resultSet2);
+        when(connection.getCatalog()).thenReturn("testCatalog");
+        when(connection.getMetaData().getColumns("testCatalog", inputTableName.getSchemaName(), inputTableName.getTableName(), null)).thenReturn(resultSet2);
 
         GetTableResponse getTableResponse = this.synapseMetadataHandler.doGetTable(
                 blockAllocator, new GetTableRequest(this.federatedIdentity, "testQueryId", "testCatalog", inputTableName, Collections.emptyMap()));
-        Assert.assertEquals(expected, getTableResponse.getSchema());
-        Assert.assertEquals(inputTableName, getTableResponse.getTableName());
-        Assert.assertEquals("testCatalog", getTableResponse.getCatalogName());
+        assertEquals(expected, getTableResponse.getSchema());
+        assertEquals(inputTableName, getTableResponse.getTableName());
+        assertEquals("testCatalog", getTableResponse.getCatalogName());
     }
 
     @Test
@@ -393,19 +402,54 @@ public class SynapseMetadataHandlerTest
                 {Types.TIMESTAMP, 93, 0, "testCol3"}, {Types.TIMESTAMP_WITH_TIMEZONE, 93, 0, "testCol4"}};
         ResultSet resultSet2 = mockResultSet(columns, types2, values2, new AtomicInteger(-1));
 
-        PreparedStatement stmt = Mockito.mock(PreparedStatement.class);
-        Mockito.when(connection.prepareStatement(nullable(String.class))).thenReturn(stmt);
-        Mockito.when(stmt.executeQuery()).thenReturn(resultSet);
+        PreparedStatement stmt = mock(PreparedStatement.class);
+        when(connection.prepareStatement(nullable(String.class))).thenReturn(stmt);
+        when(stmt.executeQuery()).thenReturn(resultSet);
 
-        Mockito.when(connection.getMetaData().getURL()).thenReturn("jdbc:sqlserver://hostname-ondemand;databaseName=fakedatabase");
+        when(connection.getMetaData().getURL()).thenReturn("jdbc:sqlserver://hostname-ondemand;databaseName=fakedatabase");
 
         TableName inputTableName = new TableName("TESTSCHEMA", "TESTTABLE");
-        Mockito.when(connection.getCatalog()).thenReturn("testCatalog");
-        Mockito.when(connection.getMetaData().getColumns("testCatalog", inputTableName.getSchemaName(), inputTableName.getTableName(), null)).thenReturn(resultSet2);
+        when(connection.getCatalog()).thenReturn("testCatalog");
+        when(connection.getMetaData().getColumns("testCatalog", inputTableName.getSchemaName(), inputTableName.getTableName(), null)).thenReturn(resultSet2);
 
         GetTableResponse getTableResponse = this.synapseMetadataHandler.doGetTable(
                 blockAllocator, new GetTableRequest(this.federatedIdentity, "testQueryId", "testCatalog", inputTableName, Collections.emptyMap()));
-        Assert.assertEquals(inputTableName, getTableResponse.getTableName());
-        Assert.assertEquals("testCatalog", getTableResponse.getCatalogName());
+        assertEquals(inputTableName, getTableResponse.getTableName());
+        assertEquals("testCatalog", getTableResponse.getCatalogName());
+    }
+
+    @Test
+    public void doListTables() throws Exception
+    {
+        BlockAllocator blockAllocator = new BlockAllocatorImpl();
+        String schemaName = "TESTSCHEMA";
+        ListTablesRequest listTablesRequest = new ListTablesRequest(federatedIdentity, "queryId", "testCatalog", schemaName, null, 0);
+
+        DatabaseMetaData mockDatabaseMetaData = mock(DatabaseMetaData.class);
+        ResultSet mockResultSet = mock(ResultSet.class);
+
+        when(connection.getMetaData()).thenReturn(mockDatabaseMetaData);
+        when(mockDatabaseMetaData.getTables(any(), any(), any(), any())).thenReturn(mockResultSet);
+
+        when(mockResultSet.next()).thenReturn(true).thenReturn(true).thenReturn(true).thenReturn(false);
+        when(mockResultSet.getString(3)).thenReturn("TESTTABLE").thenReturn("testtable").thenReturn("testTABLE");
+        when(mockResultSet.getString(2)).thenReturn(schemaName);
+
+        mockStatic(JDBCUtil.class);
+        when(JDBCUtil.getSchemaTableName(mockResultSet)).thenReturn(new TableName("TESTSCHEMA", "TESTTABLE"))
+                .thenReturn(new TableName("TESTSCHEMA", "testtable"))
+                .thenReturn(new TableName("TESTSCHEMA", "testTABLE"));
+
+        when(this.jdbcConnectionFactory.getConnection(any())).thenReturn(connection);
+
+        ListTablesResponse listTablesResponse = this.synapseMetadataHandler.doListTables(blockAllocator, listTablesRequest);
+
+        TableName[] expectedTables = {
+                new TableName("TESTSCHEMA", "TESTTABLE"),
+                new TableName("TESTSCHEMA", "testtable"),
+                new TableName("TESTSCHEMA", "testTABLE")
+        };
+
+        assertEquals(Arrays.toString(expectedTables), listTablesResponse.getTables().toString());
     }
 }

--- a/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/SynapseMetadataHandlerTest.java
+++ b/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/SynapseMetadataHandlerTest.java
@@ -351,11 +351,6 @@ public class SynapseMetadataHandlerTest
                 {Types.TIMESTAMP, 93, 0, "testCol3"}, {Types.TIMESTAMP_WITH_TIMEZONE, 93, 0, "testCol4"}};
         ResultSet resultSet2 = mockResultSet(columns, types2, values2, new AtomicInteger(-1));
 
-        String[] schema2 = {"TABLE_SCHEMA", "TABLE_NAME"};
-        int[] types3 = {Types.VARCHAR, Types.VARCHAR};
-        Object[][] values3 = {{"TESTSCHEMA", "TESTTABLE"}};
-        ResultSet resultSet3 = mockResultSet(schema2, types3, values3, new AtomicInteger(-1));
-
         SchemaBuilder expectedSchemaBuilder = SchemaBuilder.newBuilder();
         expectedSchemaBuilder.addField(FieldBuilder.newBuilder("testCol1", org.apache.arrow.vector.types.Types.MinorType.INT.getType()).build());
         expectedSchemaBuilder.addField(FieldBuilder.newBuilder("testCol2", org.apache.arrow.vector.types.Types.MinorType.VARCHAR.getType()).build());
@@ -364,21 +359,9 @@ public class SynapseMetadataHandlerTest
         PARTITION_SCHEMA.getFields().forEach(expectedSchemaBuilder::addField);
         Schema expected = expectedSchemaBuilder.build();
 
-        PreparedStatement stmt1 = Mockito.mock(PreparedStatement.class);
-        Mockito.when(connection.prepareStatement(Mockito.eq("SELECT C.NAME AS COLUMN_NAME, TYPE_NAME(C.USER_TYPE_ID) AS DATA_TYPE, " +
-                        "C.PRECISION, C.SCALE " +
-                        "FROM sys.columns C " +
-                        "JOIN sys.types T " +
-                        "ON C.USER_TYPE_ID=T.USER_TYPE_ID " +
-                        "WHERE C.OBJECT_ID=OBJECT_ID(?)")))
-                .thenReturn(stmt1);
-        Mockito.when(stmt1.executeQuery()).thenReturn(resultSet);
-
-        PreparedStatement stmt2 = Mockito.mock(PreparedStatement.class);
-        Mockito.when(connection.prepareStatement(Mockito.eq("SELECT TABLE_SCHEMA, TABLE_NAME FROM INFORMATION_SCHEMA.TABLES " +
-                        "WHERE LOWER(TABLE_SCHEMA) = ? AND LOWER(TABLE_NAME) = ?")))
-                .thenReturn(stmt2);
-        Mockito.when(stmt2.executeQuery()).thenReturn(resultSet3);
+        PreparedStatement stmt = Mockito.mock(PreparedStatement.class);
+        Mockito.when(connection.prepareStatement(nullable(String.class))).thenReturn(stmt);
+        Mockito.when(stmt.executeQuery()).thenReturn(resultSet);
 
         Mockito.when(connection.getMetaData().getURL()).thenReturn("jdbc:sqlserver://hostname;databaseName=fakedatabase");
 
@@ -410,26 +393,9 @@ public class SynapseMetadataHandlerTest
                 {Types.TIMESTAMP, 93, 0, "testCol3"}, {Types.TIMESTAMP_WITH_TIMEZONE, 93, 0, "testCol4"}};
         ResultSet resultSet2 = mockResultSet(columns, types2, values2, new AtomicInteger(-1));
 
-        String[] schema2 = {"TABLE_SCHEMA", "TABLE_NAME"};
-        int[] types3 = {Types.VARCHAR, Types.VARCHAR};
-        Object[][] values3 = {{"TESTSCHEMA", "TESTTABLE"}};
-        ResultSet resultSet3 = mockResultSet(schema2, types3, values3, new AtomicInteger(-1));
-
-        PreparedStatement stmt1 = Mockito.mock(PreparedStatement.class);
-        Mockito.when(connection.prepareStatement(Mockito.eq("SELECT C.NAME AS COLUMN_NAME, TYPE_NAME(C.USER_TYPE_ID) AS DATA_TYPE, " +
-                        "C.PRECISION, C.SCALE " +
-                        "FROM sys.columns C " +
-                        "JOIN sys.types T " +
-                        "ON C.USER_TYPE_ID=T.USER_TYPE_ID " +
-                        "WHERE C.OBJECT_ID=OBJECT_ID(?)")))
-                .thenReturn(stmt1);
-        Mockito.when(stmt1.executeQuery()).thenReturn(resultSet);
-
-        PreparedStatement stmt2 = Mockito.mock(PreparedStatement.class);
-        Mockito.when(connection.prepareStatement(Mockito.eq("SELECT TABLE_SCHEMA, TABLE_NAME FROM INFORMATION_SCHEMA.TABLES " +
-                        "WHERE LOWER(TABLE_SCHEMA) = ? AND LOWER(TABLE_NAME) = ?")))
-                .thenReturn(stmt2);
-        Mockito.when(stmt2.executeQuery()).thenReturn(resultSet3);
+        PreparedStatement stmt = Mockito.mock(PreparedStatement.class);
+        Mockito.when(connection.prepareStatement(nullable(String.class))).thenReturn(stmt);
+        Mockito.when(stmt.executeQuery()).thenReturn(resultSet);
 
         Mockito.when(connection.getMetaData().getURL()).thenReturn("jdbc:sqlserver://hostname-ondemand;databaseName=fakedatabase");
 


### PR DESCRIPTION
*Issue #, if available:*
1) Invalid object name SYS.COLUMNS error occurs in Synapse Connector when case-sensitive collation is enabled.
![image](https://github.com/user-attachments/assets/58344762-ee34-4f07-b9ca-c9d373903125)

2) Unable to query uppercase table names when case-sensitive collation is enabled.
![image](https://github.com/user-attachments/assets/e626a1b9-d99c-4504-b570-765d6bf2a793)

*Description of changes:*
1) Uppercase SYS.COLUMNS system view is not available in Synapse when case-sensitive collation is enabled. Changed it to lowercase sys.columns.
2) Added a method getExactCaseObjectName() which retrieves the exact schema and table name from Synapse instead of converting it to uppercase.

Please find attached functional test results.
[SYNAPSE_FUNCTIONAL_TEST_2025-02-18_10_47_47.742843.csv](https://github.com/user-attachments/files/18843005/SYNAPSE_FUNCTIONAL_TEST_2025-02-18_10_47_47.742843.csv)

[synapse-cs-collation-issue.odt](https://github.com/user-attachments/files/18843383/synapse-cs-collation-issue.odt)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
