### PR TITLE
adding fake pagination for fallback jdbc logic

### DIFF
--- a/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2MetadataHandlerTest.java
+++ b/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2MetadataHandlerTest.java
@@ -223,7 +223,7 @@ public class DataLakeGen2MetadataHandlerTest
     {
         BlockAllocator blockAllocator = new BlockAllocatorImpl();
         String schemaName = "TESTSCHEMA";
-        ListTablesRequest listTablesRequest = new ListTablesRequest(federatedIdentity, "queryId", "testCatalog", schemaName, null, 0);
+        ListTablesRequest listTablesRequest = new ListTablesRequest(federatedIdentity, "queryId", "testCatalog", schemaName, null, 3);
 
         DatabaseMetaData mockDatabaseMetaData = mock(DatabaseMetaData.class);
         ResultSet mockResultSet = mock(ResultSet.class);

--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandler.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandler.java
@@ -241,7 +241,7 @@ public abstract class JdbcMetadataHandler
     protected ListTablesResponse listPaginatedTables(final Connection connection, final ListTablesRequest listTablesRequest) throws SQLException
     {
         String adjustedSchemaName = caseResolver.getAdjustedSchemaNameString(connection, listTablesRequest.getSchemaName(), configOptions);
-        LOGGER.info("Request is asking for pagination, but true pagination has not been implemented.");
+        LOGGER.debug("Request is asking for pagination, but true pagination has not been implemented.");
 
         int startToken;
         try {

--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandler.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandler.java
@@ -230,8 +230,9 @@ public abstract class JdbcMetadataHandler
     }
 
     /**
-     * This is default getAllTables no pagination.
-     * Override this if you want to support the behavior.
+     * This is default getAllTables without true pagination.
+     * Paginated list of tables will be returned by retrieving all tables first, then returning subset based off request.
+     * Override this if you want to support true pagination behavior.
      * @param connection
      * @param listTablesRequest
      * @return
@@ -239,12 +240,43 @@ public abstract class JdbcMetadataHandler
      */
     protected ListTablesResponse listPaginatedTables(final Connection connection, final ListTablesRequest listTablesRequest) throws SQLException
     {
-        // no-op is call listTables
-        // override this function to implement pagination
         String adjustedSchemaName = caseResolver.getAdjustedSchemaNameString(connection, listTablesRequest.getSchemaName(), configOptions);
-        LOGGER.debug("Request is asking for pagination, but pagination has not been implemented");
+        LOGGER.info("Request is asking for pagination, but true pagination has not been implemented.");
+
+        int startToken;
+        try {
+            startToken = listTablesRequest.getNextToken() == null ? 0 : Integer.parseInt(listTablesRequest.getNextToken());
+        }
+        catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid next token: " + listTablesRequest.getNextToken(), e);
+        }
+
+        // Retrieve all tables
+        List<TableName> allTables = listTables(connection, adjustedSchemaName);
+
+        int pageSize = listTablesRequest.getPageSize();
+
+        // If startToken is at or past the end of tables list, return empty list
+        if (startToken >= allTables.size()) {
+            return new ListTablesResponse(listTablesRequest.getCatalogName(), List.of(), null);
+        }
+
+        int endToken = Math.min(startToken + pageSize, allTables.size());
+        if (pageSize == UNLIMITED_PAGE_SIZE_VALUE) {
+            endToken = allTables.size();
+        }
+
+        String nextToken;
+        if (pageSize == UNLIMITED_PAGE_SIZE_VALUE || endToken == allTables.size()) {
+            nextToken = null;
+        }
+        else {
+            // Use long to avoid potential integer overflow
+            nextToken = Long.toString((long) startToken + pageSize);
+        }
+
         return new ListTablesResponse(listTablesRequest.getCatalogName(),
-                listTables(connection, adjustedSchemaName), null);
+                allTables.subList(startToken, endToken), nextToken);
     }
 
     protected List<TableName> listTables(final Connection jdbcConnection, final String databaseName)

