### PR TITLE
Postgresql uuid type issue fix.

### DIFF
--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandler.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandler.java
@@ -45,8 +45,6 @@ import com.amazonaws.athena.connectors.jdbc.connection.JdbcConnectionFactory;
 import com.amazonaws.athena.connectors.jdbc.qpt.JdbcQueryPassthrough;
 import com.amazonaws.athena.connectors.jdbc.resolver.DefaultJDBCCaseResolver;
 import com.amazonaws.athena.connectors.jdbc.resolver.JDBCCaseResolver;
-import com.amazonaws.athena.connectors.jdbc.splits.Splitter;
-import com.amazonaws.athena.connectors.jdbc.splits.SplitterFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -69,8 +67,6 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -88,12 +84,9 @@ public abstract class JdbcMetadataHandler
         extends MetadataHandler
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(JdbcMetadataHandler.class);
-    private static final String SQL_SPLITS_STRING = "select min(%s), max(%s) from %s.%s;";
-    private static final int DEFAULT_NUM_SPLITS = 20;
     public static final String TABLES_AND_VIEWS = "Tables and Views";
     private final JdbcConnectionFactory jdbcConnectionFactory;
     private final DatabaseConnectionConfig databaseConnectionConfig;
-    private final SplitterFactory splitterFactory = new SplitterFactory();
     protected final JDBCCaseResolver caseResolver;
     protected JdbcQueryPassthrough jdbcQueryPassthrough = new JdbcQueryPassthrough();
 
@@ -476,53 +469,6 @@ public abstract class JdbcMetadataHandler
 
     @Override
     public abstract GetSplitsResponse doGetSplits(BlockAllocator blockAllocator, GetSplitsRequest getSplitsRequest);
-
-    protected List<String> getSplitClauses(final TableName tableName)
-    {
-        return getSplitClauses(tableName, null);
-    }
-
-    protected List<String> getSplitClauses(final TableName tableName, final GetSplitsRequest getSplitsRequest)
-    {
-        List<String> splitClauses = new ArrayList<>();
-        try (Connection jdbcConnection = getJdbcConnectionFactory().getConnection(
-                getCredentialProvider(getSplitsRequest != null ? getRequestOverrideConfig(getSplitsRequest) : null));
-                ResultSet resultSet = jdbcConnection.getMetaData().getPrimaryKeys(null, tableName.getSchemaName(), tableName.getTableName())) {
-            List<String> primaryKeyColumns = new ArrayList<>();
-            while (resultSet.next()) {
-                primaryKeyColumns.add(resultSet.getString("COLUMN_NAME"));
-            }
-            if (!primaryKeyColumns.isEmpty()) {
-                try (Statement statement = jdbcConnection.createStatement();
-                        ResultSet minMaxResultSet = statement.executeQuery(String.format(SQL_SPLITS_STRING, primaryKeyColumns.get(0), primaryKeyColumns.get(0),
-                                wrapNameWithEscapedCharacter(tableName.getSchemaName()), wrapNameWithEscapedCharacter(tableName.getTableName())))) {
-                    minMaxResultSet.next(); // expecting one result row
-                    long min = minMaxResultSet.getLong(1);
-                    long max = minMaxResultSet.getLong(2);
-                    Optional<Splitter> optionalSplitter = splitterFactory.getSplitter(primaryKeyColumns.get(0), minMaxResultSet, DEFAULT_NUM_SPLITS);
-
-                    if (optionalSplitter.isPresent()) {
-                        if (max - min < DEFAULT_NUM_SPLITS) {
-                            LOGGER.info("Range too small for splitting (min={}, max={}), skipping", min, max);
-                            return splitClauses;
-                        }
-
-                        Splitter splitter = optionalSplitter.get();
-                        while (splitter.hasNext()) {
-                            String splitClause = splitter.nextRangeClause();
-                            LOGGER.debug("Split generated {}", splitClause);
-                            splitClauses.add(splitClause);
-                        }
-                    }
-                }
-            }
-        }
-        catch (Exception ex) {
-            LOGGER.warn("Unable to split data.", ex);
-        }
-
-        return splitClauses;
-    }
 
     /**
      * Converts an ARRAY column's TYPE_NAME (provided by the jdbc metadata) to an ArrowType.

--- a/athena-postgresql/src/main/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlMetadataHandler.java
+++ b/athena-postgresql/src/main/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlMetadataHandler.java
@@ -449,16 +449,13 @@ public class PostGreSqlMetadataHandler
      * @return List of split clauses, empty if splits cannot be generated or if disabled
      */
 
