### PR TITLE
Hbase namespace issue

### DIFF
--- a/athena-hbase/pom.xml
+++ b/athena-hbase/pom.xml
@@ -33,6 +33,22 @@
             <classifier>withdep</classifier>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j-log4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <version>${slf4j-log4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+            <version>${log4j2Version}</version>
+            <scope>runtime</scope>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awscdk/emr -->
         <dependency>
             <groupId>software.amazon.awscdk</groupId>

--- a/athena-hbase/src/main/java/com/amazonaws/athena/connectors/hbase/HbaseTableNameUtils.java
+++ b/athena-hbase/src/main/java/com/amazonaws/athena/connectors/hbase/HbaseTableNameUtils.java
@@ -60,7 +60,8 @@ public final class HbaseTableNameUtils
      */
    public static String getQualifiedTableName(String schema, String table)
    {
-       return schema + NAMESPACE_QUALIFIER + table;
+       String namespacePrefix = schema + NAMESPACE_QUALIFIER;
+       return table.startsWith(namespacePrefix) ? table : namespacePrefix + table;
    }
 
     /**

--- a/athena-hbase/src/test/java/com/amazonaws/athena/connectors/hbase/HbaseTableNameUtilsTest.java
+++ b/athena-hbase/src/test/java/com/amazonaws/athena/connectors/hbase/HbaseTableNameUtilsTest.java
@@ -42,6 +42,17 @@ public class HbaseTableNameUtilsTest
     public void getQualifiedTableName()
     {
         String table = "table";
+        testGetQualifiedTableName(table);
+    }
+
+    @Test
+    public void getQualifiedTableNameWithNamespace()
+    {
+        String table = "schema:table";
+        testGetQualifiedTableName(table);
+    }
+
+    private void testGetQualifiedTableName(String table) {
         String schema = "schema";
         String expected = "schema:table";
         String actualWithTable = HbaseTableNameUtils.getQualifiedTableName(new TableName(schema, table));


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When using custom namespaces (non-default) in HBase tables with the Athena connector, queries fail with the following error:

GENERIC_USER_ERROR: Encountered an exception[java.lang.IllegalArgumentException] from your LambdaFunction[arn:aws:lambda:us-east-2:891643345752:function:hbase2025] executed in context[retrieving meta-data] with message[Illegal character code:58, <:> at 7. User-space table qualifiers may only contain 'alphanumeric characters' and digits: test_ns:employees]

These changes will fix the issue and also added missing dependency for loggers. 

Please find below attached issue analysis and testing doc for reference.
[HBase Namespace issue analysis and testing.docx](https://github.com/user-attachments/files/22233569/HBase.Namespace.issue.analysis.and.testing.docx)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
