### PR TITLE
Feature to enhance pagination checks and abstraction

### DIFF
--- a/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2MetadataHandlerTest.java
+++ b/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2MetadataHandlerTest.java
@@ -246,8 +246,8 @@ public class DataLakeGen2MetadataHandlerTest
 
         TableName[] expectedTables = {
                 new TableName("TESTSCHEMA", "TESTTABLE"),
-                new TableName("TESTSCHEMA", "testtable"),
-                new TableName("TESTSCHEMA", "testTABLE")
+                new TableName("TESTSCHEMA", "testTABLE"),
+                new TableName("TESTSCHEMA", "testtable")
         };
 
         assertEquals(Arrays.toString(expectedTables), listTablesResponse.getTables().toString());

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/util/PaginationHelper.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/util/PaginationHelper.java
@@ -99,4 +99,17 @@ public class PaginationHelper
 
         return new ListTablesResponse(catalogName, sortedTables.subList(startToken, endToken), nextToken);
     }
+
+    /**
+     * Calculates the nextToken or index to begin next pagination based on number of tables returns and pageSize.
+     *
+     * @param token the start position in the subset
+     * @param pageSize the number of tables to retrieve
+     * @param paginatedTables sublist of tables that were returned after pagination
+     * @return ListTableResponse with subset of tables.
+     */
+    public static String calculateNextToken(int token, int pageSize, List<TableName> paginatedTables)
+    {
+        return (pageSize == Integer.MAX_VALUE || paginatedTables.isEmpty() || paginatedTables.size() < pageSize) ? null : Integer.toString(token + pageSize);
+    }
 }

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/util/PaginationValidator.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/util/PaginationValidator.java
@@ -25,6 +25,14 @@ public class PaginationValidator
 {
     private PaginationValidator() {}
 
+    /**
+     * Validates that nextToken and pageSize are valid non-negative integers, with the exception of
+     * pageSize allowed to be -1 signifying unlimited pages.
+     * 
+     * @param nextToken
+     * @param pageSize
+     * @return int nextToken
+     */
     public static int validateAndParsePaginationArguments(String nextToken, int pageSize)
     {
         int startToken;

--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/util/PaginationValidator.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/util/PaginationValidator.java
@@ -1,0 +1,45 @@
+/*-
+ * #%L
+ * Amazon Athena Query Federation SDK
+ * %%
+ * Copyright (C) 2019 - 2025 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connector.util;
+
+import static com.amazonaws.athena.connector.lambda.metadata.ListTablesRequest.UNLIMITED_PAGE_SIZE_VALUE;
+
+public class PaginationValidator
+{
+    private PaginationValidator() {}
+
+    public static int validateAndParsePaginationArguments(String nextToken, int pageSize)
+    {
+        int startToken;
+        try {
+            startToken = nextToken == null ? 0 : Integer.parseInt(nextToken);
+        }
+        catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid next token: " + nextToken, e);
+        }
+        if (startToken < 0) {
+            throw new IllegalArgumentException("Invalid next token format. Token must be a valid integer, received: " + startToken);
+        }
+        if (pageSize < UNLIMITED_PAGE_SIZE_VALUE) {
+            throw new IllegalArgumentException("Page size must be either -1 for unlimited or a positive integer, received: " + pageSize);
+        }
+        return startToken;
+    }
+}

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/util/PaginationHelperTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/util/PaginationHelperTest.java
@@ -1,0 +1,127 @@
+/*-
+ * #%L
+ * Amazon Athena Query Federation SDK
+ * %%
+ * Copyright (C) 2019 - 2025 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connector.util;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import com.amazonaws.athena.connector.lambda.domain.TableName;
+import com.amazonaws.athena.connector.lambda.metadata.ListTablesResponse;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+class PaginationHelperTest
+{
+
+    @Test
+    void testValidateAndParsePaginationArguments_ValidInput()
+    {
+        assertEquals(0, PaginationHelper.validateAndParsePaginationArguments(null, 10));
+        assertEquals(5, PaginationHelper.validateAndParsePaginationArguments("5", 10));
+        assertEquals(0, PaginationHelper.validateAndParsePaginationArguments("0", -1));
+    }
+
+    @Test
+    void testValidateAndParsePaginationArguments_InvalidNextToken()
+    {
+        assertThrows(IllegalArgumentException.class, () ->
+                PaginationHelper.validateAndParsePaginationArguments("invalid", 10));
+        assertThrows(IllegalArgumentException.class, () ->
+                PaginationHelper.validateAndParsePaginationArguments("-1", 10));
+    }
+
+    @Test
+    void testValidateAndParsePaginationArguments_InvalidPageSize()
+    {
+        assertThrows(IllegalArgumentException.class, () ->
+                PaginationHelper.validateAndParsePaginationArguments("0", -2));
+    }
+
+    @Test
+    void testManualPagination_NormalCase()
+    {
+        List<TableName> allTables = Arrays.asList(
+                new TableName("schema1", "table1"),
+                new TableName("schema1", "table2"),
+                new TableName("schema2", "table3"),
+                new TableName("schema2", "table4"),
+                new TableName("schema3", "table5")
+        );
+
+        ListTablesResponse response = PaginationHelper.manualPagination(allTables, 1, 2, "testCatalog");
+        List<TableName> resultTables = new ArrayList<>(response.getTables());
+
+        assertEquals("testCatalog", response.getCatalogName());
+        assertEquals(2, response.getTables().size());
+        assertEquals("table2", resultTables.get(0).getTableName());
+        assertEquals("table3", resultTables.get(1).getTableName());
+        assertEquals("3", response.getNextToken());
+    }
+
+    @Test
+    void testManualPagination_UnlimitedPageSize()
+    {
+        List<TableName> allTables = Arrays.asList(
+                new TableName("schema1", "table1"),
+                new TableName("schema1", "table2"),
+                new TableName("schema2", "table3")
+        );
+
+        ListTablesResponse response = PaginationHelper.manualPagination(allTables, 0, -1, "testCatalog");
+
+        assertEquals("testCatalog", response.getCatalogName());
+        assertEquals(3, response.getTables().size());
+        assertNull(response.getNextToken());
+    }
+
+    @Test
+    void testManualPagination_StartTokenPastEnd()
+    {
+        List<TableName> allTables = Arrays.asList(
+                new TableName("schema1", "table1"),
+                new TableName("schema1", "table2")
+        );
+
+        ListTablesResponse response = PaginationHelper.manualPagination(allTables, 3, 1, "testCatalog");
+
+        assertEquals("testCatalog", response.getCatalogName());
+        assertTrue(response.getTables().isEmpty());
+        assertNull(response.getNextToken());
+    }
+
+    @Test
+    void testManualPagination_LastPage()
+    {
+        List<TableName> allTables = Arrays.asList(
+                new TableName("schema1", "table1"),
+                new TableName("schema1", "table2"),
+                new TableName("schema2", "table3")
+        );
+
+        ListTablesResponse response = PaginationHelper.manualPagination(allTables, 2, 2, "testCatalog");
+        List<TableName> resultTables = new ArrayList<>(response.getTables());
+
+        assertEquals("testCatalog", response.getCatalogName());
+        assertEquals(1, response.getTables().size());
+        assertEquals("table3", resultTables.get(0).getTableName());
+        assertNull(response.getNextToken());
+    }
+}

--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandler.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandler.java
@@ -246,7 +246,7 @@ public abstract class JdbcMetadataHandler
 
         // Validate nextToken and pageSize
         int pageSize = listTablesRequest.getPageSize();
-        int startToken = PaginationHelper.validateAndParsePaginationArguments(listTablesRequest.getNextToken(), pageSize);
+        String startToken = listTablesRequest.getNextToken();
 
         // Retrieve all tables
         List<TableName> allTables = listTables(connection, adjustedSchemaName);

--- a/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandlerTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandlerTest.java
@@ -236,6 +236,36 @@ public class JdbcMetadataHandlerTest
                 "testCatalog", "testSchema", "not_a_valid_number", UNLIMITED_PAGE_SIZE_VALUE));
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void doListTablesInvalidArgumentExceptionNegativeToken()
+            throws Exception {
+        String[] schema = {"TABLE_SCHEM", "TABLE_NAME"};
+        Object[][] values = {{"testSchema", "testTable"}, {"testSchema", "testTable2"}, {"testSchema", "testTable3"}, {"testSchema", "testTable4"}, {"testSchema", "testTable5"}};
+        AtomicInteger rowNumber = new AtomicInteger(-1);
+        ResultSet resultSet = mockResultSet(schema, values, rowNumber);
+
+        Mockito.when(connection.getMetaData().getTables("testCatalog", "testSchema", null, new String[] {"TABLE", "VIEW", "EXTERNAL TABLE", "MATERIALIZED VIEW"})).thenReturn(resultSet);
+
+        // Test: startToken is not a valid number with pageSize unlimited (all items)
+        this.jdbcMetadataHandler.doListTables(this.blockAllocator, new ListTablesRequest(this.federatedIdentity, "testQueryId",
+                "testCatalog", "testSchema", "-1", UNLIMITED_PAGE_SIZE_VALUE));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void doListTablesInvalidArgumentExceptionNegativePageSize()
+            throws Exception {
+        String[] schema = {"TABLE_SCHEM", "TABLE_NAME"};
+        Object[][] values = {{"testSchema", "testTable"}, {"testSchema", "testTable2"}, {"testSchema", "testTable3"}, {"testSchema", "testTable4"}, {"testSchema", "testTable5"}};
+        AtomicInteger rowNumber = new AtomicInteger(-1);
+        ResultSet resultSet = mockResultSet(schema, values, rowNumber);
+
+        Mockito.when(connection.getMetaData().getTables("testCatalog", "testSchema", null, new String[] {"TABLE", "VIEW", "EXTERNAL TABLE", "MATERIALIZED VIEW"})).thenReturn(resultSet);
+
+        // Test: startToken is not a valid number with pageSize unlimited (all items)
+        this.jdbcMetadataHandler.doListTables(this.blockAllocator, new ListTablesRequest(this.federatedIdentity, "testQueryId",
+                "testCatalog", "testSchema", "0", -3));
+    }
+
     @Test
     public void doListTablesEscaped()
             throws Exception

--- a/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandlerTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandlerTest.java
@@ -25,6 +25,7 @@ import com.amazonaws.athena.connector.lambda.data.BlockWriter;
 import com.amazonaws.athena.connector.lambda.data.FieldBuilder;
 import com.amazonaws.athena.connector.lambda.data.SchemaBuilder;
 import com.amazonaws.athena.connector.lambda.domain.TableName;
+import com.amazonaws.athena.connector.lambda.exceptions.AthenaConnectorException;
 import com.amazonaws.athena.connector.lambda.metadata.GetSplitsRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetSplitsResponse;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableLayoutRequest;
@@ -221,7 +222,7 @@ public class JdbcMetadataHandlerTest
         Assert.assertEquals(null, listTablesResponse.getNextToken());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = AthenaConnectorException.class)
     public void doListTablesNumberFormatException()
             throws Exception {
         String[] schema = {"TABLE_SCHEM", "TABLE_NAME"};
@@ -236,7 +237,7 @@ public class JdbcMetadataHandlerTest
                 "testCatalog", "testSchema", "not_a_valid_number", UNLIMITED_PAGE_SIZE_VALUE));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = AthenaConnectorException.class)
     public void doListTablesInvalidArgumentExceptionNegativeToken()
             throws Exception {
         String[] schema = {"TABLE_SCHEM", "TABLE_NAME"};
@@ -246,12 +247,12 @@ public class JdbcMetadataHandlerTest
 
         Mockito.when(connection.getMetaData().getTables("testCatalog", "testSchema", null, new String[] {"TABLE", "VIEW", "EXTERNAL TABLE", "MATERIALIZED VIEW"})).thenReturn(resultSet);
 
-        // Test: startToken is not a valid number with pageSize unlimited (all items)
+        // Test: startToken is not a valid number with pageSize unlimited. (all items)
         this.jdbcMetadataHandler.doListTables(this.blockAllocator, new ListTablesRequest(this.federatedIdentity, "testQueryId",
                 "testCatalog", "testSchema", "-1", UNLIMITED_PAGE_SIZE_VALUE));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = AthenaConnectorException.class)
     public void doListTablesInvalidArgumentExceptionNegativePageSize()
             throws Exception {
         String[] schema = {"TABLE_SCHEM", "TABLE_NAME"};
@@ -261,7 +262,7 @@ public class JdbcMetadataHandlerTest
 
         Mockito.when(connection.getMetaData().getTables("testCatalog", "testSchema", null, new String[] {"TABLE", "VIEW", "EXTERNAL TABLE", "MATERIALIZED VIEW"})).thenReturn(resultSet);
 
-        // Test: startToken is not a valid number with pageSize unlimited (all items)
+        // Test: pageSize is negative and invalid.
         this.jdbcMetadataHandler.doListTables(this.blockAllocator, new ListTablesRequest(this.federatedIdentity, "testQueryId",
                 "testCatalog", "testSchema", "0", -3));
     }

--- a/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMetadataHandler.java
+++ b/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMetadataHandler.java
@@ -331,7 +331,6 @@ public class SnowflakeMetadataHandler extends JdbcMetadataHandler
         int pageSize = listTablesRequest.getPageSize();
 
         if (pageSize == UNLIMITED_PAGE_SIZE_VALUE) {
-            System.out.println("integer max is now page size.");
             pageSize = Integer.MAX_VALUE;
         }
 

--- a/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMetadataHandler.java
+++ b/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMetadataHandler.java
@@ -86,6 +86,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.amazonaws.athena.connector.lambda.metadata.ListTablesRequest.UNLIMITED_PAGE_SIZE_VALUE;
 import static com.amazonaws.athena.connectors.snowflake.SnowflakeConstants.MAX_PARTITION_COUNT;
 import static com.amazonaws.athena.connectors.snowflake.SnowflakeConstants.SINGLE_SPLIT_LIMIT_COUNT;
 import static com.amazonaws.athena.connectors.snowflake.SnowflakeConstants.SNOWFLAKE_NAME;
@@ -329,16 +330,20 @@ public class SnowflakeMetadataHandler extends JdbcMetadataHandler
         String token = listTablesRequest.getNextToken();
         int pageSize = listTablesRequest.getPageSize();
 
+        if (pageSize == UNLIMITED_PAGE_SIZE_VALUE) {
+            System.out.println("integer max is now page size.");
+            pageSize = Integer.MAX_VALUE;
+        }
+
         int t = token != null ? Integer.parseInt(token) : 0;
 
         String adjustedSchemaName = caseResolver.getAdjustedSchemaNameString(connection, listTablesRequest.getSchemaName(), configOptions);
 
         LOGGER.info("Starting pagination at {} with page size {}", t, pageSize);
         List<TableName> paginatedTables = getPaginatedTables(connection, adjustedSchemaName, t, pageSize);
-        LOGGER.info("{} tables returned. Next token is {}", paginatedTables.size(), t + pageSize);
+        String nextToken = (pageSize == Integer.MAX_VALUE || paginatedTables.isEmpty() || paginatedTables.size() < pageSize) ? null : Integer.toString(t + pageSize);
+        LOGGER.info("{} tables returned. Next token is {}", paginatedTables.size(), nextToken);
 
-        String nextToken = paginatedTables.isEmpty() || paginatedTables.size() < pageSize ? null : Integer.toString(t + pageSize);
-        // return next token is null when reaching end of files
         return new ListTablesResponse(listTablesRequest.getCatalogName(), paginatedTables, nextToken);
     }
 

--- a/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMetadataHandler.java
+++ b/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMetadataHandler.java
@@ -46,7 +46,7 @@ import com.amazonaws.athena.connector.lambda.metadata.optimizations.pushdown.Com
 import com.amazonaws.athena.connector.lambda.metadata.optimizations.pushdown.FilterPushdownSubType;
 import com.amazonaws.athena.connector.lambda.metadata.optimizations.pushdown.LimitPushdownSubType;
 import com.amazonaws.athena.connector.lambda.metadata.optimizations.pushdown.TopNPushdownSubType;
-import com.amazonaws.athena.connector.util.PaginationValidator;
+import com.amazonaws.athena.connector.util.PaginationHelper;
 import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionConfig;
 import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionInfo;
 import com.amazonaws.athena.connectors.jdbc.connection.GenericJdbcConnectionFactory;
@@ -329,7 +329,7 @@ public class SnowflakeMetadataHandler extends JdbcMetadataHandler
     {
         LOGGER.debug("Starting listPaginatedTables for Snowflake.");
         int pageSize = listTablesRequest.getPageSize();
-        int token = PaginationValidator.validateAndParsePaginationArguments(listTablesRequest.getNextToken(), pageSize);
+        int token = PaginationHelper.validateAndParsePaginationArguments(listTablesRequest.getNextToken(), pageSize);
 
         if (pageSize == UNLIMITED_PAGE_SIZE_VALUE) {
             pageSize = Integer.MAX_VALUE;

--- a/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMetadataHandler.java
+++ b/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMetadataHandler.java
@@ -339,7 +339,7 @@ public class SnowflakeMetadataHandler extends JdbcMetadataHandler
 
         LOGGER.info("Starting pagination at {} with page size {}", token, pageSize);
         List<TableName> paginatedTables = getPaginatedTables(connection, adjustedSchemaName, token, pageSize);
-        String nextToken = (pageSize == Integer.MAX_VALUE || paginatedTables.isEmpty() || paginatedTables.size() < pageSize) ? null : Integer.toString(token + pageSize);
+        String nextToken = PaginationHelper.calculateNextToken(token, pageSize, paginatedTables);
         LOGGER.info("{} tables returned. Next token is {}", paginatedTables.size(), nextToken);
 
         return new ListTablesResponse(listTablesRequest.getCatalogName(), paginatedTables, nextToken);

--- a/athena-snowflake/src/test/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMetadataHandlerTest.java
+++ b/athena-snowflake/src/test/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMetadataHandlerTest.java
@@ -341,7 +341,6 @@ public class SnowflakeMetadataHandlerTest
         Assert.assertArrayEquals(expected, listTablesResponse.getTables().toArray());
 
         // Test 4:
-        System.out.println("TESTING TEST 4");
         preparedStatement = Mockito.mock(PreparedStatement.class);
         Mockito.when(this.connection.prepareStatement(snowflakeMetadataHandler.LIST_PAGINATED_TABLES_QUERY)).thenReturn(preparedStatement);
         values = new Object[][]{{"testSchema", "testTable3"}, {"testSchema", "testTable4"}};

--- a/athena-snowflake/src/test/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMetadataHandlerTest.java
+++ b/athena-snowflake/src/test/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMetadataHandlerTest.java
@@ -339,7 +339,23 @@ public class SnowflakeMetadataHandlerTest
                         "testCatalog", "testSchema", "2", 2));
         Assert.assertEquals(null, listTablesResponse.getNextToken());
         Assert.assertArrayEquals(expected, listTablesResponse.getTables().toArray());
+
+        // Test 4:
+        System.out.println("TESTING TEST 4");
+        preparedStatement = Mockito.mock(PreparedStatement.class);
+        Mockito.when(this.connection.prepareStatement(snowflakeMetadataHandler.LIST_PAGINATED_TABLES_QUERY)).thenReturn(preparedStatement);
+        values = new Object[][]{{"testSchema", "testTable3"}, {"testSchema", "testTable4"}};
+        expected = new TableName[]{new TableName("testSchema", "testTable3"), new TableName("testSchema", "testTable4")};
+        resultSet = mockResultSet(schema, values, new AtomicInteger(-1));
+        Mockito.when(preparedStatement.executeQuery()).thenReturn(resultSet);
+
+        listTablesResponse = this.snowflakeMetadataHandler.doListTables(
+                blockAllocator, new ListTablesRequest(this.federatedIdentity, "testQueryId",
+                        "testCatalog", "testSchema", "2", ListTablesRequest.UNLIMITED_PAGE_SIZE_VALUE));
+        Assert.assertEquals(null, listTablesResponse.getNextToken());
+        Assert.assertArrayEquals(expected, listTablesResponse.getTables().toArray());
     }
+
 
     @Test
     public void doGetSplits()

--- a/athena-snowflake/src/test/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMetadataHandlerTest.java
+++ b/athena-snowflake/src/test/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMetadataHandlerTest.java
@@ -353,8 +353,35 @@ public class SnowflakeMetadataHandlerTest
                         "testCatalog", "testSchema", "2", ListTablesRequest.UNLIMITED_PAGE_SIZE_VALUE));
         Assert.assertEquals(null, listTablesResponse.getNextToken());
         Assert.assertArrayEquals(expected, listTablesResponse.getTables().toArray());
-    }
 
+        // Test 5: Illegal Argument Exception with negative nextToken value
+        preparedStatement = Mockito.mock(PreparedStatement.class);
+        Mockito.when(this.connection.prepareStatement(snowflakeMetadataHandler.LIST_PAGINATED_TABLES_QUERY)).thenReturn(preparedStatement);
+        values = new Object[][]{{"testSchema", "testTable3"}, {"testSchema", "testTable4"}};
+        expected = new TableName[]{new TableName("testSchema", "testTable3"), new TableName("testSchema", "testTable4")};
+        resultSet = mockResultSet(schema, values, new AtomicInteger(-1));
+        Mockito.when(preparedStatement.executeQuery()).thenReturn(resultSet);
+
+        Assert.assertThrows(IllegalArgumentException.class, () -> this.snowflakeMetadataHandler.doListTables(
+                blockAllocator, new ListTablesRequest(this.federatedIdentity, "testQueryId",
+                        "testCatalog", "testSchema", "-1", 3)));
+        Assert.assertEquals(null, listTablesResponse.getNextToken());
+        Assert.assertArrayEquals(expected, listTablesResponse.getTables().toArray());
+
+        // Test 6: Illegal Argument Exception with negative pageSize value
+        preparedStatement = Mockito.mock(PreparedStatement.class);
+        Mockito.when(this.connection.prepareStatement(snowflakeMetadataHandler.LIST_PAGINATED_TABLES_QUERY)).thenReturn(preparedStatement);
+        values = new Object[][]{{"testSchema", "testTable3"}, {"testSchema", "testTable4"}};
+        expected = new TableName[]{new TableName("testSchema", "testTable3"), new TableName("testSchema", "testTable4")};
+        resultSet = mockResultSet(schema, values, new AtomicInteger(-1));
+        Mockito.when(preparedStatement.executeQuery()).thenReturn(resultSet);
+
+        Assert.assertThrows(IllegalArgumentException.class, () -> this.snowflakeMetadataHandler.doListTables(
+                blockAllocator, new ListTablesRequest(this.federatedIdentity, "testQueryId",
+                        "testCatalog", "testSchema", "0", -3)));
+        Assert.assertEquals(null, listTablesResponse.getNextToken());
+        Assert.assertArrayEquals(expected, listTablesResponse.getTables().toArray());
+    }
 
     @Test
     public void doGetSplits()

--- a/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/SynapseMetadataHandlerTest.java
+++ b/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/SynapseMetadataHandlerTest.java
@@ -447,8 +447,8 @@ public class SynapseMetadataHandlerTest
 
         TableName[] expectedTables = {
                 new TableName("TESTSCHEMA", "TESTTABLE"),
-                new TableName("TESTSCHEMA", "testtable"),
-                new TableName("TESTSCHEMA", "testTABLE")
+                new TableName("TESTSCHEMA", "testTABLE"),
+                new TableName("TESTSCHEMA", "testtable")
         };
 
         assertEquals(Arrays.toString(expectedTables), listTablesResponse.getTables().toString());


### PR DESCRIPTION
added the case where start token is not null and pageSize can be unlimited size -- Added logic for common code related to pagination checks and 'fake' pagination where connectors can't support it. 

*Issue #, if available:*

*Description of changes:*

### Added use case of pageSize = UNLIMITED and startToken any value but 0.
This is a continuation of the original change where we added pagination support to `doListTables` in Snowflake connector.  This change allows for the support of use case where pageSize is UNLIMITED_PAGE_SIZE (or -1) and the nextToken is something other than 0 or null.

### Added PaginationHelper utility class
We also have added a utility class to do basic checks across all our pagination. Making sure that pageSize is never less than -1 and also that token is never a negative number. If token is a really large number that exceeds the size of array of total tables, we will return an empty list.

Let's say that nextToken is equal to 2 and pageSize is UNLIMITED_PAGE_SIZE. This means give all tables from index 2 to infinity.

Also added logic for 'fake' or manual pagination to this helper class to be used by other connectors if needed.

### Testing
Added test cases to test this while also performing manual testing to show that the SQL query works with no issues.


Manual Testing to ensure that there is no issue with passing in Integer.MAX_VALUE as the limit value in SQL query for snowflake.

`INPUT: Token = null PageSize = -1`

Results:
```
[TableName{schemaName=car_schema_lower, tableName=carsid}, TableName{schemaName=car_schema_lower, tableName=carsid10}, TableName{schemaName=car_schema_lower, tableName=carsid11}, TableName{schemaName=car_schema_lower, tableName=carsid12}, TableName{schemaName=car_schema_lower, tableName=carsid2}, TableName{schemaName=car_schema_lower, tableName=carsid3}, TableName{schemaName=car_schema_lower, tableName=carsid4}, TableName{schemaName=car_schema_lower, tableName=carsid5}, TableName{schemaName=car_schema_lower, tableName=carsid6}, TableName{schemaName=car_schema_lower, tableName=carsid7}, TableName{schemaName=car_schema_lower, tableName=carsid8}, TableName{schemaName=car_schema_lower, tableName=carsid9}, TableName{schemaName=car_schema_lower, tableName=test}]
null
```

`INPUT: Token = 1 PageSize = -1`

Results:
```
[TableName{schemaName=car_schema_lower, tableName=carsid10}, TableName{schemaName=car_schema_lower, tableName=carsid11}, TableName{schemaName=car_schema_lower, tableName=carsid12}, TableName{schemaName=car_schema_lower, tableName=carsid2}, TableName{schemaName=car_schema_lower, tableName=carsid3}, TableName{schemaName=car_schema_lower, tableName=carsid4}, TableName{schemaName=car_schema_lower, tableName=carsid5}, TableName{schemaName=car_schema_lower, tableName=carsid6}, TableName{schemaName=car_schema_lower, tableName=carsid7}, TableName{schemaName=car_schema_lower, tableName=carsid8}, TableName{schemaName=car_schema_lower, tableName=carsid9}, TableName{schemaName=car_schema_lower, tableName=test}]
null
```


`INPUT: Token = 2 PageSize = -1`

Results:
```
[TableName{schemaName=car_schema_lower, tableName=carsid11}, TableName{schemaName=car_schema_lower, tableName=carsid12}, TableName{schemaName=car_schema_lower, tableName=carsid2}, TableName{schemaName=car_schema_lower, tableName=carsid3}, TableName{schemaName=car_schema_lower, tableName=carsid4}, TableName{schemaName=car_schema_lower, tableName=carsid5}, TableName{schemaName=car_schema_lower, tableName=carsid6}, TableName{schemaName=car_schema_lower, tableName=carsid7}, TableName{schemaName=car_schema_lower, tableName=carsid8}, TableName{schemaName=car_schema_lower, tableName=carsid9}, TableName{schemaName=car_schema_lower, tableName=test}]
nextToken: null
```



`INPUT: Token = 2 PageSize = Integer.MAX_VALUE`

Results:
```
[TableName{schemaName=car_schema_lower, tableName=carsid11}, TableName{schemaName=car_schema_lower, tableName=carsid12}, TableName{schemaName=car_schema_lower, tableName=carsid2}, TableName{schemaName=car_schema_lower, tableName=carsid3}, TableName{schemaName=car_schema_lower, tableName=carsid4}, TableName{schemaName=car_schema_lower, tableName=carsid5}, TableName{schemaName=car_schema_lower, tableName=carsid6}, TableName{schemaName=car_schema_lower, tableName=carsid7}, TableName{schemaName=car_schema_lower, tableName=carsid8}, TableName{schemaName=car_schema_lower, tableName=carsid9}, TableName{schemaName=car_schema_lower, tableName=test}]
null
```

`INPUT: Token ‎ = 2 PageSize = 4`

Results:
```
[TableName{schemaName=car_schema_lower, tableName=carsid11}, TableName{schemaName=car_schema_lower, tableName=carsid12}, TableName{schemaName=car_schema_lower, tableName=carsid2}, TableName{schemaName=car_schema_lower, tableName=carsid3}]
6
```
