### PR TITLE
Fix CVE-2025-48924: exclude commons-lang 

### DIFF
--- a/athena-federation-sdk/pom.xml
+++ b/athena-federation-sdk/pom.xml
@@ -349,6 +349,11 @@
                                 <exclude>META-INF/*.SF</exclude>
                                 <exclude>META-INF/*.DSA</exclude>
                                 <exclude>META-INF/*.RSA</exclude>
+                                <!-- CRITICAL FIX for CVE-2025-48924: Exclude problematic metadata -->
+                                <!-- These POMs declare vulnerable commons-lang/commons-lang3 versions -->
+                                <!-- 1. commons-lang 2.4 (direct vulnerability) -->
+                                <exclude>META-INF/maven/commons-lang/commons-lang/pom.xml</exclude>
+                                <exclude>META-INF/maven/commons-lang/commons-lang/pom.properties</exclude>
                             </excludes>
                         </filter>
                     </filters>

--- a/athena-saphana/assembly.xml
+++ b/athena-saphana/assembly.xml
@@ -24,6 +24,9 @@
             <outputDirectory>lib</outputDirectory>
             <excludes>
                 <exclude>${project.groupId}:${project.artifactId}:jar:*</exclude>
+                <!-- CRITICAL FIX for CVE-2025-48924: Exclude vulnerable commons-lang artifacts -->
+                <!-- Exclude old commons-lang (not commons-lang3) which has CVE-2025-48924 -->
+                <exclude>commons-lang:commons-lang</exclude>
             </excludes>
         </dependencySet>
     </dependencySets>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Addressed below CVE:

**CVE-2025-48924**: Uncontrolled recursion in Apache Commons Lang's `ClassUtils.getClass(...)` method can trigger a `StackOverflowError` on very long inputs, potentially causing application crashes.

Changes:

- Excluded vulnerable `commons-lang:commons-lang` artifacts in `athena-saphana/assembly.xml`
- Excluded vulnerable `commons-lang` metadata files in `athena-federation-sdk/pom.xml` maven-shade-plugin configuration

Affected connector : 

- Saphana

Please find attached functional test documents.
[SAPHANA_FUNCTIONAL_TEST.xlsx](https://github.com/user-attachments/files/23763719/SAPHANA_FUNCTIONAL_TEST.xlsx)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
