### PR TITLE
Upgrade Glue Job version to V4_0

### DIFF
--- a/validation_testing/cdk_federation_infra_provisioning/app/lib/stacks/rds-generic-stack.ts
+++ b/validation_testing/cdk_federation_infra_provisioning/app/lib/stacks/rds-generic-stack.ts
@@ -123,7 +123,7 @@ export class RdsGenericStack extends cdk.Stack {
 
     const glueJob = new glue.Job(this, `${db_type}_glue_job_create_case_insensitive_data`, {
       executable: glue.JobExecutable.pythonShell({
-        glueVersion: glue.GlueVersion.V1_0,
+        glueVersion: glue.GlueVersion.V4_0,
         pythonVersion: (db_type == 'mysql') ? glue.PythonVersion.THREE_NINE : glue.PythonVersion.THREE,
         script: glue.Code.fromAsset(path.join(__dirname, `../../../glue_scripts/${db_type}_create_case_insensitive_data.py`))
       }),

--- a/validation_testing/cdk_federation_infra_provisioning/app/lib/stacks/redshift-stack.ts
+++ b/validation_testing/cdk_federation_infra_provisioning/app/lib/stacks/redshift-stack.ts
@@ -121,7 +121,7 @@ export class RedshiftStack extends cdk.Stack {
 
     const glueJob = new glue.Job(this, 'redshift_glue_job_create_case_insensitive_data', {
       executable: glue.JobExecutable.pythonShell({
-        glueVersion: glue.GlueVersion.V1_0,
+        glueVersion: glue.GlueVersion.V4_0,
         pythonVersion: glue.PythonVersion.THREE_NINE,
         script: glue.Code.fromAsset(path.join(__dirname, `../../../glue_scripts/redshift_create_case_insensitive_data.py`))
       }),


### PR DESCRIPTION
*Description of changes:*
Glue Jobs V1 are deprecated, upgrading them to V4
