### PR TITLE
Updated rds truststore to default truststore for oracle and docdb.

### DIFF
--- a/athena-docdb/Dockerfile
+++ b/athena-docdb/Dockerfile
@@ -5,8 +5,8 @@ FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
 ARG JAVA_TOOL_OPTIONS=""
-# Set the JAVA_TOOL_OPTIONS environment variable for Java 17
-ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
+# Set the JAVA_TOOL_OPTIONS environment variable for Java 17 and for ssl
+ENV JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Djavax.net.ssl.trustStore=/var/lang/lib/security/cacerts -Djavax.net.ssl.trustStorePassword=changeit"
 
 # Install necessary tools
 RUN yum update -y
@@ -18,9 +18,12 @@ COPY target/athena-docdb-2022.47.1.jar ${LAMBDA_TASK_ROOT}
 # Unpack the jar
 RUN jar xf athena-docdb-2022.47.1.jar
 
+# Clean up JAR
+RUN rm ${LAMBDA_TASK_ROOT}/athena-docdb-2022.47.1.jar
+
 # Set up environment variables
-ENV truststore=${LAMBDA_TASK_ROOT}/rds-truststore.jks
-ENV storepassword=federationStorePass
+ENV truststore=/var/lang/lib/security/cacerts
+ENV storepassword=changeit
 
 # Download and process the RDS certificate
 RUN curl -sS "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem" > ${LAMBDA_TASK_ROOT}/global-bundle.pem && \

--- a/athena-docdb/Dockerfile
+++ b/athena-docdb/Dockerfile
@@ -3,10 +3,10 @@ ARG JAVA_VERSION=11
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
-# Argument for Java tool options, defaulting to an empty string
-ARG JAVA_TOOL_OPTIONS=""
+# Argument for Java tool options for ssl
+ARG JAVA_TOOL_OPTIONS="-Djavax.net.ssl.trustStore=/var/lang/lib/security/cacerts"
 # Set the JAVA_TOOL_OPTIONS environment variable for Java 17 and for ssl
-ENV JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Djavax.net.ssl.trustStore=/var/lang/lib/security/cacerts -Djavax.net.ssl.trustStorePassword=changeit"
+ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
 
 # Install necessary tools
 RUN yum update -y

--- a/athena-docdb/src/main/java/com/amazonaws/athena/connectors/docdb/DocDBConnectionFactory.java
+++ b/athena-docdb/src/main/java/com/amazonaws/athena/connectors/docdb/DocDBConnectionFactory.java
@@ -56,8 +56,8 @@ public class DocDBConnectionFactory
             //Setup SSL Trust Store:
             if (connStr.toLowerCase().contains("ssl=true")) {
                 logger.info("MongoClient is using SSL; thus setting up System properties for trust store");
-                System.setProperty("javax.net.ssl.trustStore", "rds-truststore.jks");
-                System.setProperty("javax.net.ssl.trustStorePassword", "federationStorePass");
+                System.setProperty("javax.net.ssl.trustStoreType", "JKS");
+                System.setProperty("javax.net.ssl.trustStorePassword", "changeit");
             }
             result = MongoClients.create(connStr);
             clientCache.put(connStr, result);

--- a/athena-oracle/Dockerfile
+++ b/athena-oracle/Dockerfile
@@ -5,15 +5,16 @@ FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
 ARG JAVA_TOOL_OPTIONS=""
-# Set the JAVA_TOOL_OPTIONS environment variable for Java 17
-ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
+# Set the JAVA_TOOL_OPTIONS environment variable for Java 17 and for ssl
+ENV JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Djavax.net.ssl.trustStore=/var/lang/lib/security/cacerts -Djavax.net.ssl.trustStorePassword=changeit"
 
 # Install necessary tools
 RUN yum update -y
 RUN yum install -y curl perl openssl11
 
-ENV truststore=${LAMBDA_TASK_ROOT}/rds-truststore.jks
-ENV storepassword=federationStorePass
+# Set up environment variables
+ENV truststore=/var/lang/lib/security/cacerts
+ENV storepassword=changeit
 
 # Download and process the RDS certificate
 RUN curl -sS "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem" > ${LAMBDA_TASK_ROOT}/global-bundle.pem && \

--- a/athena-oracle/Dockerfile
+++ b/athena-oracle/Dockerfile
@@ -3,10 +3,10 @@ ARG JAVA_VERSION=11
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
-# Argument for Java tool options, defaulting to an empty string
-ARG JAVA_TOOL_OPTIONS=""
+# Argument for Java tool options for ssl
+ARG JAVA_TOOL_OPTIONS="-Djavax.net.ssl.trustStore=/var/lang/lib/security/cacerts"
 # Set the JAVA_TOOL_OPTIONS environment variable for Java 17 and for ssl
-ENV JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Djavax.net.ssl.trustStore=/var/lang/lib/security/cacerts -Djavax.net.ssl.trustStorePassword=changeit"
+ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
 
 # Install necessary tools
 RUN yum update -y

--- a/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleJdbcConnectionFactory.java
+++ b/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleJdbcConnectionFactory.java
@@ -65,8 +65,7 @@ public class OracleJdbcConnectionFactory extends GenericJdbcConnectionFactory
                 if (databaseConnectionConfig.getJdbcConnectionString().toLowerCase().contains("@tcps://")) {
                     LOGGER.info("Establishing connection over SSL..");
                     properties.put("javax.net.ssl.trustStoreType", "JKS");
-                    properties.put("javax.net.ssl.trustStore", "rds-truststore.jks");
-                    properties.put("javax.net.ssl.trustStorePassword", "federationStorePass");
+                    properties.put("javax.net.ssl.trustStorePassword", "changeit");
                     properties.put("oracle.net.ssl_server_dn_match", "true");
                     // By default; Oracle RDS uses SSL_RSA_WITH_AES_256_CBC_SHA
                     // Adding the following cipher suits to support others listed in Doc


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Enabling SSL for the Oracle connector resulted in a 'certificate path not found' error. This was resolved by using the default truststore. To maintain consistency, the same truststore configuration was applied to DocDB.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