-    protected List<String> getSplitClauses(final TableName tableName)
+    protected List<String> getSplitClauses(final TableName tableName, final GetSplitsRequest getSplitsRequest)
     {
         List<String> splitClauses = new ArrayList<>();
-        // getSplitClauses is only used by PostgreSQL and Redshift connectors as of now,
-        // and it does not require AwsRequestOverrideConfiguration for FAS_TOKEN query federation.
-        // So keep it as is.
-        // Check for UUID primary keys before attempting MIN/MAX query
-        try (Connection jdbcConnection = getJdbcConnectionFactory().getConnection(getCredentialProvider());
-             ResultSet resultSet = jdbcConnection.getMetaData().getPrimaryKeys(null,
-                     tableName.getSchemaName(), tableName.getTableName())) {
+
+        try (Connection jdbcConnection = getJdbcConnectionFactory().getConnection(
+                getCredentialProvider(getSplitsRequest != null ? getRequestOverrideConfig(getSplitsRequest) : null));
+             ResultSet resultSet = jdbcConnection.getMetaData().getPrimaryKeys(null, tableName.getSchemaName(), tableName.getTableName())) {
             String primaryKeyColumn = null;
             if (resultSet.next()) {
                 primaryKeyColumn = resultSet.getString("COLUMN_NAME");
@@ -477,13 +474,20 @@ public class PostGreSqlMetadataHandler
                          ResultSet minMaxResultSet = statement.executeQuery(String.format(SQL_SPLITS_STRING, primaryKeyColumn, primaryKeyColumn,
                                  wrapNameWithEscapedCharacter(tableName.getSchemaName()), wrapNameWithEscapedCharacter(tableName.getTableName())))) {
                         minMaxResultSet.next(); // expecting one result row
+                        long min = minMaxResultSet.getLong(1);
+                        long max = minMaxResultSet.getLong(2);
                         Optional<Splitter> optionalSplitter = splitterFactory.getSplitter(primaryKeyColumn, minMaxResultSet, DEFAULT_NUM_SPLITS);
 
                         if (optionalSplitter.isPresent()) {
+                            if (max - min < DEFAULT_NUM_SPLITS) {
+                                LOGGER.info("Range too small for splitting (min={}, max={}), skipping", min, max);
+                                return splitClauses;
+                            }
+
                             Splitter splitter = optionalSplitter.get();
                             while (splitter.hasNext()) {
                                 String splitClause = splitter.nextRangeClause();
-                                LOGGER.info("Split generated {}", splitClause);
+                                LOGGER.debug("Split generated {}", splitClause);
                                 splitClauses.add(splitClause);
                             }
                         }

--- a/athena-postgresql/src/main/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlMetadataHandler.java
+++ b/athena-postgresql/src/main/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlMetadataHandler.java
@@ -452,6 +452,9 @@ public class PostGreSqlMetadataHandler
     protected List<String> getSplitClauses(final TableName tableName)
     {
         List<String> splitClauses = new ArrayList<>();
+        // getSplitClauses is only used by PostgreSQL and Redshift connectors as of now,
+        // and it does not require AwsRequestOverrideConfiguration for FAS_TOKEN query federation.
+        // So keep it as is.
         // Check for UUID primary keys before attempting MIN/MAX query
         try (Connection jdbcConnection = getJdbcConnectionFactory().getConnection(getCredentialProvider());
              ResultSet resultSet = jdbcConnection.getMetaData().getPrimaryKeys(null,

--- a/athena-postgresql/src/main/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlMetadataHandler.java
+++ b/athena-postgresql/src/main/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlMetadataHandler.java
@@ -49,6 +49,8 @@ import com.amazonaws.athena.connectors.jdbc.manager.JDBCUtil;
 import com.amazonaws.athena.connectors.jdbc.manager.JdbcMetadataHandler;
 import com.amazonaws.athena.connectors.jdbc.manager.PreparedStatementBuilder;
 import com.amazonaws.athena.connectors.jdbc.resolver.JDBCCaseResolver;
+import com.amazonaws.athena.connectors.jdbc.splits.Splitter;
+import com.amazonaws.athena.connectors.jdbc.splits.SplitterFactory;
 import com.amazonaws.athena.connectors.postgresql.resolver.PostGreSqlJDBCCaseResolver;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
@@ -66,11 +68,13 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import static com.amazonaws.athena.connectors.postgresql.PostGreSqlConstants.POSTGRESQL_DEFAULT_PORT;
@@ -103,6 +107,11 @@ public class PostGreSqlMetadataHandler
 
     //Session Property Flag that hints to the engine that the data source is using none default collation
     protected static final String NON_DEFAULT_COLLATE = "non_default_collate";
+    private static final String GET_DATA_TYPE_QUERY = "SELECT data_type FROM information_schema.columns " +
+            "WHERE table_schema = ? AND table_name = ? AND column_name = ?";
+    protected final SplitterFactory splitterFactory = new SplitterFactory();
+    protected static final String SQL_SPLITS_STRING = "select min(%s), max(%s) from %s.%s;";
+    protected static final int DEFAULT_NUM_SPLITS = 20;
 
     /**
      * Instantiates handler to be used by Lambda function directly.
@@ -430,6 +439,91 @@ public class PostGreSqlMetadataHandler
             }
         }
         return charColumns;
+    }
+
+    /**
+     * This method automatically detects and skips UUID columns to prevent flooding PostgreSQL logs
+     * with "function min(uuid) does not exist" errors.
+     *
+     * @param tableName The table to generate split clauses for
+     * @return List of split clauses, empty if splits cannot be generated or if disabled
+     */
+
+    protected List<String> getSplitClauses(final TableName tableName)
+    {
+        List<String> splitClauses = new ArrayList<>();
+        // Check for UUID primary keys before attempting MIN/MAX query
+        try (Connection jdbcConnection = getJdbcConnectionFactory().getConnection(getCredentialProvider());
+             ResultSet resultSet = jdbcConnection.getMetaData().getPrimaryKeys(null,
+                     tableName.getSchemaName(), tableName.getTableName())) {
+            String primaryKeyColumn = null;
+            if (resultSet.next()) {
+                primaryKeyColumn = resultSet.getString("COLUMN_NAME");
+            }
+
+            if (primaryKeyColumn != null) {
+                // Check if the primary key column is UUID type
+                if (isUuidColumn(jdbcConnection, tableName, primaryKeyColumn)) {
+                    LOGGER.info("Primary key '{}' is UUID type. Skipping split generation for table: {}.{} " +
+                                    "(UUID columns do not support MIN/MAX functions in PostgreSQL)",
+                            primaryKeyColumn, tableName.getSchemaName(), tableName.getTableName());
+                    return splitClauses;
+                }
+                else {
+                    try (Statement statement = jdbcConnection.createStatement();
+                         ResultSet minMaxResultSet = statement.executeQuery(String.format(SQL_SPLITS_STRING, primaryKeyColumn, primaryKeyColumn,
+                                 wrapNameWithEscapedCharacter(tableName.getSchemaName()), wrapNameWithEscapedCharacter(tableName.getTableName())))) {
+                        minMaxResultSet.next(); // expecting one result row
+                        Optional<Splitter> optionalSplitter = splitterFactory.getSplitter(primaryKeyColumn, minMaxResultSet, DEFAULT_NUM_SPLITS);
+
+                        if (optionalSplitter.isPresent()) {
+                            Splitter splitter = optionalSplitter.get();
+                            while (splitter.hasNext()) {
+                                String splitClause = splitter.nextRangeClause();
+                                LOGGER.info("Split generated {}", splitClause);
+                                splitClauses.add(splitClause);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        catch (Exception ex) {
+            LOGGER.warn("Unable to split data.", ex);
+        }
+        return splitClauses;
+    }
+
+    /**
+     * Checks if a column is of UUID type in PostgreSQL.
+     *
+     * @param connection JDBC connection
+     * @param tableName Table containing the column
+     * @param columnName Column to check
+     * @return true if column is UUID type, false otherwise
+     */
+    private boolean isUuidColumn(Connection connection, TableName tableName, String columnName)
+    {
+        try (PreparedStatement stmt = connection.prepareStatement(GET_DATA_TYPE_QUERY)) {
+            stmt.setString(1, tableName.getSchemaName());
+            stmt.setString(2, tableName.getTableName());
+            stmt.setString(3, columnName);
+
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) {
+                    String dataType = rs.getString("data_type");
+                    LOGGER.debug("Data type for Column: {}.{}.{} is: {}",
+                            tableName.getSchemaName(), tableName.getTableName(), columnName, dataType);
+                    return "uuid".equalsIgnoreCase(dataType);
+                }
+            }
+        }
+        catch (SQLException ex) {
+            LOGGER.warn("Error checking if column {} is UUID type for table {}.{}: {}",
+                    columnName, tableName.getSchemaName(), tableName.getTableName(), ex.getMessage());
+        }
+
+        return false;
     }
 
     protected String wrapNameWithEscapedCharacter(String input)

--- a/athena-postgresql/src/test/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlMetadataHandlerTest.java
+++ b/athena-postgresql/src/test/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlMetadataHandlerTest.java
@@ -1074,7 +1074,7 @@ public class PostGreSqlMetadataHandlerTest
         TableName tableName = getTableName();
         mockPrimaryKeys(null, false);
 
-        List<String> result = postGreSqlMetadataHandler.getSplitClauses(tableName);
+        List<String> result = postGreSqlMetadataHandler.getSplitClauses(tableName, null);
 
         Assert.assertNotNull(result);
         Assert.assertTrue("Expected empty list when no primary key exists", result.isEmpty());
@@ -1091,7 +1091,7 @@ public class PostGreSqlMetadataHandlerTest
         mockPrimaryKeys("id", true);
         mockDataTypeCheck("uuid");
 
-        List<String> result = postGreSqlMetadataHandler.getSplitClauses(tableName);
+        List<String> result = postGreSqlMetadataHandler.getSplitClauses(tableName, null);
 
         Assert.assertNotNull(result);
         Assert.assertTrue("Expected empty list when primary key is UUID", result.isEmpty());
@@ -1109,7 +1109,7 @@ public class PostGreSqlMetadataHandlerTest
         mockDataTypeCheck("integer");
         mockMinMaxQuery("order_id", 100);
 
-        List<String> result = postGreSqlMetadataHandler.getSplitClauses(tableName);
+        List<String> result = postGreSqlMetadataHandler.getSplitClauses(tableName, null);
 
         Assert.assertNotNull(result);
         Assert.assertFalse("Expected non-empty list when splits can be generated", result.isEmpty());
@@ -1126,7 +1126,7 @@ public class PostGreSqlMetadataHandlerTest
         when(connection.getMetaData().getPrimaryKeys(null, "testSchema", "errorTable"))
                 .thenThrow(new SQLException("Database connection error"));
 
-        List<String> result = postGreSqlMetadataHandler.getSplitClauses(tableName);
+        List<String> result = postGreSqlMetadataHandler.getSplitClauses(tableName, null);
 
         Assert.assertNotNull(result);
         Assert.assertTrue("Expected empty list when exception occurs", result.isEmpty());
@@ -1144,7 +1144,7 @@ public class PostGreSqlMetadataHandlerTest
         mockDataTypeCheck(null);
         mockMinMaxQuery("product_id", 50);
 
-        List<String> result = postGreSqlMetadataHandler.getSplitClauses(tableName);
+        List<String> result = postGreSqlMetadataHandler.getSplitClauses(tableName, null);
 
         Assert.assertNotNull(result);
         Assert.assertFalse("Expected splits to be generated when UUID check returns false", result.isEmpty());
@@ -1165,7 +1165,7 @@ public class PostGreSqlMetadataHandlerTest
 
         mockMinMaxQuery("id", 100);
 
-        List<String> result = postGreSqlMetadataHandler.getSplitClauses(tableName);
+        List<String> result = postGreSqlMetadataHandler.getSplitClauses(tableName, null);
 
         Assert.assertNotNull(result);
         Assert.assertFalse("Expected splits to be generated when UUID check throws exception", result.isEmpty());
@@ -1342,8 +1342,10 @@ public class PostGreSqlMetadataHandlerTest
         when(minMaxResultSet.getMetaData()).thenReturn(minMaxMetadata);
         when(minMaxMetadata.getColumnType(1)).thenReturn(Types.INTEGER);
 
-        when(minMaxResultSet.getInt(1)).thenReturn(1);
-        when(minMaxResultSet.getInt(2)).thenReturn(maxValue);
+        /*when(minMaxResultSet.getInt(1)).thenReturn(1);
+        when(minMaxResultSet.getInt(2)).thenReturn(maxValue);*/
+        when(minMaxResultSet.getLong(1)).thenReturn(1L);
+        when(minMaxResultSet.getLong(2)).thenReturn((long) maxValue);
     }
 
     private TableName getTableName()

--- a/athena-postgresql/src/test/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlMetadataHandlerTest.java
+++ b/athena-postgresql/src/test/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlMetadataHandlerTest.java
@@ -1064,6 +1064,132 @@ public class PostGreSqlMetadataHandlerTest
         assertEquals(PostGreSqlMetadataHandler.BLOCK_PARTITION_COLUMN_NAME, partitionSchema.getFields().get(1).getName());
     }
 
+    /**
+     * Test getSplitClauses when table has no primary key.
+     * Expected: Returns empty list.
+     */
+    @Test
+    public void getSplitClauses_NoPrimaryKey_ReturnsEmptyList() throws Exception
+    {
+        TableName tableName = getTableName();
+        mockPrimaryKeys(null, false);
+
+        List<String> result = postGreSqlMetadataHandler.getSplitClauses(tableName);
+
+        Assert.assertNotNull(result);
+        Assert.assertTrue("Expected empty list when no primary key exists", result.isEmpty());
+    }
+
+    /**
+     * Test getSplitClauses when primary key is UUID type.
+     * Expected: Returns empty list and skips split generation.
+     */
+    @Test
+    public void getSplitClauses_UuidPrimaryKey_ReturnsEmptyList() throws Exception
+    {
+        TableName tableName = getTableName();
+        mockPrimaryKeys("id", true);
+        mockDataTypeCheck("uuid");
+
+        List<String> result = postGreSqlMetadataHandler.getSplitClauses(tableName);
+
+        Assert.assertNotNull(result);
+        Assert.assertTrue("Expected empty list when primary key is UUID", result.isEmpty());
+    }
+
+    /**
+     * Test getSplitClauses when primary key is INTEGER and splitter returns splits.
+     * Expected: Returns list of split clauses.
+     */
+    @Test
+    public void getSplitClauses_IntegerPrimaryKey_ReturnsSplitClauses() throws Exception
+    {
+        TableName tableName = getTableName();
+        mockPrimaryKeys("order_id", true);
+        mockDataTypeCheck("integer");
+        mockMinMaxQuery("order_id", 100);
+
+        List<String> result = postGreSqlMetadataHandler.getSplitClauses(tableName);
+
+        Assert.assertNotNull(result);
+        Assert.assertFalse("Expected non-empty list when splits can be generated", result.isEmpty());
+    }
+
+    /**
+     * Test getSplitClauses when an exception occurs during processing.
+     * Expected: Returns empty list and logs warning.
+     */
+    @Test
+    public void getSplitClauses_ExceptionDuringProcessing_ReturnsEmptyList() throws Exception
+    {
+        TableName tableName = new TableName("testSchema", "errorTable");
+        when(connection.getMetaData().getPrimaryKeys(null, "testSchema", "errorTable"))
+                .thenThrow(new SQLException("Database connection error"));
+
+        List<String> result = postGreSqlMetadataHandler.getSplitClauses(tableName);
+
+        Assert.assertNotNull(result);
+        Assert.assertTrue("Expected empty list when exception occurs", result.isEmpty());
+    }
+
+    /**
+     * Test getSplitClauses when UUID check returns false (column exists but is not UUID).
+     * Expected: Proceeds to generate splits.
+     */
+    @Test
+    public void getSplitClauses_UuidCheckReturnsFalse_GeneratesSplits() throws Exception
+    {
+        TableName tableName = getTableName();
+        mockPrimaryKeys("product_id", true);
+        mockDataTypeCheck(null);
+        mockMinMaxQuery("product_id", 50);
+
+        List<String> result = postGreSqlMetadataHandler.getSplitClauses(tableName);
+
+        Assert.assertNotNull(result);
+        Assert.assertFalse("Expected splits to be generated when UUID check returns false", result.isEmpty());
+    }
+
+    /**
+     * Test getSplitClauses when UUID check throws exception.
+     * Expected: Proceeds to generate splits (fallback).
+     */
+    @Test
+    public void getSplitClauses_UuidCheckThrowsException_GeneratesSplits() throws Exception
+    {
+        TableName tableName = getTableName();
+        mockPrimaryKeys("id", true);
+
+        when(connection.prepareStatement(Mockito.contains("SELECT data_type FROM information_schema.columns")))
+                .thenThrow(new SQLException("UUID check failed"));
+
+        mockMinMaxQuery("id", 100);
+
+        List<String> result = postGreSqlMetadataHandler.getSplitClauses(tableName);
+
+        Assert.assertNotNull(result);
+        Assert.assertFalse("Expected splits to be generated when UUID check throws exception", result.isEmpty());
+    }
+
+    /**
+     * Helper method to mock primary keys result set.
+     */
+    private void mockPrimaryKeys(String columnName, boolean hasPrimaryKey) throws SQLException
+    {
+        ResultSet primaryKeysResultSet = Mockito.mock(ResultSet.class);
+        if (hasPrimaryKey) {
+            when(primaryKeysResultSet.next()).thenReturn(true).thenReturn(false);
+            when(primaryKeysResultSet.getString("COLUMN_NAME")).thenReturn(columnName);
+        }
+        else {
+            when(primaryKeysResultSet.next()).thenReturn(false);
+        }
+
+        when(connection.getMetaData().getPrimaryKeys(null, "testSchema", "testTable"))
+                .thenReturn(primaryKeysResultSet);
+
+    }
+
     private void verifyCommonCapabilities(GetDataSourceCapabilitiesResponse response)
     {
         Map<String, List<OptimizationSubType>> capabilities = response.getCapabilities();
@@ -1177,6 +1303,52 @@ public class PostGreSqlMetadataHandlerTest
             when(tableResultSet.getString("table_name")).thenReturn(resolvedTableName);
         }
 
+    }
+
+    /**
+     * Helper method to mock UUID type check with a specific data type.
+     */
+    private void mockDataTypeCheck(String dataType) throws SQLException
+    {
+        PreparedStatement uuidCheckStmt = Mockito.mock(PreparedStatement.class);
+        ResultSet uuidCheckResultSet = Mockito.mock(ResultSet.class);
+
+        when(connection.prepareStatement(Mockito.contains("SELECT data_type FROM information_schema.columns")))
+                .thenReturn(uuidCheckStmt);
+        when(uuidCheckStmt.executeQuery()).thenReturn(uuidCheckResultSet);
+
+        if (dataType != null) {
+            when(uuidCheckResultSet.next()).thenReturn(true);
+            when(uuidCheckResultSet.getString("data_type")).thenReturn(dataType);
+        }
+        else {
+            when(uuidCheckResultSet.next()).thenReturn(false);
+        }
+    }
+
+    /**
+     * Helper method to mock MIN/MAX query execution.
+     */
+    private void mockMinMaxQuery(String columnName, int maxValue) throws SQLException
+    {
+        java.sql.Statement statement = Mockito.mock(java.sql.Statement.class);
+        ResultSet minMaxResultSet = Mockito.mock(ResultSet.class);
+        java.sql.ResultSetMetaData minMaxMetadata = Mockito.mock(java.sql.ResultSetMetaData.class);
+
+        when(connection.createStatement()).thenReturn(statement);
+        when(statement.executeQuery(Mockito.contains("select min(" + columnName + "), max(" + columnName + ")")))
+                .thenReturn(minMaxResultSet);
+        when(minMaxResultSet.next()).thenReturn(true);
+        when(minMaxResultSet.getMetaData()).thenReturn(minMaxMetadata);
+        when(minMaxMetadata.getColumnType(1)).thenReturn(Types.INTEGER);
+
+        when(minMaxResultSet.getInt(1)).thenReturn(1);
+        when(minMaxResultSet.getInt(2)).thenReturn(maxValue);
+    }
+
+    private TableName getTableName()
+    {
+        return new TableName("testSchema", "testTable");
     }
 
 }

--- a/athena-redshift/src/main/java/com/amazonaws/athena/connectors/redshift/RedshiftMetadataHandler.java
+++ b/athena-redshift/src/main/java/com/amazonaws/athena/connectors/redshift/RedshiftMetadataHandler.java
@@ -24,6 +24,7 @@ import com.amazonaws.athena.connector.lambda.domain.TableName;
 import com.amazonaws.athena.connector.lambda.domain.predicate.functions.StandardFunctions;
 import com.amazonaws.athena.connector.lambda.metadata.GetDataSourceCapabilitiesRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetDataSourceCapabilitiesResponse;
+import com.amazonaws.athena.connector.lambda.metadata.GetSplitsRequest;
 import com.amazonaws.athena.connector.lambda.metadata.optimizations.DataSourceOptimizations;
 import com.amazonaws.athena.connector.lambda.metadata.optimizations.OptimizationSubType;
 import com.amazonaws.athena.connector.lambda.metadata.optimizations.pushdown.ComplexExpressionPushdownSubType;
@@ -131,13 +132,11 @@ public class RedshiftMetadataHandler
     }
 
     @Override
-    protected List<String> getSplitClauses(final TableName tableName)
+    protected List<String> getSplitClauses(final TableName tableName, final GetSplitsRequest getSplitsRequest)
     {
         List<String> splitClauses = new ArrayList<>();
-        // getSplitClauses is only used by PostgreSQL and Redshift connectors as of now,
-        // and it does not require AwsRequestOverrideConfiguration for FAS_TOKEN query federation.
-        // So keep it as is.
-        try (Connection jdbcConnection = getJdbcConnectionFactory().getConnection(getCredentialProvider());
+        try (Connection jdbcConnection = getJdbcConnectionFactory().getConnection(
+                getCredentialProvider(getSplitsRequest != null ? getRequestOverrideConfig(getSplitsRequest) : null));
              ResultSet resultSet = jdbcConnection.getMetaData().getPrimaryKeys(null, tableName.getSchemaName(), tableName.getTableName())) {
             List<String> primaryKeyColumns = new ArrayList<>();
             while (resultSet.next()) {
@@ -148,13 +147,20 @@ public class RedshiftMetadataHandler
                      ResultSet minMaxResultSet = statement.executeQuery(String.format(SQL_SPLITS_STRING, primaryKeyColumns.get(0), primaryKeyColumns.get(0),
                              wrapNameWithEscapedCharacter(tableName.getSchemaName()), wrapNameWithEscapedCharacter(tableName.getTableName())))) {
                     minMaxResultSet.next(); // expecting one result row
+                    long min = minMaxResultSet.getLong(1);
+                    long max = minMaxResultSet.getLong(2);
                     Optional<Splitter> optionalSplitter = splitterFactory.getSplitter(primaryKeyColumns.get(0), minMaxResultSet, DEFAULT_NUM_SPLITS);
 
                     if (optionalSplitter.isPresent()) {
+                        if (max - min < DEFAULT_NUM_SPLITS) {
+                            LOGGER.info("Range too small for splitting (min={}, max={}), skipping", min, max);
+                            return splitClauses;
+                        }
+
                         Splitter splitter = optionalSplitter.get();
                         while (splitter.hasNext()) {
                             String splitClause = splitter.nextRangeClause();
-                            LOGGER.info("Split generated {}", splitClause);
+                            LOGGER.debug("Split generated {}", splitClause);
                             splitClauses.add(splitClause);
                         }
                     }
@@ -164,6 +170,7 @@ public class RedshiftMetadataHandler
         catch (Exception ex) {
             LOGGER.warn("Unable to split data.", ex);
         }
+
         return splitClauses;
     }
 }

--- a/athena-redshift/src/test/java/com/amazonaws/athena/connectors/redshift/RedshiftMetadataHandlerTest.java
+++ b/athena-redshift/src/test/java/com/amazonaws/athena/connectors/redshift/RedshiftMetadataHandlerTest.java
@@ -535,7 +535,7 @@ public class RedshiftMetadataHandlerTest
         TableName tableName = new TableName(TEST_SCHEMA, TEST_TABLE);
         mockPrimaryKeysForSplits(null, false);
 
-        List<String> result = redshiftMetadataHandler.getSplitClauses(tableName);
+        List<String> result = redshiftMetadataHandler.getSplitClauses(tableName, null);
 
         Assert.assertNotNull(result);
         Assert.assertTrue("Expected empty list when no primary key exists", result.isEmpty());
@@ -548,7 +548,7 @@ public class RedshiftMetadataHandlerTest
         mockPrimaryKeysForSplits("order_id", true);
         mockMinMaxQueryForSplits("order_id");
 
-        List<String> result = redshiftMetadataHandler.getSplitClauses(tableName);
+        List<String> result = redshiftMetadataHandler.getSplitClauses(tableName, null);
 
         Assert.assertNotNull(result);
         Assert.assertFalse("Expected non-empty list when splits can be generated", result.isEmpty());
@@ -561,7 +561,7 @@ public class RedshiftMetadataHandlerTest
         Mockito.when(connection.getMetaData().getPrimaryKeys(null, TEST_SCHEMA, "errorTable"))
                 .thenThrow(new SQLException("Database connection error"));
 
-        List<String> result = redshiftMetadataHandler.getSplitClauses(tableName);
+        List<String> result = redshiftMetadataHandler.getSplitClauses(tableName, null);
 
         Assert.assertNotNull(result);
         Assert.assertTrue("Expected empty list when exception occurs", result.isEmpty());
@@ -580,7 +580,7 @@ public class RedshiftMetadataHandlerTest
         
         mockMinMaxQueryForSplits("id");
 
-        List<String> result = redshiftMetadataHandler.getSplitClauses(tableName);
+        List<String> result = redshiftMetadataHandler.getSplitClauses(tableName, null);
 
         Assert.assertNotNull(result);
         Assert.assertFalse("Expected splits to be generated using first primary key column", result.isEmpty());
@@ -620,7 +620,9 @@ public class RedshiftMetadataHandlerTest
         Mockito.when(minMaxResultSet.getMetaData()).thenReturn(minMaxMetadata);
         Mockito.when(minMaxMetadata.getColumnType(1)).thenReturn(Types.INTEGER);
 
-        Mockito.when(minMaxResultSet.getInt(1)).thenReturn(1);
-        Mockito.when(minMaxResultSet.getInt(2)).thenReturn(100);
+        /*Mockito.when(minMaxResultSet.getInt(1)).thenReturn(1);
+        Mockito.when(minMaxResultSet.getInt(2)).thenReturn(100);*/
+        Mockito.when(minMaxResultSet.getLong(1)).thenReturn(1L);
+        Mockito.when(minMaxResultSet.getLong(2)).thenReturn(100L);
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-athena-query-federation/issues/3102
*Description of changes:*
Moved getSplitClauses() to Postgres since it is used only by the PostgreSQL connector. Also added a condition to skip split generation for UUID primary key columns, as PostgreSQL does not support MIN/MAX on UUIDs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
