### PR TITLE
feat: Add support for cross-account metrics in CloudWatch Metrics

### DIFF
--- a/athena-cloudwatch-metrics/athena-cloudwatch-metrics-package.yaml
+++ b/athena-cloudwatch-metrics/athena-cloudwatch-metrics-package.yaml
@@ -55,6 +55,7 @@ Resources:
           disable_spill_encryption: !Ref DisableSpillEncryption
           spill_bucket: !Ref SpillBucket
           spill_prefix: !Ref SpillPrefix
+          include_linked_accounts: !Ref IncludeLinkedAccounts
       FunctionName: !Ref AthenaCatalogName
       Handler: "com.amazonaws.athena.connectors.cloudwatch.metrics.MetricsCompositeHandler"
       CodeUri: "./target/athena-cloudwatch-metrics-2022.47.1.jar"

--- a/athena-cloudwatch-metrics/athena-cloudwatch-metrics-package.yaml
+++ b/athena-cloudwatch-metrics/athena-cloudwatch-metrics-package.yaml
@@ -40,6 +40,10 @@ Parameters:
     Description: "(Optional) An IAM policy ARN to use as the PermissionsBoundary for the created Lambda function's execution role"
     Default: ''
     Type: String
+  IncludeLinkedAccounts:
+    Description: "If set to 'true', metrics from linked accounts will be included in the results."
+    Default: 'false'
+    Type: String
 Conditions:
   HasPermissionsBoundary: !Not [ !Equals [ !Ref PermissionsBoundaryARN, "" ] ]
 Resources:

--- a/athena-cloudwatch-metrics/athena-cloudwatch-metrics.yaml
+++ b/athena-cloudwatch-metrics/athena-cloudwatch-metrics.yaml
@@ -57,6 +57,7 @@ Resources:
           disable_spill_encryption: !Ref DisableSpillEncryption
           spill_bucket: !Ref SpillBucket
           spill_prefix: !Ref SpillPrefix
+          include_linked_accounts: !Ref IncludeLinkedAccounts
       FunctionName: !Ref AthenaCatalogName
       PackageType: "Image"
       ImageUri: !Sub

--- a/athena-cloudwatch-metrics/athena-cloudwatch-metrics.yaml
+++ b/athena-cloudwatch-metrics/athena-cloudwatch-metrics.yaml
@@ -40,6 +40,10 @@ Parameters:
     Description: "(Optional) An IAM policy ARN to use as the PermissionsBoundary for the created Lambda function's execution role"
     Default: ''
     Type: String
+  IncludeLinkedAccounts:
+    Description: "If set to 'true', metrics from linked accounts will be included in the results."
+    Default: 'false'
+    Type: String
 Conditions:
   HasPermissionsBoundary: !Not [ !Equals [ !Ref PermissionsBoundaryARN, "" ] ]
   IsRegionBAH: !Equals [!Ref "AWS::Region", "me-south-1"]

--- a/athena-cloudwatch-metrics/pom.xml
+++ b/athena-cloudwatch-metrics/pom.xml
@@ -62,6 +62,12 @@
             <version>${log4j2Version}</version>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.stefanbirkner</groupId>
+            <artifactId>system-lambda</artifactId>
+            <version>1.2.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/athena-cloudwatch-metrics/src/main/java/com/amazonaws/athena/connectors/cloudwatch/metrics/MetricUtils.java
+++ b/athena-cloudwatch-metrics/src/main/java/com/amazonaws/athena/connectors/cloudwatch/metrics/MetricUtils.java
@@ -59,7 +59,21 @@ public class MetricUtils
     //this is a format required by Cloudwatch Metrics
     private static final String METRIC_ID = "m1";
 
+    // Environment variable to control cross-account metrics inclusion
+    private static final String INCLUDE_LINKED_ACCOUNTS_ENV_VAR = "include_linked_accounts";
+
     private MetricUtils() {}
+
+    /**
+     * Checks if cross-account metrics should be included based on environment variable
+     *
+     * @return True if cross-account metrics should be included, false otherwise
+     */
+    private static boolean shouldIncludeLinkedAccounts()
+    {
+        String includeLinkedAccounts = System.getenv(INCLUDE_LINKED_ACCOUNTS_ENV_VAR);
+        return Boolean.parseBoolean(includeLinkedAccounts);
+    }
 
     /**
      * Filters metrics who have at least 1 metric dimension that matches DIMENSION_NAME_FIELD and DIMENSION_VALUE_FIELD filters.
@@ -103,6 +117,8 @@ public class MetricUtils
     protected static void pushDownPredicate(Constraints constraints, ListMetricsRequest.Builder listMetricsRequest)
     {
         Map<String, ValueSet> summary = constraints.getSummary();
+
+        listMetricsRequest.includeLinkedAccounts(shouldIncludeLinkedAccounts());
 
         ValueSet namespaceConstraint = summary.get(NAMESPACE_FIELD);
         if (namespaceConstraint != null && namespaceConstraint.isSingleValue()) {


### PR DESCRIPTION
*Issue #, if available:*
#1333 and #2365
*Description of changes:*
Add support for cross-account metrics in CloudWatch Metrics by enabling the includeLinkedAccounts feature using a env variable. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
