### PR TITLE
Add Query Federation Support for SAP HANA

### DIFF
--- a/athena-saphana/pom.xml
+++ b/athena-saphana/pom.xml
@@ -65,6 +65,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.sap.cloud.db.jdbc</groupId>
             <artifactId>ngdbc</artifactId>
             <!--            <version>2.11.17</version>-->
@@ -93,6 +98,17 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Multi-Release>true</Multi-Release>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/athena-saphana/src/main/java/com/amazonaws/athena/connectors/saphana/SAPHanaSqlDialect.java
+++ b/athena-saphana/src/main/java/com/amazonaws/athena/connectors/saphana/SAPHanaSqlDialect.java
@@ -1,0 +1,165 @@
+/*-
+ * #%L
+ * athena-saphana
+ * %%
+ * Copyright (C) 2019 - 2026 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.saphana;
+
+import org.apache.calcite.avatica.util.Casing;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.sql.SqlBasicCall;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlDialect;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.dialect.PostgresqlSqlDialect;
+import org.apache.calcite.sql.fun.SqlLibraryOperators;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Calcite SQL dialect for SAP HANA (Calcite 1.40.0).
+ *
+ * Behavior:
+ *  - Unquoted identifiers are folded to UPPERCASE
+ *  - Quoted identifiers preserve case
+ *  - BOOLEAN MAX/MIN rewritten to BOOL aggregations
+ *  - OFFSET/FETCH rendered as LIMIT/OFFSET
+ */
+public class SAPHanaSqlDialect extends PostgresqlSqlDialect
+{
+    public static final SqlDialect.Context DEFAULT_CONTEXT =
+            SqlDialect.EMPTY_CONTEXT
+                    .withDatabaseProduct(DatabaseProduct.UNKNOWN)
+                    .withIdentifierQuoteString("\"")
+                    .withUnquotedCasing(Casing.TO_UPPER)
+                    .withQuotedCasing(Casing.UNCHANGED)
+                    .withCaseSensitive(false);
+
+    public static final SAPHanaSqlDialect DEFAULT =
+            new SAPHanaSqlDialect(DEFAULT_CONTEXT, false);
+    private final boolean upperCaseFilterApplied;
+
+    public SAPHanaSqlDialect(Context context, boolean upperCaseFilterApplied)
+    {
+        super(context);
+        this.upperCaseFilterApplied = upperCaseFilterApplied;
+    }
+
+    // ----------------------------------------------------------------------
+    // Function rewriting
+    // ----------------------------------------------------------------------
+
+    @Override
+    public void unparseCall(
+            SqlWriter writer,
+            SqlCall call,
+            int leftPrec,
+            int rightPrec)
+    {
+        switch (call.getKind()) {
+            case CHAR_LENGTH:
+                // Normalize CHAR_LENGTH(x) -> LENGTH(x)
+                SqlCall lengthCall =
+                        SqlLibraryOperators.LENGTH.createCall(
+                                SqlParserPos.ZERO,
+                                call.getOperandList());
+                super.unparseCall(writer, lengthCall, leftPrec, rightPrec);
+                return;
+
+            default:
+                super.unparseCall(writer, call, leftPrec, rightPrec);
+        }
+    }
+
+    // ----------------------------------------------------------------------
+    // Aggregate rewrites
+    // ----------------------------------------------------------------------
+
+    /**
+     * Rewrite MAX/MIN(boolean) since SAP HANA does not support
+     * MAX/MIN on BOOLEAN types.
+     *
+     * MAX(boolean) -> BOOLOR_AGG
+     * MIN(boolean) -> BOOLAND_AGG
+     */
+    public SqlNode rewriteMaxMinExpr(SqlNode aggCall, RelDataType relDataType)
+    {
+        if (!(aggCall instanceof SqlBasicCall)) {
+            return aggCall;
+        }
+
+        SqlTypeName type = relDataType.getSqlTypeName();
+        if (type != SqlTypeName.BOOLEAN) {
+            return aggCall;
+        }
+
+        SqlKind kind = aggCall.getKind();
+        if (kind != SqlKind.MAX && kind != SqlKind.MIN) {
+            return aggCall;
+        }
+
+        boolean isMax = kind == SqlKind.MAX;
+        SqlOperator operator =
+                isMax
+                        ? SqlLibraryOperators.BOOLOR_AGG
+                        : SqlLibraryOperators.BOOLAND_AGG;
+
+        SqlNode operand = ((SqlBasicCall) aggCall).operand(0);
+        return operator.createCall(SqlParserPos.ZERO, operand);
+    }
+
+    // ----------------------------------------------------------------------
+    // LIMIT / OFFSET
+    // ----------------------------------------------------------------------
+
+    @Override
+    public void unparseOffsetFetch(
+            SqlWriter writer,
+            @Nullable SqlNode offset,
+            @Nullable SqlNode fetch)
+    {
+        // SAP HANA uses: LIMIT <fetch> OFFSET <offset>
+        unparseFetchUsingLimit(writer, offset, fetch);
+    }
+
+    // ----------------------------------------------------------------------
+    // Feature support
+    // ----------------------------------------------------------------------
+
+    @Override
+    public boolean supportsApproxCountDistinct()
+    {
+        // SAP HANA does not support approximate distinct aggregates
+        return false;
+    }
+
+    @Override
+    public StringBuilder quoteIdentifier(StringBuilder buf, String identifier)
+    {
+        if (upperCaseFilterApplied) {
+            buf.append(identifier);
+        }
+        else {
+            buf.append('"').append(identifier).append('"');
+        }
+        return buf;
+    }
+}

