### PR TITLE
Neptune Gremlin QPT Enhancement for valueMap Traversal Queries

### DIFF
--- a/athena-neptune/src/main/java/com/amazonaws/athena/connectors/neptune/propertygraph/rowwriters/CustomSchemaRowWriter.java
+++ b/athena-neptune/src/main/java/com/amazonaws/athena/connectors/neptune/propertygraph/rowwriters/CustomSchemaRowWriter.java
@@ -43,8 +43,8 @@ import org.apache.tinkerpop.gremlin.structure.T;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
@@ -81,18 +81,14 @@ public final class CustomSchemaRowWriter
                             logger.debug("writeRowTemplate BIT*" + field.getName() + "*" + minorType + "*"
                                     + (fieldValue == null ? "" : fieldValue.getClass()) + "*");
 
-                            if (fieldValue.getClass().equals(Boolean.class)) {
-                                Boolean booleanValue = Boolean.parseBoolean(fieldValue.toString());
+                            if (fieldValue == null) {
+                                return;
+                            }
+                            List<Object> objValues = FieldValueNormalizer.toValueList(fieldValue);
+                            if (objValues != null && !objValues.isEmpty() && objValues.get(0) != null && !(objValues.get(0).toString().trim().isEmpty())) {
+                                Boolean booleanValue = Boolean.parseBoolean(objValues.get(0).toString());
                                 value.value = booleanValue ? 1 : 0;
                                 value.isSet = 1;
-                            }
-                            else if (fieldValue instanceof ArrayList) {
-                                ArrayList<Object> objValues = (ArrayList) obj.get(field.getName());
-                                if (objValues != null && objValues.get(0) != null && !(objValues.get(0).toString().trim().isEmpty())) {
-                                    Boolean booleanValue = Boolean.parseBoolean(objValues.get(0).toString());
-                                    value.value = booleanValue ? 1 : 0;
-                                    value.isSet = 1;
-                                }
                             }
                         });
                 break;
