### PR TITLE
Upgrade Redshift JDBC driver to 2.2.1 and re-enable Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,8 +16,6 @@ updates:
       - dependency-name: "com.google.api.grpc:grpc-google-cloud-bigquerystorage-v1"
       - dependency-name: "io.grpc:grpc-api"
       - dependency-name: "software.amazon.msk:aws-msk-iam-auth"
-      # bumping redshift version causes release tests to fail
-      - dependency-name: "com.amazon.redshift:redshift-jdbc42"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/athena-redshift/pom.xml
+++ b/athena-redshift/pom.xml
@@ -24,8 +24,7 @@
         <dependency>
             <groupId>com.amazon.redshift</groupId>
             <artifactId>redshift-jdbc42</artifactId>
-            <!-- Increasing to 2.1.0.31 caused a casing issue in release tests -->
-            <version>2.1.0.30</version>
+            <version>2.2.1</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>


### PR DESCRIPTION
*Issue #, if available:*

The project previously disabled automatic version bumps for the Amazon Redshift JDBC driver because versions beyond 2.1.0.30 caused casing-related failures in the release test suite as mentioned in this PR [#2469](https://github.com/awslabs/aws-athena-query-federation/pull/2469). As a result, Dependabot was configured to ignore updates for this dependency.

*Description of changes:*
- Upgraded the Amazon Redshift JDBC driver to 2.2.1.
- Removed the Dependabot ignore rule so that future updates for this dependency are tracked automatically.

A full release tests run using the updated driver has passed successfully. Please find the attached screenshot from my fork confirming the successful execution.
<img width="1777" height="546" alt="image" src="https://github.com/user-attachments/assets/78b68929-719f-461d-a859-23280a1abbcf" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