--- a/athena-saphana/src/main/java/com/amazonaws/athena/connectors/saphana/SAPHanaSqlDialect.java
+++ b/athena-saphana/src/main/java/com/amazonaws/athena/connectors/saphana/SAPHanaSqlDialect.java
@@ -100,6 +100,7 @@ public class SAPHanaSqlDialect extends PostgresqlSqlDialect
      * MAX(boolean) -> BOOLOR_AGG
      * MIN(boolean) -> BOOLAND_AGG
      */
+    @Override
     public SqlNode rewriteMaxMinExpr(SqlNode aggCall, RelDataType relDataType)
     {
         if (!(aggCall instanceof SqlBasicCall)) {
@@ -155,11 +156,10 @@ public class SAPHanaSqlDialect extends PostgresqlSqlDialect
     public StringBuilder quoteIdentifier(StringBuilder buf, String identifier)
     {
         if (upperCaseFilterApplied) {
-            buf.append(identifier);
+            return buf.append(identifier);
         }
         else {
-            buf.append('"').append(identifier).append('"');
+            return super.quoteIdentifier(buf, identifier.toLowerCase());
         }
-        return buf;
     }
 }

--- a/athena-saphana/src/main/java/com/amazonaws/athena/connectors/saphana/SaphanaMetadataHandler.java
+++ b/athena-saphana/src/main/java/com/amazonaws/athena/connectors/saphana/SaphanaMetadataHandler.java
@@ -23,6 +23,7 @@ package com.amazonaws.athena.connectors.saphana;
 import com.amazonaws.athena.connector.credentials.CredentialsProvider;
 import com.amazonaws.athena.connector.credentials.CredentialsProviderFactory;
 import com.amazonaws.athena.connector.lambda.QueryStatusChecker;
+import com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants;
 import com.amazonaws.athena.connector.lambda.data.Block;
 import com.amazonaws.athena.connector.lambda.data.BlockAllocator;
 import com.amazonaws.athena.connector.lambda.data.BlockWriter;
@@ -192,7 +193,7 @@ public class SaphanaMetadataHandler extends JdbcMetadataHandler
         //check if the input table is a view
         boolean viewFlag = false;
         List<String> viewparameters = Arrays.asList(getTableLayoutRequest.getTableName().getSchemaName(), getTableLayoutRequest.getTableName().getTableName());
-        try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider())) {
+        try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider(getRequestOverrideConfig(getTableLayoutRequest)))) {
             try (PreparedStatement preparedStatement = new PreparedStatementBuilder().withConnection(connection).withQuery(SaphanaConstants.VIEW_CHECK_QUERY).withParameters(viewparameters).build();
                  ResultSet resultSet = preparedStatement.executeQuery()) {
                 if (resultSet.next()) {
@@ -211,7 +212,7 @@ public class SaphanaMetadataHandler extends JdbcMetadataHandler
         else {
             List<String> parameters = Arrays.asList(getTableLayoutRequest.getTableName().getTableName(),
                     getTableLayoutRequest.getTableName().getSchemaName());
-            try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider())) {
+            try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider(getRequestOverrideConfig(getTableLayoutRequest)))) {
                 try (PreparedStatement preparedStatement = new PreparedStatementBuilder().withConnection(connection)
                         .withQuery(SaphanaConstants.GET_PARTITIONS_QUERY).withParameters(parameters).build();
                      ResultSet resultSet = preparedStatement.executeQuery()) {
@@ -300,6 +301,12 @@ public class SaphanaMetadataHandler extends JdbcMetadataHandler
             LOGGER.debug("{}: Input partition is {}", getSplitsRequest.getQueryId(), locationReader.readText());
             Split.Builder splitBuilder = Split.newBuilder(spillLocation, makeEncryptionKey())
                     .add(SaphanaConstants.BLOCK_PARTITION_COLUMN_NAME, String.valueOf(locationReader.readText()));
+            if (getSplitsRequest.getIdentity()
+                    .getConfigOptions().containsKey(EnvironmentConstants.CATALOG_CASING_FILTER)) {
+                splitBuilder.add(EnvironmentConstants.CATALOG_CASING_FILTER,
+                        getSplitsRequest.getIdentity()
+                                .getConfigOptions().get(EnvironmentConstants.CATALOG_CASING_FILTER));
+            }
             splits.add(splitBuilder.build());
             if (splits.size() >= SaphanaConstants.MAX_SPLITS_PER_REQUEST) {
                 //We exceeded the number of split we want to return in a single request, return and provide a continuation token.
@@ -337,7 +344,7 @@ public class SaphanaMetadataHandler extends JdbcMetadataHandler
         SchemaBuilder schemaBuilder = SchemaBuilder.newBuilder();
 
         try (ResultSet resultSet = getColumns(jdbcConnection.getCatalog(), tableName, jdbcConnection.getMetaData());
-             Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider())) {
+             Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider(requestOverrideConfiguration))) {
             HashMap<String, String> hashMap = new HashMap<String, String>();
             // fetch data types for columns for appropriate datatype to arrowtype conversions.
             ResultSet dataTypeResultSet = getColumnDatatype(connection, tableName);
@@ -456,9 +463,10 @@ public class SaphanaMetadataHandler extends JdbcMetadataHandler
     public CredentialsProvider createCredentialsProvider(String secretName, AwsRequestOverrideConfiguration requestOverrideConfiguration)
     {
         return CredentialsProviderFactory.createCredentialProvider(
-                getDatabaseConnectionConfig().getSecret(),
+                secretName,
                 getCachableSecretsManager(),
-                new SaphanaOAuthCredentialsProvider()
+                new SaphanaOAuthCredentialsProvider(),
+                requestOverrideConfiguration
         );
     }
 }

--- a/athena-saphana/src/main/java/com/amazonaws/athena/connectors/saphana/SaphanaQueryStringBuilder.java
+++ b/athena-saphana/src/main/java/com/amazonaws/athena/connectors/saphana/SaphanaQueryStringBuilder.java
@@ -36,6 +36,7 @@ import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.calcite.sql.SqlDialect;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -134,6 +135,12 @@ public class SaphanaQueryStringBuilder extends JdbcSplitQueryBuilder
             final Split split)
             throws SQLException
     {
+        if (constraints.getQueryPlan() != null) {
+            boolean casingFilter = isCatalogCasingFilterApplied(split);
+            SqlDialect sqlDialect = getSqlDialect(casingFilter);
+            return prepareStatementWithCalciteSql(jdbcConnection, constraints, sqlDialect, split);
+        }
+
         StringBuilder sql = new StringBuilder();
         String columnNames = tableSchema.getFields().stream()
                 .map(this::quoteField)
@@ -228,6 +235,19 @@ public class SaphanaQueryStringBuilder extends JdbcSplitQueryBuilder
         LOGGER.debug("Field name to quote {}", name);
         name = name.replace(SAPHANA_QUOTE_CHARACTER, SAPHANA_QUOTE_CHARACTER + SAPHANA_QUOTE_CHARACTER);
         return SAPHANA_QUOTE_CHARACTER + name + SAPHANA_QUOTE_CHARACTER;
+    }
+
+    @Override
+    protected SqlDialect getSqlDialect()
+    {
+        return SAPHanaSqlDialect.DEFAULT;
+    }
+
+    @Override
+    protected SqlDialect getSqlDialect(boolean catalogCasingFilterApplied)
+    {
+        return new SAPHanaSqlDialect(SAPHanaSqlDialect.DEFAULT_CONTEXT,
+                catalogCasingFilterApplied);
     }
 
     private String quoteField(Field field)

--- a/athena-saphana/src/main/java/com/amazonaws/athena/connectors/saphana/SaphanaQueryStringBuilder.java
+++ b/athena-saphana/src/main/java/com/amazonaws/athena/connectors/saphana/SaphanaQueryStringBuilder.java
@@ -20,6 +20,7 @@
  */
 package com.amazonaws.athena.connectors.saphana;
 
+import com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants;
 import com.amazonaws.athena.connector.lambda.domain.Split;
 import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
 import com.amazonaws.athena.connector.lambda.domain.predicate.Range;
@@ -136,8 +137,15 @@ public class SaphanaQueryStringBuilder extends JdbcSplitQueryBuilder
             throws SQLException
     {
         if (constraints.getQueryPlan() != null) {
-            boolean casingFilter = isCatalogCasingFilterApplied(split);
-            SqlDialect sqlDialect = getSqlDialect(casingFilter);
+            String catalogCasingFilter = split.getProperty(EnvironmentConstants.CATALOG_CASING_FILTER);
+            SqlDialect sqlDialect;
+            if (catalogCasingFilter != null) {
+                LOGGER.debug("Found catalogCasingFilter for getSqlDialect: {}", catalogCasingFilter);
+                sqlDialect = getSqlDialect(catalogCasingFilter.equals(EnvironmentConstants.UPPERCASE_ONLY));
+            }
+            else {
+                sqlDialect = getSqlDialect();
+            }
             return prepareStatementWithCalciteSql(jdbcConnection, constraints, sqlDialect, split);
         }
 

--- a/athena-saphana/src/main/java/com/amazonaws/athena/connectors/saphana/SaphanaRecordHandler.java
+++ b/athena-saphana/src/main/java/com/amazonaws/athena/connectors/saphana/SaphanaRecordHandler.java
@@ -122,7 +122,8 @@ public class SaphanaRecordHandler extends JdbcRecordHandler
         return CredentialsProviderFactory.createCredentialProvider(
                 getDatabaseConnectionConfig().getSecret(),
                 getCachableSecretsManager(),
-                new SaphanaOAuthCredentialsProvider()
+                new SaphanaOAuthCredentialsProvider(),
+                requestOverrideConfiguration
         );
     }
 }

