### PR TITLE
Dependabot guava upgrade issue fix

### DIFF
--- a/athena-federation-sdk/pom.xml
+++ b/athena-federation-sdk/pom.xml
@@ -192,6 +192,11 @@
             <version>${guava.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j-log4j.version}</version>


### PR DESCRIPTION
*Issue #, if available:*
PR #2728
*Description of changes:*
Dependabot guava upgrade build issue fix.

**The Reason:** Starting with Guava 33.0.0, Google removed the transitive dependency on JSR-305 annotations. Athena code using @Nonnull from javax.annotation package, but this annotation library is no longer automatically included with Guava 33.x versions.

PFA test results for your reference.
[KAFKA_FUNCTIONAL_TEST.xlsx](https://github.com/user-attachments/files/22977162/KAFKA_FUNCTIONAL_TEST.xlsx)
[SNOWFLAKE_FUNCTIONAL_TEST.xlsx](https://github.com/user-attachments/files/22977163/SNOWFLAKE_FUNCTIONAL_TEST.xlsx)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
