### PR TITLE
Timestream connector: removes the check on disallowed words and allows queries to start with `SELECT` and `WITH`

### DIFF
--- a/athena-clickhouse/pom.xml
+++ b/athena-clickhouse/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>com.clickhouse</groupId>
             <artifactId>clickhouse-jdbc</artifactId>
-            <version>0.8.5</version>
+            <version>0.8.6</version>
             <classifier>all</classifier>
         </dependency>
         <dependency>


### PR DESCRIPTION
*Issue #2789*

*Removes the check on disallowed words and allows queries to start with `SELECT` and `WITH`*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
