### PR TITLE
Fix Metadata Queries and Skip setAutoCommit(false) and commit() for ClickHouse Connector

### DIFF
--- a/athena-clickhouse/src/main/java/com/amazonaws/athena/connectors/clickhouse/ClickHouseMetadataHandler.java
+++ b/athena-clickhouse/src/main/java/com/amazonaws/athena/connectors/clickhouse/ClickHouseMetadataHandler.java
@@ -64,8 +64,8 @@ import java.util.Set;
 public class ClickHouseMetadataHandler
         extends MySqlMetadataHandler
 {
-    static final String GET_PARTITIONS_QUERY = "SELECT DISTINCT partition_name FROM INFORMATION_SCHEMA.PARTITIONS WHERE TABLE_NAME = ? AND TABLE_SCHEMA = ? " +
-            "AND partition_name IS NOT NULL";
+    static final String GET_PARTITIONS_QUERY = "SELECT DISTINCT partition AS partition_name FROM system.parts " +
+            "WHERE table = ? AND database = ? AND partition IS NOT NULL";
     static final String BLOCK_PARTITION_COLUMN_NAME = "partition_name";
     static final String ALL_PARTITIONS = "*";
     static final String PARTITION_COLUMN_NAME = "partition_name";
@@ -73,7 +73,7 @@ public class ClickHouseMetadataHandler
     private static final int MAX_SPLITS_PER_REQUEST = 1000_000;
 
     static final String LIST_PAGINATED_TABLES_QUERY = "SELECT DISTINCT table_name as \"TABLE_NAME\", table_schema as \"TABLE_SCHEM\" FROM information_schema.tables WHERE table_schema = ? ORDER BY TABLE_NAME LIMIT ?, ?";
-    static final String LIST_SCHEMA_QUERY = "SELECT schema_name AS DATABASE_SCHEMA, schema_owner AS DATABASE_OWNER FROM INFORMATION_SCHEMA.schemata";
+    static final String LIST_SCHEMA_QUERY = "SELECT name AS DATABASE_SCHEMA FROM system.databases";
 
     /**
      * Instantiates handler to be used by Lambda function directly.


### PR DESCRIPTION
*Issue #, if available:*
1) java.sql.SQLException: Code: 60. DB::Exception: Table INFORMATION_SCHEMA.schemata doesn't exist. (UNKNOWN_TABLE) (version 22.2.2.1).
2) java.sql.SQLFeatureNotSupportedException: setAutoCommit = false not supported.

*Description of changes:*
1) Fixed incorrect metadata queries for listing schemas.
2) Skipped setAutoCommit(false) and connection.commit() for ClickHouse, as ClickHouse operates in auto-commit mode and does not support transactions. Please find the attached test document.
[clickhouse-connector-issue.odt](https://github.com/user-attachments/files/19123988/clickhouse-connector-issue.odt)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
