### PR TITLE
Ignore upgrading kafka-protobuf-provider dependency via Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,8 @@ updates:
       - dependency-name: "software.amazon.msk:aws-msk-iam-auth"
       # bumping redshift version causes release tests to fail
       - dependency-name: "com.amazon.redshift:redshift-jdbc42"
-
+      # bumping kafka-protobuf-provider causing conflicts with square wire transitive dependencies
+      - dependency-name: "io.confluent:kafka-protobuf-provider"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
*Issue #, if available:*

[#2767](https://github.com/awslabs/aws-athena-query-federation/pull/2767)
The above PR should be closed, as upgrading kafka-protobuf-provider to version 7.9.1 introduces conflicts due to incompatible transitive dependencies of com.squareup.wire

![image](https://github.com/user-attachments/assets/69093b70-b494-4701-b6b0-ff7a46bfe749)

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