--- a/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandlerTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandlerTest.java
@@ -221,6 +221,21 @@ public class JdbcMetadataHandlerTest
         Assert.assertEquals(null, listTablesResponse.getNextToken());
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void doListTablesNumberFormatException()
+            throws Exception {
+        String[] schema = {"TABLE_SCHEM", "TABLE_NAME"};
+        Object[][] values = {{"testSchema", "testTable"}, {"testSchema", "testTable2"}, {"testSchema", "testTable3"}, {"testSchema", "testTable4"}, {"testSchema", "testTable5"}};
+        AtomicInteger rowNumber = new AtomicInteger(-1);
+        ResultSet resultSet = mockResultSet(schema, values, rowNumber);
+
+        Mockito.when(connection.getMetaData().getTables("testCatalog", "testSchema", null, new String[] {"TABLE", "VIEW", "EXTERNAL TABLE", "MATERIALIZED VIEW"})).thenReturn(resultSet);
+
+        // Test: startToken is not a valid number with pageSize unlimited (all items)
+        this.jdbcMetadataHandler.doListTables(this.blockAllocator, new ListTablesRequest(this.federatedIdentity, "testQueryId",
+                "testCatalog", "testSchema", "not_a_valid_number", UNLIMITED_PAGE_SIZE_VALUE));
+    }
+
     @Test
     public void doListTablesEscaped()
             throws Exception

--- a/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandlerTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandlerTest.java
@@ -55,6 +55,7 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Types;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -158,6 +159,66 @@ public class JdbcMetadataHandlerTest
                 this.blockAllocator, new ListTablesRequest(this.federatedIdentity, "testQueryId",
                         "testCatalog", "testSchema", null, UNLIMITED_PAGE_SIZE_VALUE));
         Assert.assertArrayEquals(expected, listTablesResponse.getTables().toArray());
