### PR TITLE
Fix CVE: Cloudera Hive

### DIFF
--- a/athena-cloudera-hive/pom.xml
+++ b/athena-cloudera-hive/pom.xml
@@ -90,45 +90,46 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>${mvn.shade.plugin.version}</version>
-                <configuration>
-                    <createDependencyReducedPom>false</createDependencyReducedPom>
-                    <filters>
-                        <filter>
-                            <artifact>*:*</artifact>
-                            <excludes>
-                                <exclude>META-INF/*.SF</exclude>
-                                <exclude>META-INF/*.DSA</exclude>
-                                <exclude>META-INF/*.RSA</exclude>
-                            </excludes>
-                        </filter>
-                        <filter>
-                            <artifact>Hive:HiveJDBC42</artifact>
-                            <excludes>
-                                <exclude>org/apache/zookeeper/**</exclude>
-                                <exclude>com/cloudera/hive/jdbc42/internal/apache/zookeeper/**</exclude>
-                                <exclude>META-INF/maven/org.apache.zookeeper/**</exclude>
-                            </excludes>
-                        </filter>
-                    </filters>
-                    <transformers>
-                        <!-- This transformer is here to concatenate log4j2 cache during shading -->
-                        <transformer implementation="com.github.edwgiz.maven_shade_plugin.log4j2_cache_transformer.PluginsCacheFileTransformer">
-</transformer>
-                    </transformers>
-                </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>com.github.edwgiz</groupId>
-                        <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
-                        <version>${log4j2.cachefile.transformer.version}</version>
-                    </dependency>
-                </dependencies>
                 <executions>
                     <execution>
                         <phase>package</phase>
                         <goals>
                             <goal>shade</goal>
                         </goals>
+                        <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <filters>
+                                <!-- Remove signature files -->
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                        <exclude>META-INF/maven/**/pom.xml</exclude>
+                                        <exclude>META-INF/maven/**/pom.properties</exclude>
+                                    </excludes>
+                                </filter>
+                                <!-- Remove Zookeeper 3.7.0 embedded inside HiveJDBC42 -->
+                                <filter>
+                                    <artifact>Hive:HiveJDBC42</artifact>
+                                    <excludes>
+                                        <exclude>org/apache/zookeeper/**</exclude>
+                                        <exclude>com/cloudera/hive/jdbc42/internal/**/zookeeper/**</exclude>
+                                        <exclude>com/cloudera/hive/jdbc42/shaded/**/zookeeper/**</exclude>
+                                        <exclude>META-INF/maven/org.apache.zookeeper/**</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <!-- Keep normal transformers -->
+                            <transformers>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                </transformer>
+                            </transformers>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Addressed below CVEs:

**CVE-2023-44981**: Apache ZooKeeper vulnerability allowing unauthorized endpoints to join a cluster when SASL Quorum Peer authentication is enabled.
**CVE-2024-23944**: Apache ZooKeeper information disclosure vulnerability in persistent watchers due to missing ACL check.

Changes:

- Added maven-shade-plugin filters to exclude vulnerable ZooKeeper 3.7.0 classes and metadata embedded in HiveJDBC42 artifact
- Configured ServicesResourceTransformer and ManifestResourceTransformer to properly merge resources in shaded JAR

Affected connector:
Cloudera Hive

Please find attached functional test documents.
[Cloudera-Hive cve fix.docx](https://github.com/user-attachments/files/23880790/Cloudera-Hive.cve.fix.docx)
[CLOUDERAHIVE_FUNCTIONAL_TEST.xlsx](https://github.com/user-attachments/files/23880791/CLOUDERAHIVE_FUNCTIONAL_TEST.xlsx)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
