### PR TITLE
Update snakeyaml dependency to 2.0 to address vulnerability with 1.26

### DIFF
--- a/athena-elasticsearch/pom.xml
+++ b/athena-elasticsearch/pom.xml
@@ -80,6 +80,18 @@
             <groupId>org.elasticsearch.client</groupId>
             <artifactId>elasticsearch-rest-high-level-client</artifactId>
             <version>7.10.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.yaml</groupId>
+                    <artifactId>snakeyaml</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>2.0</version>
+            <!-- Override to address CVE vulnerabilities in snakeyaml 1.26 from elasticsearch dependency -->
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/elasticsearch -->
         <dependency>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

snakeyaml 1.26 has a critical CVE (CVE-2022-1471). This overrides the dependency pulled in by the elasticsearch client.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
