### PR TITLE
Removing exception on table with no columns during get table call

### DIFF
--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandler.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandler.java
@@ -414,12 +414,13 @@ public abstract class JdbcMetadataHandler
             }
 
             if (!found) {
-                throw new AthenaConnectorException(String.format("Could not find table %s in %s", tableName.getTableName(), tableName.getSchemaName()),
-                        ErrorDetails.builder().errorCode(FederationSourceErrorCode.ENTITY_NOT_FOUND_EXCEPTION.toString()).build());
+                // log a warning if table columns are not found
+                LOGGER.warn("getSchema: Could not find table " + tableName.getTableName() + " in " + tableName.getSchemaName());
             }
-
-            // add partition columns
-            partitionSchema.getFields().forEach(schemaBuilder::addField);
+            else {
+                // add partition columns
+                partitionSchema.getFields().forEach(schemaBuilder::addField);
+            }
 
             return schemaBuilder.build();
         }

--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandler.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandler.java
@@ -415,7 +415,7 @@ public abstract class JdbcMetadataHandler
 
             if (!found) {
                 // log a warning if table columns are not found
-                LOGGER.warn("getSchema: Could not find table " + tableName.getTableName() + " in " + tableName.getSchemaName());
+                LOGGER.warn("getSchema: Could not find table {} in {}", tableName.getTableName(), tableName.getSchemaName());
             }
             else {
                 // add partition columns

--- a/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandlerTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandlerTest.java
@@ -290,6 +290,7 @@ public class JdbcMetadataHandlerTest
                 new GetTableRequest(this.federatedIdentity, "testQueryId", "testCatalog", inputTableName, Collections.emptyMap()));
 
         Assert.assertEquals("testTable", getTableResponse.getTableName().getTableName());
+        Assert.assertTrue(getTableResponse.getSchema().getFields().isEmpty());
     }
 
     @Test(expected = SQLException.class)

--- a/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandlerTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandlerTest.java
@@ -280,13 +280,16 @@ public class JdbcMetadataHandlerTest
         Assert.assertEquals("testTable", getTableResponse.getTableName().getTableName());
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void doGetTableNoColumns()
             throws Exception
     {
         TableName inputTableName = new TableName("testSchema", "testTable");
 
-        this.jdbcMetadataHandler.doGetTable(this.blockAllocator, new GetTableRequest(this.federatedIdentity, "testQueryId", "testCatalog", inputTableName, Collections.emptyMap()));
+        GetTableResponse getTableResponse = this.jdbcMetadataHandler.doGetTable(this.blockAllocator,
+                new GetTableRequest(this.federatedIdentity, "testQueryId", "testCatalog", inputTableName, Collections.emptyMap()));
+
+        Assert.assertEquals("testTable", getTableResponse.getTableName().getTableName());
     }
 
     @Test(expected = SQLException.class)


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-athena-query-federation/issues/2699

*Description of changes:*
This PR fixes the issue that currently exists where query editor window does not load any tables if another table in the db is empty and instead shows an exception (as described in the bug https://github.com/awslabs/aws-athena-query-federation/issues/2699). Verified the fix in dev account.

Implemented the following changes -
- `athena-jdbc->JdbcMetadataHandler`: Removed the exception in getSchema call for when a table has no columns, instead added a log warning for it. Moved the partition schema updates to happen only for tables where columns exist since we're not exiting out of the call due to the exception anymore.
- `athena-jdbc->JdbcMetadataHandlerTest`: Updated the test to account for this change.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
