### PR TITLE
BigQuery CVE issues fix.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -369,6 +369,19 @@
                                         <!-- 6. Exclude old junit POM metadata directly -->
                                         <exclude>META-INF/maven/junit/junit/pom.xml</exclude>
                                         <exclude>META-INF/maven/junit/junit/pom.properties</exclude>
+                                        <!-- 7. Fix for CVE-2023-2976, CVE-2020-8908: Exclude escapevelocity metadata that declares vulnerable guava -->
+                                        <exclude>META-INF/maven/com.google.escapevelocity/escapevelocity/pom.xml</exclude>
+                                        <exclude>META-INF/maven/com.google.escapevelocity/escapevelocity/pom.properties</exclude>
+                                        <!-- 8. Fix for CVE-2025-55163: Exclude Google Cloud BigQuery metadata that declares vulnerable io.grpc -->
+                                        <exclude>META-INF/maven/com.google.cloud/google-cloud-bigquery/pom.xml</exclude>
+                                        <exclude>META-INF/maven/com.google.cloud/google-cloud-bigquery/pom.properties</exclude>
+                                        <exclude>META-INF/maven/com.google.cloud/google-cloud-bigquerystorage/pom.xml</exclude>
+                                        <exclude>META-INF/maven/com.google.cloud/google-cloud-bigquerystorage/pom.properties</exclude>
+                                        <!-- 9. Fix for CVE-2024-7254: Exclude google.api.grpc metadata that declares vulnerable protobuf -->
+                                        <exclude>META-INF/maven/com.google.api.grpc/grpc-google-cloud-bigquerystorage-v1/pom.xml</exclude>
+                                        <exclude>META-INF/maven/com.google.api.grpc/grpc-google-cloud-bigquerystorage-v1/pom.properties</exclude>
+                                        <exclude>META-INF/maven/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/pom.xml</exclude>
+                                        <exclude>META-INF/maven/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/pom.properties</exclude>
                                     </excludes>
                                 </filter>
                             </filters>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
 Fixed all CVE issues related to META-INF path vulnerabilities for BigQuery connector.
 
Fixed CVEs: [CVE-2025-55163](https://github.com/advisories/GHSA-prj3-ccx8-p6x4), [CVE-2024-7254](https://github.com/advisories/GHSA-735f-pc8j-v9w8), [CVE-2023-2976](https://github.com/advisories/GHSA-7g45-4rm6-3mm3), [CVE-2020-8908](https://github.com/advisories/GHSA-5mg8-w23w-74h3)

Please find attached below test documents.
[BIGQUERY_FUNCTIONAL_TEST_2025-12-01.xlsx](https://github.com/user-attachments/files/23853808/BIGQUERY_FUNCTIONAL_TEST_2025-12-01.xlsx)
[BigQuery CVE issues fix.docx](https://github.com/user-attachments/files/23853811/BigQuery.CVE.issues.fix.docx)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
