### PR TITLE
GCS CVE issues fix

### DIFF
--- a/athena-gcs/assembly.xml
+++ b/athena-gcs/assembly.xml
@@ -32,6 +32,10 @@
                     <exclude>META-INF/*.DSA</exclude>
                     <exclude>META-INF/*.RSA</exclude>
                     <exclude>**/Log4j2Plugins.dat</exclude>
+                    <!-- Fix for ALL CVEs related to META-INF path: Exclude all Maven POM metadata files -->
+                    <!-- These POM files cause false-positive CVE alerts in AWS Inspector -->
+                    <exclude>META-INF/maven/**/pom.xml</exclude>
+                    <exclude>META-INF/maven/**/pom.properties</exclude>
                 </excludes>
             </unpackOptions>
         </dependencySet> 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixed all CVE issues related to META-INF path vulnerabilities for GCS connector.
13 CVEs were fixed using a wildcard approach because all of them were related to META-INF.

**Fixed CVEs:** CVE-2022-23305, CVE-2022-23305, CVE-2019-17571, CVE-2023-26464,
CVE-2022-23302, CVE-2022-23307, CVE-2025-55163, CVE-2023-2976, CVE-2021-4104,
CVE-2020-15250, CVE-2025-48924, CVE-2018-10237, CVE-2020-9488, CVE-2020-8908

Please find attached below test documents.
[GCS CVE issues fix.docx](https://github.com/user-attachments/files/23820916/GCS.CVE.issues.fix.docx)
[GCS_FUNCTIONAL_TEST_2025-11-27.xlsx](https://github.com/user-attachments/files/23796666/GCS_FUNCTIONAL_TEST_2025-11-27.xlsx)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

