### PR TITLE
Revert "build(deps): bump aws-cdk-lib from 2.177.0 to 2.186.0 in /val…

### DIFF
--- a/validation_testing/cdk_federation_infra_provisioning/app/package.json
+++ b/validation_testing/cdk_federation_infra_provisioning/app/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@aws-cdk/aws-glue-alpha": "2.130.0-alpha.0",
     "@aws-cdk/aws-redshift-alpha": "2.130.0-alpha.0",
-    "aws-cdk-lib": "2.186.0",
+    "aws-cdk-lib": "2.177.0",
     "dotenv": "^16.0.3",
     "source-map-support": "^0.5.21",
     "typescript": "4.9.5"


### PR DESCRIPTION
…idation_testing/cdk_federation_infra_provisioning/app (#2697)"

This reverts commit fb89c3eda158dd6d23258cf8731f4d7171a63cdb.

*Description of changes:*

Version bump causes release test failures (https://github.com/awslabs/aws-athena-query-federation/pull/2687)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
