### PR TITLE
Feature to support string templates in bigquery.

### DIFF
--- a/athena-google-bigquery/pom.xml
+++ b/athena-google-bigquery/pom.xml
@@ -91,6 +91,11 @@
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.antlr</groupId>
+            <artifactId>ST4</artifactId>
+            <version>${antlr.st4.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryFederationExpressionParser.java
+++ b/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryFederationExpressionParser.java
@@ -30,15 +30,12 @@ import com.amazonaws.athena.connector.lambda.domain.predicate.functions.Function
 import com.amazonaws.athena.connector.lambda.domain.predicate.functions.OperatorType;
 import com.amazonaws.athena.connector.lambda.domain.predicate.functions.StandardFunctions;
 import com.amazonaws.athena.connectors.jdbc.manager.FederationExpressionParser;
-import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.commons.lang3.NotImplementedException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -52,11 +49,10 @@ import static com.amazonaws.athena.connector.lambda.domain.predicate.expression.
 public class BigQueryFederationExpressionParser extends FederationExpressionParser
 {
     private static final String quoteCharacter = "'";
-    private static final Logger LOGGER = LoggerFactory.getLogger(BigQueryFederationExpressionParser.class);
 
-    public String writeArrayConstructorClause(ArrowType type, List<String> arguments)
+    public String writeArrayConstructorClause(List<String> arguments)
     {
-        return Joiner.on(", ").join(arguments);
+        return BigQuerySqlUtils.renderTemplate("comma_separated_list_with_parentheses", "items", arguments);
     }
 
     public List<String> parseComplexExpressions(List<Field> columns, Constraints constraints)
@@ -119,7 +115,7 @@ public class BigQueryFederationExpressionParser extends FederationExpressionPars
                     .collect(Collectors.toList());
         }
 
-        return Joiner.on(",").join(constants);
+        return BigQuerySqlUtils.renderTemplate("comma_separated_list", "items", constants);
     }
 
     @Override
@@ -128,7 +124,7 @@ public class BigQueryFederationExpressionParser extends FederationExpressionPars
         StandardFunctions functionEnum = StandardFunctions.fromFunctionName(functionName);
         OperatorType operatorType = functionEnum.getOperatorType();
 
