### PR TITLE
Remove hard-coded Glue list-jobs --max-results 100 to find all Glue jobs

### DIFF
--- a/validation_testing/run_glue.sh
+++ b/validation_testing/run_glue.sh
@@ -8,8 +8,21 @@ cd $VALIDATION_TESTING_ROOT
 # If there is any output to glue_job_synchronous_execution.py, we will exit this script with a failure code.
 # The 2>&1 lets us pipe both stdout and stderr to grep, as opposed to just the stdout. https://stackoverflow.com/questions/818255/what-does-21-mean
 echo "Starting glue jobs..."
-aws glue list-jobs --max-results 100 \
-| jq ".JobNames[] | select(startswith(\"${CONNECTOR_NAME}gluejob\"))" \
+# Capture matching job names
+JOB_NAMES=$(aws glue list-jobs \
+    | jq -r ".JobNames[] | select(startswith(\"${CONNECTOR_NAME}gluejob\"))")
+
+# Fail early if no jobs matched
+if [ -z "$JOB_NAMES" ]; then
+    echo "ERROR: No Glue jobs found matching: ${CONNECTOR_NAME}gluejob"
+    exit 1
+fi
+
+echo "Running jobs:"
+echo "$JOB_NAMES"
+
+# Run each job
+echo "$JOB_NAMES" \
 | xargs -I{} python3 scripts/glue_job_synchronous_execution.py {} 2>&1 \
 | grep -q '.' && exit 1
 

--- a/validation_testing/run_release_tests.sh
+++ b/validation_testing/run_release_tests.sh
@@ -49,8 +49,21 @@ cd $VALIDATION_TESTING_ROOT
 # If there is any output to glue_job_synchronous_execution.py, we will exit this script with a failure code.
 # The 2>&1 lets us pipe both stdout and stderr to grep, as opposed to just the stdout. https://stackoverflow.com/questions/818255/what-does-21-mean
 echo "Starting glue jobs..."
-aws glue list-jobs --max-results 100 \
-| jq ".JobNames[] | select(startswith(\"${CONNECTOR_NAME}gluejob\"))" \
+# Capture matching job names
+JOB_NAMES=$(aws glue list-jobs \
+    | jq -r ".JobNames[] | select(startswith(\"${CONNECTOR_NAME}gluejob\"))")
+
+# Fail early if no jobs matched
+if [ -z "$JOB_NAMES" ]; then
+    echo "ERROR: No Glue jobs found matching: ${CONNECTOR_NAME}gluejob"
+    exit 1
+fi
+
+echo "Running jobs:"
+echo "$JOB_NAMES"
+
+# Run each job
+echo "$JOB_NAMES" \
 | xargs -I{} python3 scripts/glue_job_synchronous_execution.py {} 2>&1 \
 | grep -q '.' && exit 1
 


### PR DESCRIPTION
*Issue #, if available:*
While running the release tests locally, we noticed that data wasn’t loaded because the Glue jobs didn’t run. The root cause was that our script searched only the first 100 Glue jobs, while our account has more than that. As a result, the ${CONNECTOR_NAME}gluejob jobs were never picked up.

*Description of changes:*
This change removes the hard-coded --max-results 100 constraint used when listing Glue jobs.
Also added early failure and logging of matched jobs. Sample output after the fix (Redshift connector):
<img width="1821" height="211" alt="image" src="https://github.com/user-attachments/assets/ea746580-c3b4-4c6b-bd0c-33b63f037bd4" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
