### PR TITLE
Replace Confluent ProtobufSchema parser with protoc compiler

### DIFF
--- a/athena-msk/pom.xml
+++ b/athena-msk/pom.xml
@@ -44,28 +44,6 @@
                 <scope>runtime</scope>
             </dependency>
             <dependency>
-                <groupId>com.squareup.wire</groupId>
-                <artifactId>wire-schema</artifactId>
-                <version>5.3.3</version>
-            </dependency>
-            <dependency>
-                <groupId>com.squareup.wire</groupId>
-                <artifactId>wire-schema-jvm</artifactId>
-                <version>4.9.0</version>
-            </dependency>
-            <dependency>
-                <groupId>com.squareup.wire</groupId>
-                <artifactId>wire-runtime-jvm</artifactId>
-                <version>5.3.3</version>
-                <scope>runtime</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.squareup.wire</groupId>
-                <artifactId>wire-compiler</artifactId>
-                <version>5.3.3</version>
-                <scope>runtime</scope>
-            </dependency>
-            <dependency>
                 <groupId>software.amazon.msk</groupId>
                 <artifactId>aws-msk-iam-auth</artifactId>
                 <version>2.1.1</version>
@@ -83,7 +61,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>7.9.1-ce</version>
+            <version>4.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.avro</groupId>
@@ -96,14 +74,15 @@
             <version>3.25.5</version>
         </dependency>
         <dependency>
+            <groupId>com.github.os72</groupId>
+            <artifactId>protoc-jar</artifactId>
+            <version>3.11.4</version>
+        </dependency>
+
+        <dependency>
             <groupId>software.amazon.glue</groupId>
             <artifactId>schema-registry-serde</artifactId>
             <version>1.1.23</version>
-        </dependency>
-        <dependency>
-            <groupId>io.confluent</groupId>
-            <artifactId>kafka-protobuf-provider</artifactId>
-            <version>7.7.2</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -274,10 +253,4 @@
             </plugin>
         </plugins>
     </build>
-    <repositories>
-        <repository>
-            <id>confluent</id>
-            <url>https://packages.confluent.io/maven/</url>
-        </repository>
-    </repositories>
 </project>

--- a/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/AmazonMskUtils.java
+++ b/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/AmazonMskUtils.java
@@ -100,7 +100,6 @@ public class AmazonMskUtils
     private static final String KAFKA_MAX_PARTITION_FETCH_BYTES_CONFIG = "max.partition.fetch.bytes";
     private static final String KAFKA_KEY_DESERIALIZER_CLASS_CONFIG = "key.deserializer";
     private static final String KAFKA_VALUE_DESERIALIZER_CLASS_CONFIG = "value.deserializer";
-
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
     private AmazonMskUtils() {}

--- a/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/dto/MSKField.java
+++ b/athena-msk/src/main/java/com/amazonaws/athena/connectors/msk/dto/MSKField.java
@@ -40,6 +40,12 @@ public class MSKField
         this.value = value;
     }
 