-        if (arguments == null || arguments.size() == 0) {
+        if (arguments == null || arguments.isEmpty()) {
             throw new IllegalArgumentException("Arguments cannot be null or empty.");
         }
         switch (operatorType) {
@@ -151,69 +147,67 @@ public class BigQueryFederationExpressionParser extends FederationExpressionPars
         String clause = "";
         switch (functionEnum) {
             case ADD_FUNCTION_NAME:
-                clause = Joiner.on(" + ").join(arguments);
+                clause = BigQuerySqlUtils.renderTemplate("join_expression", "items", arguments, "separator", " + ");
                 break;
             case AND_FUNCTION_NAME:
-                clause = Joiner.on(" AND ").join(arguments);
+                clause = BigQuerySqlUtils.renderTemplate("join_expression", "items", arguments, "separator", " AND ");
                 break;
             case ARRAY_CONSTRUCTOR_FUNCTION_NAME: // up to subclass
-                clause = writeArrayConstructorClause(type, arguments);
+                clause = writeArrayConstructorClause(arguments);
                 break;
             case DIVIDE_FUNCTION_NAME:
-                clause = Joiner.on(" / ").join(arguments);
+                clause = BigQuerySqlUtils.renderTemplate("join_expression", "items", arguments, "separator", " / ");
                 break;
             case EQUAL_OPERATOR_FUNCTION_NAME:
-                clause = Joiner.on(" = ").join(arguments);
+                clause = BigQuerySqlUtils.renderTemplate("join_expression", "items", arguments, "separator", " = ");
                 break;
             case GREATER_THAN_OPERATOR_FUNCTION_NAME:
-                clause = Joiner.on(" > ").join(arguments);
+                clause = BigQuerySqlUtils.renderTemplate("join_expression", "items", arguments, "separator", " > ");
                 break;
             case GREATER_THAN_OR_EQUAL_OPERATOR_FUNCTION_NAME:
-                clause = Joiner.on(" >= ").join(arguments);
+                clause = BigQuerySqlUtils.renderTemplate("join_expression", "items", arguments, "separator", " >= ");
                 break;
             case IN_PREDICATE_FUNCTION_NAME:
-                clause = arguments.get(0) + " IN " + arguments.get(1);
+                clause = BigQuerySqlUtils.renderTemplate("in_expression", "column", arguments.get(0), "values", arguments.get(1));
                 break;
             case IS_DISTINCT_FROM_OPERATOR_FUNCTION_NAME:
-                String argZero = arguments.get(0);
-                String argOne = arguments.get(1);
-                clause = argZero + " IS DISTINCT FROM " + argOne;
+                clause = BigQuerySqlUtils.renderTemplate("is_distinct_from", "left", arguments.get(0), "right", arguments.get(1));
                 break;
             case IS_NULL_FUNCTION_NAME:
-                clause = arguments.get(0) + " IS NULL";
+                clause = BigQuerySqlUtils.renderTemplate("null_predicate", "columnName", arguments.get(0), "isNull", true);
                 break;
             case LESS_THAN_OPERATOR_FUNCTION_NAME:
-                clause = Joiner.on(" < ").join(arguments);
+                clause = BigQuerySqlUtils.renderTemplate("join_expression", "items", arguments, "separator", " < ");
                 break;
             case LESS_THAN_OR_EQUAL_OPERATOR_FUNCTION_NAME:
-                clause = Joiner.on(" <= ").join(arguments);
+                clause = BigQuerySqlUtils.renderTemplate("join_expression", "items", arguments, "separator", " <= ");
                 break;
             case LIKE_PATTERN_FUNCTION_NAME:
-                clause = arguments.get(0) + " LIKE " + arguments.get(1);
+                clause = BigQuerySqlUtils.renderTemplate("like_expression", "column", arguments.get(0), "pattern", arguments.get(1));
                 break;
             case MODULUS_FUNCTION_NAME:
-                clause = " MOD(" + arguments.get(0) + "," + arguments.get(1) + ")";
+                clause = BigQuerySqlUtils.renderTemplate("function_call_2args", "functionName", "MOD", "arg1", arguments.get(0), "arg2", arguments.get(1));
                 break;
             case MULTIPLY_FUNCTION_NAME:
-                clause = Joiner.on(" * ").join(arguments);
+                clause = BigQuerySqlUtils.renderTemplate("join_expression", "items", arguments, "separator", " * ");
                 break;
             case NEGATE_FUNCTION_NAME:
-                clause = "-" + arguments.get(0);
+                clause = BigQuerySqlUtils.renderTemplate("unary_operator", "operator", "-", "operand", arguments.get(0));
                 break;
             case NOT_EQUAL_OPERATOR_FUNCTION_NAME:
-                clause = Joiner.on(" <> ").join(arguments);
+                clause = BigQuerySqlUtils.renderTemplate("join_expression", "items", arguments, "separator", " <> ");
                 break;
             case NOT_FUNCTION_NAME:
-                clause = " NOT " + arguments.get(0);
+                clause = BigQuerySqlUtils.renderTemplate("unary_operator", "operator", "NOT ", "operand", arguments.get(0));
                 break;
             case NULLIF_FUNCTION_NAME:
-                clause = "NULLIF(" + arguments.get(0) + ", " + arguments.get(1) + ")";
+                clause = BigQuerySqlUtils.renderTemplate("function_call_2args", "functionName", "NULLIF", "arg1", arguments.get(0), "arg2", arguments.get(1));
                 break;
             case OR_FUNCTION_NAME:
-                clause = Joiner.on(" OR ").join(arguments);
+                clause = BigQuerySqlUtils.renderTemplate("join_expression", "items", arguments, "separator", " OR ");
                 break;
             case SUBTRACT_FUNCTION_NAME:
-                clause = Joiner.on(" - ").join(arguments);
+                clause = BigQuerySqlUtils.renderTemplate("join_expression", "items", arguments, "separator", " - ");
                 break;
             default:
                 throw new NotImplementedException("The function " + functionName.getFunctionName() + " does not have an implementation");
@@ -221,6 +215,6 @@ public class BigQueryFederationExpressionParser extends FederationExpressionPars
         if (clause == null) {
             return "";
         }
-        return "(" + clause + ")";
+        return clause;
     }
 }

--- a/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQuerySqlUtils.java
+++ b/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQuerySqlUtils.java
@@ -21,48 +21,28 @@ package com.amazonaws.athena.connectors.google.bigquery;
 
 import com.amazonaws.athena.connector.lambda.domain.TableName;
 import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
-import com.amazonaws.athena.connector.lambda.domain.predicate.OrderByField;
-import com.amazonaws.athena.connector.lambda.domain.predicate.Range;
-import com.amazonaws.athena.connector.lambda.domain.predicate.SortedRangeSet;
-import com.amazonaws.athena.connector.lambda.domain.predicate.ValueSet;
+import com.amazonaws.athena.connectors.google.bigquery.query.BigQueryQueryBuilder;
+import com.amazonaws.athena.connectors.google.bigquery.query.BigQueryQueryFactory;
 import com.google.cloud.bigquery.QueryParameterValue;
-import com.google.common.base.Joiner;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
-import org.apache.arrow.vector.types.pojo.ArrowType;
-import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.stringtemplate.v4.ST;
 
-import java.math.BigDecimal;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
 import java.util.List;
-import java.util.StringJoiner;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 /**
- * Utilities that help with Sql operations.
+ * Utilities that help with Sql operations using StringTemplate.
  */
 public class BigQuerySqlUtils
 {
-    private static final Logger LOGGER = LoggerFactory.getLogger(BigQuerySqlUtils.class);
-
-    private static final String BIGQUERY_QUOTE_CHAR = "`";
+    private static final BigQueryQueryFactory queryFactory = new BigQueryQueryFactory();
 
     private BigQuerySqlUtils()
     {
     }
 
     /**
-     * Builds an SQL statement from the schema, table name, split and contraints that can be executable by
-     * BigQuery.
+     * Builds an SQL statement from the schema, table name, split and constraints that can be executable by
+     * BigQuery using StringTemplate approach.
      *
      * @param tableName The table name of the table we are querying.
      * @param schema The schema of the table that we are querying.
@@ -72,224 +52,41 @@ public class BigQuerySqlUtils
      */
     public static String buildSql(TableName tableName, Schema schema, Constraints constraints, List<QueryParameterValue> parameterValues)
     {
-        LOGGER.info("Inside buildSql(): ");
-        StringBuilder sqlBuilder = new StringBuilder("SELECT ");
+        BigQueryQueryBuilder queryBuilder = queryFactory.createQueryBuilder();
+        
+        String sql = queryBuilder
+                .withTableName(tableName)
+                .withProjection(schema)
+                .withConjuncts(schema, constraints)
+                .withOrderByClause(constraints)
+                .withLimitClause(constraints)
+                .build();
+        
+        // Copy the parameter values from the builder to the provided list
+        parameterValues.clear();
+        parameterValues.addAll(queryBuilder.getParameterValues());
 
-        StringJoiner sj = new StringJoiner(",");
-        if (schema.getFields().isEmpty()) {
-            sj.add("null");
-        }
-        else {
-            for (Field field : schema.getFields()) {
-                sj.add(quote(field.getName()));
-            }
-        }
-        sqlBuilder.append(sj.toString())
-                .append(" from ")
-                .append(quote(tableName.getSchemaName()))
-                .append(".")
-                .append(quote(tableName.getTableName()));
-
-        LOGGER.info("constraints: " + constraints);
-        List<String> clauses = toConjuncts(schema.getFields(), constraints, parameterValues);
-
-        if (!clauses.isEmpty()) {
-            sqlBuilder.append(" WHERE ")
-                    .append(Joiner.on(" AND ").join(clauses));
-        }
-
-        String orderByClause = extractOrderByClause(constraints);
-        if (!Strings.isNullOrEmpty(orderByClause)) {
-            sqlBuilder.append(" ").append(orderByClause);
-        }
-
-        if (constraints.getLimit() > 0) {
-            sqlBuilder.append(" limit " + constraints.getLimit());
-        }
-
-        LOGGER.info("Generated SQL : {}", sqlBuilder.toString());
-        return sqlBuilder.toString();
-    }
-
-    private static String quote(final String identifier)
-    {
-        return BIGQUERY_QUOTE_CHAR + identifier + BIGQUERY_QUOTE_CHAR;
-    }
-
-    private static List<String> toConjuncts(List<Field> columns, Constraints constraints, List<QueryParameterValue> parameterValues)
-    {
-        LOGGER.debug("Inside toConjuncts(): ");
-        ImmutableList.Builder<String> builder = ImmutableList.builder();
-        for (Field column : columns) {
-            ArrowType type = column.getType();
-            if (constraints.getSummary() != null && !constraints.getSummary().isEmpty()) {
-                ValueSet valueSet = constraints.getSummary().get(column.getName());
-                if (valueSet != null) {
-                    LOGGER.info("valueSet: ", valueSet);
-                    builder.add(toPredicate(column.getName(), valueSet, type, parameterValues));
-                }
-            }
-        }
-        builder.addAll(new BigQueryFederationExpressionParser().parseComplexExpressions(columns, constraints));
-        return builder.build();
-    }
-
-    private static String toPredicate(String columnName, ValueSet valueSet, ArrowType type, List<QueryParameterValue> parameterValues)
-    {
-        List<String> disjuncts = new ArrayList<>();
-        List<Object> singleValues = new ArrayList<>();
-
-        if (valueSet instanceof SortedRangeSet) {
-            if (valueSet.isNone() && valueSet.isNullAllowed()) {
-                return String.format("(%s IS NULL)", columnName);
-            }
-
-            if (valueSet.isNullAllowed()) {
-                disjuncts.add(String.format("(%s IS NULL)", columnName));
-            }
-
-            Range rangeSpan = ((SortedRangeSet) valueSet).getSpan();
-            if (!valueSet.isNullAllowed() && rangeSpan.getLow().isLowerUnbounded() && rangeSpan.getHigh().isUpperUnbounded()) {
-                return String.format("(%s IS NOT NULL)", columnName);
-            }
-
-            for (Range range : valueSet.getRanges().getOrderedRanges()) {
-                if (range.isSingleValue()) {
-                    singleValues.add(range.getLow().getValue());
-                }
-                else {
-                    List<String> rangeConjuncts = new ArrayList<>();
-                    if (!range.getLow().isLowerUnbounded()) {
-                        switch (range.getLow().getBound()) {
-                            case ABOVE:
-                                rangeConjuncts.add(toPredicate(columnName, ">", range.getLow().getValue(), type, parameterValues));
-                                break;
-                            case EXACTLY:
-                                rangeConjuncts.add(toPredicate(columnName, ">=", range.getLow().getValue(), type, parameterValues));
-                                break;
-                            case BELOW:
-                                throw new IllegalArgumentException("Low marker should never use BELOW bound");
-                            default:
-                                throw new AssertionError("Unhandled bound: " + range.getLow().getBound());
-                        }
-                    }
-                    if (!range.getHigh().isUpperUnbounded()) {
-                        switch (range.getHigh().getBound()) {
-                            case ABOVE:
-                                throw new IllegalArgumentException("High marker should never use ABOVE bound");
-                            case EXACTLY:
-                                rangeConjuncts.add(toPredicate(columnName, "<=", range.getHigh().getValue(), type, parameterValues));
-                                break;
-                            case BELOW:
-                                rangeConjuncts.add(toPredicate(columnName, "<", range.getHigh().getValue(), type, parameterValues));
-                                break;
-                            default:
-                                throw new AssertionError("Unhandled bound: " + range.getHigh().getBound());
-                        }
-                    }
-                    // If rangeConjuncts is null, then the range was ALL, which should already have been checked for
-                    Preconditions.checkState(!rangeConjuncts.isEmpty());
-                    disjuncts.add("(" + Joiner.on(" AND ").join(rangeConjuncts) + ")");
-                }
-            }
-
-            // Add back all of the possible single values either as an equality or an IN predicate
-            if (singleValues.size() == 1) {
-                disjuncts.add(toPredicate(columnName, "=", Iterables.getOnlyElement(singleValues), type, parameterValues));
-            }
-            else if (singleValues.size() > 1) {
-                for (Object value : singleValues) {
-                    parameterValues.add(getValueForWhereClause(columnName, value, type));
-                }
-                String values = Joiner.on(",").join(Collections.nCopies(singleValues.size(), "?"));
-                disjuncts.add(quote(columnName) + " IN (" + values + ")");
-            }
-        }
-
-        return "(" + Joiner.on(" OR ").join(disjuncts) + ")";
-    }
-
-    private static String toPredicate(String columnName, String operator, Object value, ArrowType type,
-                                      List<QueryParameterValue> parameterValues)
-    {
-        parameterValues.add(getValueForWhereClause(columnName, value, type));
-        return quote(columnName) + " " + operator + " ?";
-    }
-
-    //Gets the representation of a value that can be used in a where clause, ie String values need to be quoted, numeric doesn't.
-    private static QueryParameterValue getValueForWhereClause(String columnName, Object value, ArrowType arrowType)
-    {
-        LOGGER.info("Inside getValueForWhereClause(-, -, -): ");
-        LOGGER.info("arrowType.getTypeID():" + arrowType.getTypeID());
-        LOGGER.info("value:" + value);
-        String val;
-        StringBuilder tempVal;
-        switch (arrowType.getTypeID()) {
-            case Int:
-                return QueryParameterValue.int64(((Number) value).longValue());
-            case Decimal:
-                ArrowType.Decimal decimalType = (ArrowType.Decimal) arrowType;
-                return QueryParameterValue.numeric(BigDecimal.valueOf((long) value, decimalType.getScale()));
-            case FloatingPoint:
-                return QueryParameterValue.float64((double) value);
-            case Bool:
-                return QueryParameterValue.bool((Boolean) value);
-            case Utf8:
-                return QueryParameterValue.string(value.toString());
-            case Date:
-                val = value.toString();
-                // Timestamp search: timestamp parameter in  where clause will come as string so it will be converted to date
-                if
-                (val.contains("-")) {
-                    // Adding dot zero when parameter does not have micro seconds
-                    tempVal = new StringBuilder(val);
-                    tempVal = tempVal.length() == 19 ? tempVal.append(".0") : tempVal;
-
-                    // Right side padding with required zeros
-                    val = String.format("%-26s", tempVal).replace(' ', '0').replace("T", " ");
-                    return QueryParameterValue.dateTime(val);
-                }
-                else {
-                    // date search: date parameter used in where clause will come as days so it will be converted to date
-                    long days = Long.parseLong(val);
-                    long milliseconds = TimeUnit.DAYS.toMillis(days);
-                    return QueryParameterValue.date(new SimpleDateFormat("yyyy-MM-dd").format(new Date(milliseconds)));
-                }
-            case Time:
-            case Timestamp:
-            case Interval:
-            case Binary:
-            case FixedSizeBinary:
-            case Null:
-            case Struct:
-            case List:
-            case FixedSizeList:
-            case Union:
-            case NONE:
-                throw new UnsupportedOperationException("The Arrow type: " + arrowType.getTypeID().name() + " is currently not supported");
-            default:
-                throw new IllegalArgumentException("Unknown type has been encountered during range processing: " + columnName +
-                        " Field Type: " + arrowType.getTypeID().name());
-        }
+        return sql;
     }
 
     /**
-     * Based on com.amazonaws.athena.connectors.jdbc.manager.JdbcSplitQueryBuilder.extractOrderByClause() method
-     * @param constraints
-     * @return a string representing ORDER BY clause or an empty string if there is no ORDER BY clause
+     * Generic method to render any string template with parameters
+     *
+     * @param templateName The name of the template to render
+     * @param params Parameters in pairs: (key, value, key, value, ...)
+     * @return The rendered template string
      */
-    private static String extractOrderByClause(Constraints constraints)
+    public static String renderTemplate(String templateName, Object... params)
     {
-        List<OrderByField> orderByClause = constraints.getOrderByClause();
-        if (orderByClause == null || orderByClause.size() == 0) {
-            return "";
+        ST template = queryFactory.getQueryTemplate(templateName);
+        
+        // Add parameters in pairs: (key, value, key, value, ...)
+        for (int i = 0; i < params.length; i += 2) {
+            if (i + 1 < params.length) {
+                template.add((String) params[i], params[i + 1]);
+            }
         }
-        return "ORDER BY " + orderByClause.stream()
-                .map(orderByField -> {
-                    String ordering = orderByField.getDirection().isAscending() ? "ASC" : "DESC";
-                    String nullsHandling = orderByField.getDirection().isNullsFirst() ? "NULLS FIRST" : "NULLS LAST";
-                    return quote(orderByField.getColumnName()) + " " + ordering + " " + nullsHandling;
-                })
-                .collect(Collectors.joining(", "));
+        
+        return template.render().trim();
     }
 }

--- a/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryStorageApiUtils.java
+++ b/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryStorageApiUtils.java
@@ -26,7 +26,6 @@ import com.amazonaws.athena.connector.lambda.domain.predicate.SortedRangeSet;
 import com.amazonaws.athena.connector.lambda.domain.predicate.ValueSet;
 import com.google.cloud.bigquery.QueryParameterValue;
 import com.google.cloud.bigquery.storage.v1.ReadSession;
-import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
@@ -88,16 +87,17 @@ public class BigQueryStorageApiUtils
 
         if (valueSet instanceof SortedRangeSet) {
             if (valueSet.isNone() && valueSet.isNullAllowed()) {
-                return String.format("%s IS NULL", columnName);
+                return BigQuerySqlUtils.renderTemplate("null_predicate", "columnName", columnName, "isNull", true);
             }
 
             if (valueSet.isNullAllowed()) {
-                disjuncts.add(String.format("%s IS NULL", columnName));
+                disjuncts.add(BigQuerySqlUtils.renderTemplate("null_predicate", "columnName", columnName, "isNull", true));
             }
 
             Range rangeSpan = ((SortedRangeSet) valueSet).getSpan();
+
             if (!valueSet.isNullAllowed() && rangeSpan.getLow().isLowerUnbounded() && rangeSpan.getHigh().isUpperUnbounded()) {
-                return String.format("%s IS NOT NULL", columnName);
+                return BigQuerySqlUtils.renderTemplate("null_predicate", "columnName", columnName, "isNull", false);
             }
 
             for (Range range : valueSet.getRanges().getOrderedRanges()) {
@@ -136,7 +136,7 @@ public class BigQueryStorageApiUtils
                     }
                     // If rangeConjuncts is null, then the range was ALL, which should already have been checked for
                     Preconditions.checkState(!rangeConjuncts.isEmpty());
-                    disjuncts.add(Joiner.on(" AND ").join(rangeConjuncts));
+                    disjuncts.add(BigQuerySqlUtils.renderTemplate("range_predicate", "conjuncts", rangeConjuncts));
                 }
             }
 
@@ -149,21 +149,29 @@ public class BigQueryStorageApiUtils
                 for (Object value : singleValues) {
                     val.add(((type.getTypeID().equals(Utf8) || type.getTypeID().equals(ArrowType.ArrowTypeID.Date)) ? quote(getValueForWhereClause(columnName, value, type).getValue()) : getValueForWhereClause(columnName, value, type).getValue()));
                 }
-                String values = Joiner.on(",").join(val);
-                disjuncts.add(columnName + " IN (" + values + ")");
+                disjuncts.add(BigQuerySqlUtils.renderTemplate("storage_api_in_predicate", 
+                    "columnName", columnName, 
+                    "placeholderList", val));
             }
         }
 
