### PR TITLE
Updating versions of bouncy castle and protobuf

### DIFF
--- a/athena-federation-sdk/pom.xml
+++ b/athena-federation-sdk/pom.xml
@@ -216,8 +216,8 @@
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.70</version>
+            <artifactId>bcprov-jdk18on</artifactId>
+            <version>1.78</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <log4j2Version>2.24.2</log4j2Version>
         <apache.arrow.version>18.1.0</apache.arrow.version>
         <guava.version>33.4.0-jre</guava.version>
-        <protobuf3.version>3.25.3</protobuf3.version>
+        <protobuf3.version>3.25.5</protobuf3.version>
         <antlr.st4.version>4.3.4</antlr.st4.version>
         <log4j2.cachefile.transformer.version>2.15</log4j2.cachefile.transformer.version>
         <apache.httpclient.version>4.5.14</apache.httpclient.version>


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*
Updating some dependency versions due to security vulnerabilities as listed below
- [CVE-2024-29857](https://nvd.nist.gov/vuln/detail/cve-2024-29857) - bouncy castle vulnerability, upgrading from 1.70 to 1.78
- [CVE-2024-7254](https://nvd.nist.gov/vuln/detail/cve-2024-7254) - protobuf vulnerability, upgrading from 3.25.3 to 3.25.5

did a `mv clean install` and it succeeded.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
