### PR TITLE
add redshift v1 sdk back for iam auth support

### DIFF
--- a/athena-redshift/pom.xml
+++ b/athena-redshift/pom.xml
@@ -50,6 +50,16 @@
             <artifactId>redshiftserverless</artifactId>
             <version>${aws-sdk-v2.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-redshift</artifactId>
+            <version>${aws-sdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-redshiftserverless</artifactId>
+            <version>${aws-sdk.version}</version>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awscdk/redshift -->
         <dependency>
             <groupId>software.amazon.awscdk</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,8 @@
         <maven.compiler.plugin.version>3.14.0</maven.compiler.plugin.version>
         <!--- to meet engine version 1.12.533-->
         <aws-sdk-v2.version>2.31.77</aws-sdk-v2.version>
+        <!-- for redshift iam auth still using sdkv1 -->
+        <aws-sdk.version>1.12.773</aws-sdk.version>
         <aws.lambda-java-core.version>1.2.2</aws.lambda-java-core.version>
         <aws.lambda-java-log4j2.version>1.6.0</aws.lambda-java-log4j2.version>
         <aws-cdk.version>1.204.0</aws-cdk.version>


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* The upgrade to AWS SDK v2 in the athena connectors removed redshift and redshift serverless java sdk v1 dependencies which are still required for redshift-jdbc when using IAM authentication. This PR adds these 2 maven dependencies back to the pom.xml for athena-redshift.

Tested by building locally the athena redshift connector and using the jar in a custom athena connector lambda to query data from Redshift.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
