### PR TITLE
update oracle and docdb dockerfiles again

### DIFF
--- a/athena-docdb/Dockerfile
+++ b/athena-docdb/Dockerfile
@@ -9,7 +9,7 @@ ARG JAVA_TOOL_OPTIONS=""
 ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
 
 # Install necessary tools
-RUN yum update -y && yum install -y curl perl openssl-1.0.2k-24.amzn2.0.14
+RUN yum update -y && yum install -y curl perl openssl-1.0.2k-24.amzn2.0.14 openssl-snapsafe-libs
 
 # Copy function code and runtime dependencies from Maven layout
 COPY target/athena-docdb-2022.47.1.jar ${LAMBDA_TASK_ROOT}

--- a/athena-oracle/Dockerfile
+++ b/athena-oracle/Dockerfile
@@ -9,7 +9,7 @@ ARG JAVA_TOOL_OPTIONS=""
 ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
 
 # Install necessary tools
-RUN yum update -y && yum install -y curl perl openssl-1.0.2k-24.amzn2.0.14
+RUN yum update -y && yum install -y curl perl openssl-1.0.2k-24.amzn2.0.14 openssl-snapsafe-libs
 
 ENV truststore=${LAMBDA_TASK_ROOT}/rds-truststore.jks
 ENV storepassword=federationStorePass


### PR DESCRIPTION
*Description of changes:*
```
Error: openssl-snapsafe-libs conflicts with 1:openssl-libs-1.0.2k-24.amzn2.0.14.x86_64
 You could try using --skip-broken to work around the problem
 You could try running: rpm -Va --nofiles --nodigest
The command '/bin/sh -c yum update -y && yum install -y curl perl openssl-1.0.2k-24.amzn2.0.14' returned a non-zero code: 1
```
When building locally:
```
7.054 --> Processing Conflict: 1:openssl-snapsafe-libs-1.0.2k-24.amzn2.0.14.aarch64 conflicts openssl-libs
7.060 --> Finished Dependency Resolution
7.060  You could try using --skip-broken to work around the problem
7.060 Error: openssl-snapsafe-libs conflicts with 1:openssl-libs-1.0.2k-24.amzn2.0.15.aarch64
7.088  You could try running: rpm -Va --nofiles --nodigest
------
Dockerfile:12
--------------------
  10 |     
  11 |     # Install necessary tools
  12 | >>> RUN yum update -y && yum install -y curl perl openssl
  13 |     
  14 |     # Copy function code and runtime dependencies from Maven layout
--------------------
ERROR: failed to solve: process "/bin/sh -c yum update -y && yum install -y curl perl openssl" did not complete successfully: exit code: 1
```
Adding the `openssl-snapsafe-libs` fixed the build.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
