### PR TITLE
Vertica export bucket prefix path support implementation.

### DIFF
--- a/athena-vertica/athena-vertica.yaml
+++ b/athena-vertica/athena-vertica.yaml
@@ -103,7 +103,9 @@ Resources:
                 - s3:ListBucket
               Effect: Allow
               Resource:
-                - !Sub 'arn:${AWS::Partition}:s3:::${VerticaExportBucket}'
+                - !Sub
+                  - "arn:${AWS::Partition}:s3:::${BucketName}"
+                  - BucketName: !Select [ 0, !Split [ '/', !Ref VerticaExportBucket ] ]
                 - !Sub 'arn:${AWS::Partition}:s3:::${SpillBucket}'
           Version: '2012-10-17'
         - Statement:

--- a/athena-vertica/src/test/java/com/amazonaws/athena/connectors/vertica/VerticaMetadataHandlerTest.java
+++ b/athena-vertica/src/test/java/com/amazonaws/athena/connectors/vertica/VerticaMetadataHandlerTest.java
@@ -355,6 +355,12 @@ public class VerticaMetadataHandlerTest extends TestBase
         GetSplitsRequest req = new GetSplitsRequest(originalReq, null);
 
         logger.info("doGetSplits: req[{}]", req);
+        doGetSplitsFunctionTest(req);
+        Mockito.when(verticaMetadataHandlerMocked.getS3ExportBucket()).thenReturn("testS3Bucket/testWithFolderPath");
+        doGetSplitsFunctionTest(req);
+    }
+
+    private void doGetSplitsFunctionTest(GetSplitsRequest req) {
         MetadataResponse rawResponse = verticaMetadataHandlerMocked.doGetSplits(allocator, req);
         assertEquals(MetadataRequestType.GET_SPLITS, rawResponse.getRequestType());
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The Vertica connector previously required the export bucket parameter to be a bucket name only; folder paths were not supported. This change adds support for both bucket names and bucket names with folder paths.

Before fixing supported format: my_vertica_exportbucket.
After fixing supported format: my_vertica_exportbucket and my_vertica_exportbucket/vertica.
[Vertica Export Bucket Prefix Path Support Testing.docx](https://github.com/user-attachments/files/18961669/Vertica.Export.Bucket.Prefix.Path.Support.Testing.docx)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