-        return Joiner.on(" OR ").join(disjuncts);
+        return BigQuerySqlUtils.renderTemplate("or_predicate", "disjuncts", disjuncts);
     }
 
     private static String toPredicate(String columnName, String operator, Object value, ArrowType type)
     {
-        return columnName + " " + operator + " " + ((type.getTypeID().equals(Utf8) || type.getTypeID().equals(ArrowType.ArrowTypeID.Date)) ? quote(getValueForWhereClause(columnName, value, type).getValue()) : getValueForWhereClause(columnName, value, type).getValue());
+        String formattedValue = (type.getTypeID().equals(Utf8) || type.getTypeID().equals(ArrowType.ArrowTypeID.Date)) ? 
+                               quote(getValueForWhereClause(columnName, value, type).getValue()) :
+                getValueForWhereClause(columnName, value, type).getValue();
+        
+        return BigQuerySqlUtils.renderTemplate("storage_api_comparison_predicate", 
+                "columnName", columnName, 
+                "operator", operator, 
+                "value", formattedValue);
     }
 
     //Gets the representation of a value that can be used in a where clause, ie String values need to be quoted, numeric doesn't.
-    private static QueryParameterValue getValueForWhereClause(String columnName, Object value, ArrowType arrowType)
+    public static QueryParameterValue getValueForWhereClause(String columnName, Object value, ArrowType arrowType)
     {
         LOGGER.info("Inside getValueForWhereClause(-, -, -): ");
         LOGGER.info("arrowType.getTypeID():" + arrowType.getTypeID());
@@ -185,8 +193,7 @@ public class BigQueryStorageApiUtils
             case Date:
                 val = value.toString();
                 // Timestamp search: timestamp parameter in  where clause will come as string so it will be converted to date
-                if
-                (val.contains("-")) {
+                if (val.contains("-")) {
                     // Adding dot zero when parameter does not have micro seconds
                     tempVal = new StringBuilder(val);
                     tempVal = tempVal.length() == 19 ? tempVal.append(".0") : tempVal;
@@ -224,7 +231,7 @@ public class BigQueryStorageApiUtils
         List<String> clauses = toConjuncts(schema.getFields(), constraints);
 
         if (!clauses.isEmpty()) {
-            String clause = Joiner.on(" AND ").join(clauses);
+            String clause = BigQuerySqlUtils.renderTemplate("where_clause", "clauses", clauses);
             LOGGER.debug("clause {}", clause);
             optionsBuilder = optionsBuilder.setRowRestriction(clause);
         }

--- a/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/query/BigQueryPredicateBuilder.java
+++ b/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/query/BigQueryPredicateBuilder.java
@@ -1,0 +1,148 @@
+/*-
+ * #%L
+ * athena-google-bigquery
+ * %%
+ * Copyright (C) 2019-2025 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.google.bigquery.query;
+
+import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
+import com.amazonaws.athena.connector.lambda.domain.predicate.Range;
+import com.amazonaws.athena.connector.lambda.domain.predicate.SortedRangeSet;
+import com.amazonaws.athena.connector.lambda.domain.predicate.ValueSet;
+import com.amazonaws.athena.connectors.google.bigquery.BigQueryFederationExpressionParser;
+import com.amazonaws.athena.connectors.google.bigquery.BigQuerySqlUtils;
+import com.amazonaws.athena.connectors.google.bigquery.BigQueryStorageApiUtils;
+import com.google.cloud.bigquery.QueryParameterValue;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class BigQueryPredicateBuilder
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(BigQueryPredicateBuilder.class);
+    
+    private BigQueryPredicateBuilder() {}
+
+    public static List<String> buildConjuncts(List<Field> columns, Constraints constraints, List<QueryParameterValue> parameterValues)
+    {
+        LOGGER.debug("Inside buildConjuncts(): ");
+        ImmutableList.Builder<String> builder = ImmutableList.builder();
+        
+        for (Field column : columns) {
+            ArrowType type = column.getType();
+            if (constraints.getSummary() != null && !constraints.getSummary().isEmpty()) {
+                ValueSet valueSet = constraints.getSummary().get(column.getName());
+                if (valueSet != null) {
+                    builder.add(toPredicate(column.getName(), valueSet, type, parameterValues));
+                }
+            }
+        }
+        
+        // Add complex expressions (federation expressions)
+        builder.addAll(new BigQueryFederationExpressionParser().parseComplexExpressions(columns, constraints));
+        return builder.build();
+    }
+
+    private static String toPredicate(String columnName, ValueSet valueSet, ArrowType type, List<QueryParameterValue> parameterValues)
+    {
+        List<String> disjuncts = new ArrayList<>();
+        List<Object> singleValues = new ArrayList<>();
+
+        if (valueSet instanceof SortedRangeSet) {
+            if (valueSet.isNone() && valueSet.isNullAllowed()) {
+                return BigQuerySqlUtils.renderTemplate("null_predicate", "columnName", columnName, "isNull", true);
+            }
+
+            if (valueSet.isNullAllowed()) {
+                disjuncts.add(BigQuerySqlUtils.renderTemplate("null_predicate", "columnName", columnName, "isNull", true));
+            }
+
+            Range rangeSpan = ((SortedRangeSet) valueSet).getSpan();
+
+            if (!valueSet.isNullAllowed() && rangeSpan.getLow().isLowerUnbounded() && rangeSpan.getHigh().isUpperUnbounded()) {
+                return BigQuerySqlUtils.renderTemplate("null_predicate", "columnName", columnName, "isNull", false);
+            }
+
+            for (Range range : valueSet.getRanges().getOrderedRanges()) {
+                if (range.isSingleValue()) {
+                    singleValues.add(range.getLow().getValue());
+                }
+                else {
+                    List<String> rangeConjuncts = new ArrayList<>();
+                    if (!range.getLow().isLowerUnbounded()) {
+                        switch (range.getLow().getBound()) {
+                            case ABOVE:
+                                parameterValues.add(BigQueryStorageApiUtils.getValueForWhereClause(columnName, range.getLow().getValue(), type));
+                                rangeConjuncts.add(BigQuerySqlUtils.renderTemplate("comparison_predicate", "columnName", columnName, "operator", ">"));
+                                break;
+                            case EXACTLY:
+                                parameterValues.add(BigQueryStorageApiUtils.getValueForWhereClause(columnName, range.getLow().getValue(), type));
+                                rangeConjuncts.add(BigQuerySqlUtils.renderTemplate("comparison_predicate", "columnName", columnName, "operator", ">="));
+                                break;
+                            case BELOW:
+                                throw new IllegalArgumentException("Low marker should never use BELOW bound");
+                            default:
+                                throw new AssertionError("Unhandled bound: " + range.getLow().getBound());
+                        }
+                    }
+                    if (!range.getHigh().isUpperUnbounded()) {
+                        switch (range.getHigh().getBound()) {
+                            case ABOVE:
+                                throw new IllegalArgumentException("High marker should never use ABOVE bound");
+                            case EXACTLY:
+                                parameterValues.add(BigQueryStorageApiUtils.getValueForWhereClause(columnName, range.getHigh().getValue(), type));
+                                rangeConjuncts.add(BigQuerySqlUtils.renderTemplate("comparison_predicate", "columnName", columnName, "operator", "<="));
+                                break;
+                            case BELOW:
+                                parameterValues.add(BigQueryStorageApiUtils.getValueForWhereClause(columnName, range.getHigh().getValue(), type));
+                                rangeConjuncts.add(BigQuerySqlUtils.renderTemplate("comparison_predicate", "columnName", columnName, "operator", "<"));
+                                break;
+                            default:
+                                throw new AssertionError("Unhandled bound: " + range.getHigh().getBound());
+                        }
+                    }
+                    // If rangeConjuncts is null, then the range was ALL, which should already have been checked for
+                    Preconditions.checkState(!rangeConjuncts.isEmpty());
+                    disjuncts.add(BigQuerySqlUtils.renderTemplate("range_predicate", "conjuncts", rangeConjuncts));
+                }
+            }
+
+            // Add back all of the possible single values either as an equality or an IN predicate
+            if (singleValues.size() == 1) {
+                parameterValues.add(BigQueryStorageApiUtils.getValueForWhereClause(columnName, Iterables.getOnlyElement(singleValues), type));
+                disjuncts.add(BigQuerySqlUtils.renderTemplate("comparison_predicate", "columnName", columnName, "operator", "="));
+            }
+            else if (singleValues.size() > 1) {
+                for (Object value : singleValues) {
+                    parameterValues.add(BigQueryStorageApiUtils.getValueForWhereClause(columnName, value, type));
+                }
+                List<String> placeholders = Collections.nCopies(singleValues.size(), "?");
+                disjuncts.add(BigQuerySqlUtils.renderTemplate("in_predicate", "columnName", columnName, "counts", placeholders));
+            }
+        }
+
+        return BigQuerySqlUtils.renderTemplate("or_predicate", "disjuncts", disjuncts);
+    }
+}

--- a/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/query/BigQueryQueryBuilder.java
+++ b/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/query/BigQueryQueryBuilder.java
@@ -1,0 +1,161 @@
+/*-
+ * #%L
+ * athena-google-bigquery
+ * %%
+ * Copyright (C) 2019-2025 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.google.bigquery.query;
+
+import com.amazonaws.athena.connector.lambda.domain.TableName;
+import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
+import com.amazonaws.athena.connector.lambda.domain.predicate.OrderByField;
+import com.google.cloud.bigquery.QueryParameterValue;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.commons.lang3.Validate;
+import org.stringtemplate.v4.ST;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class BigQueryQueryBuilder
+{
+    private static final String TEMPLATE_NAME = "select_query";
+    private static final String TEMPLATE_FIELD = "builder";
+    private static final String BIGQUERY_QUOTE_CHAR = "`";
+    
+    private final ST query;
+    private List<String> projection;
+    private String schemaName;
+    private String tableName;
+    private List<String> conjuncts;
+    private String orderByClause;
+    private String limitClause;
+    private List<QueryParameterValue> parameterValues;
+
+    public BigQueryQueryBuilder(ST template)
+    {
+        this.query = Validate.notNull(template, "The StringTemplate for " + TEMPLATE_NAME + " can not be null!");
+        this.parameterValues = new ArrayList<>();
+    }
+
+    static String getTemplateName()
+    {
+        return TEMPLATE_NAME;
+    }
+
+    public BigQueryQueryBuilder withProjection(Schema schema)
+    {
+        this.projection = schema.getFields().stream()
+                .map(Field::getName)
+                .collect(Collectors.toList());
+        return this;
+    }
+
+    public BigQueryQueryBuilder withTableName(TableName tableName)
+    {
+        this.schemaName = tableName.getSchemaName();
+        this.tableName = tableName.getTableName();
+        return this;
+    }
+
+    public BigQueryQueryBuilder withConjuncts(Schema schema, Constraints constraints)
+    {
+        this.conjuncts = BigQueryPredicateBuilder.buildConjuncts(schema.getFields(), constraints, this.parameterValues);
+        return this;
+    }
+
+    public BigQueryQueryBuilder withOrderByClause(Constraints constraints)
+    {
+        this.orderByClause = extractOrderByClause(constraints);
+        return this;
+    }
+
+    public BigQueryQueryBuilder withLimitClause(Constraints constraints)
+    {
+        if (constraints.getLimit() > 0) {
+            this.limitClause = "LIMIT " + constraints.getLimit();
+        }
+        return this;
+    }
+
+    public List<QueryParameterValue> getParameterValues()
+    {
+        return parameterValues;
+    }
+
+    // Getter methods for StringTemplate access
+    public List<String> getProjection()
+    {
+        return projection;
+    }
+
+    public String getSchemaName()
+    {
+        return schemaName;
+    }
+
+    public String getTableName()
+    {
+        return tableName;
+    }
+
+    public List<String> getConjuncts()
+    {
+        return conjuncts;
+    }
+
+    public String getOrderByClause()
+    {
+        return orderByClause;
+    }
+
+    public String getLimitClause()
+    {
+        return limitClause;
+    }
+
+    public String build()
+    {
+        Validate.notNull(schemaName, "schemaName can not be null.");
+        Validate.notNull(tableName, "tableName can not be null.");
+        Validate.notNull(projection, "projection can not be null.");
+
+        query.add(TEMPLATE_FIELD, this);
+        return query.render().trim();
+    }
+
+    private static String quote(final String identifier)
+    {
+        return BIGQUERY_QUOTE_CHAR + identifier + BIGQUERY_QUOTE_CHAR;
+    }
+
+    private static String extractOrderByClause(Constraints constraints)
+    {
+        List<OrderByField> orderByClause = constraints.getOrderByClause();
+        if (orderByClause == null || orderByClause.isEmpty()) {
+            return "";
+        }
+        return "ORDER BY " + orderByClause.stream()
+                .map(orderByField -> {
+                    String ordering = orderByField.getDirection().isAscending() ? "ASC" : "DESC";
+                    String nullsHandling = orderByField.getDirection().isNullsFirst() ? "NULLS FIRST" : "NULLS LAST";
+                    return quote(orderByField.getColumnName()) + " " + ordering + " " + nullsHandling;
+                })
+                .collect(Collectors.joining(", "));
+    }
+}

--- a/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/query/BigQueryQueryFactory.java
+++ b/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/query/BigQueryQueryFactory.java
@@ -1,0 +1,108 @@
+/*-
+ * #%L
+ * athena-google-bigquery
+ * %%
+ * Copyright (C) 2019 - 2025 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.google.bigquery.query;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.stringtemplate.v4.ST;
+import org.stringtemplate.v4.STGroupFile;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Factory for creating BigQuery query builders with StringTemplate support.
+ */
+public class BigQueryQueryFactory
+{
+    private static final Logger logger = LoggerFactory.getLogger(BigQueryQueryFactory.class);
+
+    private static final String TEMPLATE_FILE = "BigQuery.stg";
+    private static final String LOCAL_TEMPLATE_FILE = "/tmp/BigQuery.stg";
+    private static final String TEST_TEMPLATE = "test_template";
+    private volatile boolean useLocalFallback = false;
+
+    private STGroupFile createGroupFile()
+    {
+        if (!useLocalFallback) {
+            try {
+                STGroupFile stGroupFile = new STGroupFile(TEMPLATE_FILE);
+                requireNonNull(stGroupFile.getInstanceOf(TEST_TEMPLATE), "Test template must not be null");
+                return stGroupFile;
+            }
+            catch (RuntimeException ex) {
+                logger.info("createGroupFile: Error while attempting to load STGroupFile.", ex);
+                return createLocalGroupFile();
+            }
+        }
+
+        STGroupFile stGroupFile = new STGroupFile(LOCAL_TEMPLATE_FILE);
+        requireNonNull(stGroupFile.getInstanceOf(TEST_TEMPLATE), "Test template must not be null");
+        return stGroupFile;
+    }
+
+    private STGroupFile createLocalGroupFile()
+    {
+        logger.info("createLocalGroupFile: Attempting STGroupFile fallback.");
+        InputStream in = this.getClass().getClassLoader().getResourceAsStream(TEMPLATE_FILE);
+        BufferedReader reader = new BufferedReader(new InputStreamReader(in));
+        StringBuilder sb = new StringBuilder();
+        try {
+            String line = reader.readLine();
+            sb.append(line);
+            while (line != null) {
+                line = reader.readLine();
+                if (line != null) {
+                    sb.append(line);
+                }
+            }
+
+            BufferedWriter writer = new BufferedWriter(new FileWriter(LOCAL_TEMPLATE_FILE));
+            writer.write(sb.toString());
+            writer.close();
+        }
+        catch (IOException ex) {
+            logger.error("createLocalGroupFile: Exception ", ex);
+        }
+
+        useLocalFallback = true;
+        logger.info("createLocalGroupFile: {}", sb);
+
+        STGroupFile stGroupFile = new STGroupFile(LOCAL_TEMPLATE_FILE);
+        requireNonNull(stGroupFile.getInstanceOf(TEST_TEMPLATE), "Test template must not be null");
+        return stGroupFile;
+    }
+
+    public ST getQueryTemplate(String templateName)
+    {
+        return createGroupFile().getInstanceOf(templateName);
+    }
+
+    public BigQueryQueryBuilder createQueryBuilder()
+    {
+        return new BigQueryQueryBuilder(getQueryTemplate(BigQueryQueryBuilder.getTemplateName()));
+    }
+} 

--- a/athena-google-bigquery/src/main/resources/BigQuery.stg
+++ b/athena-google-bigquery/src/main/resources/BigQuery.stg
@@ -1,0 +1,182 @@
+test_template() ::= <%
+    test template for validating file is accessible.
+%>
+
+/**
+ *@UsedBy: BigQueryQueryBuilder.java
+ *@Description: This template is used to build BigQuery SELECT statements with constraints, ordering, and limits.
+ *@param builder An Instance of BigQueryQueryBuilder.
+ *@return A SQL query that can be executed by BigQuery.
+ */
+select_query(builder) ::= <%
+    SELECT <if(builder.projection)><builder.projection:{col|`<col>`}; separator=","><else>null<endif> from `<builder.schemaName>`.`<builder.tableName>`<if(builder.conjuncts)> WHERE <builder.conjuncts:{conjunct|<conjunct>}; separator=" AND "><endif><if(builder.orderByClause)> <builder.orderByClause><endif><if(builder.limitClause)> <builder.limitClause><endif>
+%>
+
+/**
+ *@UsedBy: BigQueryPredicateBuilder.java
+ *@Description: Template for simple comparison predicates (=, >, <, >=, <=, !=).
+ *@param columnName The column name (no backticks for storage API compatibility).
+ *@param operator The comparison operator.
+ *@return A comparison predicate like `column` > ?
+ */
+comparison_predicate(columnName, operator) ::= <%
+    `<columnName>` <operator> ?
+%>
+
+/**
+ *@UsedBy: BigQueryPredicateBuilder.java
+ *@Description: Template for IN predicates with parameterized values.
+ *@param columnName The column name (no backticks for storage API compatibility).
+ *@param counts List of parameter positions.
+ *@return An IN predicate like column IN (?,?)
+ */
+in_predicate(columnName, counts) ::= <%
+    `<columnName>` IN (<counts:{c|?}; separator=",">)
+%>
+
+/**
+ *@UsedBy: BigQueryPredicateBuilder.java, BigQueryStorageApiUtils.java, BigQueryFederationExpressionParser.java
+ *@Description: Template for NULL checking predicates and expressions.
+ *@param columnName The column name or expression (NO backticks for NULL predicates).
+ *@param isNull Whether checking for NULL (true) or NOT NULL (false).
+ *@return A null predicate like column IS NULL or column IS NOT NULL
+ */
+null_predicate(columnName, isNull) ::= <%
+    <columnName> IS <if(isNull)>NULL<else>NOT NULL<endif>
+%>
+
+/**
+ *@UsedBy: BigQueryPredicateBuilder.java, BigQueryStorageApiUtils.java
+ *@Description: Template for range predicates (BETWEEN-like conditions).
+ *@param conjuncts List of range conditions to join with AND.
+ *@return A range predicate like `column` >= ? AND `column` <= ?
+ */
+range_predicate(conjuncts) ::= <%
+    <conjuncts; separator=" AND ">
+%>
+
+/**
+ *@UsedBy: BigQueryPredicateBuilder.java, BigQueryStorageApiUtils.java
+ *@Description: Template for combining multiple predicates with OR.
+ *@param disjuncts List of predicates to join with OR.
+ *@return Combined predicates like pred1 OR pred2 OR pred3
+ */
+or_predicate(disjuncts) ::= <%
+    <disjuncts; separator=" OR ">
+%>
+
+/**
+ *@UsedBy: BigQueryStorageApiUtils.java
+ *@Description: Template for combining WHERE clauses with AND.
+ *@param clauses List of WHERE clause conditions to join with AND.
+ *@return A WHERE clause like clause1 AND clause2 AND clause3
+ */
+where_clause(clauses) ::= <%
+    <clauses; separator=" AND ">
+%>
+
+/**
+ *@UsedBy: BigQueryFederationExpressionParser.java
+ *@Description: Template for function calls with two arguments.
+ *@param functionName The function name.
+ *@param arg1 First argument.
+ *@param arg2 Second argument.
+ *@return A function call like MOD(arg1, arg2)
+ */
+function_call_2args(functionName, arg1, arg2) ::= <%
+    <functionName>(<arg1>, <arg2>)
+%>
+
+/**
+ *@UsedBy: BigQueryFederationExpressionParser.java
+ *@Description: Template for unary operators.
+ *@param operator The unary operator (-, NOT, etc.).
+ *@param operand The operand.
+ *@return A unary expression like (-operand) or (NOT operand)
+ */
+unary_operator(operator, operand) ::= <%
+    (<operator><operand>)
+%>
+
+/**
+ *@UsedBy: BigQueryFederationExpressionParser.java
+ *@Description: Template for IN expressions.
+ *@param column The column or expression.
+ *@param values The values for IN clause.
+ *@return An IN expression like (column IN values)
+ */
+in_expression(column, values) ::= <%
+    (<column> IN <values>)
+%>
+
+/**
+ *@UsedBy: BigQueryFederationExpressionParser.java
+ *@Description: Template for IS DISTINCT FROM expressions.
+ *@param left Left operand.
+ *@param right Right operand.
+ *@return An IS DISTINCT FROM expression
+ */
+is_distinct_from(left, right) ::= <%
+    <left> IS DISTINCT FROM <right>
+%>
+
+/**
+ *@UsedBy: BigQueryFederationExpressionParser.java
+ *@Description: Template for LIKE expressions.
+ *@param column The column.
+ *@param pattern The pattern.
+ *@return A LIKE expression
+ */
+like_expression(column, pattern) ::= <%
+    <column> LIKE <pattern>
+%>
+
+/**
+ *@UsedBy: BigQueryFederationExpressionParser.java, BigQueryStorageApiUtils.java
+ *@Description: Template for joining expressions with an operator.
+ *Used for building arithmetic, logical, and other expressions.
+ *@param items List of expressions to join
+ *@param separator The operator to use between items (e.g. "+", "*", "AND", etc.)
+ *@return A joined expression like (a + b + c)
+ */
+join_expression(items, separator) ::= <%
+    (<items; separator=separator>)
+%>
+
+/**
+ *@UsedBy: BigQueryFederationExpressionParser.java
+ *@Description: Template for creating comma-separated lists.
+ *Used for constant expressions and array constructors.
+ *@param items List of items to join
+ *@return A comma-separated list like item1, item2, item3
+ */
+comma_separated_list(items) ::= <%
+    <items; separator=",">
+%>
+
+comma_separated_list_with_parentheses(items) ::= <%
+    (<items; separator=", ">)
+%>
+
+/**
+ *@UsedBy: BigQueryStorageApiUtils.java
+ *@Description: Template for Storage API IN predicates (no backticks).
+ *@param columnName The column name without backticks.
+ *@param placeholderList List of placeholder values.
+ *@return Simple IN predicate like column IN (?)
+ */
+storage_api_in_predicate(columnName, placeholderList) ::= <%
+    <columnName> IN (<placeholderList; separator=",">)
+%>
+
+/**
+ *@UsedBy: BigQueryStorageApiUtils.java
+ *@Description: Template for Storage API comparison predicates (no backticks).
+ *@param columnName The column name without backticks.
+ *@param operator The comparison operator (=, >, <, >=, <=, !=).
+ *@param value The actual value to compare against.
+ *@return Simple comparison predicate like column > value
+ */
+storage_api_comparison_predicate(columnName, operator, value) ::= <%
+    <columnName> <operator> <value>
+%>

--- a/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQuerySqlUtilsTest.java
+++ b/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQuerySqlUtilsTest.java
@@ -103,12 +103,8 @@ public class BigQuerySqlUtilsTest
             List<QueryParameterValue> parameterValues = new ArrayList<>();
             String sql = BigQuerySqlUtils.buildSql(tableName, makeSchema(constraintMap), constraints, parameterValues);
             assertEquals(expectedParameterValues, parameterValues);
-            assertEquals("SELECT `integerRange`,`isNullRange`,`isNotNullRange`,`stringRange`,`booleanRange`,`integerInRange` from `schema`.`table` " +
-                    "WHERE ((integerRange IS NULL) OR (`integerRange` > ? AND `integerRange` < ?)) " +
-                    "AND (isNullRange IS NULL) AND (isNotNullRange IS NOT NULL) " +
-                    "AND ((`stringRange` >= ? AND `stringRange` < ?)) " +
-                    "AND (`booleanRange` = ?) " +
-                    "AND (`integerInRange` IN (?,?))", sql);
+            // Standardize SQL formatting by removing extra parentheses to match BigQuery Storage API format for consistent query generation across views and tables
+            assertEquals("SELECT `integerRange`,`isNullRange`,`isNotNullRange`,`stringRange`,`booleanRange`,`integerInRange` from `schema`.`table` WHERE integerRange IS NULL OR `integerRange` > ? AND `integerRange` < ? AND isNullRange IS NULL AND isNotNullRange IS NOT NULL AND `stringRange` >= ? AND `stringRange` < ? AND `booleanRange` = ? AND `integerInRange` IN (?,?)", sql);
         }
     }
 }

