### PR TITLE
Updating redshift cluster node type in release tests due to deprecation of dc2 large node type

### DIFF
--- a/validation_testing/cdk_federation_infra_provisioning/app/lib/stacks/redshift-stack.ts
+++ b/validation_testing/cdk_federation_infra_provisioning/app/lib/stacks/redshift-stack.ts
@@ -73,6 +73,7 @@ export class RedshiftStack extends cdk.Stack {
     // Original L2 Construct
     const cluster = new redshift.Cluster(this, 'redshift_cluster', {
         numberOfNodes: 2,
+        nodeType: redshift.NodeType.RA3_LARGE,
         port: 5439,
         vpc: vpc,
         vpcSubnets: {

--- a/validation_testing/cdk_federation_infra_provisioning/app/package.json
+++ b/validation_testing/cdk_federation_infra_provisioning/app/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@aws-cdk/aws-glue-alpha": "2.130.0-alpha.0",
-    "@aws-cdk/aws-redshift-alpha": "2.130.0-alpha.0",
+    "@aws-cdk/aws-redshift-alpha": "2.173.0-alpha.0",
     "aws-cdk-lib": "2.177.0",
     "dotenv": "^16.0.3",
     "source-map-support": "^0.5.21",


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-athena-query-federation/actions/runs/15838247685/job/44646102243

*Description of changes:*
Redshift has deprecated dc2 large node types which prevents creation of new clusters with dc2.large as the node type, so upgrading that to ra3.large as advised in the migration doc ([ref](https://w.amazon.com/bin/view/RedshiftDC2Deprecation/)).

*Testing:*
- Maven build succeeded 
- Validated the node type changes in local cdk.out as added below
```
"redshiftcluster5BDFFF97": {
   "Type": "AWS::Redshift::Cluster",
   "Properties": {
    "AllowVersionUpgrade": true,
    "AutomatedSnapshotRetentionPeriod": 1,
    "ClusterParameterGroupName": {
     "Ref": "redshiftclusterParameterGroup3FF70CEF"
    },
    "ClusterSubnetGroupName": {
     "Ref": "redshiftclusterSubnets7A92E844"
    },
    "ClusterType": "multi-node",
    "DBName": "test",
    "Encrypted": true,
    "MasterUsername": "athena",
    "NodeType": "ra3.large",
    "NumberOfNodes": 2,
    "Port": 5439,
    "PubliclyAccessible": false,
    "VpcSecurityGroupIds": [
     {
      "Fn::GetAtt": [
       "redshiftsecuritygroup56E42E96",
       "GroupId"
      ]
     }
    ]
   },
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
