### PR TITLE
[Fix] Include default truststore path when passing JAVA_TOOL_OPTIONS for Java 17 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,10 @@ ARG JAVA_VERSION=11
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
-# Argument for Java tool options for ssl
-ARG JAVA_TOOL_OPTIONS="-Djavax.net.ssl.trustStore=/var/lang/lib/security/cacerts"
-# Set the JAVA_TOOL_OPTIONS environment variable for Java 17
-ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
+# Argument for Java tool options
+ARG JAVA_TOOL_OPTIONS=""
+# Set the JAVA_TOOL_OPTIONS environment variable for Java 17 and always include default truststore to avoid SSL handshake issues
+ENV JAVA_TOOL_OPTIONS="-Djavax.net.ssl.trustStore=/var/lang/lib/security/cacerts ${JAVA_TOOL_OPTIONS}"
 
 # Install necessary tools
 RUN yum update -y

--- a/athena-docdb/Dockerfile
+++ b/athena-docdb/Dockerfile
@@ -3,10 +3,10 @@ ARG JAVA_VERSION=11
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
-# Argument for Java tool options for ssl
-ARG JAVA_TOOL_OPTIONS="-Djavax.net.ssl.trustStore=/var/lang/lib/security/cacerts"
-# Set the JAVA_TOOL_OPTIONS environment variable for Java 17 and for ssl
-ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
+# Argument for Java tool options
+ARG JAVA_TOOL_OPTIONS=""
+# Set the JAVA_TOOL_OPTIONS environment variable for Java 17 and always include default truststore to avoid SSL handshake issues
+ENV JAVA_TOOL_OPTIONS="-Djavax.net.ssl.trustStore=/var/lang/lib/security/cacerts ${JAVA_TOOL_OPTIONS}"
 
 # Install necessary tools
 RUN yum update -y

--- a/athena-oracle/Dockerfile
+++ b/athena-oracle/Dockerfile
@@ -3,10 +3,10 @@ ARG JAVA_VERSION=11
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
-# Argument for Java tool options for ssl
-ARG JAVA_TOOL_OPTIONS="-Djavax.net.ssl.trustStore=/var/lang/lib/security/cacerts"
-# Set the JAVA_TOOL_OPTIONS environment variable for Java 17 and for ssl
-ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
+# Argument for Java tool options
+ARG JAVA_TOOL_OPTIONS=""
+# Set the JAVA_TOOL_OPTIONS environment variable for Java 17 and always include default truststore to avoid SSL handshake issues
+ENV JAVA_TOOL_OPTIONS="-Djavax.net.ssl.trustStore=/var/lang/lib/security/cacerts ${JAVA_TOOL_OPTIONS}"
 
 # Install necessary tools
 RUN yum update -y


### PR DESCRIPTION
Issue #, if available:
**javax.net.ssl.SSLHandshakeException: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target**

The above error occurred while querying the DocumentDB database on Athena because passing JAVA_TOOL_OPTIONS (**--add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation**) as a build argument in Java 17 was overriding the default truststore path (**-Djavax.net.ssl.trustStore=/var/lang/lib/security/cacerts**).

Description of changes:

Updated Dockerfiles to always prepend **-Djavax.net.ssl.trustStore=/var/lang/lib/security/cacerts** in JAVA_TOOL_OPTIONS instead of replacing it. Please find attached document.
[fix-java-17-ssl-handshake.odt](https://github.com/user-attachments/files/22388297/fix-java-17-ssl-handshake.odt)





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution under the terms of your choice.