### PR TITLE
Fix CVEs related to `Apache Commons-lang3 ` and `Netty`

### DIFF
--- a/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQuerySqlUtils.java
+++ b/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQuerySqlUtils.java
@@ -38,11 +38,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.math.BigDecimal;
-import java.time.Instant;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.StringJoiner;
 import java.util.concurrent.TimeUnit;
@@ -254,13 +253,7 @@ public class BigQuerySqlUtils
                     // date search: date parameter used in where clause will come as days so it will be converted to date
                     long days = Long.parseLong(val);
                     long milliseconds = TimeUnit.DAYS.toMillis(days);
-
-                    // convert date using UTC to avoid timezone conversion.
-                    String dateString = Instant.ofEpochMilli(milliseconds)
-                            .atOffset(ZoneOffset.UTC)
-                            .format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
-
-                    return QueryParameterValue.date(dateString);
+                    return QueryParameterValue.date(new SimpleDateFormat("yyyy-MM-dd").format(new Date(milliseconds)));
                 }
             case Time:
             case Timestamp:

--- a/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryStorageApiUtils.java
+++ b/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryStorageApiUtils.java
@@ -38,9 +38,6 @@ import org.slf4j.LoggerFactory;
 
 import java.math.BigDecimal;
 import java.text.SimpleDateFormat;
-import java.time.Instant;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -202,12 +199,7 @@ public class BigQueryStorageApiUtils
                     // date search: date parameter used in where clause will come as days so it will be converted to date
                     long days = Long.parseLong(val);
                     long milliseconds = TimeUnit.DAYS.toMillis(days);
-                    // convert date using UTC to avoid timezone conversion.
-                    String dateString = Instant.ofEpochMilli(milliseconds)
-                            .atOffset(ZoneOffset.UTC)
-                            .format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
-
-                    return QueryParameterValue.date(dateString);
+                    return QueryParameterValue.date(new SimpleDateFormat("yyyy-MM-dd").format(new Date(milliseconds)));
                 }
             case Time:
             case Timestamp:

--- a/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeQueryStringBuilder.java
+++ b/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeQueryStringBuilder.java
@@ -42,9 +42,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
-import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -284,10 +282,7 @@ public class SnowflakeQueryStringBuilder
                 else {
                     long days = Long.parseLong(dateStr);
                     long milliseconds = TimeUnit.DAYS.toMillis(days);
-                    // convert date using UTC to avoid timezone conversion.
-                    return Instant.ofEpochMilli(milliseconds)
-                            .atOffset(ZoneOffset.UTC)
-                            .format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+                    return new SimpleDateFormat("yyyy-MM-dd").format(new Date(milliseconds));
                 }
             case Timestamp:
             case Time:


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-athena-query-federation/issues/2970 
https://github.com/awslabs/aws-athena-query-federation/issues/2569 

*Description of changes:*
*Problem:*
Addressed below CVE
- CVE-2020-15250
- CVE-2025-24970
- CVE-2025-58056
- CVE-2025-58057
- CVE-2025-55163
- CVE-2025-27820
- CVE-2024-57699
- CVE-2025-48924
- - AWS Inspector flagged CVE-2025-48924 in athena-dynamodb connector (version 2025.34.3)
The vulnerability affects Apache Commons Lang3 versions < 3.18.0
Multiple connectors are impacted due to transitive dependencies pulling in older versions.

*Solution:*
Upgraded Apache Commons-lang3 to 3.19.0 to address a transitive dependency and exclude problematic metadata, which fixes CVE-2025-48924. Since similar CVEs were observed for other connectors as well, we have updated the code in the root POM.
Upgraded netty to 4.1.128.Final.

Please find the attached DynamoDB testing documentation for reference.

[CVE-2025-48924-Fix.docx](https://github.com/user-attachments/files/23355582/CVE-2025-48924-Fix.docx)
[DYNAMODB_FUNCTIONAL_TEST_2025-11-04.xlsx](https://github.com/user-attachments/files/23355583/DYNAMODB_FUNCTIONAL_TEST_2025-11-04.xlsx)
[DynamoDB All CVE issues fix.docx](https://github.com/user-attachments/files/23524828/DynamoDB.All.CVE.issues.fix.docx)
[DDB_FUNCTIONAL_TEST_2025-11-13.xlsx](https://github.com/user-attachments/files/23524843/DDB_FUNCTIONAL_TEST_2025-11-13.xlsx)

---------------------------------------------------------------------------------------------------------
*Bug fixes*
- Address Epoch Date to Date conversion bug where we were using machine local timezone and cause correctness issue.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
