### PR TITLE
improve ElasticSearch on handling domain_endpoint from Glue connection

### DIFF
--- a/athena-elasticsearch/src/main/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchMetadataHandler.java
+++ b/athena-elasticsearch/src/main/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchMetadataHandler.java
@@ -63,10 +63,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.DEFAULT_GLUE_CONNECTION;
 import static com.amazonaws.athena.connector.lambda.metadata.ListTablesRequest.UNLIMITED_PAGE_SIZE_VALUE;
+import static java.util.Objects.requireNonNull;
 
 /**
  * This class is responsible for providing Athena with metadata about the domain (aka databases), indices, contained
@@ -77,6 +80,10 @@ public class ElasticsearchMetadataHandler
         extends GlueMetadataHandler
 {
     private static final Logger logger = LoggerFactory.getLogger(ElasticsearchMetadataHandler.class);
+
+    // regular expression to match the old pattern of having domain name in `DOMAIN_ENDPOINT` field
+    private static final Pattern DOMAIN_NAME_WITH_ENDPOINT_PATTERN = Pattern.compile("^.+=https.*");
+    private static final String DEFAULT_DOMAIN_NAME = "default";
 
     // Used to denote the 'type' of this connector for diagnostic purposes.
     private static final String SOURCE_TYPE = "elasticsearch";
@@ -153,13 +160,14 @@ public class ElasticsearchMetadataHandler
         ElasticsearchDomainMapProvider domainMapProvider,
         AwsRestHighLevelClientFactory clientFactory,
         long queryTimeout,
-        Map<String, String> configOptions)
+        Map<String, String> configOptions,
+        boolean simulateGlueConnection)
     {
         super(awsGlue, keyFactory, awsSecretsManager, athena, SOURCE_TYPE, spillBucket, spillPrefix, configOptions);
         this.awsGlue = awsGlue;
         this.secretMap = new HashMap<>();
         this.domainMapProvider = domainMapProvider;
-        this.domainMap = this.domainMapProvider.getDomainMap(null);
+        this.domainMap = simulateGlueConnection ? resolveDomainMap(configOptions) : this.domainMapProvider.getDomainMap(null);
         this.clientFactory = clientFactory;
         this.glueTypeMapper = new ElasticsearchGlueTypeMapper();
         this.queryTimeout = queryTimeout;
@@ -167,21 +175,36 @@ public class ElasticsearchMetadataHandler
 
     protected Map<String, String> resolveDomainMap(Map<String, String> config)
     {
-        String secretName = config.getOrDefault(SECRET_NAME, "");
-        String domainEndpoint = config.getOrDefault(DOMAIN_ENDPOINT, "");
-        if (StringUtils.isNotBlank(secretName) && StringUtils.isNotBlank(domainEndpoint)) {
-            logger.info("Using Secrets Manager provided by Glue Connection secret_name.");
+        // Glue connection usage
+        String domainEndpoint;
+        if (StringUtils.isNotBlank(config.getOrDefault(DEFAULT_GLUE_CONNECTION, ""))) {
+            String secretName = requireNonNull(config.get(SECRET_NAME), String.format("Glue connection field: '%s' is required for Elastic Search connector", SECRET_NAME));
+            domainEndpoint = requireNonNull(config.get(DOMAIN_ENDPOINT), String.format("Glue connection field: '%s' is required for Elastic Search connector", DOMAIN_ENDPOINT));
+
+            domainEndpoint = appendDomainNameIfNeeded(domainEndpoint);
             this.secretMap.put(domainEndpoint.split("=")[0], new ElasticsearchCredentialProvider(getSecret(secretName)));
         }
         else {
-            logger.info("No secret_name provided as Config property.");
-            if (StringUtils.isBlank(domainEndpoint)) {
-                domainEndpoint = config.getOrDefault(DOMAIN_MAPPING, "");
-            }
+            // non-glue connection use case
+            domainEndpoint = config.getOrDefault(DOMAIN_MAPPING, "");
+            // resolve secret as non-glue connection use case can embedded secret name into domain.
             domainEndpoint = resolveSecrets(domainEndpoint);
         }
 
         return domainMapProvider.getDomainMap(domainEndpoint);
+    }
+
+    /*
+     Given glue connection doesn’t support multi domain, domain endpoint does not required a domain name anymore. We will automatically map the one and only domain as `default`
+     */
+    private String appendDomainNameIfNeeded(String domainEndpoint)
+    {
+        if (!DOMAIN_NAME_WITH_ENDPOINT_PATTERN.matcher(domainEndpoint).find()) {
+            logger.info("Glue Connection's `{}` field has no domain mapping, adding `default` as domain name", DOMAIN_ENDPOINT);
+            return DEFAULT_DOMAIN_NAME + "=" + domainEndpoint;
+        }
+
+        return domainEndpoint;
     }
 
     /**
@@ -467,5 +490,10 @@ public class ElasticsearchMetadataHandler
         logger.debug("convertField - fieldName: {}, glueType: {}", fieldName, glueType);
 
         return GlueFieldLexer.lex(fieldName, glueType, glueTypeMapper);
+    }
+
+    public Map<String, String> getDomainMap()
+    {
+        return domainMap;
     }
 }

--- a/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchMetadataHandlerTest.java
+++ b/athena-elasticsearch/src/test/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchMetadataHandlerTest.java
@@ -54,6 +54,8 @@ import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.athena.AthenaClient;
 import software.amazon.awssdk.services.glue.GlueClient;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -63,8 +65,11 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.DEFAULT_GLUE_CONNECTION;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.SECRET_NAME;
 import static com.amazonaws.athena.connector.lambda.metadata.ListTablesRequest.UNLIMITED_PAGE_SIZE_VALUE;
 import static com.amazonaws.athena.connector.lambda.domain.predicate.Constraints.DEFAULT_NO_LIMIT;
 import static org.junit.Assert.assertEquals;
@@ -83,6 +88,7 @@ import static org.mockito.Mockito.when;
 public class ElasticsearchMetadataHandlerTest
 {
     private static final Logger logger = LoggerFactory.getLogger(ElasticsearchMetadataHandlerTest.class);
+    private static final String MOCK_SECRET_NAME = "asdf_secret";
 
     private ElasticsearchMetadataHandler handler;
     private boolean enableTests = System.getenv("publishing") != null &&
@@ -116,6 +122,9 @@ public class ElasticsearchMetadataHandlerTest
         when(clientFactory.getOrCreateClient(nullable(String.class))).thenReturn(mockClient);
 
         logger.info("setUpBefore - exit");
+
+        when(awsSecretsManager.getSecretValue(GetSecretValueRequest.builder().secretId(MOCK_SECRET_NAME).build()))
+                .thenReturn(GetSecretValueResponse.builder().secretString("{\"username\": \"asdf_mock_user_name\", \"password\": \"asdf_mock_user_federation_password_1@!$\"}").build());
     }
 
     @After
@@ -141,7 +150,7 @@ public class ElasticsearchMetadataHandlerTest
                 "domain2", "endpoint2","domain3", "endpoint3"));
 
         handler = new ElasticsearchMetadataHandler(awsGlue, new LocalKeyFactory(), awsSecretsManager, amazonAthena,
-                "spill-bucket", "spill-prefix", domainMapProvider, clientFactory, 10, ImmutableMap.of());
+                "spill-bucket", "spill-prefix", domainMapProvider, clientFactory, 10, ImmutableMap.of(), false);
 
         ListSchemasRequest req = new ListSchemasRequest(fakeIdentity(), "queryId", "elasticsearch");
         ListSchemasResponse realDomains = handler.doListSchemaNames(allocator, req);
@@ -205,7 +214,7 @@ public class ElasticsearchMetadataHandlerTest
         when(domainMapProvider.getDomainMap(null)).thenReturn(ImmutableMap.of("movies",
                 "https://search-movies-ne3fcqzfipy6jcrew2wca6kyqu.us-east-1.es.amazonaws.com"));
         handler = new ElasticsearchMetadataHandler(awsGlue, new LocalKeyFactory(), awsSecretsManager, amazonAthena,
-                "spill-bucket", "spill-prefix", domainMapProvider, clientFactory, 10, ImmutableMap.of());
+                "spill-bucket", "spill-prefix", domainMapProvider, clientFactory, 10, ImmutableMap.of(), false);
 
         IndicesClient indices = mock(IndicesClient.class);
         GetDataStreamResponse mockIndexResponse = mock(GetDataStreamResponse.class);
@@ -385,7 +394,7 @@ public class ElasticsearchMetadataHandlerTest
         when(domainMapProvider.getDomainMap(null)).thenReturn(ImmutableMap.of("movies",
                 "https://search-movies-ne3fcqzfipy6jcrew2wca6kyqu.us-east-1.es.amazonaws.com"));
         handler = new ElasticsearchMetadataHandler(awsGlue, new LocalKeyFactory(), awsSecretsManager, amazonAthena,
-                "spill-bucket", "spill-prefix", domainMapProvider, clientFactory, 10, ImmutableMap.of());
+                "spill-bucket", "spill-prefix", domainMapProvider, clientFactory, 10, ImmutableMap.of(), false);
         GetTableRequest req = new GetTableRequest(fakeIdentity(), "queryId", "elasticsearch",
                 new TableName("movies", "mishmash"), Collections.emptyMap());
         GetTableResponse res = handler.doGetTable(allocator, req);
@@ -446,7 +455,7 @@ public class ElasticsearchMetadataHandlerTest
 
         // Instantiate handler
         handler = new ElasticsearchMetadataHandler(awsGlue, new LocalKeyFactory(), awsSecretsManager, amazonAthena,
-                "spill-bucket", "spill-prefix", domainMapProvider, clientFactory, 10, ImmutableMap.of());
+                "spill-bucket", "spill-prefix", domainMapProvider, clientFactory, 10, ImmutableMap.of(), false);
 
         // Call doGetSplits()
         MetadataResponse rawResponse = handler.doGetSplits(allocator, req);
@@ -493,7 +502,7 @@ public class ElasticsearchMetadataHandlerTest
         logger.info("convertFieldTest: enter");
 
         handler = new ElasticsearchMetadataHandler(awsGlue, new LocalKeyFactory(), awsSecretsManager, amazonAthena,
-                "spill-bucket", "spill-prefix", domainMapProvider, clientFactory, 10, ImmutableMap.of());
+                "spill-bucket", "spill-prefix", domainMapProvider, clientFactory, 10, ImmutableMap.of(), false);
 
         Field field = handler.convertField("myscaled", "SCALED_FLOAT(10.51)");
 
@@ -513,5 +522,34 @@ public class ElasticsearchMetadataHandlerTest
         assertEquals("10.0", field.getChildren().get(0).getMetadata().get("scaling_factor"));
 
         logger.info("convertFieldTest: exit");
+    }
+
+    @Test
+    public void glueConnectionDomainEndpointNoDomainName()
+    {
+        String endpoint = "https://search-opensearch-phase2test-domain-bxdc4bfecnsm3stqp4x5rh3acq.us-east-1.es.amazonaws.com";
+        Map<String, String> configMap = Map.of(DEFAULT_GLUE_CONNECTION, "asdf",
+                SECRET_NAME, "asdf_secret",
+                "domain_endpoint", endpoint);
+
+        ElasticsearchMetadataHandler elasticsearchMetadataHandler = new ElasticsearchMetadataHandler(awsGlue, new LocalKeyFactory(), awsSecretsManager, amazonAthena,
+                "spill-bucket", "spill-prefix", new ElasticsearchDomainMapProvider(false), clientFactory, 10, configMap, true);
+        assertTrue(elasticsearchMetadataHandler.getDomainMap().containsKey("default"));
+        assertEquals(elasticsearchMetadataHandler.getDomainMap().get("default"), endpoint);
+    }
+
+    @Test
+    public void glueConnectionDomainEndpointWithDomainNameForBackwardCompatibility()
+    {
+        String domainName = "iamdomain";
+        String domain = "https://search-opensearch-phase2test-domain-bxdc4bfecnsm3stqp4x5rh3acq.us-east-1.es.amazonaws.com";
+        Map<String, String> configMap = Map.of(DEFAULT_GLUE_CONNECTION, "asdf",
+                SECRET_NAME, "asdf_secret",
+                "domain_endpoint", domainName + "=" + domain);
+
+        ElasticsearchMetadataHandler elasticsearchMetadataHandler = new ElasticsearchMetadataHandler(awsGlue, new LocalKeyFactory(), awsSecretsManager, amazonAthena,
+                "spill-bucket", "spill-prefix", new ElasticsearchDomainMapProvider(false), clientFactory, 10, configMap, true);
+        assertTrue(elasticsearchMetadataHandler.getDomainMap().containsKey(domainName));
+        assertEquals(elasticsearchMetadataHandler.getDomainMap().get(domainName), domain);
     }
 }

--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/connection/DatabaseConnectionConfigBuilder.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/connection/DatabaseConnectionConfigBuilder.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -29,6 +29,8 @@ import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.DEFAULT_GLUE_CONNECTION;
+
 /**
  * Builds connection configurations for all catalogs and databases provided in environment properties.
  */
@@ -42,8 +44,6 @@ public class DatabaseConnectionConfigBuilder
     private static final Pattern CONNECTION_STRING_PATTERN = Pattern.compile(CONNECTION_STRING_REGEX);
     private static final String SECRET_PATTERN_STRING = "\\$\\{(([a-z-]+!)?[a-zA-Z0-9:/_+=.@-]+)}";
     public static final Pattern SECRET_PATTERN = Pattern.compile(SECRET_PATTERN_STRING);
-
-    public static final String DEFAULT_GLUE_CONNECTION = "glue_connection";
 
     private Map<String, String> properties;
 


### PR DESCRIPTION
 Adding `default` domain name when domain mapping missing from Glue connection, as Glue connection can contains only domain_endpoint.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
