### PR TITLE
Remove shaded jar from container image 

### DIFF
--- a/athena-postgresql/Dockerfile
+++ b/athena-postgresql/Dockerfile
@@ -1,6 +1,18 @@
 # Argument for Java version, defaulting to 11.al2023-x86_64
 ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
+FROM public.ecr.aws/lambda/java:${JAVA_VERSION} AS builder
+
+# Argument for JAR version
+ARG JAR_VERSION=2022.47.1
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-postgresql-${JAR_VERSION}.jar /app/
+
+# Unpack the JAR and then remove it
+WORKDIR /app
+RUN jar xf athena-postgresql-${JAR_VERSION}.jar && rm -f athena-postgresql-${JAR_VERSION}.jar
+
+# Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
@@ -8,10 +20,8 @@ ARG JAVA_TOOL_OPTIONS=""
 # Set the JAVA_TOOL_OPTIONS environment variable for Java 17
 ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
 
-# Copy function code and runtime dependencies from Maven layout
-COPY target/athena-postgresql-2022.47.1.jar ${LAMBDA_TASK_ROOT}
-# Unpack the jar
-RUN jar xf athena-postgresql-2022.47.1.jar
+# Copy the extracted contents from the builder stage to the Lambda task root directory
+COPY --from=builder /app/ ${LAMBDA_TASK_ROOT}/
 
 # Command can be overwritten by providing a different command in the template directly.
 # No need to specify here (already defined in athena-postgresql.yaml because has two different handlers)

--- a/tools/bump_versions/common.py
+++ b/tools/bump_versions/common.py
@@ -41,7 +41,10 @@ def update_yaml(yaml_files, new_version):
 
 def update_dockerfile(dockerfiles, new_version):
     for file in dockerfiles:
+        # Replace literal athena-*-X.Y.Z.jar (e.g. athena-mysql-2022.47.1.jar)
         subprocess.run(["sed", "-i", f"s|\(athena-.*\)-[0-9]*\.[0-9]*\.[0-9]*\.jar|\\1-{new_version}.jar|g", file])
+        # Replace ARG JAR_VERSION=X.Y.Z (e.g. athena-postgresql Dockerfile uses this)
+        subprocess.run(["sed", "-i", f"s/\\(ARG JAR_VERSION=\\)[0-9]*\\.[0-9]*\\.[0-9]*/\\1{new_version}/", file])
 
 
 def update_project_version(soup, new_version):


### PR DESCRIPTION
*Issue #, if available:*
[#2410](https://github.com/awslabs/aws-athena-query-federation/issues/2410)

*Description of changes:*

This PR does two things: 
1. Shrinks the Athena PostgreSQL connector Lambda image size by removing the JAR file from the final image layer after extraction. This reduced the image size by 83MB.
2. Ensures the release bump script updates ARG JAR_VERSION in connector Dockerfiles (e.g. athena-postgresql).

Please find the attached change documentation and functional test document.
[Postgres_docker_image_optimization.docx](https://github.com/user-attachments/files/26046435/Postgres_docker_image_optimization.docx)
[POSTGRES_FUNCTIONAL_TEST.xlsx](https://github.com/user-attachments/files/26046434/POSTGRES_FUNCTIONAL_TEST.xlsx)

Note: Once this PR is approved, we will raise pull requests for the other connectors to apply the same changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
