### PR TITLE
Update PostgreSQL engine version to 15.10

### DIFF
--- a/validation_testing/cdk_federation_infra_provisioning/app/lib/stacks/rds-generic-stack.ts
+++ b/validation_testing/cdk_federation_infra_provisioning/app/lib/stacks/rds-generic-stack.ts
@@ -181,7 +181,7 @@ export class RdsGenericStack extends cdk.Stack {
     if (db_type == 'mysql') {
       return rds.DatabaseClusterEngine.auroraMysql({version:rds.AuroraMysqlEngineVersion.VER_3_04_1});
     } else if (db_type == 'postgresql') {
-      return rds.DatabaseClusterEngine.auroraPostgres({version:rds.AuroraPostgresEngineVersion.VER_15_4});
+      return rds.DatabaseClusterEngine.auroraPostgres({version:rds.AuroraPostgresEngineVersion.VER_15_10});
     } else {
       throw new Error("unsupported rds engine version");
     }


### PR DESCRIPTION
Updating Aurora postgres to 15.10 which is the LTS supported version: https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Updates.LTS.html

the current version is no longer supported.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