@@ -118,26 +114,16 @@ public final class CustomSchemaRowWriter
                                         + (fieldValue == null ? "" : fieldValue.getClass()) + "*");
 
                                 if (fieldValue != null) {
-                                    if (fieldValue.getClass().equals(String.class)) {
-                                        value.value = fieldValue.toString();
-                                        value.isSet = 1;
-                                    }
-                                    else if (fieldValue instanceof ArrayList) {
-                                        ArrayList<Object> objValues = (ArrayList) fieldValue;
-                                        if (objValues != null && objValues.get(0) != null) {
-                                            if (objValues.size() > 1) {
-                                                value.value = String.join(";", objValues.stream()
-                                                        .map(Object::toString)
-                                                        .collect(Collectors.toList()));
-                                            }
-                                            else {
-                                                value.value = objValues.get(0).toString();
-                                            }
-                                            value.isSet = 1;
+                                    List<Object> objValues = FieldValueNormalizer.toValueList(fieldValue);
+                                    if (objValues != null && !objValues.isEmpty() && objValues.get(0) != null) {
+                                        if (objValues.size() > 1) {
+                                            value.value = String.join(";", objValues.stream()
+                                                    .map(o -> o == null ? "" : o.toString())
+                                                    .collect(Collectors.toList()));
                                         }
-                                    }
-                                    else {
-                                        value.value = "" + fieldValue;
+                                        else {
+                                            value.value = objValues.get(0).toString();
+                                        }
                                         value.isSet = 1;
                                     }
                                 }
@@ -155,14 +141,18 @@ public final class CustomSchemaRowWriter
                             Object fieldValue = obj.get(fieldName);
                             logger.debug("writeRowTemplate DATEMILLI*" + field.getName() + "*" + minorType + "*"
                                     + (fieldValue == null ? "" : fieldValue.getClass()) + "*");
-                            if (fieldValue.getClass().equals(Date.class)) {
-                                value.value = ((Date) fieldValue).getTime();
-                                value.isSet = 1;
+                            if (fieldValue == null) {
+                                return;
                             }
-                            else if (fieldValue instanceof ArrayList) {
-                                ArrayList<Object> objValues = (ArrayList) fieldValue;
-                                if (objValues != null && (objValues.get(0) != null) && !(objValues.get(0).toString().trim().isEmpty())) {
-                                    value.value = ((Date) objValues.get(0)).getTime();
+                            List<Object> objValues = FieldValueNormalizer.toValueList(fieldValue);
+                            if (objValues != null && !objValues.isEmpty() && objValues.get(0) != null && !(objValues.get(0).toString().trim().isEmpty())) {
+                                Object first = objValues.get(0);
+                                if (first instanceof Date) {
+                                    value.value = ((Date) first).getTime();
+                                    value.isSet = 1;
+                                }
+                                else {
+                                    value.value = Long.parseLong(first.toString());
                                     value.isSet = 1;
                                 }
                             }
@@ -179,16 +169,13 @@ public final class CustomSchemaRowWriter
                             Object fieldValue = obj.get(fieldName);
                             logger.debug("writeRowTemplate INT*" + field.getName() + "*" + minorType + "*"
                                     + (fieldValue == null ? "" : fieldValue.getClass()) + "*");
-                            if (fieldValue.getClass().equals(Integer.class)) {
-                                value.value = Integer.parseInt(fieldValue.toString());
-                                value.isSet = 1;
+                            if (fieldValue == null) {
+                                return;
                             }
-                            else if (fieldValue instanceof ArrayList) {
-                                ArrayList<Object> objValues = (ArrayList) fieldValue;
-                                if (objValues != null && objValues.get(0) != null && !(objValues.get(0).toString().trim().isEmpty())) {
-                                    value.value = Integer.parseInt(objValues.get(0).toString());
-                                    value.isSet = 1;
-                                }
+                            List<Object> objValues = FieldValueNormalizer.toValueList(fieldValue);
+                            if (objValues != null && !objValues.isEmpty() && objValues.get(0) != null && !(objValues.get(0).toString().trim().isEmpty())) {
+                                value.value = Integer.parseInt(objValues.get(0).toString());
+                                value.isSet = 1;
                             }
                         });
                 break;
@@ -203,16 +190,13 @@ public final class CustomSchemaRowWriter
                             Object fieldValue = obj.get(fieldName);
                             logger.debug("writeRowTemplate BIGINT*" + field.getName() + "*" + minorType + "*"
                                     + (fieldValue == null ? "" : fieldValue.getClass()) + "*");
-                            if (fieldValue.getClass().equals(Long.class)) {
-                                value.value = Long.parseLong(fieldValue.toString());
-                                value.isSet = 1;
+                            if (fieldValue == null) {
+                                return;
                             }
-                            else if (fieldValue instanceof ArrayList) {
-                                ArrayList<Object> objValues = (ArrayList) fieldValue;
-                                if (objValues != null && objValues.get(0) != null && !(objValues.get(0).toString().trim().isEmpty())) {
-                                    value.value = Long.parseLong(objValues.get(0).toString());
-                                    value.isSet = 1;
-                                }
+                            List<Object> objValues = FieldValueNormalizer.toValueList(fieldValue);
+                            if (objValues != null && !objValues.isEmpty() && objValues.get(0) != null && !(objValues.get(0).toString().trim().isEmpty())) {
+                                value.value = Long.parseLong(objValues.get(0).toString());
+                                value.isSet = 1;
                             }
                         });
                 break;
@@ -227,16 +211,13 @@ public final class CustomSchemaRowWriter
                             Object fieldValue = obj.get(fieldName);
                             logger.debug("writeRowTemplate FLOAT4*" + field.getName() + "*" + minorType + "*"
                                     + (fieldValue == null ? "" : fieldValue.getClass()) + "*");
-                            if (fieldValue.getClass().equals(Float.class)) {
-                                value.value = Float.parseFloat(fieldValue.toString());
-                                value.isSet = 1;
+                            if (fieldValue == null) {
+                                return;
                             }
-                            else if (fieldValue instanceof ArrayList) {
-                                ArrayList<Object> objValues = (ArrayList) fieldValue;
-                                if (objValues != null && objValues.get(0) != null && !(objValues.get(0).toString().trim().isEmpty())) {
-                                    value.value = Float.parseFloat(objValues.get(0).toString());
-                                    value.isSet = 1;
-                                }
+                            List<Object> objValues = FieldValueNormalizer.toValueList(fieldValue);
+                            if (objValues != null && !objValues.isEmpty() && objValues.get(0) != null && !(objValues.get(0).toString().trim().isEmpty())) {
+                                value.value = Float.parseFloat(objValues.get(0).toString());
+                                value.isSet = 1;
                             }
                         });
                 break;
@@ -251,16 +232,13 @@ public final class CustomSchemaRowWriter
                             Object fieldValue = obj.get(fieldName);
                             logger.debug("writeRowTemplate FLOAT8*" + field.getName() + "*" + minorType + "*"
                                     + (fieldValue == null ? "" : fieldValue.getClass()) + "*");
-                            if (fieldValue.getClass().equals(Double.class)) {
-                                value.value = Double.parseDouble(fieldValue.toString());
-                                value.isSet = 1;
+                            if (fieldValue == null) {
+                                return;
                             }
-                            else if (fieldValue instanceof ArrayList) {
-                                ArrayList<Object> objValues = (ArrayList) fieldValue;
-                                if (objValues != null && objValues.get(0) != null && !(objValues.get(0).toString().trim().isEmpty())) {
-                                    value.value = Double.parseDouble(objValues.get(0).toString());
-                                    value.isSet = 1;
-                                }
+                            List<Object> objValues = FieldValueNormalizer.toValueList(fieldValue);
+                            if (objValues != null && !objValues.isEmpty() && objValues.get(0) != null && !(objValues.get(0).toString().trim().isEmpty())) {
+                                value.value = Double.parseDouble(objValues.get(0).toString());
+                                value.isSet = 1;
                             }
                         });
 

--- a/athena-neptune/src/main/java/com/amazonaws/athena/connectors/neptune/propertygraph/rowwriters/EdgeRowWriter.java
+++ b/athena-neptune/src/main/java/com/amazonaws/athena/connectors/neptune/propertygraph/rowwriters/EdgeRowWriter.java
@@ -44,8 +44,10 @@ import org.apache.tinkerpop.gremlin.structure.T;
 
 import java.util.Date;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
 
 /**
  * This class is a Utility class to create Extractors for each field type as per
@@ -69,11 +71,11 @@ public final class EdgeRowWriter
                 rowWriterBuilder.withExtractor(field.getName(),
                         (BitExtractor) (Object context, NullableBitHolder value) -> {
                             Map<String, Object> obj = (Map<String, Object>) contextAsMap(context, enableCaseinsensitivematch);
-                            Object fieldValue = obj.get(field.getName());
-                            value.isSet = 0;
+                            List<Object> objValues = FieldValueNormalizer.toValueList(obj.get(field.getName()));
 
-                            if (fieldValue != null && !(fieldValue.toString().trim().isEmpty())) {
-                                Boolean booleanValue = Boolean.parseBoolean(fieldValue.toString());
+                            value.isSet = 0;
+                            if (objValues != null && !objValues.isEmpty() && objValues.get(0) != null && !(objValues.get(0).toString().trim().isEmpty())) {
+                                Boolean booleanValue = Boolean.parseBoolean(objValues.get(0).toString());
                                 value.value = booleanValue ? 1 : 0;
                                 value.isSet = 1;
                             }
@@ -83,14 +85,44 @@ public final class EdgeRowWriter
             case VARCHAR:
                 rowWriterBuilder.withExtractor(field.getName(),
                         (VarCharExtractor) (Object context, NullableVarCharHolder value) -> {
-                            Map<String, Object> obj = (Map<String, Object>) contextAsMap(context, enableCaseinsensitivematch);
                             String fieldName = field.getName();
+                            Map<String, Object> obj = (Map<String, Object>) contextAsMap(context, enableCaseinsensitivematch);
+
                             value.isSet = 0;
-                            Object fieldValue = obj.get(fieldName);
-                            
-                            if (fieldValue != null) {
-                                value.value = fieldValue.toString();
-                                value.isSet = 1;
+                            if (fieldName.equals(SpecialKeys.ID.toString().toLowerCase())) {
+                                Object fieldValue = obj.get(SpecialKeys.ID.toString());
+                                if (fieldValue != null) {
+                                    value.value = fieldValue.toString();
+                                    value.isSet = 1;
+                                }
+                            }
+                            else if (fieldName.equals(SpecialKeys.IN.toString().toLowerCase())) {
+                                Object fieldValue = obj.get(SpecialKeys.IN.toString());
+                                if (fieldValue != null) {
+                                    value.value = fieldValue.toString();
+                                    value.isSet = 1;
+                                }
+                            }
+                            else if (fieldName.equals(SpecialKeys.OUT.toString().toLowerCase())) {
+                                Object fieldValue = obj.get(SpecialKeys.OUT.toString());
+                                if (fieldValue != null) {
+                                    value.value = fieldValue.toString();
+                                    value.isSet = 1;
+                                }
+                            }
+                            else {
+                                List<Object> objValues = FieldValueNormalizer.toValueList(obj.get(fieldName));
+                                if (objValues != null && !objValues.isEmpty() && objValues.get(0) != null) {
+                                    if (objValues.size() > 1) {
+                                        value.value = String.join(";", objValues.stream()
+                                                .map(o -> o == null ? "" : o.toString())
+                                                .collect(Collectors.toList()));
+                                    }
+                                    else {
+                                        value.value = objValues.get(0).toString();
+                                    }
+                                    value.isSet = 1;
+                                }
                             }
                         });
                 break;
@@ -98,13 +130,21 @@ public final class EdgeRowWriter
             case DATEMILLI:
                 rowWriterBuilder.withExtractor(field.getName(),
                         (DateMilliExtractor) (Object context, NullableDateMilliHolder value) -> {
+                            String fieldName = field.getName();
                             Map<String, Object> obj = (Map<String, Object>) contextAsMap(context, enableCaseinsensitivematch);
-                            Object fieldValue = obj.get(field.getName());
-                            value.isSet = 0;
+                            List<Object> objValues = FieldValueNormalizer.toValueList(obj.get(fieldName));
 
-                            if (fieldValue != null && !(fieldValue.toString().trim().isEmpty())) {
-                                value.value = ((Date) fieldValue).getTime();
-                                value.isSet = 1;
+                            value.isSet = 0;
+                            if (objValues != null && !objValues.isEmpty() && objValues.get(0) != null && !(objValues.get(0).toString().trim().isEmpty())) {
+                                Object first = objValues.get(0);
+                                if (first instanceof Date) {
+                                    value.value = ((Date) first).getTime();
+                                    value.isSet = 1;
+                                }
+                                else {
+                                    value.value = Long.parseLong(first.toString());
+                                    value.isSet = 1;
+                                }
                             }
                         });
                 break;
@@ -112,12 +152,13 @@ public final class EdgeRowWriter
             case INT:
                 rowWriterBuilder.withExtractor(field.getName(),
                         (IntExtractor) (Object context, NullableIntHolder value) -> {
+                            String fieldName = field.getName();
                             Map<String, Object> obj = (Map<String, Object>) contextAsMap(context, enableCaseinsensitivematch);
-                            Object fieldValue = obj.get(field.getName());
-                            value.isSet = 0;
+                            List<Object> objValues = FieldValueNormalizer.toValueList(obj.get(fieldName));
 
-                            if (fieldValue != null && !(fieldValue.toString().trim().isEmpty())) {
-                                value.value = Integer.parseInt(fieldValue.toString());
+                            value.isSet = 0;
+                            if (objValues != null && !objValues.isEmpty() && objValues.get(0) != null && !(objValues.get(0).toString().trim().isEmpty())) {
+                                value.value = Integer.parseInt(objValues.get(0).toString());
                                 value.isSet = 1;
                             }
                         });
@@ -126,12 +167,13 @@ public final class EdgeRowWriter
             case BIGINT:
                 rowWriterBuilder.withExtractor(field.getName(),
                         (BigIntExtractor) (Object context, NullableBigIntHolder value) -> {
+                            String fieldName = field.getName();
                             Map<String, Object> obj = (Map<String, Object>) contextAsMap(context, enableCaseinsensitivematch);
-                            Object fieldValue = obj.get(field.getName());
-                            value.isSet = 0;
+                            List<Object> objValues = FieldValueNormalizer.toValueList(obj.get(fieldName));
 
-                            if (fieldValue != null && !(fieldValue.toString().trim().isEmpty())) {
-                                value.value = Long.parseLong(fieldValue.toString());
+                            value.isSet = 0;
+                            if (objValues != null && !objValues.isEmpty() && objValues.get(0) != null && !(objValues.get(0).toString().trim().isEmpty())) {
+                                value.value = Long.parseLong(objValues.get(0).toString());
                                 value.isSet = 1;
                             }
                         });
@@ -141,11 +183,11 @@ public final class EdgeRowWriter
                 rowWriterBuilder.withExtractor(field.getName(),
                         (Float4Extractor) (Object context, NullableFloat4Holder value) -> {
                             Map<String, Object> obj = (Map<String, Object>) contextAsMap(context, enableCaseinsensitivematch);
-                            Object fieldValue = obj.get(field.getName());
-                            value.isSet = 0;
+                            List<Object> objValues = FieldValueNormalizer.toValueList(obj.get(field.getName()));
 
-                            if (fieldValue != null && !(fieldValue.toString().trim().isEmpty())) {
-                                value.value = Float.parseFloat(fieldValue.toString());
+                            value.isSet = 0;
+                            if (objValues != null && !objValues.isEmpty() && objValues.get(0) != null && !(objValues.get(0).toString().trim().isEmpty())) {
+                                value.value = Float.parseFloat(objValues.get(0).toString());
                                 value.isSet = 1;
                             }
                         });
@@ -155,11 +197,11 @@ public final class EdgeRowWriter
                 rowWriterBuilder.withExtractor(field.getName(),
                         (Float8Extractor) (Object context, NullableFloat8Holder value) -> {
                             Map<String, Object> obj = (Map<String, Object>) contextAsMap(context, enableCaseinsensitivematch);
-                            Object fieldValue = obj.get(field.getName());
-                            value.isSet = 0;
+                            List<Object> objValues = FieldValueNormalizer.toValueList(obj.get(field.getName()));
 
-                            if (fieldValue != null && !fieldValue.toString().trim().isEmpty()) {
-                                value.value = Double.parseDouble(fieldValue.toString());
+                            value.isSet = 0;
+                            if (objValues != null && !objValues.isEmpty() && objValues.get(0) != null && !(objValues.get(0).toString().trim().isEmpty())) {
+                                value.value = Double.parseDouble(objValues.get(0).toString());
                                 value.isSet = 1;
                             }
                         });
@@ -184,13 +226,12 @@ public final class EdgeRowWriter
 
             contextAsMap.put(SpecialKeys.ID.toString(), fieldValueID);
             contextAsMap.put(SpecialKeys.IN.toString(), fieldValueIN);
-            contextAsMap.put(SpecialKeys.OUT.toString(), fieldValueOUT);         
-        } 
+            contextAsMap.put(SpecialKeys.OUT.toString(), fieldValueOUT);
+        }
 
         if (!caseInsensitive) {
             return contextAsMap;
         }
- 
 
         TreeMap<String, Object> caseInsensitiveMap = new TreeMap<String, Object>(String.CASE_INSENSITIVE_ORDER);
         caseInsensitiveMap.putAll(contextAsMap);

--- a/athena-neptune/src/main/java/com/amazonaws/athena/connectors/neptune/propertygraph/rowwriters/FieldValueNormalizer.java
+++ b/athena-neptune/src/main/java/com/amazonaws/athena/connectors/neptune/propertygraph/rowwriters/FieldValueNormalizer.java
@@ -1,0 +1,75 @@
+/*-
+ * #%L
+ * athena-neptune
+ * %%
+ * Copyright (C) 2019 - 2026 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.neptune.propertygraph.rowwriters;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Normalizes Gremlin result field values so row writers can handle both
+ * valueMap-style results (Map with ArrayList values) and project().by()-style
+ * results (Map with scalar or Map values) without ClassCastException.
+ */
+public final class FieldValueNormalizer
+{
+    private FieldValueNormalizer()
+    {
+    }
+
+    /**
+     * Converts a raw field value from a Gremlin result into a list suitable for
+     * row writers. Handles: valueMap() lists, project().by() scalars, and
+     * .by(valueMap()) Map values (e.g. all_properties).
+     *
+     * @param fieldValue raw value (may be List, Map, scalar, or null)
+     * @return null if fieldValue is null; otherwise a list of one or more
+     * elements that can be read by row writers (Map is serialized to string)
+     */
+    @SuppressWarnings("unchecked")
+    public static List<Object> toValueList(Object fieldValue)
+    {
+        if (fieldValue == null) {
+            return null;
+        }
+        if (fieldValue instanceof List) {
+            return (List<Object>) fieldValue;
+        }
+        if (fieldValue instanceof Map) {
+            return Collections.singletonList(mapToString((Map<?, ?>) fieldValue));
+        }
+        return Collections.singletonList(fieldValue);
+    }
+
+    private static String mapToString(Map<?, ?> map)
+    {
+        if (map == null || map.isEmpty()) {
+            return "{}";
+        }
+        StringBuilder sb = new StringBuilder();
+        for (Map.Entry<?, ?> entry : map.entrySet()) {
+            if (sb.length() > 0) {
+                sb.append(",");
+            }
+            sb.append(entry.getKey()).append("=").append(entry.getValue());
+        }
+        return "{" + sb + "}";
+    }
+}

--- a/athena-neptune/src/main/java/com/amazonaws/athena/connectors/neptune/propertygraph/rowwriters/VertexRowWriter.java
+++ b/athena-neptune/src/main/java/com/amazonaws/athena/connectors/neptune/propertygraph/rowwriters/VertexRowWriter.java
@@ -41,8 +41,8 @@ import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.tinkerpop.gremlin.structure.T;
 
-import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
@@ -51,9 +51,9 @@ import java.util.stream.Collectors;
  * This class is a Utility class to create Extractors for each field type as per
  * Schema
  */
-public final class VertexRowWriter 
+public final class VertexRowWriter
 {
-    private VertexRowWriter() 
+    private VertexRowWriter()
     {
         // Empty private constructor
     }
@@ -69,10 +69,10 @@ public final class VertexRowWriter
                 rowWriterBuilder.withExtractor(field.getName(),
                         (BitExtractor) (Object context, NullableBitHolder value) -> {
                             Map<String, Object> obj = (Map<String, Object>) contextAsMap(context, enableCaseinsensitivematch);
-                            ArrayList<Object> objValues = (ArrayList) obj.get(field.getName());
+                            List<Object> objValues = FieldValueNormalizer.toValueList(obj.get(field.getName()));
 
                             value.isSet = 0;
-                            if (objValues != null && objValues.get(0) != null && !(objValues.get(0).toString().trim().isEmpty())) {
+                            if (objValues != null && !objValues.isEmpty() && objValues.get(0) != null && !(objValues.get(0).toString().trim().isEmpty())) {
                                 Boolean booleanValue = Boolean.parseBoolean(objValues.get(0).toString());
                                 value.value = booleanValue ? 1 : 0;
                                 value.isSet = 1;
@@ -94,13 +94,13 @@ public final class VertexRowWriter
                                     value.value = fieldValue.toString();
                                     value.isSet = 1;
                                 }
-                            } 
+                            }
                             else {
-                                ArrayList<Object> objValues = (ArrayList) obj.get(fieldName);
-                                if (objValues != null && !objValues.isEmpty()) {
+                                List<Object> objValues = FieldValueNormalizer.toValueList(obj.get(fieldName));
+                                if (objValues != null && !objValues.isEmpty() && objValues.get(0) != null) {
                                     if (objValues.size() > 1) {
                                         value.value = String.join(";", objValues.stream()
-                                                .map(Object::toString)
+                                                .map(o -> o == null ? "" : o.toString())
                                                 .collect(Collectors.toList()));
                                     }
                                     else {
@@ -118,12 +118,19 @@ public final class VertexRowWriter
                         (DateMilliExtractor) (Object context, NullableDateMilliHolder value) -> {
                             String fieldName = field.getName();
                             Map<String, Object> obj = (Map<String, Object>) contextAsMap(context, enableCaseinsensitivematch);
-                            ArrayList<Object> objValues = (ArrayList) obj.get(fieldName);
+                            List<Object> objValues = FieldValueNormalizer.toValueList(obj.get(fieldName));
 
                             value.isSet = 0;
-                            if (objValues != null && (objValues.get(0) != null) && !(objValues.get(0).toString().trim().isEmpty())) {
-                                value.value = ((Date) objValues.get(0)).getTime();
-                                value.isSet = 1;
+                            if (objValues != null && !objValues.isEmpty() && objValues.get(0) != null && !(objValues.get(0).toString().trim().isEmpty())) {
+                                Object first = objValues.get(0);
+                                if (first instanceof Date) {
+                                    value.value = ((Date) first).getTime();
+                                    value.isSet = 1;
+                                }
+                                else {
+                                    value.value = Long.parseLong(first.toString());
+                                    value.isSet = 1;
+                                }
                             }
                         });
                 break;
@@ -133,11 +140,10 @@ public final class VertexRowWriter
                         (IntExtractor) (Object context, NullableIntHolder value) -> {
                             String fieldName = field.getName();
                             Map<String, Object> obj = (Map<String, Object>) contextAsMap(context, enableCaseinsensitivematch);
-                            ArrayList<Object> objValues = (ArrayList) obj.get(fieldName);
+                            List<Object> objValues = FieldValueNormalizer.toValueList(obj.get(fieldName));
 
                             value.isSet = 0;
-
-                            if (objValues != null && objValues.get(0) != null && !(objValues.get(0).toString().trim().isEmpty())) {
+                            if (objValues != null && !objValues.isEmpty() && objValues.get(0) != null && !(objValues.get(0).toString().trim().isEmpty())) {
                                 value.value = Integer.parseInt(objValues.get(0).toString());
                                 value.isSet = 1;
                             }
@@ -149,10 +155,10 @@ public final class VertexRowWriter
                         (BigIntExtractor) (Object context, NullableBigIntHolder value) -> {
                             String fieldName = field.getName();
                             Map<String, Object> obj = (Map<String, Object>) contextAsMap(context, enableCaseinsensitivematch);
-                            ArrayList<Object> objValues = (ArrayList) obj.get(fieldName);
+                            List<Object> objValues = FieldValueNormalizer.toValueList(obj.get(fieldName));
 
                             value.isSet = 0;
-                            if (objValues != null && objValues.get(0) != null && !(objValues.get(0).toString().trim().isEmpty())) {
+                            if (objValues != null && !objValues.isEmpty() && objValues.get(0) != null && !(objValues.get(0).toString().trim().isEmpty())) {
                                 value.value = Long.parseLong(objValues.get(0).toString());
                                 value.isSet = 1;
                             }
@@ -163,10 +169,10 @@ public final class VertexRowWriter
                 rowWriterBuilder.withExtractor(field.getName(),
                         (Float4Extractor) (Object context, NullableFloat4Holder value) -> {
                             Map<String, Object> obj = (Map<String, Object>) contextAsMap(context, enableCaseinsensitivematch);
-                            ArrayList<Object> objValues = (ArrayList) obj.get(field.getName());
+                            List<Object> objValues = FieldValueNormalizer.toValueList(obj.get(field.getName()));
 
                             value.isSet = 0;
-                            if (objValues != null && objValues.get(0) != null && !(objValues.get(0).toString().trim().isEmpty())) {
+                            if (objValues != null && !objValues.isEmpty() && objValues.get(0) != null && !(objValues.get(0).toString().trim().isEmpty())) {
                                 value.value = Float.parseFloat(objValues.get(0).toString());
                                 value.isSet = 1;
                             }
@@ -177,10 +183,10 @@ public final class VertexRowWriter
                 rowWriterBuilder.withExtractor(field.getName(),
                         (Float8Extractor) (Object context, NullableFloat8Holder value) -> {
                             Map<String, Object> obj = (Map<String, Object>) contextAsMap(context, enableCaseinsensitivematch);
-                            ArrayList<Object> objValues = (ArrayList) obj.get(field.getName());
+                            List<Object> objValues = FieldValueNormalizer.toValueList(obj.get(field.getName()));
 
                             value.isSet = 0;
-                            if (objValues != null && objValues.get(0) != null && !(objValues.get(0).toString().trim().isEmpty())) {
+                            if (objValues != null && !objValues.isEmpty() && objValues.get(0) != null && !(objValues.get(0).toString().trim().isEmpty())) {
                                 value.value = Double.parseDouble(objValues.get(0).toString());
                                 value.isSet = 1;
                             }
@@ -190,7 +196,7 @@ public final class VertexRowWriter
         }
     }
 
-    private static Map<String, Object> contextAsMap(Object context, boolean caseInsensitive) 
+    private static Map<String, Object> contextAsMap(Object context, boolean caseInsensitive)
     {
         Map<String, Object> contextAsMap = (Map<String, Object>) context;
         Object fieldValueID = contextAsMap.get(T.id);

--- a/athena-neptune/src/test/java/com/amazonaws/athena/connectors/neptune/propertygraph/rowwriters/CustomSchemaRowWriterTest.java
+++ b/athena-neptune/src/test/java/com/amazonaws/athena/connectors/neptune/propertygraph/rowwriters/CustomSchemaRowWriterTest.java
@@ -36,6 +36,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -49,6 +50,17 @@ import static org.junit.Assert.assertTrue;
  */
 public class CustomSchemaRowWriterTest
 {
+    private static final String FLAG = "flag";
+    private static final String TIMESTAMP = "timestamp";
+    private static final String NUMBER_FIELD = "numberField";
+    private static final String BIG_INT_FIELD = "bigIntField";
+    private static final String FLOAT_FIELD = "floatField";
+    private static final String DOUBLE_FIELD = "doubleField";
+    private static final String NAME = "name";
+    private static final String TAGS = "tags";
+    private static final String ALL_PROPERTIES = "all_properties";
+    private static final String ID = "id";
+
     private BlockAllocatorImpl allocator;
 
     @Before
@@ -95,13 +107,7 @@ public class CustomSchemaRowWriterTest
     @Test
     public void writeRowTemplate_varchar_valueMapList_writesFirstElement() throws Exception
     {
-        Schema schema = SchemaBuilder.newBuilder().addStringField("name").build();
-        Map<String, Object> context = new HashMap<>();
-        ArrayList<Object> list = new ArrayList<>();
-        list.add("alice");
-        context.put("name", list);
-
-        Object result = writeAndReadOneRow(schema, "name", context);
+        Object result = writeAndReadOneRow(varcharSchema(NAME), NAME, contextWith(NAME, listWith("alice")));
         assertNotNull(result);
         assertEquals("alice", result.toString());
     }
@@ -109,11 +115,7 @@ public class CustomSchemaRowWriterTest
     @Test
     public void writeRowTemplate_varchar_scalarString_writesValue() throws Exception
     {
-        Schema schema = SchemaBuilder.newBuilder().addStringField("name").build();
-        Map<String, Object> context = new HashMap<>();
-        context.put("name", "bob");
-
-        Object result = writeAndReadOneRow(schema, "name", context);
+        Object result = writeAndReadOneRow(varcharSchema(NAME), NAME, contextWith(NAME, "bob"));
         assertNotNull(result);
         assertEquals("bob", result.toString());
     }
@@ -121,14 +123,10 @@ public class CustomSchemaRowWriterTest
     @Test
     public void writeRowTemplate_varchar_mapFromByValueMap_writesStringRepresentation() throws Exception
     {
-        Schema schema = SchemaBuilder.newBuilder().addStringField("all_properties").build();
-        Map<String, Object> context = new HashMap<>();
         Map<String, Object> map = new LinkedHashMap<>();
         map.put("k1", "v1");
         map.put("k2", 2);
-        context.put("all_properties", map);
-
-        Object result = writeAndReadOneRow(schema, "all_properties", context);
+        Object result = writeAndReadOneRow(varcharSchema(ALL_PROPERTIES), ALL_PROPERTIES, contextWith(ALL_PROPERTIES, map));
         assertNotNull(result);
         String str = result.toString();
         assertTrue(str.contains("k1=v1"));
@@ -138,28 +136,14 @@ public class CustomSchemaRowWriterTest
     @Test
     public void writeRowTemplate_varchar_listWithNullFirstElement_doesNotSetValue() throws Exception
     {
-        Schema schema = SchemaBuilder.newBuilder().addStringField("name").build();
-        Map<String, Object> context = new HashMap<>();
-        ArrayList<Object> list = new ArrayList<>();
-        list.add(null);
-        context.put("name", list);
-
-        Object result = writeAndReadOneRow(schema, "name", context);
+        Object result = writeAndReadOneRow(varcharSchema(NAME), NAME, contextWith(NAME, listWith(null)));
         assertNull(result);
     }
 
     @Test
     public void writeRowTemplate_varchar_multipleValues_joinsWithSemicolon() throws Exception
     {
-        Schema schema = SchemaBuilder.newBuilder().addStringField("tags").build();
-        Map<String, Object> context = new HashMap<>();
-        ArrayList<Object> list = new ArrayList<>();
-        list.add("a");
-        list.add("b");
-        list.add("c");
-        context.put("tags", list);
-
-        Object result = writeAndReadOneRow(schema, "tags", context);
+        Object result = writeAndReadOneRow(varcharSchema(TAGS), TAGS, contextWith(TAGS, listWith("a", "b", "c")));
         assertNotNull(result);
         assertEquals("a;b;c", result.toString());
     }
@@ -167,17 +151,16 @@ public class CustomSchemaRowWriterTest
     @Test
     public void writeRowTemplate_varchar_multipleValuesWithNull_joinsWithoutNpe() throws Exception
     {
-        Schema schema = SchemaBuilder.newBuilder().addStringField("tags").build();
-        Map<String, Object> context = new HashMap<>();
-        ArrayList<Object> list = new ArrayList<>();
-        list.add("a");
-        list.add(null);
-        list.add("c");
-        context.put("tags", list);
-
-        Object result = writeAndReadOneRow(schema, "tags", context);
+        Object result = writeAndReadOneRow(varcharSchema(TAGS), TAGS, contextWith(TAGS, listWith("a", null, "c")));
         assertNotNull(result);
         assertEquals("a;;c", result.toString());
+    }
+
+    @Test
+    public void writeRowTemplate_varchar_emptyList_doesNotSetValue() throws Exception
+    {
+        Object result = writeAndReadOneRow(varcharSchema(NAME), NAME, contextWith(NAME, Collections.emptyList()));
+        assertNull(result);
     }
 
     // ---- BIT ----
@@ -185,13 +168,7 @@ public class CustomSchemaRowWriterTest
     @Test
     public void writeRowTemplate_bit_valueMapListTrue_writesOne() throws Exception
     {
-        Schema schema = SchemaBuilder.newBuilder().addBitField("flag").build();
-        Map<String, Object> context = new HashMap<>();
-        ArrayList<Object> list = new ArrayList<>();
-        list.add(true);
-        context.put("flag", list);
-
-        Object result = writeAndReadOneRow(schema, "flag", context);
+        Object result = writeAndReadOneRow(bitSchema(), FLAG, contextWith(FLAG,listWith(true)));
         assertNotNull(result);
         assertTrue((Boolean) result);
     }
@@ -199,13 +176,45 @@ public class CustomSchemaRowWriterTest
     @Test
     public void writeRowTemplate_bit_scalarTrue_writesOne() throws Exception
     {
-        Schema schema = SchemaBuilder.newBuilder().addBitField("flag").build();
-        Map<String, Object> context = new HashMap<>();
-        context.put("flag", true);
-
-        Object result = writeAndReadOneRow(schema, "flag", context);
+        Object result = writeAndReadOneRow(bitSchema(), FLAG, contextWith(FLAG,true));
         assertNotNull(result);
         assertTrue((Boolean) result);
+    }
+
+    @Test
+    public void writeRowTemplate_bit_scalarFalse_writesZero() throws Exception
+    {
+        Object result = writeAndReadOneRow(bitSchema(), FLAG, contextWith(FLAG,false));
+        assertNotNull(result);
+        assertEquals(Boolean.FALSE, result);
+    }
+
+    @Test
+    public void writeRowTemplate_bit_nullField_doesNotSetValue() throws Exception
+    {
+        Object result = writeAndReadOneRow(bitSchema(), FLAG, contextWith(FLAG,null));
+        assertNull(result);
+    }
+
+    @Test
+    public void writeRowTemplate_bit_emptyList_doesNotSetValue() throws Exception
+    {
+        Object result = writeAndReadOneRow(bitSchema(), FLAG, contextWith(FLAG,Collections.emptyList()));
+        assertNull(result);
+    }
+
+    @Test
+    public void writeRowTemplate_bit_listWithNullFirstElement_doesNotSetValue() throws Exception
+    {
+        Object result = writeAndReadOneRow(bitSchema(), FLAG, contextWith(FLAG,listWith(null)));
+        assertNull(result);
+    }
+
+    @Test
+    public void writeRowTemplate_bit_listWithBlankStringFirstElement_doesNotSetValue() throws Exception
+    {
+        Object result = writeAndReadOneRow(bitSchema(), FLAG, contextWith(FLAG,listWith("   ")));
+        assertNull(result);
     }
 
     // ---- DATEMILLI ----
@@ -213,12 +222,7 @@ public class CustomSchemaRowWriterTest
     @Test
     public void writeRowTemplate_datemilli_dateInstance_writesEpochMillis() throws Exception
     {
-        Schema schema = SchemaBuilder.newBuilder().addDateMilliField("timestamp").build();
-        Date d = new Date(1000L);
-        Map<String, Object> context = new HashMap<>();
-        context.put("timestamp", d);
-
-        Object result = writeAndReadOneRow(schema, "timestamp", context);
+        Object result = writeAndReadOneRow(datemilliSchema(), TIMESTAMP, contextWith(TIMESTAMP,new Date(1000L)));
         assertNotNull(result);
         assertEquals(1000L, ((LocalDateTime) result).toInstant(ZoneOffset.UTC).toEpochMilli());
     }
@@ -226,11 +230,7 @@ public class CustomSchemaRowWriterTest
     @Test
     public void writeRowTemplate_datemilli_longEpoch_writesValue() throws Exception
     {
-        Schema schema = SchemaBuilder.newBuilder().addDateMilliField("timestamp").build();
-        Map<String, Object> context = new HashMap<>();
-        context.put("timestamp", 2000L);
-
-        Object result = writeAndReadOneRow(schema, "timestamp", context);
+        Object result = writeAndReadOneRow(datemilliSchema(), TIMESTAMP, contextWith(TIMESTAMP,2000L));
         assertNotNull(result);
         assertEquals(2000L, ((LocalDateTime) result).toInstant(ZoneOffset.UTC).toEpochMilli());
     }
@@ -238,16 +238,37 @@ public class CustomSchemaRowWriterTest
     @Test
     public void writeRowTemplate_datemilli_valueMapList_writesFirstElement() throws Exception
     {
-        Schema schema = SchemaBuilder.newBuilder().addDateMilliField("timestamp").build();
-        Date d = new Date(3000L);
-        Map<String, Object> context = new HashMap<>();
-        ArrayList<Object> list = new ArrayList<>();
-        list.add(d);
-        context.put("timestamp", list);
-
-        Object result = writeAndReadOneRow(schema, "timestamp", context);
+        Object result = writeAndReadOneRow(datemilliSchema(), TIMESTAMP, contextWith(TIMESTAMP,listWith(new Date(3000L))));
         assertNotNull(result);
         assertEquals(3000L, ((LocalDateTime) result).toInstant(ZoneOffset.UTC).toEpochMilli());
+    }
+
+    @Test
+    public void writeRowTemplate_datemilli_nullField_doesNotSetValue() throws Exception
+    {
+        Object result = writeAndReadOneRow(datemilliSchema(), TIMESTAMP, contextWith(TIMESTAMP,null));
+        assertNull(result);
+    }
+
+    @Test
+    public void writeRowTemplate_datemilli_emptyList_doesNotSetValue() throws Exception
+    {
+        Object result = writeAndReadOneRow(datemilliSchema(), TIMESTAMP, contextWith(TIMESTAMP,Collections.emptyList()));
+        assertNull(result);
+    }
+
+    @Test
+    public void writeRowTemplate_datemilli_listWithNullFirstElement_doesNotSetValue() throws Exception
+    {
+        Object result = writeAndReadOneRow(datemilliSchema(), TIMESTAMP, contextWith(TIMESTAMP,listWith(null)));
+        assertNull(result);
+    }
+
+    @Test
+    public void writeRowTemplate_datemilli_listWithBlankStringFirstElement_doesNotSetValue() throws Exception
+    {
+        Object result = writeAndReadOneRow(datemilliSchema(), TIMESTAMP, contextWith(TIMESTAMP,listWith("   ")));
+        assertNull(result);
     }
 
     // ---- INT, BIGINT, FLOAT4, FLOAT8 ----
@@ -255,11 +276,7 @@ public class CustomSchemaRowWriterTest
     @Test
     public void writeRowTemplate_int_scalar_writesValue() throws Exception
     {
-        Schema schema = SchemaBuilder.newBuilder().addIntField("numberField").build();
-        Map<String, Object> context = new HashMap<>();
-        context.put("numberField", 42);
-
-        Object result = writeAndReadOneRow(schema, "numberField", context);
+        Object result = writeAndReadOneRow(intSchema(), NUMBER_FIELD, contextWith(NUMBER_FIELD,42));
         assertNotNull(result);
         assertEquals(42, ((Number) result).intValue());
     }
@@ -267,63 +284,210 @@ public class CustomSchemaRowWriterTest
     @Test
     public void writeRowTemplate_int_valueMapList_writesFirstElement() throws Exception
     {
-        Schema schema = SchemaBuilder.newBuilder().addIntField("numberField").build();
-        Map<String, Object> context = new HashMap<>();
-        ArrayList<Object> list = new ArrayList<>();
-        list.add(100);
-        context.put("numberField", list);
-
-        Object result = writeAndReadOneRow(schema, "numberField", context);
+        Object result = writeAndReadOneRow(intSchema(), NUMBER_FIELD, contextWith(NUMBER_FIELD,listWith(100)));
         assertNotNull(result);
         assertEquals(100, ((Number) result).intValue());
     }
 
     @Test
+    public void writeRowTemplate_int_nullField_doesNotSetValue() throws Exception
+    {
+        Object result = writeAndReadOneRow(intSchema(), NUMBER_FIELD, contextWith(NUMBER_FIELD,null));
+        assertNull(result);
+    }
+
+    @Test
+    public void writeRowTemplate_int_emptyList_doesNotSetValue() throws Exception
+    {
+        Object result = writeAndReadOneRow(intSchema(), NUMBER_FIELD, contextWith(NUMBER_FIELD,Collections.emptyList()));
+        assertNull(result);
+    }
+
+    @Test
+    public void writeRowTemplate_int_listWithNullFirstElement_doesNotSetValue() throws Exception
+    {
+        Object result = writeAndReadOneRow(intSchema(), NUMBER_FIELD, contextWith(NUMBER_FIELD,listWith(null)));
+        assertNull(result);
+    }
+
+    @Test
+    public void writeRowTemplate_int_listWithBlankStringFirstElement_doesNotSetValue() throws Exception
+    {
+        Object result = writeAndReadOneRow(intSchema(), NUMBER_FIELD, contextWith(NUMBER_FIELD,listWith("   ")));
+        assertNull(result);
+    }
+
+    @Test
     public void writeRowTemplate_bigint_scalar_writesValue() throws Exception
     {
-        Schema schema = SchemaBuilder.newBuilder().addBigIntField("bigIntField").build();
-        Map<String, Object> context = new HashMap<>();
-        context.put("bigIntField", 12345L);
-
-        Object result = writeAndReadOneRow(schema, "bigIntField", context);
+        Object result = writeAndReadOneRow(bigintSchema(), BIG_INT_FIELD, contextWith(BIG_INT_FIELD,12345L));
         assertNotNull(result);
         assertEquals(12345L, ((Number) result).longValue());
     }
 
     @Test
+    public void writeRowTemplate_bigint_nullField_doesNotSetValue() throws Exception
+    {
+        Object result = writeAndReadOneRow(bigintSchema(), BIG_INT_FIELD, contextWith(BIG_INT_FIELD,null));
+        assertNull(result);
+    }
+
+    @Test
+    public void writeRowTemplate_bigint_emptyList_doesNotSetValue() throws Exception
+    {
+        Object result = writeAndReadOneRow(bigintSchema(), BIG_INT_FIELD, contextWith(BIG_INT_FIELD,Collections.emptyList()));
+        assertNull(result);
+    }
+
+    @Test
+    public void writeRowTemplate_bigint_listWithNullFirstElement_doesNotSetValue() throws Exception
+    {
+        Object result = writeAndReadOneRow(bigintSchema(), BIG_INT_FIELD, contextWith(BIG_INT_FIELD,listWith(null)));
+        assertNull(result);
+    }
+
+    @Test
+    public void writeRowTemplate_bigint_listWithBlankStringFirstElement_doesNotSetValue() throws Exception
+    {
+        Object result = writeAndReadOneRow(bigintSchema(), BIG_INT_FIELD, contextWith(BIG_INT_FIELD,listWith("   ")));
+        assertNull(result);
+    }
+
+    @Test
     public void writeRowTemplate_float4_scalar_writesValue() throws Exception
     {
-        Schema schema = SchemaBuilder.newBuilder().addFloat4Field("floatField").build();
-        Map<String, Object> context = new HashMap<>();
-        context.put("floatField", 1.5f);
-
-        Object result = writeAndReadOneRow(schema, "floatField", context);
+        Object result = writeAndReadOneRow(float4Schema(), FLOAT_FIELD, contextWith(FLOAT_FIELD,1.5f));
         assertNotNull(result);
         assertEquals(1.5f, ((Number) result).floatValue(), 1e-6f);
     }
 
     @Test
+    public void writeRowTemplate_float4_nullField_doesNotSetValue() throws Exception
+    {
+        Object result = writeAndReadOneRow(float4Schema(), FLOAT_FIELD, contextWith(FLOAT_FIELD,null));
+        assertNull(result);
+    }
+
+    @Test
+    public void writeRowTemplate_float4_emptyList_doesNotSetValue() throws Exception
+    {
+        Object result = writeAndReadOneRow(float4Schema(), FLOAT_FIELD, contextWith(FLOAT_FIELD,Collections.emptyList()));
+        assertNull(result);
+    }
+
+    @Test
+    public void writeRowTemplate_float4_listWithNullFirstElement_doesNotSetValue() throws Exception
+    {
+        Object result = writeAndReadOneRow(float4Schema(), FLOAT_FIELD, contextWith(FLOAT_FIELD,listWith(null)));
+        assertNull(result);
+    }
+
+    @Test
+    public void writeRowTemplate_float4_listWithBlankStringFirstElement_doesNotSetValue() throws Exception
+    {
+        Object result = writeAndReadOneRow(float4Schema(), FLOAT_FIELD, contextWith(FLOAT_FIELD,listWith("   ")));
+        assertNull(result);
+    }
+
+    @Test
     public void writeRowTemplate_float8_valueMapList_writesFirstElement() throws Exception
     {
-        Schema schema = SchemaBuilder.newBuilder().addFloat8Field("doubleField").build();
-        Map<String, Object> context = new HashMap<>();
-        ArrayList<Object> list = new ArrayList<>();
-        list.add(3.14);
-        context.put("doubleField", list);
-
-        Object result = writeAndReadOneRow(schema, "doubleField", context);
+        Object result = writeAndReadOneRow(float8Schema(), DOUBLE_FIELD, contextWith(DOUBLE_FIELD,listWith(3.14)));
         assertNotNull(result);
         assertEquals(3.14, ((Number) result).doubleValue(), 1e-9);
     }
 
     @Test
+    public void writeRowTemplate_float8_nullField_doesNotSetValue() throws Exception
+    {
+        Object result = writeAndReadOneRow(float8Schema(), DOUBLE_FIELD, contextWith(DOUBLE_FIELD,null));
+        assertNull(result);
+    }
+
+    @Test
+    public void writeRowTemplate_float8_emptyList_doesNotSetValue() throws Exception
+    {
+        Object result = writeAndReadOneRow(float8Schema(), DOUBLE_FIELD, contextWith(DOUBLE_FIELD,Collections.emptyList()));
+        assertNull(result);
+    }
+
+    @Test
+    public void writeRowTemplate_float8_listWithNullFirstElement_doesNotSetValue() throws Exception
+    {
+        Object result = writeAndReadOneRow(float8Schema(), DOUBLE_FIELD, contextWith(DOUBLE_FIELD,listWith(null)));
+        assertNull(result);
+    }
+
+    @Test
+    public void writeRowTemplate_float8_listWithBlankStringFirstElement_doesNotSetValue() throws Exception
+    {
+        Object result = writeAndReadOneRow(float8Schema(), DOUBLE_FIELD, contextWith(DOUBLE_FIELD,listWith("   ")));
+        assertNull(result);
+    }
+
+    @Test
     public void writeRowTemplate_varchar_nullField_doesNotSetValue() throws Exception
     {
-        Schema schema = SchemaBuilder.newBuilder().addStringField("name").build();
-        Map<String, Object> context = new HashMap<>();
-        context.put("name", null);
-
-        Object result = writeAndReadOneRow(schema, "name", context);
+        Object result = writeAndReadOneRow(varcharSchema(NAME), NAME, contextWith(NAME, null));
         assertNull(result);
+    }
+
+    @Test
+    public void writeRowTemplate_varchar_specialKeyId_nullId_doesNotSetValue() throws Exception
+    {
+        Object result = writeAndReadOneRow(varcharSchema(ID), ID, contextWith("ID", null));
+        assertNull(result);
+    }
+
+    private static Map<String, Object> contextWith(String fieldName, Object value)
+    {
+        Map<String, Object> context = new HashMap<>();
+        context.put(fieldName, value);
+        return context;
+    }
+
+    private static List<Object> listWith(Object... elements)
+    {
+        if (elements == null) {
+            return Collections.singletonList(null);
+        }
+        List<Object> list = new ArrayList<>();
+        Collections.addAll(list, elements);
+        return list;
+    }
+
+    private static Schema bitSchema()
+    {
+        return SchemaBuilder.newBuilder().addBitField(FLAG).build();
+    }
+
+    private static Schema datemilliSchema()
+    {
+        return SchemaBuilder.newBuilder().addDateMilliField(TIMESTAMP).build();
+    }
+
+    private static Schema intSchema()
+    {
+        return SchemaBuilder.newBuilder().addIntField(NUMBER_FIELD).build();
+    }
+
+    private static Schema bigintSchema()
+    {
+        return SchemaBuilder.newBuilder().addBigIntField(BIG_INT_FIELD).build();
+    }
+
+    private static Schema float4Schema()
+    {
+        return SchemaBuilder.newBuilder().addFloat4Field(FLOAT_FIELD).build();
+    }
+
+    private static Schema float8Schema()
+    {
+        return SchemaBuilder.newBuilder().addFloat8Field(DOUBLE_FIELD).build();
+    }
+
+    private static Schema varcharSchema(String fieldName)
+    {
+        return SchemaBuilder.newBuilder().addStringField(fieldName).build();
     }
 }

--- a/athena-neptune/src/test/java/com/amazonaws/athena/connectors/neptune/propertygraph/rowwriters/CustomSchemaRowWriterTest.java
+++ b/athena-neptune/src/test/java/com/amazonaws/athena/connectors/neptune/propertygraph/rowwriters/CustomSchemaRowWriterTest.java
@@ -1,0 +1,329 @@
+/*-
+ * #%L
+ * athena-neptune
+ * %%
+ * Copyright (C) 2019 - 2026 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.neptune.propertygraph.rowwriters;
+
+import com.amazonaws.athena.connector.lambda.data.Block;
+import com.amazonaws.athena.connector.lambda.data.BlockAllocatorImpl;
+import com.amazonaws.athena.connector.lambda.data.SchemaBuilder;
+import com.amazonaws.athena.connector.lambda.data.writers.GeneratedRowWriter;
+import org.apache.arrow.vector.complex.reader.FieldReader;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for the changed logic in CustomSchemaRowWriter: FieldValueNormalizer usage,
+ * valueMap vs project().by() (list vs scalar vs Map), and VARCHAR null-first-element handling.
+ */
+public class CustomSchemaRowWriterTest
+{
+    private BlockAllocatorImpl allocator;
+
+    @Before
+    public void setUp()
+    {
+        allocator = new BlockAllocatorImpl();
+    }
+
+    @After
+    public void tearDown()
+    {
+        if (allocator != null) {
+            allocator.close();
+        }
+    }
+
+    private Map<String, String> configOptions()
+    {
+        return Collections.emptyMap();
+    }
+
+    private Object writeAndReadOneRow(Schema schema, String fieldName, Map<String, Object> context) throws Exception
+    {
+        GeneratedRowWriter.RowWriterBuilder builder = GeneratedRowWriter.newBuilder();
+        for (org.apache.arrow.vector.types.pojo.Field f : schema.getFields()) {
+            CustomSchemaRowWriter.writeRowTemplate(builder, f, configOptions());
+        }
+        GeneratedRowWriter rowWriter = builder.build();
+        try (Block block = allocator.createBlock(schema)) {
+            assertTrue(rowWriter.writeRow(block, 0, context));
+            block.setRowCount(1);
+            FieldReader reader = block.getFieldReaders().stream()
+                    .filter(r -> r.getField().getName().equals(fieldName))
+                    .findFirst()
+                    .orElseThrow();
+            reader.setPosition(0);
+            if (!reader.isSet()) {
+                return null;
+            }
+            return reader.readObject();
+        }
+    }
+
+    @Test
+    public void writeRowTemplate_varchar_valueMapList_writesFirstElement() throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder().addStringField("name").build();
+        Map<String, Object> context = new HashMap<>();
+        ArrayList<Object> list = new ArrayList<>();
+        list.add("alice");
+        context.put("name", list);
+
+        Object result = writeAndReadOneRow(schema, "name", context);
+        assertNotNull(result);
+        assertEquals("alice", result.toString());
+    }
+
+    @Test
+    public void writeRowTemplate_varchar_scalarString_writesValue() throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder().addStringField("name").build();
+        Map<String, Object> context = new HashMap<>();
+        context.put("name", "bob");
+
+        Object result = writeAndReadOneRow(schema, "name", context);
+        assertNotNull(result);
+        assertEquals("bob", result.toString());
+    }
+
+    @Test
+    public void writeRowTemplate_varchar_mapFromByValueMap_writesStringRepresentation() throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder().addStringField("all_properties").build();
+        Map<String, Object> context = new HashMap<>();
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("k1", "v1");
+        map.put("k2", 2);
+        context.put("all_properties", map);
+
+        Object result = writeAndReadOneRow(schema, "all_properties", context);
+        assertNotNull(result);
+        String str = result.toString();
+        assertTrue(str.contains("k1=v1"));
+        assertTrue(str.contains("k2=2"));
+    }
+
+    @Test
+    public void writeRowTemplate_varchar_listWithNullFirstElement_doesNotSetValue() throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder().addStringField("name").build();
+        Map<String, Object> context = new HashMap<>();
+        ArrayList<Object> list = new ArrayList<>();
+        list.add(null);
+        context.put("name", list);
+
+        Object result = writeAndReadOneRow(schema, "name", context);
+        assertNull(result);
+    }
+
+    @Test
+    public void writeRowTemplate_varchar_multipleValues_joinsWithSemicolon() throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder().addStringField("tags").build();
+        Map<String, Object> context = new HashMap<>();
+        ArrayList<Object> list = new ArrayList<>();
+        list.add("a");
+        list.add("b");
+        list.add("c");
+        context.put("tags", list);
+
+        Object result = writeAndReadOneRow(schema, "tags", context);
+        assertNotNull(result);
+        assertEquals("a;b;c", result.toString());
+    }
+
+    @Test
+    public void writeRowTemplate_varchar_multipleValuesWithNull_joinsWithoutNpe() throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder().addStringField("tags").build();
+        Map<String, Object> context = new HashMap<>();
+        ArrayList<Object> list = new ArrayList<>();
+        list.add("a");
+        list.add(null);
+        list.add("c");
+        context.put("tags", list);
+
+        Object result = writeAndReadOneRow(schema, "tags", context);
+        assertNotNull(result);
+        assertEquals("a;;c", result.toString());
+    }
+
+    // ---- BIT ----
+
+    @Test
+    public void writeRowTemplate_bit_valueMapListTrue_writesOne() throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder().addBitField("flag").build();
+        Map<String, Object> context = new HashMap<>();
+        ArrayList<Object> list = new ArrayList<>();
+        list.add(true);
+        context.put("flag", list);
+
+        Object result = writeAndReadOneRow(schema, "flag", context);
+        assertNotNull(result);
+        assertTrue((Boolean) result);
+    }
+
+    @Test
+    public void writeRowTemplate_bit_scalarTrue_writesOne() throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder().addBitField("flag").build();
+        Map<String, Object> context = new HashMap<>();
+        context.put("flag", true);
+
+        Object result = writeAndReadOneRow(schema, "flag", context);
+        assertNotNull(result);
+        assertTrue((Boolean) result);
+    }
+
+    // ---- DATEMILLI ----
+
+    @Test
+    public void writeRowTemplate_datemilli_dateInstance_writesEpochMillis() throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder().addDateMilliField("timestamp").build();
+        Date d = new Date(1000L);
+        Map<String, Object> context = new HashMap<>();
+        context.put("timestamp", d);
+
+        Object result = writeAndReadOneRow(schema, "timestamp", context);
+        assertNotNull(result);
+        assertEquals(1000L, ((LocalDateTime) result).toInstant(ZoneOffset.UTC).toEpochMilli());
+    }
+
+    @Test
+    public void writeRowTemplate_datemilli_longEpoch_writesValue() throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder().addDateMilliField("timestamp").build();
+        Map<String, Object> context = new HashMap<>();
+        context.put("timestamp", 2000L);
+
+        Object result = writeAndReadOneRow(schema, "timestamp", context);
+        assertNotNull(result);
+        assertEquals(2000L, ((LocalDateTime) result).toInstant(ZoneOffset.UTC).toEpochMilli());
+    }
+
+    @Test
+    public void writeRowTemplate_datemilli_valueMapList_writesFirstElement() throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder().addDateMilliField("timestamp").build();
+        Date d = new Date(3000L);
+        Map<String, Object> context = new HashMap<>();
+        ArrayList<Object> list = new ArrayList<>();
+        list.add(d);
+        context.put("timestamp", list);
+
+        Object result = writeAndReadOneRow(schema, "timestamp", context);
+        assertNotNull(result);
+        assertEquals(3000L, ((LocalDateTime) result).toInstant(ZoneOffset.UTC).toEpochMilli());
+    }
+
+    // ---- INT, BIGINT, FLOAT4, FLOAT8 ----
+
+    @Test
+    public void writeRowTemplate_int_scalar_writesValue() throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder().addIntField("numberField").build();
+        Map<String, Object> context = new HashMap<>();
+        context.put("numberField", 42);
+
+        Object result = writeAndReadOneRow(schema, "numberField", context);
+        assertNotNull(result);
+        assertEquals(42, ((Number) result).intValue());
+    }
+
+    @Test
+    public void writeRowTemplate_int_valueMapList_writesFirstElement() throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder().addIntField("numberField").build();
+        Map<String, Object> context = new HashMap<>();
+        ArrayList<Object> list = new ArrayList<>();
+        list.add(100);
+        context.put("numberField", list);
+
+        Object result = writeAndReadOneRow(schema, "numberField", context);
+        assertNotNull(result);
+        assertEquals(100, ((Number) result).intValue());
+    }
+
+    @Test
+    public void writeRowTemplate_bigint_scalar_writesValue() throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder().addBigIntField("bigIntField").build();
+        Map<String, Object> context = new HashMap<>();
+        context.put("bigIntField", 12345L);
+
+        Object result = writeAndReadOneRow(schema, "bigIntField", context);
+        assertNotNull(result);
+        assertEquals(12345L, ((Number) result).longValue());
+    }
+
+    @Test
+    public void writeRowTemplate_float4_scalar_writesValue() throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder().addFloat4Field("floatField").build();
+        Map<String, Object> context = new HashMap<>();
+        context.put("floatField", 1.5f);
+
+        Object result = writeAndReadOneRow(schema, "floatField", context);
+        assertNotNull(result);
+        assertEquals(1.5f, ((Number) result).floatValue(), 1e-6f);
+    }
+
+    @Test
+    public void writeRowTemplate_float8_valueMapList_writesFirstElement() throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder().addFloat8Field("doubleField").build();
+        Map<String, Object> context = new HashMap<>();
+        ArrayList<Object> list = new ArrayList<>();
+        list.add(3.14);
+        context.put("doubleField", list);
+
+        Object result = writeAndReadOneRow(schema, "doubleField", context);
+        assertNotNull(result);
+        assertEquals(3.14, ((Number) result).doubleValue(), 1e-9);
+    }
+
+    @Test
+    public void writeRowTemplate_varchar_nullField_doesNotSetValue() throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder().addStringField("name").build();
+        Map<String, Object> context = new HashMap<>();
+        context.put("name", null);
+
+        Object result = writeAndReadOneRow(schema, "name", context);
+        assertNull(result);
+    }
+}

--- a/athena-neptune/src/test/java/com/amazonaws/athena/connectors/neptune/propertygraph/rowwriters/EdgeRowWriterTest.java
+++ b/athena-neptune/src/test/java/com/amazonaws/athena/connectors/neptune/propertygraph/rowwriters/EdgeRowWriterTest.java
@@ -1,0 +1,368 @@
+/*-
+ * #%L
+ * athena-neptune
+ * %%
+ * Copyright (C) 2019 - 2026 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.neptune.propertygraph.rowwriters;
+
+import com.amazonaws.athena.connector.lambda.data.Block;
+import com.amazonaws.athena.connector.lambda.data.BlockAllocatorImpl;
+import com.amazonaws.athena.connector.lambda.data.SchemaBuilder;
+import com.amazonaws.athena.connector.lambda.data.writers.GeneratedRowWriter;
+import org.apache.tinkerpop.gremlin.structure.Direction;
+import org.apache.tinkerpop.gremlin.structure.T;
+import org.apache.arrow.vector.complex.reader.FieldReader;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for the changed logic in EdgeRowWriter: FieldValueNormalizer usage,
+ * valueMap vs project().by() (list vs scalar vs Map), VARCHAR null-first-element handling,
+ * and special keys (id, in, out).
+ */
+public class EdgeRowWriterTest
+{
+    private BlockAllocatorImpl allocator;
+
+    @Before
+    public void setUp()
+    {
+        allocator = new BlockAllocatorImpl();
+    }
+
+    @After
+    public void tearDown()
+    {
+        if (allocator != null) {
+            allocator.close();
+        }
+    }
+
+    private Map<String, String> configOptions()
+    {
+        return Collections.emptyMap();
+    }
+
+    private Object writeAndReadOneRow(Schema schema, String fieldName, Map<String, Object> context) throws Exception
+    {
+        GeneratedRowWriter.RowWriterBuilder builder = GeneratedRowWriter.newBuilder();
+        for (org.apache.arrow.vector.types.pojo.Field f : schema.getFields()) {
+            EdgeRowWriter.writeRowTemplate(builder, f, configOptions());
+        }
+        GeneratedRowWriter rowWriter = builder.build();
+        try (Block block = allocator.createBlock(schema)) {
+            assertTrue(rowWriter.writeRow(block, 0, context));
+            block.setRowCount(1);
+            FieldReader reader = block.getFieldReaders().stream()
+                    .filter(r -> r.getField().getName().equals(fieldName))
+                    .findFirst()
+                    .orElseThrow();
+            reader.setPosition(0);
+            if (!reader.isSet()) {
+                return null;
+            }
+            return reader.readObject();
+        }
+    }
+
+    /**
+     * Builds an edge-like context with T.id, Direction.IN, Direction.OUT so that
+     * EdgeRowWriter.contextAsMap puts ID, IN, OUT into the map for special key tests.
+     * Keys are T.id, T.label, Direction.IN, Direction.OUT (Gremlin tokens), not strings.
+     */
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> edgeContextWithIdInOut(String edgeId, String inVertexId, String outVertexId)
+    {
+        Map<Object, Object> ctx = new HashMap<>();
+        ctx.put(T.id, edgeId);
+        ctx.put(T.label, "e");
+        LinkedHashMap<Object, Object> inMap = new LinkedHashMap<>();
+        inMap.put(T.id, inVertexId);
+        ctx.put(Direction.IN, inMap);
+        LinkedHashMap<Object, Object> outMap = new LinkedHashMap<>();
+        outMap.put(T.id, outVertexId);
+        ctx.put(Direction.OUT, outMap);
+        return (Map<String, Object>) (Map<?, ?>) ctx;
+    }
+
+    @Test
+    public void writeRowTemplate_varchar_specialKeyId_writesEdgeId() throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder().addStringField("id").build();
+        Map<String, Object> context = edgeContextWithIdInOut("edge-1", "v-in", "v-out");
+
+        Object result = writeAndReadOneRow(schema, "id", context);
+        assertNotNull(result);
+        assertEquals("edge-1", result.toString());
+    }
+
+    @Test
+    public void writeRowTemplate_varchar_specialKeyIn_writesInVertexId() throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder().addStringField("in").build();
+        Map<String, Object> context = edgeContextWithIdInOut("e2", "vertex-in-id", "vertex-out-id");
+
+        Object result = writeAndReadOneRow(schema, "in", context);
+        assertNotNull(result);
+        assertEquals("vertex-in-id", result.toString());
+    }
+
+    @Test
+    public void writeRowTemplate_varchar_specialKeyOut_writesOutVertexId() throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder().addStringField("out").build();
+        Map<String, Object> context = edgeContextWithIdInOut("e3", "v1", "v2");
+
+        Object result = writeAndReadOneRow(schema, "out", context);
+        assertNotNull(result);
+        assertEquals("v2", result.toString());
+    }
+
+    // ---- VARCHAR: valueMap list, scalar, Map, null first, multi-value ----
+
+    @Test
+    public void writeRowTemplate_varchar_valueMapList_writesFirstElement() throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder().addStringField("name").build();
+        Map<String, Object> context = new HashMap<>();
+        ArrayList<Object> list = new ArrayList<>();
+        list.add("alice");
+        context.put("name", list);
+
+        Object result = writeAndReadOneRow(schema, "name", context);
+        assertNotNull(result);
+        assertEquals("alice", result.toString());
+    }
+
+    @Test
+    public void writeRowTemplate_varchar_scalarString_writesValue() throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder().addStringField("name").build();
+        Map<String, Object> context = new HashMap<>();
+        context.put("name", "bob");
+
+        Object result = writeAndReadOneRow(schema, "name", context);
+        assertNotNull(result);
+        assertEquals("bob", result.toString());
+    }
+
+    @Test
+    public void writeRowTemplate_varchar_mapFromByValueMap_writesStringRepresentation() throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder().addStringField("props").build();
+        Map<String, Object> context = new HashMap<>();
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("a", 1);
+        map.put("b", "two");
+        context.put("props", map);
+
+        Object result = writeAndReadOneRow(schema, "props", context);
+        assertNotNull(result);
+        String str = result.toString();
+        assertTrue(str.contains("a=1"));
+        assertTrue(str.contains("b=two"));
+    }
+
+    @Test
+    public void writeRowTemplate_varchar_listWithNullFirstElement_doesNotSetValue() throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder().addStringField("name").build();
+        Map<String, Object> context = new HashMap<>();
+        ArrayList<Object> list = new ArrayList<>();
+        list.add(null);
+        context.put("name", list);
+
+        Object result = writeAndReadOneRow(schema, "name", context);
+        assertNull(result);
+    }
+
+    @Test
+    public void writeRowTemplate_varchar_multipleValuesWithNull_joinsWithoutNpe() throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder().addStringField("tags").build();
+        Map<String, Object> context = new HashMap<>();
+        ArrayList<Object> list = new ArrayList<>();
+        list.add("x");
+        list.add(null);
+        list.add("z");
+        context.put("tags", list);
+
+        Object result = writeAndReadOneRow(schema, "tags", context);
+        assertNotNull(result);
+        assertEquals("x;;z", result.toString());
+    }
+
+    @Test
+    public void writeRowTemplate_varchar_nullField_doesNotSetValue() throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder().addStringField("name").build();
+        Map<String, Object> context = new HashMap<>();
+        context.put("name", null);
+
+        Object result = writeAndReadOneRow(schema, "name", context);
+        assertNull(result);
+    }
+
+    // ---- BIT ----
+
+    @Test
+    public void writeRowTemplate_bit_valueMapListTrue_writesOne() throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder().addBitField("flag").build();
+        Map<String, Object> context = new HashMap<>();
+        ArrayList<Object> list = new ArrayList<>();
+        list.add(true);
+        context.put("flag", list);
+
+        Object result = writeAndReadOneRow(schema, "flag", context);
+        assertNotNull(result);
+        assertTrue((Boolean) result);
+    }
+
+    @Test
+    public void writeRowTemplate_bit_scalarTrue_writesOne() throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder().addBitField("flag").build();
+        Map<String, Object> context = new HashMap<>();
+        context.put("flag", true);
+
+        Object result = writeAndReadOneRow(schema, "flag", context);
+        assertNotNull(result);
+        assertTrue((Boolean) result);
+    }
+
+    @Test
+    public void writeRowTemplate_datemilli_longEpoch_writesValue() throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder().addDateMilliField("timestamp").build();
+        Map<String, Object> context = new HashMap<>();
+        context.put("timestamp", 5000L);
+
+        Object result = writeAndReadOneRow(schema, "timestamp", context);
+        assertNotNull(result);
+        assertEquals(5000L, ((LocalDateTime) result).toInstant(ZoneOffset.UTC).toEpochMilli());
+    }
+
+    @Test
+    public void writeRowTemplate_datemilli_dateInstance_writesEpochMillis() throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder().addDateMilliField("timestamp").build();
+        Date d = new Date(6000L);
+        Map<String, Object> context = new HashMap<>();
+        context.put("timestamp", d);
+
+        Object result = writeAndReadOneRow(schema, "timestamp", context);
+        assertNotNull(result);
+        assertEquals(6000L, ((LocalDateTime) result).toInstant(ZoneOffset.UTC).toEpochMilli());
+    }
+
+    @Test
+    public void writeRowTemplate_datemilli_valueMapList_writesFirstElement() throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder().addDateMilliField("timestamp").build();
+        ArrayList<Object> list = new ArrayList<>();
+        list.add(7000L);
+        Map<String, Object> context = new HashMap<>();
+        context.put("timestamp", list);
+
+        Object result = writeAndReadOneRow(schema, "timestamp", context);
+        assertNotNull(result);
+        assertEquals(7000L, ((LocalDateTime) result).toInstant(ZoneOffset.UTC).toEpochMilli());
+    }
+
+    @Test
+    public void writeRowTemplate_int_scalar_writesValue() throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder().addIntField("numberField").build();
+        Map<String, Object> context = new HashMap<>();
+        context.put("numberField", 99);
+
+        Object result = writeAndReadOneRow(schema, "numberField", context);
+        assertNotNull(result);
+        assertEquals(99, ((Number) result).intValue());
+    }
+
+    @Test
+    public void writeRowTemplate_int_valueMapList_writesFirstElement() throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder().addIntField("numberField").build();
+        Map<String, Object> context = new HashMap<>();
+        ArrayList<Object> list = new ArrayList<>();
+        list.add(42);
+        context.put("numberField", list);
+
+        Object result = writeAndReadOneRow(schema, "numberField", context);
+        assertNotNull(result);
+        assertEquals(42, ((Number) result).intValue());
+    }
+
+    @Test
+    public void writeRowTemplate_bigint_valueMapList_writesFirstElement() throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder().addBigIntField("bigIntField").build();
+        Map<String, Object> context = new HashMap<>();
+        ArrayList<Object> list = new ArrayList<>();
+        list.add(999L);
+        context.put("bigIntField", list);
+
+        Object result = writeAndReadOneRow(schema, "bigIntField", context);
+        assertNotNull(result);
+        assertEquals(999L, ((Number) result).longValue());
+    }
+
+    @Test
+    public void writeRowTemplate_float4_valueMapList_writesFirstElement() throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder().addFloat4Field("floatField").build();
+        Map<String, Object> context = new HashMap<>();
+        ArrayList<Object> list = new ArrayList<>();
+        list.add(2.5f);
+        context.put("floatField", list);
+
+        Object result = writeAndReadOneRow(schema, "floatField", context);
+        assertNotNull(result);
+        assertEquals(2.5f, ((Number) result).floatValue(), 1e-6f);
+    }
+
+    @Test
+    public void writeRowTemplate_float8_scalar_writesValue() throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder().addFloat8Field("doubleField").build();
+        Map<String, Object> context = new HashMap<>();
+        context.put("doubleField", 1.5);
+
+        Object result = writeAndReadOneRow(schema, "doubleField", context);
+        assertNotNull(result);
+        assertEquals(1.5, ((Number) result).doubleValue(), 1e-9);
+    }
+}

