### PR TITLE
Enforce DynamoDB maximum page size as 100.

### DIFF
--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/resolver/DynamoDBTableResolver.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/resolver/DynamoDBTableResolver.java
@@ -94,7 +94,7 @@ public class DynamoDBTableResolver
         do {
             ListTablesRequest ddbRequest = ListTablesRequest.builder()
                     .exclusiveStartTableName(nextToken)
-                    .limit(limit)
+                    .limit(Math.min(100, limit))
                     .overrideConfiguration(awsRequestOverrideConfiguration)
                     .build();
             ListTablesResponse response = invoker.invoke(() -> ddbClient.listTables(ddbRequest));


### PR DESCRIPTION
Enforce DynamoDB maximum page size as 100 because DynamoDB has a maximum page size of 100: https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ListTables.html#DDB-ListTables-request-Limit


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