+    }
+
+    @Test
+    public void doListTablesFakePaginationSinglePage()
+            throws Exception {
+        String[] schema = {"TABLE_SCHEM", "TABLE_NAME"};
+        Object[][] values = {{"testSchema", "testTable"}, {"testSchema", "testtable2"}, {"testSchema", "testtable3"}, {"testSchema", "testtable4"}, {"testSchema", "testtable5"}};
+        AtomicInteger rowNumber = new AtomicInteger(-1);
+        ResultSet resultSet = mockResultSet(schema, values, rowNumber);
+
+        Mockito.when(connection.getMetaData().getTables("testCatalog", "testSchema", null, new String[] {"TABLE", "VIEW", "EXTERNAL TABLE", "MATERIALIZED VIEW"})).thenReturn(resultSet);
+
+        // Test: null token with pageSize 1 (single item with next token at 1)
+        ListTablesResponse listTablesResponse = this.jdbcMetadataHandler.doListTables(
+                this.blockAllocator, new ListTablesRequest(this.federatedIdentity, "testQueryId",
+                        "testCatalog", "testSchema", null, 1));
+
+        TableName[] expected = {new TableName("testSchema", "testTable")};
+        Assert.assertArrayEquals(expected, listTablesResponse.getTables().toArray());
+        Assert.assertEquals("1", listTablesResponse.getNextToken());
+    }
+
+    @Test
+    public void doListTablesFakePaginationMultiPage()
+            throws Exception {
+        String[] schema = {"TABLE_SCHEM", "TABLE_NAME"};
+        Object[][] values = {{"testSchema", "testTable"}, {"testSchema", "testTable2"}, {"testSchema", "testTable3"}, {"testSchema", "testTable4"}, {"testSchema", "testTable5"}};
+        AtomicInteger rowNumber = new AtomicInteger(-1);
+        ResultSet resultSet = mockResultSet(schema, values, rowNumber);
+
+        Mockito.when(connection.getMetaData().getTables("testCatalog", "testSchema", null, new String[] {"TABLE", "VIEW", "EXTERNAL TABLE", "MATERIALIZED VIEW"})).thenReturn(resultSet);
+
+        // Test: null token with pageSize 5 (all items)
+        ListTablesResponse listTablesResponse = this.jdbcMetadataHandler.doListTables(
+                this.blockAllocator, new ListTablesRequest(this.federatedIdentity, "testQueryId",
+                        "testCatalog", "testSchema", null, 5));
+
+        TableName[] expected = {new TableName("testSchema", "testTable"), new TableName("testSchema", "testTable2"), new TableName("testSchema", "testTable3"), new TableName("testSchema", "testTable4"), new TableName("testSchema", "testTable5")};
+        Assert.assertArrayEquals(expected, listTablesResponse.getTables().toArray());
+        Assert.assertEquals(null, listTablesResponse.getNextToken());
+    }
+
+    @Test
+    public void doListTablesFakePaginationUnlimitedPageSize()
+            throws Exception {
+        String[] schema = {"TABLE_SCHEM", "TABLE_NAME"};
+        Object[][] values = {{"testSchema", "testTable"}, {"testSchema", "testTable2"}, {"testSchema", "testTable3"}, {"testSchema", "testTable4"}, {"testSchema", "testTable5"}};
+        AtomicInteger rowNumber = new AtomicInteger(-1);
+        ResultSet resultSet = mockResultSet(schema, values, rowNumber);
+
+        Mockito.when(connection.getMetaData().getTables("testCatalog", "testSchema", null, new String[] {"TABLE", "VIEW", "EXTERNAL TABLE", "MATERIALIZED VIEW"})).thenReturn(resultSet);
+
+        // Test: startToken at index "1" with pageSize unlimited (all items)
+        ListTablesResponse listTablesResponse = this.jdbcMetadataHandler.doListTables(
+                this.blockAllocator, new ListTablesRequest(this.federatedIdentity, "testQueryId",
+                        "testCatalog", "testSchema", "1", UNLIMITED_PAGE_SIZE_VALUE));
+
+        TableName[] expected = {new TableName("testSchema", "testTable2"), new TableName("testSchema", "testTable3"), new TableName("testSchema", "testTable4"), new TableName("testSchema", "testTable5")};
+        Assert.assertArrayEquals(expected, listTablesResponse.getTables().toArray());
+        Assert.assertEquals(null, listTablesResponse.getNextToken());
     }
 
     @Test

--- a/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/SynapseMetadataHandlerTest.java
+++ b/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/SynapseMetadataHandlerTest.java
@@ -424,7 +424,7 @@ public class SynapseMetadataHandlerTest
     {
         BlockAllocator blockAllocator = new BlockAllocatorImpl();
         String schemaName = "TESTSCHEMA";
-        ListTablesRequest listTablesRequest = new ListTablesRequest(federatedIdentity, "queryId", "testCatalog", schemaName, null, 0);
+        ListTablesRequest listTablesRequest = new ListTablesRequest(federatedIdentity, "queryId", "testCatalog", schemaName, null, 3);
 
         DatabaseMetaData mockDatabaseMetaData = mock(DatabaseMetaData.class);
         ResultSet mockResultSet = mock(ResultSet.class);


### PR DESCRIPTION
*Issue #, if available:*
Adding Fake Pagination to default listPaginatedTables in jdbcMetadataHandler.

*Description of changes:*
Every connector should have the method listPaginatedTables overridden and implemented since each connectors pagination logic. Some connectors don't have it overridden in which case the logic defaults to the method `listPaginatedTables` in jdbcMetadataHandler - which did not do any pagination.

We want to 'fake' pagination here. All tables are being pulled into memory, however, we will return a subset of those tables based on the nextToken and pageSize provided in the ListTablesRequest object to mimic the effects of pagination. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