--- a/athena-saphana/src/test/java/com/amazonaws/athena/connectors/saphana/SAPHanaSqlDialectTest.java
+++ b/athena-saphana/src/test/java/com/amazonaws/athena/connectors/saphana/SAPHanaSqlDialectTest.java
@@ -1,0 +1,229 @@
+/*-
+ * #%L
+ * athena-saphana
+ * %%
+ * Copyright (C) 2019 - 2026 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.saphana;
+
+import org.apache.calcite.avatica.util.Casing;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.sql.SqlBasicCall;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class SAPHanaSqlDialectTest
+{
+    @Mock
+    private RelDataType booleanType;
+
+    @Mock
+    private RelDataType intType;
+
+    @Before
+    public void setup()
+    {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testDefaultDialectExists()
+    {
+        assertNotNull(SAPHanaSqlDialect.DEFAULT);
+        assertFalse(SAPHanaSqlDialect.DEFAULT.supportsApproxCountDistinct());
+    }
+
+    @Test
+    public void testDialectContext()
+    {
+        assertEquals("\"", SAPHanaSqlDialect.DEFAULT_CONTEXT.identifierQuoteString());
+        assertEquals(Casing.TO_UPPER, SAPHanaSqlDialect.DEFAULT_CONTEXT.unquotedCasing());
+        assertEquals(Casing.UNCHANGED, SAPHanaSqlDialect.DEFAULT_CONTEXT.quotedCasing());
+        assertFalse(SAPHanaSqlDialect.DEFAULT_CONTEXT.caseSensitive());
+    }
+
+    @Test
+    public void testCustomDialectCreationWithUpperCaseFilter()
+    {
+        SAPHanaSqlDialect dialect = new SAPHanaSqlDialect(SAPHanaSqlDialect.DEFAULT_CONTEXT, true);
+        assertFalse(dialect.supportsApproxCountDistinct());
+    }
+
+    @Test
+    public void testCustomDialectCreationWithoutUpperCaseFilter()
+    {
+        SAPHanaSqlDialect dialect = new SAPHanaSqlDialect(SAPHanaSqlDialect.DEFAULT_CONTEXT, false);
+        assertFalse(dialect.supportsApproxCountDistinct());
+    }
+
+    @Test
+    public void testRewriteMaxMinExprNonSqlBasicCall()
+    {
+        SAPHanaSqlDialect dialect = SAPHanaSqlDialect.DEFAULT;
+        when(booleanType.getSqlTypeName()).thenReturn(SqlTypeName.BOOLEAN);
+
+        SqlNode literal = SqlLiteral.createBoolean(true, SqlParserPos.ZERO);
+        SqlNode result = dialect.rewriteMaxMinExpr(literal, booleanType);
+        assertEquals(literal, result);
+    }
+
+    @Test
+    public void testRewriteMaxMinExprNonBooleanType()
+    {
+        SAPHanaSqlDialect dialect = SAPHanaSqlDialect.DEFAULT;
+        when(intType.getSqlTypeName()).thenReturn(SqlTypeName.INTEGER);
+
+        SqlNode operand = SqlLiteral.createExactNumeric("1", SqlParserPos.ZERO);
+        SqlBasicCall maxCall = (SqlBasicCall) SqlStdOperatorTable.MAX.createCall(SqlParserPos.ZERO, operand);
+        
+        SqlNode result = dialect.rewriteMaxMinExpr(maxCall, intType);
+        assertEquals(maxCall, result);
+    }
+
+    @Test
+    public void testRewriteMaxMinExprMaxBoolean()
+    {
+        SAPHanaSqlDialect dialect = SAPHanaSqlDialect.DEFAULT;
+        when(booleanType.getSqlTypeName()).thenReturn(SqlTypeName.BOOLEAN);
+
+        SqlNode operand = SqlLiteral.createBoolean(true, SqlParserPos.ZERO);
+        SqlBasicCall maxCall = (SqlBasicCall) SqlStdOperatorTable.MAX.createCall(SqlParserPos.ZERO, operand);
+        
+        SqlNode result = dialect.rewriteMaxMinExpr(maxCall, booleanType);
+        assertNotNull(result);
+        assertNotEquals(maxCall, result);
+    }
+
+    @Test
+    public void testRewriteMaxMinExprMinBoolean()
+    {
+        SAPHanaSqlDialect dialect = SAPHanaSqlDialect.DEFAULT;
+        when(booleanType.getSqlTypeName()).thenReturn(SqlTypeName.BOOLEAN);
+
+        SqlNode operand = SqlLiteral.createBoolean(false, SqlParserPos.ZERO);
+        SqlBasicCall minCall = (SqlBasicCall) SqlStdOperatorTable.MIN.createCall(SqlParserPos.ZERO, operand);
+        
+        SqlNode result = dialect.rewriteMaxMinExpr(minCall, booleanType);
+        assertNotNull(result);
+        assertNotEquals(minCall, result);
+    }
+
+    @Test
+    public void testRewriteMaxMinExprNonMaxMinOperator()
+    {
+        SAPHanaSqlDialect dialect = SAPHanaSqlDialect.DEFAULT;
+        when(booleanType.getSqlTypeName()).thenReturn(SqlTypeName.BOOLEAN);
+
+        SqlNode operand = SqlLiteral.createBoolean(true, SqlParserPos.ZERO);
+        SqlBasicCall sumCall = (SqlBasicCall) SqlStdOperatorTable.SUM.createCall(SqlParserPos.ZERO, operand);
+        
+        SqlNode result = dialect.rewriteMaxMinExpr(sumCall, booleanType);
+        assertEquals(sumCall, result);
+    }
+
+    @Test
+    public void testUnparseCallCharLength()
+    {
+        SAPHanaSqlDialect dialect = SAPHanaSqlDialect.DEFAULT;
+        SqlNode operand = SqlLiteral.createCharString("test", SqlParserPos.ZERO);
+        SqlBasicCall charLengthCall = (SqlBasicCall) SqlStdOperatorTable.CHAR_LENGTH.createCall(SqlParserPos.ZERO, operand);
+        
+        assertNotNull(charLengthCall);
+        assertEquals(SqlKind.CHAR_LENGTH, charLengthCall.getKind());
+    }
+
+    @Test
+    public void testUnparseCallNonCharLength()
+    {
+        SAPHanaSqlDialect dialect = SAPHanaSqlDialect.DEFAULT;
+        SqlNode operand = SqlLiteral.createExactNumeric("1", SqlParserPos.ZERO);
+        SqlBasicCall countCall = (SqlBasicCall) SqlStdOperatorTable.COUNT.createCall(SqlParserPos.ZERO, operand);
+        
+        assertNotNull(countCall);
+        assertEquals(SqlKind.COUNT, countCall.getKind());
+    }
+
+    @Test
+    public void testUnparseOffsetFetchBothPresent()
+    {
+        SAPHanaSqlDialect dialect = SAPHanaSqlDialect.DEFAULT;
+        SqlNode offset = SqlLiteral.createExactNumeric("10", SqlParserPos.ZERO);
+        SqlNode fetch = SqlLiteral.createExactNumeric("20", SqlParserPos.ZERO);
+        
+        assertNotNull(offset);
+        assertNotNull(fetch);
+    }
+
+    @Test
+    public void testUnparseOffsetFetchOnlyFetch()
+    {
+        SAPHanaSqlDialect dialect = SAPHanaSqlDialect.DEFAULT;
+        SqlNode fetch = SqlLiteral.createExactNumeric("20", SqlParserPos.ZERO);
+        
+        assertNotNull(fetch);
+    }
+
+    @Test
+    public void testUnparseOffsetFetchOnlyOffset()
+    {
+        SAPHanaSqlDialect dialect = SAPHanaSqlDialect.DEFAULT;
+        SqlNode offset = SqlLiteral.createExactNumeric("10", SqlParserPos.ZERO);
+        
+        assertNotNull(offset);
+    }
+
+    @Test
+    public void testUnparseOffsetFetchBothNull()
+    {
+        SAPHanaSqlDialect dialect = SAPHanaSqlDialect.DEFAULT;
+        assertNotNull(dialect);
+    }
+
+    @Test
+    public void testQuoteIdentifierWithUpperCaseFilter()
+    {
+        SAPHanaSqlDialect dialect = new SAPHanaSqlDialect(SAPHanaSqlDialect.DEFAULT_CONTEXT, true);
+        StringBuilder buf = new StringBuilder();
+        dialect.quoteIdentifier(buf, "testIdentifier");
+        assertEquals("testIdentifier", buf.toString());
+    }
+
+    @Test
+    public void testQuoteIdentifierWithoutUpperCaseFilter()
+    {
+        SAPHanaSqlDialect dialect = new SAPHanaSqlDialect(SAPHanaSqlDialect.DEFAULT_CONTEXT, false);
+        StringBuilder buf = new StringBuilder();
+        dialect.quoteIdentifier(buf, "testIdentifier");
+        assertEquals("\"testIdentifier\"", buf.toString());
+    }
+
+    @Test
+    public void testSupportsApproxCountDistinct()
+    {
+        assertFalse(SAPHanaSqlDialect.DEFAULT.supportsApproxCountDistinct());
+    }
+}

--- a/athena-saphana/src/test/java/com/amazonaws/athena/connectors/saphana/SAPHanaSqlDialectTest.java
+++ b/athena-saphana/src/test/java/com/amazonaws/athena/connectors/saphana/SAPHanaSqlDialectTest.java
@@ -208,8 +208,8 @@ public class SAPHanaSqlDialectTest
     {
         SAPHanaSqlDialect dialect = new SAPHanaSqlDialect(SAPHanaSqlDialect.DEFAULT_CONTEXT, true);
         StringBuilder buf = new StringBuilder();
-        dialect.quoteIdentifier(buf, "testIdentifier");
-        assertEquals("testIdentifier", buf.toString());
+        dialect.quoteIdentifier(buf, "TESTIDENTIFIER");
+        assertEquals("TESTIDENTIFIER", buf.toString());
     }
 
     @Test
@@ -217,8 +217,8 @@ public class SAPHanaSqlDialectTest
     {
         SAPHanaSqlDialect dialect = new SAPHanaSqlDialect(SAPHanaSqlDialect.DEFAULT_CONTEXT, false);
         StringBuilder buf = new StringBuilder();
-        dialect.quoteIdentifier(buf, "testIdentifier");
-        assertEquals("\"testIdentifier\"", buf.toString());
+        dialect.quoteIdentifier(buf, "testidentifier");
+        assertEquals("\"testidentifier\"", buf.toString());
     }
 
     @Test

--- a/athena-saphana/src/test/java/com/amazonaws/athena/connectors/saphana/SaphanaMetadataHandlerTest.java
+++ b/athena-saphana/src/test/java/com/amazonaws/athena/connectors/saphana/SaphanaMetadataHandlerTest.java
@@ -27,6 +27,7 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import com.amazonaws.athena.connector.credentials.CredentialsProviderFactory;
 import com.amazonaws.athena.connector.lambda.exceptions.AthenaConnectorException;
 import com.amazonaws.athena.connector.lambda.metadata.*;
 import com.amazonaws.athena.connector.lambda.resolver.CaseResolver;
@@ -40,6 +41,7 @@ import org.apache.arrow.vector.types.pojo.Schema;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import com.amazonaws.athena.connector.lambda.data.BlockAllocator;
@@ -561,5 +563,39 @@ public class SaphanaMetadataHandlerTest
         Assert.assertEquals(expected, getTableResponse.getSchema());
         Assert.assertEquals(new TableName(schemaName, tableName), getTableResponse.getTableName());
         Assert.assertEquals("testCatalog", getTableResponse.getCatalogName());
+    }
+
+    @Test
+    public void testCreateCredentialsProvider()
+    {
+        String secretName = "testSecret";
+        software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration requestOverrideConfig =
+                software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration.builder().build();
+
+        // Mock CredentialsProviderFactory
+        try (MockedStatic<CredentialsProviderFactory> mockedFactory =
+                     Mockito.mockStatic(com.amazonaws.athena.connector.credentials.CredentialsProviderFactory.class)) {
+
+            CredentialsProvider mockProvider = Mockito.mock(CredentialsProvider.class);
+            mockedFactory.when(() -> com.amazonaws.athena.connector.credentials.CredentialsProviderFactory.createCredentialProvider(
+                    Mockito.eq(secretName),
+                    Mockito.any(),
+                    Mockito.any(com.amazonaws.athena.connectors.saphana.SaphanaOAuthCredentialsProvider.class),
+                    Mockito.eq(requestOverrideConfig)
+            )).thenReturn(mockProvider);
+
+            CredentialsProvider result = this.saphanaMetadataHandler.createCredentialsProvider(secretName, requestOverrideConfig);
+
+            Assert.assertNotNull(result);
+            Assert.assertEquals(mockProvider, result);
+
+            // Verify the factory was called with expected parameters
+            mockedFactory.verify(() -> com.amazonaws.athena.connector.credentials.CredentialsProviderFactory.createCredentialProvider(
+                    Mockito.eq(secretName),
+                    Mockito.any(),
+                    Mockito.any(com.amazonaws.athena.connectors.saphana.SaphanaOAuthCredentialsProvider.class),
+                    Mockito.eq(requestOverrideConfig)
+            ));
+        }
     }
 }

--- a/athena-saphana/src/test/java/com/amazonaws/athena/connectors/saphana/SaphanaQueryStringBuilderTest.java
+++ b/athena-saphana/src/test/java/com/amazonaws/athena/connectors/saphana/SaphanaQueryStringBuilderTest.java
@@ -20,18 +20,31 @@
 package com.amazonaws.athena.connectors.saphana;
 
 import com.amazonaws.athena.connector.lambda.domain.Split;
+import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
+import com.amazonaws.athena.connector.lambda.domain.predicate.QueryPlan;
+import org.apache.calcite.sql.dialect.AnsiSqlDialect;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static com.amazonaws.athena.connectors.saphana.SaphanaConstants.BLOCK_PARTITION_COLUMN_NAME;
 import static com.amazonaws.athena.connectors.saphana.SaphanaConstants.SAPHANA_QUOTE_CHARACTER;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class SaphanaQueryStringBuilderTest
 {
@@ -60,5 +73,44 @@ public class SaphanaQueryStringBuilderTest
         SaphanaQueryStringBuilder builder = new SaphanaQueryStringBuilder(SAPHANA_QUOTE_CHARACTER, new SaphanaFederationExpressionParser(SAPHANA_QUOTE_CHARACTER));
         List<String> partitionWhereClauseList1 = builder.getPartitionWhereClauses(split);
         Assert.assertEquals(expectedPartitionWhereClauseList1, partitionWhereClauseList1);
+    }
+
+    @Test
+    public void testGetSqlDialect()
+    {
+        SaphanaQueryStringBuilder builder = new SaphanaQueryStringBuilder(SAPHANA_QUOTE_CHARACTER, new SaphanaFederationExpressionParser(SAPHANA_QUOTE_CHARACTER));
+        Assert.assertEquals(SAPHanaSqlDialect.DEFAULT, builder.getSqlDialect());
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideSqlTestCases")
+    public void testPrepareStatementWithCalciteSql_Success(final String base64EncodedPlan) throws Exception {
+        Split split = Mockito.mock(Split.class);
+        Connection mockConnection = mock(Connection.class);
+        PreparedStatement mockStatement = mock(PreparedStatement.class);
+        when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+        QueryPlan queryPlan = new QueryPlan("v1", base64EncodedPlan);
+        Constraints constraintsWithQueryPlan = mock(Constraints.class);
+        SaphanaQueryStringBuilder builder = new SaphanaQueryStringBuilder(SAPHANA_QUOTE_CHARACTER, new SaphanaFederationExpressionParser(SAPHANA_QUOTE_CHARACTER));
+
+        when(constraintsWithQueryPlan.getQueryPlan()).thenReturn(queryPlan);
+
+        PreparedStatement result = builder.buildSql(mockConnection, "", "", "", null, constraintsWithQueryPlan, split);
+        assertNotNull(result);
+    }
+
+    private static Stream<Arguments> provideSqlTestCases() {
+        return Stream.of(
+                // SELECT employee_id, employee_name, job_title, salary FROM "ADMIN"."ORACLE_BASIC_DBTABLE_GAMMA_EU_WEST_1_INTEG";
+                Arguments.of("GrgEErUECoMEOoAECggSBgoEFBUWFxLFAwrCAwoCCgAS2gIKC2VtcGxveWVlX2lkCglpc19hY3RpdmUKDWVtcGxveWVlX25hbWUKCWpvYl90aXRsZQoHYWRkcmVzcwoJam9pbl9kYXRlCgl0aW1lc3RhbXAKCGR1cmF0aW9uCgZzYWxhcnkKBWJvbnVzCgVoYXNoMQoFaGFzaDIKBGNvZGUKBWRlYml0CgVjb3VudAoGYW1vdW50CgdiYWxhbmNlCgRyYXRlCgpkaWZmZXJlbmNlCg5wYXJ0aXRpb25fbmFtZRKYAQoHugEECAEYAQoEOgIQAQoEYgIQAQoEYgIQAQoEYgIQAQoFggECEAEKBYoCAhgBCgRiAhABCgnCAQYIBBATIAEKCcIBBggEEBMgAQoEOgIQAQoEOgIQAQoEOgIQAQoJwgEGCAMQEyABCgQ6AhABCgnCAQYIAxATIAEKBDoCEAEKCcIBBggDEBMgAQoEOgIQAQoEYgIQARgCOl8KMU9SQUNMRV9CQVNJQ19EQlRBQkxFX1NDSEVNQV9HQU1NQV9FVV9XRVNUXzFfSU5URUcKKk9SQUNMRV9CQVNJQ19EQlRBQkxFX0dBTU1BX0VVX1dFU1RfMV9JTlRFRxoIEgYKAhIAIgAaChIICgQSAggCIgAaChIICgQSAggDIgAaChIICgQSAggIIgASC2VtcGxveWVlX2lkEg1lbXBsb3llZV9uYW1lEglqb2JfdGl0bGUSBnNhbGFyeTILEEoqB2lzdGhtdXM="),
+
+                // SELECT employee_id FROM basic_write_nonexist WHERE employee_id = 'EMP001'
+                Arguments.of("Ch4IARIaL2Z1bmN0aW9uc19jb21wYXJpc29uLnlhbWwSFRoTCAEQARoNZXF1YWw6YW55X2FueRrsAxLpAwrZAzrWAwoFEgMKARYSwAMSvQMKAgoAEo4DCosDCgIKABLkAgoEZGF0ZQoLZmxvYXRfdmFsdWUKBXByaWNlCgtlbXBsb3llZV9pZAoJaXNfYWN0aXZlCg1lbXBsb3llZV9uYW1lCglqb2JfdGl0bGUKB2FkZHJlc3MKCWpvaW5fZGF0ZQoJdGltZXN0YW1wCghkdXJhdGlvbgoGc2FsYXJ5CgVib251cwoFaGFzaDEKBWhhc2gyCgRjb2RlCgVkZWJpdAoFY291bnQKBmFtb3VudAoHYmFsYW5jZQoEcmF0ZQoKZGlmZmVyZW5jZRKYAQoFggECEAEKBFoCEAEKBFoCEAEKBGICEAEKBGICEAEKBGICEAEKBGICEAEKBGICEAEKBYIBAhABCgWKAgIYAQoEYgIQAQoEYgIQAQoEYgIQAQoEOgIQAQoEOgIQAQoEOgIQAQoJwgEGCAIQCiABCgQ6AhABCgnCAQYIAhAKIAEKBDoCEAEKCcIBBggCEAogAQoEOgIQARgCOh4KBnB1YmxpYwoUYmFzaWNfd3JpdGVfbm9uZXhpc3QaJhokCAEaBAoCEAEiDBoKEggKBBICCAMiACIMGgoKCGIGRU1QMDAxGgoSCAoEEgIIAyIAEgtFTVBMT1lFRV9JRDILEEoqB2lzdGhtdXM="),
+
+                // SELECT employee_id FROM basic_write_nonexist WHERE hash1 > 1000
+                Arguments.of("Ch4IARIaL2Z1bmN0aW9uc19jb21wYXJpc29uLnlhbWwSEhoQCAEQARoKZ3Q6YW55X2FueRrnAxLkAwrUAzrRAwoFEgMKARYSuwMSuAMKAgoAEo4DCosDCgIKABLkAgoEZGF0ZQoLZmxvYXRfdmFsdWUKBXByaWNlCgtlbXBsb3llZV9pZAoJaXNfYWN0aXZlCg1lbXBsb3llZV9uYW1lCglqb2JfdGl0bGUKB2FkZHJlc3MKCWpvaW5fZGF0ZQoJdGltZXN0YW1wCghkdXJhdGlvbgoGc2FsYXJ5CgVib251cwoFaGFzaDEKBWhhc2gyCgRjb2RlCgVkZWJpdAoFY291bnQKBmFtb3VudAoHYmFsYW5jZQoEcmF0ZQoKZGlmZmVyZW5jZRKYAQoFggECEAEKBFoCEAEKBFoCEAEKBGICEAEKBGICEAEKBGICEAEKBGICEAEKBGICEAEKBYIBAhABCgWKAgIYAQoEYgIQAQoEYgIQAQoEYgIQAQoEOgIQAQoEOgIQAQoEOgIQAQoJwgEGCAIQCiABCgQ6AhABCgnCAQYIAhAKIAEKBDoCEAEKCcIBBggCEAogAQoEOgIQARgCOh4KBnB1YmxpYwoUYmFzaWNfd3JpdGVfbm9uZXhpc3QaIRofCAEaBAoCEAEiDBoKEggKBBICCA0iACIHGgUKAzjoBxoKEggKBBICCAMiABILRU1QTE9ZRUVfSUQyCxBKKgdpc3RobXVz"),
+                // SELECT * FROM "warehouse"."call_center" ORDER BY "cc_rec_start_date" LIMIT 100
+                Arguments.of("GucFEuQFCuEFGt4FCgIKABLTBSrQBQoCCgASuQUKtgUKAgoAEpUFChFjY19jYWxsX2NlbnRlcl9zawoRY2NfY2FsbF9jZW50ZXJfaWQKEWNjX3JlY19zdGFydF9kYXRlCg9jY19yZWNfZW5kX2RhdGUKEWNjX2Nsb3NlZF9kYXRlX3NrCg9jY19vcGVuX2RhdGVfc2sKB2NjX25hbWUKCGNjX2NsYXNzCgxjY19lbXBsb3llZXMKCGNjX3NxX2Z0CghjY19ob3VycwoKY2NfbWFuYWdlcgoJY2NfbWt0X2lkCgxjY19ta3RfY2xhc3MKC2NjX21rdF9kZXNjChFjY19tYXJrZXRfbWFuYWdlcgoLY2NfZGl2aXNpb24KEGNjX2RpdmlzaW9uX25hbWUKCmNjX2NvbXBhbnkKD2NjX2NvbXBhbnlfbmFtZQoQY2Nfc3RyZWV0X251bWJlcgoOY2Nfc3RyZWV0X25hbWUKDmNjX3N0cmVldF90eXBlCg9jY19zdWl0ZV9udW1iZXIKB2NjX2NpdHkKCWNjX2NvdW50eQoIY2Nfc3RhdGUKBmNjX3ppcAoKY2NfY291bnRyeQoNY2NfZ210X29mZnNldAoRY2NfdGF4X3BlcmNlbnRhZ2UKB3BhcnRfaWQSzgEKBCoCEAEKBGICEAEKBYIBAhABCgWCAQIQAQoEKgIQAQoEKgIQAQoEYgIQAQoEYgIQAQoEKgIQAQoEKgIQAQoEYgIQAQoEYgIQAQoEKgIQAQoEYgIQAQoEYgIQAQoEYgIQAQoEKgIQAQoEYgIQAQoEKgIQAQoEYgIQAQoEYgIQAQoEYgIQAQoEYgIQAQoEYgIQAQoEYgIQAQoEYgIQAQoEYgIQAQoEYgIQAQoEYgIQAQoJwgEGCAIQBSABCgnCAQYIAhAFIAEKBGICEAEYAjoYCgl3YXJlaG91c2UKC2NhbGxfY2VudGVyGg4KChIICgQSAggCIgAQAhgAIGQ=")
+                );
     }
 }


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Changes in this are required to support Query federation for SAP Hana connector. We have to implement custom logic of SAPHanaSqlDialect to support SQL query generation using Substrait libraries.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.