### PR TITLE
Publish oracle, postgres, and redshift connectors to maven

### DIFF
--- a/.github/workflows/publish_to_maven_central.yml
+++ b/.github/workflows/publish_to_maven_central.yml
@@ -26,7 +26,7 @@ jobs:
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
       - name: Publish to Apache Maven Central
-        run: mvn clean deploy --batch-mode -Dmaven.compiler.release=11 -am -P release -pl ".,athena-federation-sdk,athena-dynamodb,athena-cloudwatch,athena-cloudwatch-metrics,athena-aws-cmdb,athena-jdbc,athena-mysql"
+        run: mvn clean deploy --batch-mode -Dmaven.compiler.release=11 -am -P release -pl ".,athena-federation-sdk,athena-dynamodb,athena-cloudwatch,athena-cloudwatch-metrics,athena-aws-cmdb,athena-jdbc,athena-mysql,athena-oracle,athena-redshift,athena-postgres"
         env:
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}


### PR DESCRIPTION
Customer requested that we publish these additional connectors to maven to help unblock their critical workflows.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
