### PR TITLE
Fix Build and Deploy GitHub Action failure and copyright license headers warnings

### DIFF
--- a/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/query/BigQueryPredicateBuilder.java
+++ b/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/query/BigQueryPredicateBuilder.java
@@ -2,7 +2,7 @@
  * #%L
  * athena-google-bigquery
  * %%
- * Copyright (C) 2019-2025 Amazon Web Services
+ * Copyright (C) 2019 - 2025 Amazon Web Services
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/query/BigQueryQueryBuilder.java
+++ b/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/query/BigQueryQueryBuilder.java
@@ -2,7 +2,7 @@
  * #%L
  * athena-google-bigquery
  * %%
- * Copyright (C) 2019-2025 Amazon Web Services
+ * Copyright (C) 2019 - 2025 Amazon Web Services
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/JdbcEnvironmentPropertiesTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/JdbcEnvironmentPropertiesTest.java
@@ -2,7 +2,7 @@
  * #%L
  * athena-jdbc
  * %%
- * Copyright (C) 2019-2025 Amazon Web Services
+ * Copyright (C) 2019 - 2025 Amazon Web Services
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -507,24 +507,6 @@
                     <notimestamp>true</notimestamp>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <version>3.6.2</version>
-                <executions>
-                    <execution>
-                        <id>print-java-info</id>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <configuration>
-                            <executable>bash</executable>
-                            <commandlineArgs>-c "echo '[INFO] ========================================'; echo '[INFO] Maven Build Configuration Verification'; echo '[INFO] ========================================'; if [ '${maven.compiler.release}' = '8' ]; then echo '[INFO] Activated Profile: java8'; elif [ '${maven.compiler.release}' = '17' ]; then echo '[INFO] Activated Profile: java17'; else echo '[INFO] Activated Profile: default (Java 11)'; fi; echo '[INFO] maven.compiler.release = ${maven.compiler.release}'; echo '[INFO] Java version = ${java.version}'; echo '[INFO] ========================================'"</commandlineArgs>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
     <profiles>


### PR DESCRIPTION
*Issue #, if available:*
The Build and Deploy (Javadoc aggregation) GitHub Action in the main repository started failing due to the addition of a validate-phase exec-maven-plugin in the root pom.xml.
*Description of changes:*
Removed the validate-phase exec-maven-plugin, which was used only for logging and had no functional impact and cleaned up copyright license header formatting to eliminate non-blocking warnings. Please find attached screenshots for reference.

Before fix:
<img width="1779" height="973" alt="image" src="https://github.com/user-attachments/assets/11657671-af13-49c4-9c00-83a7c167a4f8" />

After fix:
<img width="1757" height="719" alt="image" src="https://github.com/user-attachments/assets/6e50b2b7-1609-4da8-afbe-acd0d65c1d34" />

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