+    public MSKField(String name, String type)
+    {
+        this.name = name;
+        this.type = type;
+    }
+
     public String getName()
     {
         return name;

--- a/athena-msk/src/test/java/com/amazonaws/athena/connectors/msk/AmazonMskRecordHandlerTest.java
+++ b/athena-msk/src/test/java/com/amazonaws/athena/connectors/msk/AmazonMskRecordHandlerTest.java
@@ -20,23 +20,37 @@
 package com.amazonaws.athena.connectors.msk;
 
 import com.amazonaws.athena.connector.lambda.QueryStatusChecker;
-import com.amazonaws.athena.connector.lambda.data.*;
+import com.amazonaws.athena.connector.lambda.data.BlockAllocatorImpl;
+import com.amazonaws.athena.connector.lambda.data.BlockSpiller;
+import com.amazonaws.athena.connector.lambda.data.S3BlockSpiller;
+import com.amazonaws.athena.connector.lambda.data.SchemaBuilder;
+import com.amazonaws.athena.connector.lambda.data.SpillConfig;
 import com.amazonaws.athena.connector.lambda.domain.Split;
 import com.amazonaws.athena.connector.lambda.domain.TableName;
 import com.amazonaws.athena.connector.lambda.domain.predicate.ConstraintEvaluator;
 import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
 import com.amazonaws.athena.connector.lambda.domain.spill.S3SpillLocation;
+import com.amazonaws.athena.connector.lambda.exceptions.AthenaConnectorException;
 import com.amazonaws.athena.connector.lambda.records.ReadRecordsRequest;
 import com.amazonaws.athena.connector.lambda.security.EncryptionKey;
 import com.amazonaws.athena.connector.lambda.security.EncryptionKeyFactory;
 import com.amazonaws.athena.connector.lambda.security.FederatedIdentity;
 import com.amazonaws.athena.connector.lambda.security.LocalKeyFactory;
-import com.amazonaws.athena.connectors.msk.dto.*;
+import com.amazonaws.athena.connectors.msk.dto.AvroTopicSchema;
+import com.amazonaws.athena.connectors.msk.dto.MSKField;
+import com.amazonaws.athena.connectors.msk.dto.Message;
+import com.amazonaws.athena.connectors.msk.dto.SplitParameters;
+import com.amazonaws.athena.connectors.msk.dto.TopicResultSet;
+import com.amazonaws.athena.connectors.msk.dto.TopicSchema;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.os72.protocjar.Protoc;
+import com.google.protobuf.DescriptorProtos;
+import com.google.protobuf.DescriptorProtos.DescriptorProto;
+import com.google.protobuf.DescriptorProtos.FieldDescriptorProto;
+import com.google.protobuf.DescriptorProtos.FileDescriptorSet;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.DynamicMessage;
-import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.types.pojo.Schema;
@@ -55,8 +69,12 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.athena.AthenaClient;
 import software.amazon.awssdk.services.glue.GlueClient;
+import software.amazon.awssdk.services.glue.model.ErrorDetails;
+import software.amazon.awssdk.services.glue.model.FederationSourceErrorCode;
 import software.amazon.awssdk.services.glue.model.GetSchemaRequest;
 import software.amazon.awssdk.services.glue.model.GetSchemaResponse;
 import software.amazon.awssdk.services.glue.model.GetSchemaVersionRequest;
@@ -64,6 +82,11 @@ import software.amazon.awssdk.services.glue.model.GetSchemaVersionResponse;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.UUID;
@@ -74,11 +97,13 @@ import static com.amazonaws.athena.connectors.msk.AmazonMskConstants.PROTOBUF_DA
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class AmazonMskRecordHandlerTest {
-
+public class AmazonMskRecordHandlerTest
+{
+    private static final Logger logger = LoggerFactory.getLogger(AmazonMskRecordHandlerTest.class);
     private static final ObjectMapper objectMapper = new ObjectMapper();
     private MockedStatic<GlueClient> awsGlueClientBuilder;
 
@@ -118,7 +143,8 @@ public class AmazonMskRecordHandlerTest {
     private MockedStatic<AmazonMskUtils> mockedMskUtils;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() throws Exception
+    {
         MockitoAnnotations.initMocks(this);
 
         consumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
@@ -131,7 +157,7 @@ public class AmazonMskRecordHandlerTest {
             consumer.addRecord(nullValueRecord);
         });
         avroConsumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
-        ConsumerRecord<String, GenericRecord> avroRecord = createAvroConsumerRecord("greetings", 0 , 0, "k1", createGenericRecord("greetings"));
+        ConsumerRecord<String, GenericRecord> avroRecord = createAvroConsumerRecord("greetings", 0, 0, "k1", createGenericRecord("greetings"));
         ConsumerRecord<String, GenericRecord> avroNullValueRecord = createAvroConsumerRecord("greetings", 0, 1, "k2", null);
         avroConsumer.schedulePollTask(() -> {
             avroConsumer.addRecord(avroRecord);
@@ -163,13 +189,15 @@ public class AmazonMskRecordHandlerTest {
     }
 
     @After
-    public void close(){
+    public void close()
+    {
         mockedMskUtils.close();
         awsGlueClientBuilder.close();
     }
 
     @Test
-    public void testForConsumeDataFromTopic() throws Exception {
+    public void testForConsumeDataFromTopic() throws Exception
+    {
         HashMap<TopicPartition, Long> offsets;
         offsets = new HashMap<>();
         offsets.put(new TopicPartition("myTopic", 0), 0L);
@@ -196,7 +224,8 @@ public class AmazonMskRecordHandlerTest {
         amazonMskRecordHandler.readWithConstraint(spiller, request, queryStatusChecker);
     }
     @Test
-    public void testForConsumeAvroDataFromTopic() throws Exception {
+    public void testForConsumeAvroDataFromTopic() throws Exception
+    {
         HashMap<TopicPartition, Long> offsets;
         offsets = new HashMap<>();
         offsets.put(new TopicPartition("greetings", 0), 0L);
@@ -225,7 +254,8 @@ public class AmazonMskRecordHandlerTest {
     }
 
     @Test
-    public void testForConsumeProtobufDataFromTopic() throws Exception {
+    public void testForConsumeProtobufDataFromTopic() throws Exception
+    {
         HashMap<TopicPartition, Long> offsets;
         offsets = new HashMap<>();
         offsets.put(new TopicPartition("protobuftest", 0), 0L);
@@ -236,7 +266,7 @@ public class AmazonMskRecordHandlerTest {
         protobufConsumer.updateEndOffsets(offsets);
 
         SplitParameters splitParameters = new SplitParameters("protobuftest", 0, 0, 1);
-        Schema schema = createProtobufSchema(createProtobufTopicSchema());
+        Schema schema = createProtobufSchema(createProtobufSchemaDefinition());
 
         mockedMskUtils.when(() -> AmazonMskUtils.getProtobufKafkaConsumer(com.google.common.collect.ImmutableMap.of())).thenReturn(protobufConsumer);
         mockedMskUtils.when(() -> AmazonMskUtils.createSplitParam(anyMap())).thenReturn(splitParameters);
@@ -254,7 +284,8 @@ public class AmazonMskRecordHandlerTest {
     }
 
     @Test
-    public void testForQueryStatusChecker() throws Exception {
+    public void testForQueryStatusChecker() throws Exception
+    {
         HashMap<TopicPartition, Long> offsets;
         offsets = new HashMap<>();
         offsets.put(new TopicPartition("myTopic", 0), 0L);
@@ -282,7 +313,8 @@ public class AmazonMskRecordHandlerTest {
     }
 
     @Test
-    public void testForEndOffsetIsZero() throws Exception {
+    public void testForEndOffsetIsZero() throws Exception
+    {
         consumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
 
         HashMap<TopicPartition, Long> offsets;
@@ -308,7 +340,8 @@ public class AmazonMskRecordHandlerTest {
     }
 
     @Test
-    public void testForContinuousEmptyDataFromTopic() throws Exception {
+    public void testForContinuousEmptyDataFromTopic() throws Exception
+    {
         consumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
 
         HashMap<TopicPartition, Long> offsets;
@@ -336,7 +369,8 @@ public class AmazonMskRecordHandlerTest {
         amazonMskRecordHandler.readWithConstraint(null, request, queryStatusChecker);
     }
 
-    private ReadRecordsRequest createReadRecordsRequest(Schema schema) {
+    private ReadRecordsRequest createReadRecordsRequest(Schema schema)
+    {
         return new ReadRecordsRequest(
                 federatedIdentity,
                 "testCatalog",
@@ -356,19 +390,23 @@ public class AmazonMskRecordHandlerTest {
                 0);
     }
 
-    private ConsumerRecord<String, TopicResultSet> createConsumerRecord(String topic, int partition, long offset, String key, TopicResultSet data) throws Exception {
+    private ConsumerRecord<String, TopicResultSet> createConsumerRecord(String topic, int partition, long offset, String key, TopicResultSet data) throws Exception
+    {
         return new ConsumerRecord<>(topic, partition, offset, key, data);
     }
 
-    private ConsumerRecord<String, GenericRecord> createAvroConsumerRecord(String topic, int partition, long offset, String key, GenericRecord data) throws Exception {
+    private ConsumerRecord<String, GenericRecord> createAvroConsumerRecord(String topic, int partition, long offset, String key, GenericRecord data) throws Exception
+    {
         return new ConsumerRecord<>(topic, partition, offset, key, data);
     }
 
-    private ConsumerRecord<String, DynamicMessage> createProtobufConsumerRecord(String topic, int partition, long offset, String key, DynamicMessage data) throws Exception {
+    private ConsumerRecord<String, DynamicMessage> createProtobufConsumerRecord(String topic, int partition, long offset, String key, DynamicMessage data) throws Exception
+    {
         return new ConsumerRecord<>(topic, partition, offset, key, data);
     }
 
-    private TopicResultSet createTopicResultSet(String topic) {
+    private TopicResultSet createTopicResultSet(String topic)
+    {
         TopicResultSet resultSet = new TopicResultSet();
         resultSet.setTopicName(topic);
         resultSet.setDataFormat(Message.DATA_FORMAT_CSV);
@@ -378,7 +416,8 @@ public class AmazonMskRecordHandlerTest {
         resultSet.getFields().add(new MSKField("code", "3", "TINYINT", "", Byte.parseByte("101")));
         return resultSet;
     }
-    private GenericRecord createGenericRecord(String topic) {
+    private GenericRecord createGenericRecord(String topic)
+    {
         org.apache.avro.Schema.Parser parser = new org.apache.avro.Schema.Parser();
         String schemaString = "{\"type\": \"record\",\"name\":\"" + topic + "\",\"fields\": [{\"name\": \"id\", \"type\": \"int\"},{\"name\": \"name\", \"type\": \"string\"},{\"name\": \"greeting\",\"type\": \"string\"}]}";
         org.apache.avro.Schema schema = parser.parse(schemaString);
@@ -391,15 +430,42 @@ public class AmazonMskRecordHandlerTest {
         return record;
     }
 
-    private DynamicMessage createDynamicRecord() {
-        String schema = "syntax = \"proto3\";\n" +
-                "message protobuftest {\n" +
-                "string name = 1;\n" +
-                "int32 calories = 2;\n" +
-                "string colour = 3; \n" +
-                "}";
-        ProtobufSchema protobufSchema = new ProtobufSchema(schema);
-        Descriptors.Descriptor descriptor = protobufSchema.toDescriptor();
+    private DynamicMessage createDynamicRecord() throws Exception
+    {
+        // Create a FileDescriptorProto builder
+        DescriptorProtos.FileDescriptorProto.Builder fileBuilder = DescriptorProtos.FileDescriptorProto.newBuilder();
+        fileBuilder.setPackage("athena_msk");
+        fileBuilder.setSyntax("proto3");
+
+        // Create message builder
+        DescriptorProtos.DescriptorProto.Builder msgBuilder = DescriptorProtos.DescriptorProto.newBuilder()
+                .setName("protobuftest");
+
+        // Add fields
+        msgBuilder.addField(DescriptorProtos.FieldDescriptorProto.newBuilder()
+                .setName("name")
+                .setNumber(1)
+                .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_STRING)
+                .build());
+
+        msgBuilder.addField(DescriptorProtos.FieldDescriptorProto.newBuilder()
+                .setName("calories")
+                .setNumber(2)
+                .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_INT32)
+                .build());
+
+        msgBuilder.addField(DescriptorProtos.FieldDescriptorProto.newBuilder()
+                .setName("colour")
+                .setNumber(3)
+                .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_STRING)
+                .build());
+
+        fileBuilder.addMessageType(msgBuilder.build());
+
+        // Build the file descriptor
+        DescriptorProtos.FileDescriptorProto fileDescriptorProto = fileBuilder.build();
+        Descriptors.FileDescriptor fileDescriptor = Descriptors.FileDescriptor.buildFrom(fileDescriptorProto, new Descriptors.FileDescriptor[]{});
+        Descriptors.Descriptor descriptor = fileDescriptor.getMessageTypes().get(0);
 
         // Build the dynamic message
         DynamicMessage.Builder builder = DynamicMessage.newBuilder(descriptor);
@@ -410,8 +476,8 @@ public class AmazonMskRecordHandlerTest {
         return builder.build();
     }
 
-
-    private Schema createSchema(TopicSchema topicSchema) throws Exception {
+    private Schema createSchema(TopicSchema topicSchema) throws Exception
+    {
         SchemaBuilder schemaBuilder = SchemaBuilder.newBuilder();
         topicSchema.getMessage().getFields().forEach(it -> {
             FieldType fieldType = new FieldType(
@@ -432,7 +498,8 @@ public class AmazonMskRecordHandlerTest {
         return schemaBuilder.build();
     }
 
-    private Schema createAvroSchema(AvroTopicSchema avroTopicSchema) throws Exception {
+    private Schema createAvroSchema(AvroTopicSchema avroTopicSchema) throws Exception
+    {
         SchemaBuilder schemaBuilder = SchemaBuilder.newBuilder();
         avroTopicSchema.getFields().forEach(it -> {
             FieldType fieldType = new FieldType(
@@ -452,23 +519,97 @@ public class AmazonMskRecordHandlerTest {
         return schemaBuilder.build();
     }
 
-    private Schema createProtobufSchema(ProtobufSchema protobufTopicSchema) throws Exception {
+    /**
+     * Parse protobuf schema string using protoc compiler and build Arrow Schema.
+     *
+     * @param protobufSchema Protobuf message definition as a string
+     * @return Arrow {@link Schema} representing the Protobuf structure
+     * @throws AthenaConnectorException if schema parsing fails
+     */
+    private Schema createProtobufSchema(String protobufSchema)
+    {
         SchemaBuilder schemaBuilder = SchemaBuilder.newBuilder();
-        Descriptors.Descriptor descriptor = protobufTopicSchema.toDescriptor();
-        for (Descriptors.FieldDescriptor fieldDescriptor : descriptor.getFields()) {
-            FieldType fieldType = new FieldType(
-                    true,
-                    AmazonMskUtils.toArrowType(fieldDescriptor.getType().toString()),
-                    null
-            );
-            Field field = new Field(fieldDescriptor.getName(), fieldType, null);
-            schemaBuilder.addField(field);
+
+        // Use a unique temporary directory under /tmp
+        Path protoDir = Paths.get("/tmp", "proto_" + UUID.randomUUID());
+        Path protoFile = protoDir.resolve("test.proto");
+        Path descFile = protoDir.resolve("test.desc");
+
+        try {
+            Files.createDirectories(protoDir);
+            Files.writeString(protoFile, protobufSchema);
+            
+            // Compile using protoc-jar
+            int exitCode = Protoc.runProtoc(new String[]{
+                    "--descriptor_set_out=" + descFile.toAbsolutePath(),
+                    "--proto_path=" + protoDir.toAbsolutePath(),
+                    protoFile.getFileName().toString()
+            });
+
+            if (exitCode != 0 || !Files.exists(descFile)) {
+                throw new AthenaConnectorException(
+                        "Failed to generate descriptor set with protoc",
+                        ErrorDetails.builder()
+                                .errorCode(FederationSourceErrorCode.INTERNAL_SERVICE_EXCEPTION.toString())
+                                .build()
+                );
+            }
+
+            try (FileInputStream fis = new FileInputStream(descFile.toFile())) {
+                FileDescriptorSet descriptorSet = FileDescriptorSet.parseFrom(fis);
+
+                if (descriptorSet.getFileList().isEmpty() ||
+                        descriptorSet.getFile(0).getMessageTypeList().isEmpty()) {
+                    throw new AthenaConnectorException(
+                            "No message types found in compiled schema",
+                            ErrorDetails.builder()
+                                    .errorCode(FederationSourceErrorCode.INVALID_RESPONSE_EXCEPTION.toString())
+                                    .build()
+                    );
+                }
+
+                DescriptorProto messageType = descriptorSet.getFile(0).getMessageType(0);
+                for (FieldDescriptorProto field : messageType.getFieldList()) {
+                    String baseType = field.getType().toString().toLowerCase().replace("type_", "");
+                    String fieldType = field.getLabel() == FieldDescriptorProto.Label.LABEL_REPEATED
+                            ? "repeated " + baseType
+                            : baseType;
+
+                    FieldType arrowFieldType = new FieldType(
+                            true,
+                            AmazonMskUtils.toArrowType(fieldType),
+                            null
+                    );
+                    Field arrowField = new Field(field.getName(), arrowFieldType, null);
+                    schemaBuilder.addField(arrowField);
+                }
+            }
         }
+        catch (IOException | InterruptedException e) {
+            throw new AthenaConnectorException(
+                    "Failed to parse Protobuf schema: " + e.getMessage(),
+                    ErrorDetails.builder()
+                            .errorCode(FederationSourceErrorCode.INTERNAL_SERVICE_EXCEPTION.toString())
+                            .build()
+            );
+        }
+        finally {
+            try {
+                Files.deleteIfExists(protoFile);
+                Files.deleteIfExists(descFile);
+                Files.deleteIfExists(protoDir);
+            }
+            catch (IOException e) {
+                logger.warn("Failed to clean up temporary proto directory: {}", protoDir.toAbsolutePath(), e);
+            }
+        }
+
         schemaBuilder.addMetadata("dataFormat", PROTOBUF_DATA_FORMAT);
         return schemaBuilder.build();
     }
 
-    private TopicSchema createCsvTopicSchema() throws JsonProcessingException {
+    private TopicSchema createCsvTopicSchema() throws JsonProcessingException
+    {
         String csv = "{" +
                 "\"topicName\":\"test\"," +
                 "\"message\":{" +
@@ -482,24 +623,26 @@ public class AmazonMskRecordHandlerTest {
         return objectMapper.readValue(csv, TopicSchema.class);
     }
 
-    private AvroTopicSchema createAvroTopicSchema() throws JsonProcessingException {
+    private AvroTopicSchema createAvroTopicSchema() throws JsonProcessingException
+    {
         String avro = "{\"type\": \"record\",\"name\":\"greetings\",\"fields\": [{\"name\": \"id\", \"type\": \"int\"},{\"name\": \"name\", \"type\": \"string\"},{\"name\": \"greeting\",\"type\": \"string\"}]}";
         return objectMapper.readValue(avro, AvroTopicSchema.class);
     }
 
-    private ProtobufSchema createProtobufTopicSchema() {
-        String protobuf = "syntax = \"proto3\";\n" +
+    private String createProtobufSchemaDefinition()
+    {
+        return "syntax = \"proto3\";\n" +
                 "message protobuftest {\n" +
                 "string name = 1;\n" +
                 "int32 calories = 2;\n" +
                 "string colour = 3; \n" +
                 "}";
-        ProtobufSchema protobufSchema = new ProtobufSchema(protobuf);
-        return protobufSchema;
     }
 
-    private GetSchemaResponse getSchemaResponse() {
-        String arn = "defaultArn", schemaName = "defaultSchemaName";
+    private GetSchemaResponse getSchemaResponse()
+    {
+        String arn = "defaultArn";
+        String schemaName = "defaultSchemaName";
         Long latestSchemaVersion = 123L;
         return GetSchemaResponse.builder()
                 .schemaArn(arn)
@@ -508,8 +651,10 @@ public class AmazonMskRecordHandlerTest {
                 .build();
     }
 
-    private GetSchemaVersionResponse getJsonSchemaVersionResponse() {
-        String arn = "defaultArn", schemaVersionId = "defaultVersionId";
+    private GetSchemaVersionResponse getJsonSchemaVersionResponse()
+    {
+        String arn = "defaultArn";
+        String schemaVersionId = "defaultVersionId";
         return GetSchemaVersionResponse.builder()
                 .schemaArn(arn)
                 .schemaVersionId(schemaVersionId)
@@ -518,29 +663,27 @@ public class AmazonMskRecordHandlerTest {
                 .build();
     }
 
-    private GetSchemaVersionResponse getAvroSchemaVersionResponse() {
-        String arn = "defaultArn", schemaVersionId = "defaultVersionId";
+    private GetSchemaVersionResponse getAvroSchemaVersionResponse()
+    {
+        String arn = "defaultArn";
+        String schemaVersionId = "defaultVersionId";
         return GetSchemaVersionResponse.builder()
                 .schemaArn(arn)
                 .schemaVersionId(schemaVersionId)
                 .dataFormat("avro")
                 .schemaDefinition("{\"type\": \"record\",\"name\":\"greetings\",\"fields\": [{\"name\": \"id\", \"type\": \"int\"},{\"name\": \"name\", \"type\": \"string\"},{\"name\": \"greeting\",\"type\": \"string\"}]}")
                 .build();
-
     }
 
-    private GetSchemaVersionResponse getProtobufSchemaVersionResponse() {
-        String arn = "defaultArn", schemaVersionId = "defaultVersionId";
+    private GetSchemaVersionResponse getProtobufSchemaVersionResponse()
+    {
+        String arn = "defaultArn";
+        String schemaVersionId = "defaultVersionId";
         return GetSchemaVersionResponse.builder()
                 .schemaArn(arn)
                 .schemaVersionId(schemaVersionId)
                 .dataFormat("protobuf")
-                .schemaDefinition("syntax = \"proto3\";\n" +
-                        "message protobuftest {\n" +
-                        "string name = 1;\n" +
-                        "int32 calories = 2;\n" +
-                        "string colour = 3; \n" +
-                        "}")
+                .schemaDefinition(createProtobufSchemaDefinition())
                 .build();
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-athena-query-federation/pull/2826
Upgrading the kafka-protobuf-provider dependency introduces conflicts with schema-registry-serde due to incompatible transitive dependencies from com.squareup.wire.

*Description of changes:*
This PR removes the dependency on the Confluent Protobuf provider and introduces protoc compiler (via protoc-jar) to parse Protobuf message definitions. Please find attached test document.
[msk-protobuf.odt](https://github.com/user-attachments/files/20977694/msk-protobuf.odt)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
