### PR TITLE
Update cut_release.yml to add apt-get update

### DIFF
--- a/.github/workflows/cut_release.yml
+++ b/.github/workflows/cut_release.yml
@@ -10,6 +10,7 @@ jobs:
     steps:
       - name: Setup dependencies
         run: |
+          sudo apt update --fix-missing
           sudo apt-get install -y libxml2-utils python3
           pip3 install lxml beautifulsoup4
 


### PR DESCRIPTION
When running the cut-release workflow, it failed with the following error. Adding recommended command.
```
Run sudo apt-get install -y libxml2-utils python3
  sudo apt-get install -y libxml2-utils python3
  pip3 install lxml beautifulsoup4
  shell: /usr/bin/bash -e {0}
Reading package lists...
Building dependency tree...
Reading state information...
python3 is already the newest version (3.12.3-0ubuntu2).
The following NEW packages will be installed:
  libxml2-utils
0 upgraded, 1 newly installed, 0 to remove and 13 not upgraded.
Need to get 39.4 kB of archives.
After this operation, 188 kB of additional disk space will be used.
Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [144 B]
Ign:2 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libxml2-utils amd64 2.9.14+dfsg-1.3ubuntu3.3
Ign:2 https://archive.ubuntu.com/ubuntu noble-updates/main amd64 libxml2-utils amd64 2.9.14+dfsg-1.3ubuntu3.3
Ign:2 https://security.ubuntu.com/ubuntu noble-updates/main amd64 libxml2-utils amd64 2.9.14+dfsg-1.3ubuntu3.3
Err:2 mirror+file:/etc/apt/apt-mirrors.txt noble-updates/main amd64 libxml2-utils amd64 2.9.14+dfsg-1.3ubuntu3.3
  404  Not Found [IP: 52.252.75.106 80]
E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/main/libx/libxml2/libxml2-utils_2.9.14%2bdfsg-1.3ubuntu3.3_amd64.deb  404  Not Found [IP: 52.252.75.106 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: Process completed with exit code 100.
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