--- a/athena-neptune/src/test/java/com/amazonaws/athena/connectors/neptune/propertygraph/rowwriters/FieldValueNormalizerTest.java
+++ b/athena-neptune/src/test/java/com/amazonaws/athena/connectors/neptune/propertygraph/rowwriters/FieldValueNormalizerTest.java
@@ -1,0 +1,164 @@
+/*-
+ * #%L
+ * athena-neptune
+ * %%
+ * Copyright (C) 2019 - 2026 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.neptune.propertygraph.rowwriters;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+public class FieldValueNormalizerTest
+{
+    @Test
+    public void toValueList_nullInput_returnsNull()
+    {
+        assertNull(FieldValueNormalizer.toValueList(null));
+    }
+
+    @Test
+    public void toValueList_listInput_returnsSameList()
+    {
+        List<Object> list = new ArrayList<>();
+        list.add("a");
+        list.add(1);
+        List<Object> result = FieldValueNormalizer.toValueList(list);
+        assertNotNull(result);
+        assertSame(list, result);
+        assertEquals(2, result.size());
+        assertEquals("a", result.get(0));
+        assertEquals(1, result.get(1));
+    }
+
+    @Test
+    public void toValueList_emptyListInput_returnsSameList()
+    {
+        List<Object> list = Collections.emptyList();
+        List<Object> result = FieldValueNormalizer.toValueList(list);
+        assertNotNull(result);
+        assertSame(list, result);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void toValueList_stringScalarInput_returnsSingletonList()
+    {
+        List<Object> result = FieldValueNormalizer.toValueList("hello");
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals("hello", result.get(0));
+    }
+
+    @Test
+    public void toValueList_integerScalarInput_returnsSingletonList()
+    {
+        List<Object> result = FieldValueNormalizer.toValueList(42);
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals(42, result.get(0));
+    }
+
+    @Test
+    public void toValueList_longScalarInput_returnsSingletonList()
+    {
+        List<Object> result = FieldValueNormalizer.toValueList(123L);
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals(123L, result.get(0));
+    }
+
+    @Test
+    public void toValueList_booleanScalarInput_returnsSingletonList()
+    {
+        List<Object> result = FieldValueNormalizer.toValueList(true);
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals(true, result.get(0));
+    }
+
+    @Test
+    public void toValueList_emptyMapInput_returnsSingletonListWithEmptyBraces()
+    {
+        Map<String, Object> map = new HashMap<>();
+        List<Object> result = FieldValueNormalizer.toValueList(map);
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals("{}", result.get(0));
+    }
+
+    @Test
+    public void toValueList_singleEntryMapInput_returnsSingletonListWithStringRepresentation()
+    {
+        Map<String, Object> map = new HashMap<>();
+        map.put("name", "alice");
+        List<Object> result = FieldValueNormalizer.toValueList(map);
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        String str = (String) result.get(0);
+        assertTrue(str.startsWith("{"));
+        assertTrue(str.endsWith("}"));
+        assertTrue(str.contains("name=alice"));
+    }
+
+    @Test
+    public void toValueList_multipleEntryMapInput_returnsSingletonListWithStringRepresentation()
+    {
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("a", 1);
+        map.put("b", "two");
+        List<Object> result = FieldValueNormalizer.toValueList(map);
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals("{a=1,b=two}", result.get(0));
+    }
+
+    @Test
+    public void toValueList_mapWithNullValue_returnsStringContainingNull()
+    {
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("key", null);
+        List<Object> result = FieldValueNormalizer.toValueList(map);
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertTrue(((String) result.get(0)).contains("null"));
+    }
+
+    @Test
+    public void toValueList_valueMapStyleListInput_returnsSameList()
+    {
+        List<Object> valueMapStyle = new ArrayList<>();
+        valueMapStyle.add("v1");
+        valueMapStyle.add("v2");
+        List<Object> result = FieldValueNormalizer.toValueList(valueMapStyle);
+        assertNotNull(result);
+        assertSame(valueMapStyle, result);
+        assertEquals("v1", result.get(0));
+        assertEquals("v2", result.get(1));
+    }
+}

--- a/athena-neptune/src/test/java/com/amazonaws/athena/connectors/neptune/propertygraph/rowwriters/VertexRowWriterTest.java
+++ b/athena-neptune/src/test/java/com/amazonaws/athena/connectors/neptune/propertygraph/rowwriters/VertexRowWriterTest.java
@@ -1,0 +1,268 @@
+/*-
+ * #%L
+ * athena-neptune
+ * %%
+ * Copyright (C) 2019 - 2026 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.neptune.propertygraph.rowwriters;
+
+import com.amazonaws.athena.connector.lambda.data.Block;
+import com.amazonaws.athena.connector.lambda.data.BlockAllocatorImpl;
+import com.amazonaws.athena.connector.lambda.data.SchemaBuilder;
+import com.amazonaws.athena.connector.lambda.data.writers.GeneratedRowWriter;
+import org.apache.arrow.vector.complex.reader.FieldReader;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for the changed logic in VertexRowWriter: FieldValueNormalizer usage,
+ * valueMap vs project().by() (list vs scalar vs Map), and VARCHAR null-first-element handling.
+ */
+public class VertexRowWriterTest
+{
+    private BlockAllocatorImpl allocator;
+
+    @Before
+    public void setUp()
+    {
+        allocator = new BlockAllocatorImpl();
+    }
+
+    @After
+    public void tearDown()
+    {
+        if (allocator != null) {
+            allocator.close();
+        }
+    }
+
+    private Map<String, String> configOptions()
+    {
+        return Collections.emptyMap();
+    }
+
+    private Object writeAndReadOneRow(Schema schema, String fieldName, Map<String, Object> context) throws Exception
+    {
+        GeneratedRowWriter.RowWriterBuilder builder = GeneratedRowWriter.newBuilder();
+        for (org.apache.arrow.vector.types.pojo.Field f : schema.getFields()) {
+            VertexRowWriter.writeRowTemplate(builder, f, configOptions());
+        }
+        GeneratedRowWriter rowWriter = builder.build();
+        try (Block block = allocator.createBlock(schema)) {
+            assertTrue(rowWriter.writeRow(block, 0, context));
+            block.setRowCount(1);
+            FieldReader reader = block.getFieldReaders().stream()
+                    .filter(r -> r.getField().getName().equals(fieldName))
+                    .findFirst()
+                    .orElseThrow();
+            reader.setPosition(0);
+            if (!reader.isSet()) {
+                return null;
+            }
+            return reader.readObject();
+        }
+    }
+
+    @Test
+    public void writeRowTemplate_varchar_valueMapList_writesFirstElement() throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder().addStringField("name").build();
+        Map<String, Object> context = new HashMap<>();
+        ArrayList<Object> list = new ArrayList<>();
+        list.add("alice");
+        context.put("name", list);
+
+        Object result = writeAndReadOneRow(schema, "name", context);
+        assertNotNull(result);
+        assertEquals("alice", result.toString());
+    }
+
+    @Test
+    public void writeRowTemplate_varchar_scalarString_writesValue() throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder().addStringField("name").build();
+        Map<String, Object> context = new HashMap<>();
+        context.put("name", "bob");
+
+        Object result = writeAndReadOneRow(schema, "name", context);
+        assertNotNull(result);
+        assertEquals("bob", result.toString());
+    }
+
+    @Test
+    public void writeRowTemplate_varchar_mapFromByValueMap_writesStringRepresentation() throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder().addStringField("props").build();
+        Map<String, Object> context = new HashMap<>();
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("a", 1);
+        map.put("b", "two");
+        context.put("props", map);
+
+        Object result = writeAndReadOneRow(schema, "props", context);
+        assertNotNull(result);
+        String str = result.toString();
+        assertTrue(str.contains("a=1"));
+        assertTrue(str.contains("b=two"));
+    }
+
+    @Test
+    public void writeRowTemplate_varchar_listWithNullFirstElement_doesNotSetValue() throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder().addStringField("name").build();
+        Map<String, Object> context = new HashMap<>();
+        ArrayList<Object> list = new ArrayList<>();
+        list.add(null);
+        context.put("name", list);
+
+        Object result = writeAndReadOneRow(schema, "name", context);
+        assertNull(result);
+    }
+
+    @Test
+    public void writeRowTemplate_varchar_multipleValuesWithNull_joinsWithoutNpe() throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder().addStringField("tags").build();
+        Map<String, Object> context = new HashMap<>();
+        ArrayList<Object> list = new ArrayList<>();
+        list.add("x");
+        list.add(null);
+        list.add("z");
+        context.put("tags", list);
+
+        Object result = writeAndReadOneRow(schema, "tags", context);
+        assertNotNull(result);
+        assertEquals("x;;z", result.toString());
+    }
+
+    @Test
+    public void writeRowTemplate_bit_valueMapListTrue_writesOne() throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder().addBitField("flag").build();
+        Map<String, Object> context = new HashMap<>();
+        ArrayList<Object> list = new ArrayList<>();
+        list.add(true);
+        context.put("flag", list);
+
+        Object result = writeAndReadOneRow(schema, "flag", context);
+        assertNotNull(result);
+        assertTrue((Boolean) result);
+    }
+
+    @Test
+    public void writeRowTemplate_datemilli_longEpoch_writesValue() throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder().addDateMilliField("timestamp").build();
+        Map<String, Object> context = new HashMap<>();
+        context.put("timestamp", 5000L);
+
+        Object result = writeAndReadOneRow(schema, "timestamp", context);
+        assertNotNull(result);
+        assertEquals(5000L, ((LocalDateTime) result).toInstant(ZoneOffset.UTC).toEpochMilli());
+    }
+
+    @Test
+    public void writeRowTemplate_datemilli_dateInstance_writesEpochMillis() throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder().addDateMilliField("timestamp").build();
+        Date d = new Date(6000L);
+        Map<String, Object> context = new HashMap<>();
+        context.put("timestamp", d);
+
+        Object result = writeAndReadOneRow(schema, "timestamp", context);
+        assertNotNull(result);
+        assertEquals(6000L, ((LocalDateTime) result).toInstant(ZoneOffset.UTC).toEpochMilli());
+    }
+
+    @Test
+    public void writeRowTemplate_int_scalar_writesValue() throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder().addIntField("numberField").build();
+        Map<String, Object> context = new HashMap<>();
+        context.put("numberField", 99);
+
+        Object result = writeAndReadOneRow(schema, "numberField", context);
+        assertNotNull(result);
+        assertEquals(99, ((Number) result).intValue());
+    }
+
+    @Test
+    public void writeRowTemplate_bigint_valueMapList_writesFirstElement() throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder().addBigIntField("bigIntField").build();
+        Map<String, Object> context = new HashMap<>();
+        ArrayList<Object> list = new ArrayList<>();
+        list.add(999L);
+        context.put("bigIntField", list);
+
+        Object result = writeAndReadOneRow(schema, "bigIntField", context);
+        assertNotNull(result);
+        assertEquals(999L, ((Number) result).longValue());
+    }
+
+    @Test
+    public void writeRowTemplate_float4_valueMapList_writesFirstElement() throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder().addFloat4Field("floatField").build();
+        Map<String, Object> context = new HashMap<>();
+        ArrayList<Object> list = new ArrayList<>();
+        list.add(2.5f);
+        context.put("floatField", list);
+
+        Object result = writeAndReadOneRow(schema, "floatField", context);
+        assertNotNull(result);
+        assertEquals(2.5f, ((Number) result).floatValue(), 1e-6f);
+    }
+
+    @Test
+    public void writeRowTemplate_float8_scalar_writesValue() throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder().addFloat8Field("doubleField").build();
+        Map<String, Object> context = new HashMap<>();
+        context.put("doubleField", 1.5);
+
+        Object result = writeAndReadOneRow(schema, "doubleField", context);
+        assertNotNull(result);
+        assertEquals(1.5, ((Number) result).doubleValue(), 1e-9);
+    }
+
+    @Test
+    public void writeRowTemplate_varchar_nullField_doesNotSetValue() throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder().addStringField("name").build();
+        Map<String, Object> context = new HashMap<>();
+        context.put("name", null);
+
+        Object result = writeAndReadOneRow(schema, "name", context);
+        assertNull(result);
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
**Overview**
This PR adds full valueMap() support for Gremlin Query Pushdown (QPT) in the Athena–Neptune connector.
Row writers now correctly handle both:

