### PR TITLE
Fix CVE-2025-48924: Clickhouse

### DIFF
--- a/athena-clickhouse/pom.xml
+++ b/athena-clickhouse/pom.xml
@@ -70,6 +70,22 @@
                         <goals>
                             <goal>shade</goal>
                         </goals>
+                        <configuration>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                        <!-- Fix for CVE-2025-48924 and CVE-2020-15250: Exclude all Maven metadata files -->
+                                        <!-- This excludes all pom.xml and pom.properties files that may declare vulnerable dependency versions -->
+                                        <exclude>META-INF/maven/**/pom.xml</exclude>
+                                        <exclude>META-INF/maven/**/pom.properties</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
**CVE-2025-48924**: Uncontrolled recursion in Apache Commons Lang's ClassUtils.getClass(...) method can trigger a StackOverflowError on very long inputs, potentially causing application crashes.

Changes:
Excluded vulnerable artifacts.

Affected connector:
Clickhouse

Please find attached functional test documents.
[CLICKHOUSE_FUNCTIONAL_TEST.xlsx](https://github.com/user-attachments/files/23816142/CLICKHOUSE_FUNCTIONAL_TEST.xlsx)
[Clickhouse_CVE_Fix.docx](https://github.com/user-attachments/files/23816149/Clickhouse_CVE_Fix.docx)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
