### PR TITLE
[Fix] Add default surefire/failsafe argLine for Java 17 to enable Jacoco reports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -490,7 +490,6 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${surefire.failsafe.version}</version>
                 <configuration>
-                    <argLine>--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED</argLine>
                     <excludes>
                         <exclude>*IntegTest</exclude>
                     </excludes>
@@ -544,7 +543,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <version>${surefire.failsafe.version}</version>
                         <configuration>
-                            <argLine>--add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED</argLine>
+                            <argLine>${argLine} --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED</argLine>
                             <excludes>
                                 <exclude>*IntegTest</exclude>
                             </excludes>
@@ -555,7 +554,7 @@
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <version>${surefire.failsafe.version}</version>
                         <configuration>
-                            <argLine>--add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED</argLine>
+                            <argLine>${argLine} --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED</argLine>
                             <forkCount>3C</forkCount>
                             <reuseForks>false</reuseForks>
                             <includes>


### PR DESCRIPTION
*Issue #, if available:*
JaCoCo reports were not generated when running tests. The root cause is that the Java 17 profile overrides the Surefire and Failsafe plugin configuration without carrying forward the default ${argLine} used by the JaCoCo plugin. These settings are required when the Surefire and Failsafe configuration is overridden (Java 17 profile), but are not needed for the default Java 11 configuration, where Java 17–specific --add-opens arguments were added to the default Surefire configuration as part of PR [#3150](https://github.com/awslabs/aws-athena-query-federation/pull/3150), which are unnecessary.

*Description of changes:*
This PR updates the Java 17 Maven profile to include the default Surefire/Failsafe ${argLine} used by the JaCoCo plugin and removes unnecessary Java 17–specific arguments from the default (Java 11) configuration.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
