### PR TITLE
fix: snowflake query string builder should follow timezone information from Arrow.

### DIFF
--- a/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeQueryStringBuilder.java
+++ b/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeQueryStringBuilder.java
@@ -288,6 +288,11 @@ public class SnowflakeQueryStringBuilder
                 long millis = ((Number) value).longValue();
                 Timestamp timestamp = new Timestamp(millis);
                 SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+                String timezone = ((ArrowType.Timestamp) arrowType).getTimezone();
+                if (timezone == null || timezone.isEmpty()) {
+                    timezone = "UTC";
+                }
+                sdf.setTimeZone(java.util.TimeZone.getTimeZone(timezone));
                 return sdf.format(timestamp);
             case Time:
             case Interval:

--- a/athena-snowflake/src/test/java/com/amazonaws/athena/connectors/snowflake/SnowflakeQueryStringBuilderTest.java
+++ b/athena-snowflake/src/test/java/com/amazonaws/athena/connectors/snowflake/SnowflakeQueryStringBuilderTest.java
@@ -129,9 +129,27 @@ class SnowflakeQueryStringBuilderTest {
     }
 
     @Test
-    void testGetObjectForWhereClause_Timestamp() {
+    void testGetObjectForWhereClause_TimestampWithNullZone() {
+        Object result = queryBuilder.getObjectForWhereClause("created_at", 1711929600000L,  new ArrowType.Timestamp(TimeUnit.MILLISECOND, null));
+        assertEquals("2024-04-01 00:00:00", result);
+    }
+
+    @Test
+    void testGetObjectForWhereClause_TimestampWithUtcZone() {
         Object result = queryBuilder.getObjectForWhereClause("created_at", 1711929600000L,  new ArrowType.Timestamp(TimeUnit.MILLISECOND, "UTC"));
         assertEquals("2024-04-01 00:00:00", result);
+    }
+
+    @Test
+    void testGetObjectForWhereClause_TimestampWithLocalZone() {
+        Object result = queryBuilder.getObjectForWhereClause("created_at", 1711929600000L,  new ArrowType.Timestamp(TimeUnit.MILLISECOND, "PST"));
+        assertEquals("2024-03-31 17:00:00", result);
+
+        Object result1 = queryBuilder.getObjectForWhereClause("created_at", 1711929600000L,  new ArrowType.Timestamp(TimeUnit.MILLISECOND, "America/Los_Angeles"));
+        assertEquals("2024-03-31 17:00:00", result1);
+
+        Object result2 = queryBuilder.getObjectForWhereClause("created_at", 1711929600000L,  new ArrowType.Timestamp(TimeUnit.MILLISECOND, "GMT-8:00"));
+        assertEquals("2024-03-31 16:00:00", result2);
     }
 
     @Test


### PR DESCRIPTION
*Issue #, if available:*
N/A (or add issue number if there's a related GitHub issue)

*Description of changes:*
Fix timezone handling in Snowflake connector timestamp formatting for WHERE clauses

**Problem:**
The SnowflakeQueryStringBuilder was not respecting timezone information when formatting timestamps for SQL WHERE clauses. This could lead to incorrect query results when timestamp data includes timezone information, as the formatter would use the system default timezone instead of the data's actual timezone.

**Solution:**
- Extract timezone information from ArrowType.Timestamp objects
- Default to "UTC" when timezone is null or empty
- Apply the correct timezone to SimpleDateFormat before formatting timestamps

**Changes:**
- Modified `getObjectForWhereClause()` method in `SnowflakeQueryStringBuilder.java` to handle timezone-aware timestamp formatting
- Added comprehensive test cases covering:
  - Timestamps with null timezone (defaults to UTC)
  - Timestamps with explicit UTC timezone
  - Timestamps with various timezone formats (PST, America/Los_Angeles, GMT-8:00)

**Testing:**
Added unit tests to verify correct timestamp formatting across different timezone scenarios, ensuring the formatted timestamps reflect the proper timezone conversion.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
