### PR TITLE
Handle ResourceNotFoundException from Dynamodb as AthenaConnectorExce…

### DIFF
--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBRecordHandler.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBRecordHandler.java
@@ -62,6 +62,7 @@ import software.amazon.awssdk.services.dynamodb.model.ExecuteStatementRequest;
 import software.amazon.awssdk.services.dynamodb.model.ExecuteStatementResponse;
 import software.amazon.awssdk.services.dynamodb.model.QueryRequest;
 import software.amazon.awssdk.services.dynamodb.model.QueryResponse;
+import software.amazon.awssdk.services.dynamodb.model.ResourceNotFoundException;
 import software.amazon.awssdk.services.dynamodb.model.ScanRequest;
 import software.amazon.awssdk.services.dynamodb.model.ScanResponse;
 import software.amazon.awssdk.services.glue.model.ErrorDetails;
@@ -524,6 +525,9 @@ public class DynamoDBRecordHandler
                 }
                 catch (TimeoutException | ExecutionException e) {
                     throw new AthenaConnectorException(e.getMessage(), ErrorDetails.builder().errorCode(FederationSourceErrorCode.OPERATION_TIMEOUT_EXCEPTION.toString()).build());
+                }
+                catch (ResourceNotFoundException e) {
+                    throw new AthenaConnectorException(e.getMessage(), ErrorDetails.builder().errorCode(FederationSourceErrorCode.ENTITY_NOT_FOUND_EXCEPTION.toString()).build());
                 }
                 currentPageIterator.set(iterator);
                 if (iterator.hasNext()) {


### PR DESCRIPTION

*Description of changes:*
Handle ResourceNotFoundException from Dynamodb as AthenaConnectorException in DynamoDBRecordHandler, so that the exception can be further handled in the service.