- valueMap()-style results (where property values are Lists), and
- project().by()-style results (scalars or nested Maps).

This avoids ClassCastException and enables consistent behavior across different Gremlin result shapes.

**Problem**
Gremlin QPT can return property data in different shapes depending on the traversal:
_valueMap()_ → properties are returned as Map<String, List<Object>>
Example: name -> [John]
_project().by() / by(valueMap())_ → properties can be scalars or Map values
Example: all_properties -> Map

Previously, row writers assumed a single result shape when reading field values.
This could lead to:

- ClassCastException
- Incorrect field handling when the result format differed

**Changes**
Row writers updated to use the normalizer
All extractors in the following classes now retrieve field values using:
FieldValueNormalizer.toValueList(...)
The extractors then read from the resulting list, ensuring compatibility with both valueMap() and project()-style results.
Updated classes:

1. CustomSchemaRowWriter – Custom schema vertex/edge row writing
2. VertexRowWriter – Vertex row writing
3. EdgeRowWriter – Edge row writing

Find attached document for [supported query types and limitations](https://github.com/user-attachments/files/25545370/Neptune_Gremlin_QPT_valueMap_Support_Updated.docx) as well as [functional test results](https://github.com/user-attachments/files/25545393/NEPTUNE_FUNCTIONAL_TEST.xlsx).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
