### PR TITLE
update oracle and docdb dockerfiles to openssl11

### DIFF
--- a/athena-docdb/Dockerfile
+++ b/athena-docdb/Dockerfile
@@ -9,7 +9,8 @@ ARG JAVA_TOOL_OPTIONS=""
 ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
 
 # Install necessary tools
-RUN yum update -y && yum install -y curl perl openssl-1.0.2k-24.amzn2.0.14 openssl-snapsafe-libs
+RUN yum update -y
+RUN yum install -y curl perl openssl11
 
 # Copy function code and runtime dependencies from Maven layout
 COPY target/athena-docdb-2022.47.1.jar ${LAMBDA_TASK_ROOT}
@@ -27,7 +28,7 @@ RUN curl -sS "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem"
 
 # Import certificates into the truststore
 RUN for CERT in rds-ca-*; do \
-        alias=$(openssl x509 -noout -text -in $CERT | perl -ne 'next unless /Subject:/; s/.*(CN=|CN = )//; print') && \
+        alias=$(openssl11 x509 -noout -text -in $CERT | perl -ne 'next unless /Subject:/; s/.*(CN=|CN = )//; print') && \
         echo "Importing $alias" && \
         keytool -import -file ${CERT} -alias "${alias}" -storepass ${storepassword} -keystore ${truststore} -noprompt && \
         rm $CERT; \

--- a/athena-oracle/Dockerfile
+++ b/athena-oracle/Dockerfile
@@ -9,7 +9,8 @@ ARG JAVA_TOOL_OPTIONS=""
 ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
 
 # Install necessary tools
-RUN yum update -y && yum install -y curl perl openssl-1.0.2k-24.amzn2.0.14 openssl-snapsafe-libs
+RUN yum update -y
+RUN yum install -y curl perl openssl11
 
 ENV truststore=${LAMBDA_TASK_ROOT}/rds-truststore.jks
 ENV storepassword=federationStorePass
@@ -20,7 +21,7 @@ RUN curl -sS "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem"
 
 # Import certificates into the truststore
 RUN for CERT in rds-ca-*; do \
-        alias=$(openssl x509 -noout -text -in $CERT | perl -ne 'next unless /Subject:/; s/.*(CN=|CN = )//; print') && \
+        alias=$(openssl11 x509 -noout -text -in $CERT | perl -ne 'next unless /Subject:/; s/.*(CN=|CN = )//; print') && \
         echo "Importing $alias" && \
         keytool -import -file ${CERT} -alias "${alias}" -storepass ${storepassword} -keystore ${truststore} -noprompt && \
         rm $CERT; \


### PR DESCRIPTION
Docker build was failing due to version mismatches. Upgrading to openssl11 (OpenSSL 1.1) fixed the issues. Because we only use it for adding certs, no functionality should change between the previous version (OpenSSL 1.0.1) and the new.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
