### PR TITLE
[Fix] SQL Server permission error handling for partition metadata queries

### DIFF
--- a/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerMetadataHandler.java
+++ b/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerMetadataHandler.java
@@ -297,9 +297,12 @@ public class SqlServerMetadataHandler extends JdbcMetadataHandler
                 }
             }
             catch (SQLServerException e) {
-                // for permission denied sqlServer exception retuning single partition
-                if (e.getMessage().contains("VIEW DATABASE STATE permission denied")) {
-                    LOGGER.warn("Permission denied to view database state for {}", e.getMessage());
+                // For permission denied SQL Server exception, return single partition
+                // SQL Server 2022 and later: "VIEW DATABASE PERFORMANCE STATE permission denied"
+                String message = e.getMessage();
+                if (message != null && (message.contains("VIEW DATABASE STATE permission denied")
+                        || message.contains("VIEW DATABASE PERFORMANCE STATE permission denied"))) {
+                    LOGGER.warn("Permission denied while accessing partition metadata: {}", message);
                     handleSinglePartition(blockWriter);
                 }
                 else {


### PR DESCRIPTION
***Issue #, if available:***
TABLE_NOT_FOUND: line 1:15: Table '"lambda:sqlserver-master-19-02-2026".dbo.partition_table' does not exist

java.lang.RuntimeException: com.microsoft.sqlserver.jdbc.SQLServerException: VIEW DATABASE PERFORMANCE STATE permission denied in database 'test_db'.

**Root Cause:**
The SQL Server connector currently handles only the "VIEW DATABASE STATE permission denied" error when querying sys.dm_db_partition_stats.

According to the official [SQL Server documentation](https://learn.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-db-partition-stats-transact-sql?view=sql-server-ver17#permissions-for-sql-server-2022-and-later), SQL Server 2022 and later require the **VIEW DATABASE PERFORMANCE STATE** permission on the database to access sys.dm_db_partition_stats for executing partition queries.

When this permission is missing, SQL Server throws a "**VIEW DATABASE PERFORMANCE STATE permission denied**" error, which is not detected by the existing error-handling logic.

***Description of changes:***
This PR handles both variations of the permission-denied error message and falls back to single-partition behavior when access to partition metadata is not permitted. Please find attached screenshots for reference.

Before fix:
<img width="1376" height="382" alt="image" src="https://github.com/user-attachments/assets/a37df92f-aa99-436c-af97-922e7db4ef6d" />

After fix:
<img width="1384" height="596" alt="image" src="https://github.com/user-attachments/assets/e4d8179d-f877-49d6-a852-6f384ab44d83" />

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
