### PR TITLE
Added pagination for GCS connector

### DIFF
--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/handlers/GlueMetadataHandler.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/handlers/GlueMetadataHandler.java
@@ -311,6 +311,7 @@ public abstract class GlueMetadataHandler
         Set<TableName> tables = new HashSet<>();
         String nextToken = request.getNextToken();
         int pageSize = request.getPageSize();
+        logger.info("Starting pagination at {} with page size {}", nextToken, pageSize);
         do {
             GetTablesRequest.Builder getTablesRequest = GetTablesRequest.builder()
                     .catalogId(getCatalog(request))
@@ -332,6 +333,7 @@ public abstract class GlueMetadataHandler
             }
 
             nextToken = response.nextToken();
+            logger.info("{} tables returned. Next token is {}", tables.size(), nextToken);
         }
         while (nextToken != null && (pageSize == UNLIMITED_PAGE_SIZE_VALUE || pageSize > 0));
 

--- a/athena-gcs/src/main/java/com/amazonaws/athena/connectors/gcs/GcsMetadataHandler.java
+++ b/athena-gcs/src/main/java/com/amazonaws/athena/connectors/gcs/GcsMetadataHandler.java
@@ -62,7 +62,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static com.amazonaws.athena.connector.lambda.metadata.ListTablesRequest.UNLIMITED_PAGE_SIZE_VALUE;
 import static com.amazonaws.athena.connectors.gcs.GcsConstants.CLASSIFICATION_GLUE_TABLE_PARAM;
 import static com.amazonaws.athena.connectors.gcs.GcsConstants.FILE_FORMAT;
 import static com.amazonaws.athena.connectors.gcs.GcsConstants.GCS_LOCATION_PREFIX;
@@ -140,10 +139,7 @@ public class GcsMetadataHandler
     @Override
     public ListTablesResponse doListTables(BlockAllocator allocator, final ListTablesRequest request) throws Exception
     {
-        return super.doListTables(allocator,
-                new ListTablesRequest(request.getIdentity(), request.getQueryId(),
-                        request.getCatalogName(), request.getSchemaName(), null, UNLIMITED_PAGE_SIZE_VALUE),
-                TABLE_FILTER);
+        return super.doListTables(allocator, request, TABLE_FILTER);
     }
 
     /**


### PR DESCRIPTION
*Issue #, if available:*
GCS Connector pagination is not implemented.

*Description of changes:*
Added pagination for GCS connector and added logs for glue metadata handler.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