--- a/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/query/BigQueryQueryBuilderTest.java
+++ b/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/query/BigQueryQueryBuilderTest.java
@@ -1,0 +1,259 @@
+/*-
+ * #%L
+ * athena-google-bigquery
+ * %%
+ * Copyright (C) 2019 - 2025 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.google.bigquery.query;
+
+import com.amazonaws.athena.connector.lambda.domain.TableName;
+import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
+import com.amazonaws.athena.connector.lambda.domain.predicate.OrderByField;
+import com.google.cloud.bigquery.QueryParameterValue;
+import com.amazonaws.athena.connector.lambda.data.BlockAllocator;
+import com.amazonaws.athena.connector.lambda.data.BlockAllocatorImpl;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
+import static com.amazonaws.athena.connector.lambda.domain.predicate.Constraints.DEFAULT_NO_LIMIT;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class BigQueryQueryBuilderTest
+{
+    private static final String TEST_SCHEMA_NAME = "test_schema";
+    private static final String TEST_TABLE_NAME = "test_table";
+    private static final TableName TEST_TABLE = new TableName(TEST_SCHEMA_NAME, TEST_TABLE_NAME);
+    
+    private static final ArrowType STRING_TYPE = new ArrowType.Utf8();
+    private static final ArrowType BIGINT_TYPE = new ArrowType.Int(64, false);
+    private static final ArrowType BOOLEAN_TYPE = ArrowType.Bool.INSTANCE;
+
+    private static final String COLUMN_ID = "id";
+    private static final String COLUMN_NAME = "name";
+    private static final String COLUMN_ACTIVE = "active";
+    private static final String COLUMN_SCORE = "score";
+    
+    private static final int TEST_LIMIT_VALUE = 100;
+
+    
+    private static final String SQL_SHOULD_CONTAIN_SELECT = "SQL should contain SELECT";
+    private static final String SQL_SHOULD_CONTAIN_ALL_COLUMNS = "SQL should contain all columns";
+    private static final String SQL_SHOULD_CONTAIN_FROM_CLAUSE = "SQL should contain FROM clause";
+
+    private BlockAllocator allocator;
+    private BigQueryQueryFactory queryFactory;
+    private Schema testSchema;
+
+    @Before
+    public void setUp()
+    {
+        allocator = new BlockAllocatorImpl();
+        queryFactory = new BigQueryQueryFactory();
+        testSchema = createTestSchema();
+    }
+
+    @After
+    public void tearDown()
+    {
+            allocator.close();
+    }
+
+    @Test
+    public void shouldLoadStringTemplateSuccessfully()
+    {
+        String templateName = BigQueryQueryBuilder.getTemplateName();
+        
+        assertNotNull("Template name should not be null", templateName);
+        assertEquals("Template name should match", "select_query", templateName);
+    }
+
+    @Test
+    public void shouldGenerateBasicSelectQueryWithProjectionAndTableName()
+    {
+        BigQueryQueryBuilder builder = queryFactory.createQueryBuilder()
+                .withProjection(testSchema)
+                .withTableName(TEST_TABLE);
+        
+        String sql = builder.build();
+        
+        assertNotNull("SQL should not be null", sql);
+        assertEquals("SQL should match expected format", "SELECT `id`,`name`,`active`,`score` from `test_schema`.`test_table`", sql);
+        assertTrue(SQL_SHOULD_CONTAIN_SELECT, sql.contains("SELECT"));
+        assertTrue(SQL_SHOULD_CONTAIN_ALL_COLUMNS, sql.contains("`id`"));
+        assertTrue(SQL_SHOULD_CONTAIN_ALL_COLUMNS, sql.contains("`name`"));
+        assertTrue(SQL_SHOULD_CONTAIN_ALL_COLUMNS, sql.contains("`active`"));
+        assertTrue(SQL_SHOULD_CONTAIN_ALL_COLUMNS, sql.contains("`score`"));
+        assertTrue(SQL_SHOULD_CONTAIN_FROM_CLAUSE, sql.contains("from `test_schema`.`test_table`"));
+    }
+
+    @Test
+    public void shouldGenerateSelectQueryWithOrderByClause()
+    {
+        List<OrderByField> orderByFields = createOrderByFields();
+        Constraints constraints = createConstraintsWithOrderBy(orderByFields);
+        
+        BigQueryQueryBuilder builder = queryFactory.createQueryBuilder()
+                .withProjection(testSchema)
+                .withTableName(TEST_TABLE)
+                .withOrderByClause(constraints);
+        
+        String sql = builder.build();
+        
+        assertNotNull("SQL should not be null", sql);
+        assertTrue("SQL should contain ORDER BY clause", sql.contains("ORDER BY"));
+        assertTrue("SQL should contain name ordering", sql.contains("`name` ASC NULLS FIRST"));
+        assertTrue("SQL should contain score ordering", sql.contains("`score` DESC NULLS LAST"));
+    }
+
+    @Test
+    public void shouldGenerateSelectQueryWithLimitClause()
+    {
+        Constraints constraints = createConstraintsWithLimit();
+        
+        BigQueryQueryBuilder builder = queryFactory.createQueryBuilder()
+                .withProjection(testSchema)
+                .withTableName(TEST_TABLE)
+                .withLimitClause(constraints);
+        
+        String sql = builder.build();
+        
+        assertNotNull("SQL should not be null", sql);
+        assertTrue("SQL should contain LIMIT clause", sql.contains("LIMIT"));
+        assertTrue("SQL should contain limit value", sql.contains(String.valueOf(TEST_LIMIT_VALUE)));
+    }
+
+    @Test
+    public void shouldGenerateSelectQueryWithEmptyProjection()
+    {
+        Schema emptySchema = new Schema(Collections.emptyList());
+        
+        BigQueryQueryBuilder builder = queryFactory.createQueryBuilder()
+                .withProjection(emptySchema)
+                .withTableName(TEST_TABLE);
+        
+        String sql = builder.build();
+        
+        assertNotNull("SQL should not be null", sql);
+        assertTrue(SQL_SHOULD_CONTAIN_SELECT, sql.contains("SELECT"));
+        assertTrue(SQL_SHOULD_CONTAIN_FROM_CLAUSE, sql.contains("from `test_schema`.`test_table`"));
+    }
+
+    @Test
+    public void shouldReturnCorrectValuesFromBuilderGetters()
+    {
+        BigQueryQueryBuilder builder = queryFactory.createQueryBuilder()
+                .withProjection(testSchema)
+                .withTableName(TEST_TABLE);
+
+        assertEquals("Schema name should match", TEST_SCHEMA_NAME, builder.getSchemaName());
+        assertEquals("Table name should match", TEST_TABLE_NAME, builder.getTableName());
+        assertEquals("Projection should have correct number of columns", 4, builder.getProjection().size());
+        assertTrue("Projection should contain id", builder.getProjection().contains(COLUMN_ID));
+        assertTrue("Projection should contain name", builder.getProjection().contains(COLUMN_NAME));
+        assertTrue("Projection should contain active", builder.getProjection().contains(COLUMN_ACTIVE));
+        assertTrue("Projection should contain score", builder.getProjection().contains(COLUMN_SCORE));
+
+        List<QueryParameterValue> parameters = builder.getParameterValues();
+        assertNotNull("Parameters should not be null", parameters);
+    }
+
+    @Test
+    public void shouldBuildQuerySuccessfullyWithAllComponents()
+    {
+        BigQueryQueryBuilder builder = queryFactory.createQueryBuilder()
+                .withProjection(testSchema)
+                .withTableName(TEST_TABLE);
+        
+        String sql = builder.build();
+        
+        assertNotNull("SQL should not be null", sql);
+        assertTrue(SQL_SHOULD_CONTAIN_SELECT, sql.contains("SELECT"));
+        assertTrue("SQL should contain schema name", sql.contains(TEST_SCHEMA_NAME));
+        assertTrue("SQL should contain table name", sql.contains(TEST_TABLE_NAME));
+        assertTrue(SQL_SHOULD_CONTAIN_ALL_COLUMNS, sql.contains("`id`"));
+        assertTrue(SQL_SHOULD_CONTAIN_ALL_COLUMNS, sql.contains("`name`"));
+        assertTrue(SQL_SHOULD_CONTAIN_ALL_COLUMNS, sql.contains("`active`"));
+        assertTrue(SQL_SHOULD_CONTAIN_ALL_COLUMNS, sql.contains("`score`"));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void shouldThrowExceptionWhenBuilderCreatedWithNullTemplate()
+    {
+        new BigQueryQueryBuilder(null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void shouldThrowExceptionWhenBuildingWithoutSchemaName()
+    {
+        BigQueryQueryBuilder builder = queryFactory.createQueryBuilder()
+                .withProjection(testSchema);
+        builder.build();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void shouldThrowExceptionWhenCreatingTableNameWithNullValue()
+    {
+        new TableName(null, TEST_TABLE_NAME);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void shouldThrowExceptionWhenBuildingWithoutProjection()
+    {
+        BigQueryQueryBuilder builder = queryFactory.createQueryBuilder()
+                .withTableName(TEST_TABLE);
+        builder.build();
+    }
+
+    private Schema createTestSchema()
+    {
+        List<Field> fields = new ArrayList<>();
+        fields.add(new Field(COLUMN_ID, new FieldType(true, BIGINT_TYPE, null), null));
+        fields.add(new Field(COLUMN_NAME, new FieldType(true, STRING_TYPE, null), null));
+        fields.add(new Field(COLUMN_ACTIVE, new FieldType(true, BOOLEAN_TYPE, null), null));
+        fields.add(new Field(COLUMN_SCORE, new FieldType(true, BIGINT_TYPE, null), null));
+        return new Schema(fields);
+    }
+
+    private List<OrderByField> createOrderByFields()
+    {
+        List<OrderByField> orderByFields = new ArrayList<>();
+        orderByFields.add(new OrderByField(COLUMN_NAME, OrderByField.Direction.ASC_NULLS_FIRST));
+        orderByFields.add(new OrderByField(COLUMN_SCORE, OrderByField.Direction.DESC_NULLS_LAST));
+        return orderByFields;
+    }
+
+    private Constraints createConstraintsWithOrderBy(List<OrderByField> orderByFields)
+    {
+        return new Constraints(new HashMap<>(), Collections.emptyList(), orderByFields, DEFAULT_NO_LIMIT,Collections.emptyMap());
+    }
+
+    private Constraints createConstraintsWithLimit()
+    {
+        return new Constraints(new HashMap<>(), Collections.emptyList(), Collections.emptyList(), TEST_LIMIT_VALUE,Collections.emptyMap());
+    }
+} 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-athena-query-federation/issues/14

*Description of changes:*
The BigQuery Connector code has been updated to leverage StringTemplate for SQL query generation, a departure from the prior use of StringBuilder and string concatenation. Attached are the test results for reference.

### Key Changes

- **Introduced StringTemplate Support:**
  - Added `BigQuery.stg` template file to define reusable SQL templates for predicates, expressions, and full queries.
  - Implemented `BigQueryQueryFactory` and `BigQueryQueryBuilder` to manage and utilize StringTemplate instances for query generation.

- **Refactored SQL Generation Logic:**
  - Replaced manual string concatenation in `BigQuerySqlUtils` and related classes with template-driven SQL construction.
  - Centralized predicate and expression building logic in `BigQueryPredicateBuilder` and `BigQueryFederationExpressionParser`, leveraging templates for all major SQL constructs.

- **Improved Predicate and Expression Handling:**
  - Standardized formatting for predicates such as `IN`, `IS NULL`, range, and logical combinations (`AND`, `OR`).

 In the current implementation, SQL query generation for views and tables follows different formatting conventions—views utilize parentheses, whereas tables do not. To promote consistency and enable reuse of a unified StringTemplate, the new approach generates SQL queries for views without parentheses as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
[BIGQUERY_FUNCTIONAL_TEST_2025-07-10_18_32_54.294084.xlsx](https://github.com/user-attachments/files/21164602/BIGQUERY_FUNCTIONAL_TEST_2025-07-10_18_32_54.294084.xlsx)

