### PR TITLE
Fix CVE-2025-59250: Upgrade mssql-jdbc Driver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <antlr.st4.version>4.3.4</antlr.st4.version>
         <log4j2.cachefile.transformer.version>2.15</log4j2.cachefile.transformer.version>
         <apache.httpclient.version>4.5.14</apache.httpclient.version>
-        <mssql.jdbc.version>12.10.0.jre11</mssql.jdbc.version>
+        <mssql.jdbc.version>13.2.1.jre11</mssql.jdbc.version>
         <commons.cli.version>1.10.0</commons.cli.version>
         <spark.version>3.2.1</spark.version>
         <test.system.rules.version>1.19.0</test.system.rules.version>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Addressed below CVE:

**CVE-2025-59250**: Improper input validation in the JDBC Driver for SQL Server allowing network spoofing attacks.

Changes:

- Upgraded `mssql.jdbc.version` property in parent `pom.xml`: `12.10.0.jre11` → `13.2.1.jre11`

Please find attached functional test documents.
[SQLSERVER_FUNCTIONAL_TEST.xlsx](https://github.com/user-attachments/files/23763341/SQLSERVER_FUNCTIONAL_TEST.xlsx)
[SYNAPSE_FUNCTIONAL_TEST.xlsx](https://github.com/user-attachments/files/23763342/SYNAPSE_FUNCTIONAL_TEST.xlsx)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
