### PR TITLE
Adding support to use custom SecretManagerClient for Google Big Query

### DIFF
--- a/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryMetadataHandlerTest.java
+++ b/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryMetadataHandlerTest.java
@@ -58,6 +58,7 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.MockitoJUnitRunner;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -108,7 +109,7 @@ public class BigQueryMetadataHandlerTest
         job = mock(Job.class);
         jobStatus = mock(JobStatus.class);
         mockedStatic = Mockito.mockStatic(BigQueryUtils.class, Mockito.CALLS_REAL_METHODS);
-        mockedStatic.when(() -> BigQueryUtils.getBigQueryClient(any(Map.class))).thenReturn(bigQuery);
+        mockedStatic.when(() -> BigQueryUtils.getBigQueryClient(any(Map.class), any(SecretsManagerClient.class))).thenReturn(bigQuery);
     }
 
     @After

--- a/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryRecordHandlerTest.java
+++ b/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryRecordHandlerTest.java
@@ -197,7 +197,7 @@ public class BigQueryRecordHandlerTest
         System.setProperty("aws.region", "us-east-1");
         logger.info("Starting init.");
         mockedStatic = Mockito.mockStatic(BigQueryUtils.class, Mockito.CALLS_REAL_METHODS);
-        mockedStatic.when(() -> BigQueryUtils.getBigQueryClient(any(Map.class))).thenReturn(bigQuery);
+        mockedStatic.when(() -> BigQueryUtils.getBigQueryClient(any(Map.class), any(SecretsManagerClient.class))).thenReturn(bigQuery);
         federatedIdentity = Mockito.mock(FederatedIdentity.class);
         allocator = new BlockAllocatorImpl();
         amazonS3 = mock(S3Client.class);


### PR DESCRIPTION
*Issue #, if available:* 
N/A

*Description of changes:*
This PR we have added to support custom object of SecretsManagerClient.

Added constructor in BigQueryMetadataHandler
Updated the constructor in BigQueryRecordHandler
Overloaded two methods getBigQueryClient and getCredentialsFromSecretsManager of BigQueryUtils which will now accept object of SecretsManagerClient as parameter.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
