### PR TITLE
Handle KMS and DDB NotFoundExceptions by throwing AthenaConnectorException

### DIFF
--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/resolver/DynamoDBTableResolver.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/resolver/DynamoDBTableResolver.java
@@ -151,7 +151,7 @@ public class DynamoDBTableResolver
                 return DDBTableUtils.getTable(caseInsensitiveMatch.get(), invoker, ddbClient, awsRequestOverrideConfiguration);
             }
             else {
-                throw e;
+                throw new AthenaConnectorException(e.getMessage(), ErrorDetails.builder().errorCode(FederationSourceErrorCode.ENTITY_NOT_FOUND_EXCEPTION.toString()).build());
             }
         }
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Handle KMS and DDB NotFoundExceptions by throwing AthenaConnectorException

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
