### PR TITLE
[Feature] Update connectors to Java 17 and add build support for Java 25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 17
+ARG JAVA_VERSION=17
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options
 ARG JAVA_TOOL_OPTIONS=""
 # Set the JAVA_TOOL_OPTIONS environment variable for Java 17 and always include default truststore to avoid SSL handshake issues
-ENV JAVA_TOOL_OPTIONS="-Djavax.net.ssl.trustStore=/var/lang/lib/security/cacerts ${JAVA_TOOL_OPTIONS}"
+# Additional JVM options (e.g., for JDK 25: -Darrow.allocation.manager.type=Unsafe)
+# can be passed and will be included along with these defaults.
+ENV JAVA_TOOL_OPTIONS="-Djavax.net.ssl.trustStore=/var/lang/lib/security/cacerts --add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation ${JAVA_TOOL_OPTIONS}"
 
 # Install necessary tools
 RUN yum update -y

--- a/athena-aws-cmdb/Dockerfile
+++ b/athena-aws-cmdb/Dockerfile
@@ -1,12 +1,14 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 17
+ARG JAVA_VERSION=17
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
 ARG JAVA_TOOL_OPTIONS=""
-# Set the JAVA_TOOL_OPTIONS environment variable for Java 17
-ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
+# Set the JAVA_TOOL_OPTIONS environment variable for Java 17.
+# Additional JVM options (e.g., for JDK 25: -Darrow.allocation.manager.type=Unsafe)
+# can be passed and will be included along with these defaults.
+ENV JAVA_TOOL_OPTIONS="--add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation ${JAVA_TOOL_OPTIONS}"
 
 # Copy function code and runtime dependencies from Maven layout
 COPY target/athena-aws-cmdb-2022.47.1.jar ${LAMBDA_TASK_ROOT}

--- a/athena-aws-cmdb/athena-aws-cmdb-package.yaml
+++ b/athena-aws-cmdb/athena-aws-cmdb-package.yaml
@@ -51,11 +51,12 @@ Resources:
           disable_spill_encryption: !Ref DisableSpillEncryption
           spill_bucket: !Ref SpillBucket
           spill_prefix: !Ref SpillPrefix
+          JAVA_TOOL_OPTIONS: --add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation
       FunctionName: !Ref AthenaCatalogName
       Handler: "com.amazonaws.athena.connectors.aws.cmdb.AwsCmdbCompositeHandler"
       CodeUri: "./target/athena-aws-cmdb-2022.47.1.jar"
       Description: "Enables Amazon Athena to communicate with various AWS Services, making your resource inventories accessible via SQL."
-      Runtime: java11
+      Runtime: java17
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       PermissionsBoundary: !If [ HasPermissionsBoundary, !Ref PermissionsBoundaryARN, !Ref "AWS::NoValue" ]

--- a/athena-clickhouse/Dockerfile
+++ b/athena-clickhouse/Dockerfile
@@ -1,12 +1,14 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 17
+ARG JAVA_VERSION=17
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
 ARG JAVA_TOOL_OPTIONS=""
-# Set the JAVA_TOOL_OPTIONS environment variable for Java 17
-ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
+# Set the JAVA_TOOL_OPTIONS environment variable for Java 17.
+# Additional JVM options (e.g., for JDK 25: -Darrow.allocation.manager.type=Unsafe)
+# can be passed and will be included along with these defaults.
+ENV JAVA_TOOL_OPTIONS="--add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation ${JAVA_TOOL_OPTIONS}"
 
 # Copy function code and runtime dependencies from Maven layout
 COPY target/athena-clickhouse-2022.47.1.jar ${LAMBDA_TASK_ROOT}

--- a/athena-clickhouse/athena-clickhouse-package.yaml
+++ b/athena-clickhouse/athena-clickhouse-package.yaml
@@ -70,11 +70,12 @@ Resources:
           spill_bucket: !Ref SpillBucket
           spill_prefix: !Ref SpillPrefix
           default: !Ref DefaultConnectionString
+          JAVA_TOOL_OPTIONS: --add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.clickhouse.ClickHouseMuxCompositeHandler"
       CodeUri: "./target/athena-clickhouse-2022.47.1.jar"
       Description: "Enables Amazon Athena to communicate with ClickHouse using JDBC"
-      Runtime: java11
+      Runtime: java17
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       Role: !If [NotHasLambdaRole, !GetAtt FunctionRole.Arn, !Ref LambdaRoleARN]

--- a/athena-cloudera-hive/Dockerfile
+++ b/athena-cloudera-hive/Dockerfile
@@ -1,12 +1,14 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 17
+ARG JAVA_VERSION=17
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
 ARG JAVA_TOOL_OPTIONS=""
-# Set the JAVA_TOOL_OPTIONS environment variable for Java 17
-ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
+# Set the JAVA_TOOL_OPTIONS environment variable for Java 17.
+# Additional JVM options (e.g., for JDK 25: -Darrow.allocation.manager.type=Unsafe)
+# can be passed and will be included along with these defaults.
+ENV JAVA_TOOL_OPTIONS="--add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation ${JAVA_TOOL_OPTIONS}"
 
 # Copy function code and runtime dependencies from Maven layout
 COPY target/athena-cloudera-hive-2022.47.1.jar ${LAMBDA_TASK_ROOT}

--- a/athena-cloudera-hive/athena-cloudera-hive-package.yaml
+++ b/athena-cloudera-hive/athena-cloudera-hive-package.yaml
@@ -64,11 +64,12 @@ Resources:
           spill_bucket: !Ref SpillBucket
           spill_prefix: !Ref SpillPrefix
           default: !Ref DefaultConnectionString
+          JAVA_TOOL_OPTIONS: --add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.cloudera.HiveMuxCompositeHandler"
       CodeUri: "./target/athena-cloudera-hive-2022.47.1.jar"
       Description: "Enables Amazon Athena to communicate with Coludera Hive using JDBC"
-      Runtime: java11
+      Runtime: java17
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       PermissionsBoundary: !If [ HasPermissionsBoundary, !Ref PermissionsBoundaryARN, !Ref "AWS::NoValue" ]

--- a/athena-cloudera-hive/pom.xml
+++ b/athena-cloudera-hive/pom.xml
@@ -46,23 +46,6 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
-        <!--
-          This is purposefully using a legacy version because these tests
-          rely on powermock and it will break on a later version.
-          Eventually we should fix the test code to not rely on powermock.
-        -->
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/rds -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/athena-cloudera-impala/Dockerfile
+++ b/athena-cloudera-impala/Dockerfile
@@ -1,12 +1,14 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 17
+ARG JAVA_VERSION=17
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
 ARG JAVA_TOOL_OPTIONS=""
-# Set the JAVA_TOOL_OPTIONS environment variable for Java 17
-ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
+# Set the JAVA_TOOL_OPTIONS environment variable for Java 17.
+# Additional JVM options (e.g., for JDK 25: -Darrow.allocation.manager.type=Unsafe)
+# can be passed and will be included along with these defaults.
+ENV JAVA_TOOL_OPTIONS="--add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation ${JAVA_TOOL_OPTIONS}"
 
 # Copy function code and runtime dependencies from Maven layout
 COPY target/athena-cloudera-impala-2022.47.1.jar ${LAMBDA_TASK_ROOT}

--- a/athena-cloudera-impala/athena-cloudera-impala-package.yaml
+++ b/athena-cloudera-impala/athena-cloudera-impala-package.yaml
@@ -69,11 +69,12 @@ Resources:
           spill_bucket: !Ref SpillBucket
           spill_prefix: !Ref SpillPrefix
           default: !Ref DefaultConnectionString
+          JAVA_TOOL_OPTIONS: --add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.cloudera.ImpalaMuxCompositeHandler"
       CodeUri: "./target/athena-cloudera-impala-2022.47.1.jar"
       Description: "Enables Amazon Athena to communicate with Cloudera Impala using JDBC"
-      Runtime: java11
+      Runtime: java17
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       PermissionsBoundary: !If [ HasPermissionsBoundary, !Ref PermissionsBoundaryARN, !Ref "AWS::NoValue" ]

--- a/athena-cloudera-impala/pom.xml
+++ b/athena-cloudera-impala/pom.xml
@@ -35,18 +35,6 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/rds -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/athena-cloudwatch-metrics/Dockerfile
+++ b/athena-cloudwatch-metrics/Dockerfile
@@ -1,12 +1,14 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 17
+ARG JAVA_VERSION=17
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
 ARG JAVA_TOOL_OPTIONS=""
-# Set the JAVA_TOOL_OPTIONS environment variable for Java 17
-ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
+# Set the JAVA_TOOL_OPTIONS environment variable for Java 17.
+# Additional JVM options (e.g., for JDK 25: -Darrow.allocation.manager.type=Unsafe)
+# can be passed and will be included along with these defaults.
+ENV JAVA_TOOL_OPTIONS="--add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation ${JAVA_TOOL_OPTIONS}"
 
 # Copy function code and runtime dependencies from Maven layout
 COPY target/athena-cloudwatch-metrics-2022.47.1.jar ${LAMBDA_TASK_ROOT}

--- a/athena-cloudwatch-metrics/athena-cloudwatch-metrics-package.yaml
+++ b/athena-cloudwatch-metrics/athena-cloudwatch-metrics-package.yaml
@@ -56,11 +56,12 @@ Resources:
           spill_bucket: !Ref SpillBucket
           spill_prefix: !Ref SpillPrefix
           include_linked_accounts: !Ref IncludeLinkedAccounts
+          JAVA_TOOL_OPTIONS: --add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation
       FunctionName: !Ref AthenaCatalogName
       Handler: "com.amazonaws.athena.connectors.cloudwatch.metrics.MetricsCompositeHandler"
       CodeUri: "./target/athena-cloudwatch-metrics-2022.47.1.jar"
       Description: "Enables Amazon Athena to communicate with Cloudwatch Metrics, making your metrics data accessible via SQL"
-      Runtime: java11
+      Runtime: java17
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       PermissionsBoundary: !If [ HasPermissionsBoundary, !Ref PermissionsBoundaryARN, !Ref "AWS::NoValue" ]

--- a/athena-cloudwatch-metrics/pom.xml
+++ b/athena-cloudwatch-metrics/pom.xml
@@ -62,12 +62,6 @@
             <version>${log4j2Version}</version>
             <scope>runtime</scope>
         </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/athena-cloudwatch/Dockerfile
+++ b/athena-cloudwatch/Dockerfile
@@ -1,12 +1,14 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 17
+ARG JAVA_VERSION=17
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
 ARG JAVA_TOOL_OPTIONS=""
-# Set the JAVA_TOOL_OPTIONS environment variable for Java 17
-ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
+# Set the JAVA_TOOL_OPTIONS environment variable for Java 17.
+# Additional JVM options (e.g., for JDK 25: -Darrow.allocation.manager.type=Unsafe)
+# can be passed and will be included along with these defaults.
+ENV JAVA_TOOL_OPTIONS="--add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation ${JAVA_TOOL_OPTIONS}"
 
 # Copy function code and runtime dependencies from Maven layout
 COPY target/athena-cloudwatch-2022.47.1.jar ${LAMBDA_TASK_ROOT}

--- a/athena-cloudwatch/athena-cloudwatch-package.yaml
+++ b/athena-cloudwatch/athena-cloudwatch-package.yaml
@@ -65,11 +65,12 @@ Resources:
           spill_bucket: !Ref SpillBucket
           spill_prefix: !Ref SpillPrefix
           kms_key_id: !If [HasKMSKeyId, !Ref KMSKeyId, !Ref "AWS::NoValue"]
+          JAVA_TOOL_OPTIONS: --add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation
       FunctionName: !Ref AthenaCatalogName
       Handler: "com.amazonaws.athena.connectors.cloudwatch.CloudwatchCompositeHandler"
       CodeUri: "./target/athena-cloudwatch-2022.47.1.jar"
       Description: "Enables Amazon Athena to communicate with Cloudwatch, making your log accessible via SQL"
-      Runtime: java11
+      Runtime: java17
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       Role: !If [NotHasLambdaRole, !GetAtt FunctionRole.Arn, !Ref LambdaRole]

--- a/athena-datalakegen2/Dockerfile
+++ b/athena-datalakegen2/Dockerfile
@@ -1,12 +1,14 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 17
+ARG JAVA_VERSION=17
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
 ARG JAVA_TOOL_OPTIONS=""
-# Set the JAVA_TOOL_OPTIONS environment variable for Java 17
-ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
+# Set the JAVA_TOOL_OPTIONS environment variable for Java 17.
+# Additional JVM options (e.g., for JDK 25: -Darrow.allocation.manager.type=Unsafe)
+# can be passed and will be included along with these defaults.
+ENV JAVA_TOOL_OPTIONS="--add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation ${JAVA_TOOL_OPTIONS}"
 
 # Copy function code and runtime dependencies from Maven layout
 COPY target/athena-datalakegen2-2022.47.1.jar ${LAMBDA_TASK_ROOT}

--- a/athena-datalakegen2/athena-datalakegen2-package.yaml
+++ b/athena-datalakegen2/athena-datalakegen2-package.yaml
@@ -70,11 +70,12 @@ Resources:
           spill_bucket: !Ref SpillBucket
           spill_prefix: !Ref SpillPrefix
           default: !Ref DefaultConnectionString
+          JAVA_TOOL_OPTIONS: --add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.datalakegen2.DataLakeGen2MuxCompositeHandler"
       CodeUri: "./target/athena-datalakegen2-2022.47.1.jar"
       Description: "Enables Amazon Athena to communicate with DataLake Gen2 using JDBC"
-      Runtime: java11
+      Runtime: java17
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       PermissionsBoundary: !If [ HasPermissionsBoundary, !Ref PermissionsBoundaryARN, !Ref "AWS::NoValue" ]

--- a/athena-datalakegen2/pom.xml
+++ b/athena-datalakegen2/pom.xml
@@ -52,18 +52,6 @@
             <version>${aws-cdk.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/athena-db2-as400/Dockerfile
+++ b/athena-db2-as400/Dockerfile
@@ -1,12 +1,14 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 17
+ARG JAVA_VERSION=17
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
 ARG JAVA_TOOL_OPTIONS=""
-# Set the JAVA_TOOL_OPTIONS environment variable for Java 17
-ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
+# Set the JAVA_TOOL_OPTIONS environment variable for Java 17.
+# Additional JVM options (e.g., for JDK 25: -Darrow.allocation.manager.type=Unsafe)
+# can be passed and will be included along with these defaults.
+ENV JAVA_TOOL_OPTIONS="--add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation ${JAVA_TOOL_OPTIONS}"
 
 # Copy function code and runtime dependencies from Maven layout
 COPY target/athena-db2-as400-2022.47.1.jar ${LAMBDA_TASK_ROOT}

--- a/athena-db2-as400/athena-db2-as400-package.yaml
+++ b/athena-db2-as400/athena-db2-as400-package.yaml
@@ -71,11 +71,12 @@ Resources:
           spill_bucket: !Ref SpillBucket
           spill_prefix: !Ref SpillPrefix
           default: !Ref DefaultConnectionString
+          JAVA_TOOL_OPTIONS: --add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.db2as400.Db2As400MuxCompositeHandler"
       CodeUri: "./target/athena-db2-as400-2022.47.1.jar"
       Description: "Enables Amazon Athena to communicate with DB2 on iSeries (AS400) using JDBC"
-      Runtime: java11
+      Runtime: java17
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       PermissionsBoundary: !If [ HasPermissionsBoundary, !Ref PermissionsBoundaryARN, !Ref "AWS::NoValue" ]

--- a/athena-db2-as400/pom.xml
+++ b/athena-db2-as400/pom.xml
@@ -53,18 +53,6 @@
             <version>${aws-cdk.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/athena-db2/Dockerfile
+++ b/athena-db2/Dockerfile
@@ -1,12 +1,14 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 17
+ARG JAVA_VERSION=17
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
 ARG JAVA_TOOL_OPTIONS=""
-# Set the JAVA_TOOL_OPTIONS environment variable for Java 17
-ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
+# Set the JAVA_TOOL_OPTIONS environment variable for Java 17.
+# Additional JVM options (e.g., for JDK 25: -Darrow.allocation.manager.type=Unsafe)
+# can be passed and will be included along with these defaults.
+ENV JAVA_TOOL_OPTIONS="--add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation ${JAVA_TOOL_OPTIONS}"
 
 # Copy function code and runtime dependencies from Maven layout
 COPY target/athena-db2-2022.47.1.jar ${LAMBDA_TASK_ROOT}

--- a/athena-db2/athena-db2-package.yaml
+++ b/athena-db2/athena-db2-package.yaml
@@ -71,11 +71,12 @@ Resources:
           spill_bucket: !Ref SpillBucket
           spill_prefix: !Ref SpillPrefix
           default: !Ref DefaultConnectionString
+          JAVA_TOOL_OPTIONS: --add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.db2.Db2MuxCompositeHandler"
       CodeUri: "./target/athena-db2-2022.47.1.jar"
       Description: "Enables Amazon Athena to communicate with DB2 using JDBC"
-      Runtime: java11
+      Runtime: java17
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       PermissionsBoundary: !If [ HasPermissionsBoundary, !Ref PermissionsBoundaryARN, !Ref "AWS::NoValue" ]

--- a/athena-db2/pom.xml
+++ b/athena-db2/pom.xml
@@ -53,18 +53,6 @@
             <version>${aws-cdk.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/athena-docdb/Dockerfile
+++ b/athena-docdb/Dockerfile
@@ -1,12 +1,14 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 17
+ARG JAVA_VERSION=17
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
-# Argument for Java tool options
+# Argument for Java tool options, defaulting to an empty string
 ARG JAVA_TOOL_OPTIONS=""
 # Set the JAVA_TOOL_OPTIONS environment variable for Java 17 and always include default truststore to avoid SSL handshake issues
-ENV JAVA_TOOL_OPTIONS="-Djavax.net.ssl.trustStore=/var/lang/lib/security/cacerts ${JAVA_TOOL_OPTIONS}"
+# Additional JVM options (e.g., for JDK 25: -Darrow.allocation.manager.type=Unsafe)
+# can be passed and will be included along with these defaults.
+ENV JAVA_TOOL_OPTIONS="-Djavax.net.ssl.trustStore=/var/lang/lib/security/cacerts --add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation ${JAVA_TOOL_OPTIONS}"
 
 # Install necessary tools
 RUN yum update -y

--- a/athena-docdb/athena-docdb-package.yaml
+++ b/athena-docdb/athena-docdb-package.yaml
@@ -65,11 +65,12 @@ Resources:
           spill_bucket: !Ref SpillBucket
           spill_prefix: !Ref SpillPrefix
           default_docdb: !Ref DocDBConnectionString
+          JAVA_TOOL_OPTIONS: "-Djavax.net.ssl.trustStore=/var/lang/lib/security/cacerts --add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation"
       FunctionName: !Ref AthenaCatalogName
       Handler: "com.amazonaws.athena.connectors.docdb.DocDBCompositeHandler"
       CodeUri: "./target/athena-docdb-2022.47.1.jar"
       Description: "Enables Amazon Athena to communicate with DocumentDB, making your DocumentDB data accessible via SQL."
-      Runtime: java11
+      Runtime: java17
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       PermissionsBoundary: !If [ HasPermissionsBoundary, !Ref PermissionsBoundaryARN, !Ref "AWS::NoValue" ]

--- a/athena-docdb/pom.xml
+++ b/athena-docdb/pom.xml
@@ -86,12 +86,6 @@
             <version>${log4j2Version}</version>
             <scope>runtime</scope>
         </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/athena-dynamodb/Dockerfile
+++ b/athena-dynamodb/Dockerfile
@@ -1,5 +1,5 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 17
+ARG JAVA_VERSION=17
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
@@ -11,8 +11,10 @@ RUN yum update -y glib2 libpng && \
 
 # Argument for Java tool options, defaulting to an empty string
 ARG JAVA_TOOL_OPTIONS=""
-# Set the JAVA_TOOL_OPTIONS environment variable for Java 17
-ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
+# Set the JAVA_TOOL_OPTIONS environment variable for Java 17.
+# Additional JVM options (e.g., for JDK 25: -Darrow.allocation.manager.type=Unsafe)
+# can be passed and will be included along with these defaults.
+ENV JAVA_TOOL_OPTIONS="--add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation ${JAVA_TOOL_OPTIONS}"
 
 # Copy function code and runtime dependencies from Maven layout
 COPY target/athena-dynamodb-2022.47.1.jar ${LAMBDA_TASK_ROOT}

--- a/athena-dynamodb/athena-dynamodb-package.yaml
+++ b/athena-dynamodb/athena-dynamodb-package.yaml
@@ -65,11 +65,12 @@ Resources:
           spill_bucket: !Ref SpillBucket
           spill_prefix: !Ref SpillPrefix
           kms_key_id: !If [HasKMSKeyId, !Ref KMSKeyId, !Ref "AWS::NoValue"]
+          JAVA_TOOL_OPTIONS: --add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation
       FunctionName: !Ref AthenaCatalogName
       Handler: "com.amazonaws.athena.connectors.dynamodb.DynamoDBCompositeHandler"
       CodeUri: "./target/athena-dynamodb-2022.47.1.jar"
       Description: "Enables Amazon Athena to communicate with DynamoDB, making your tables accessible via SQL"
-      Runtime: java11
+      Runtime: java17
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       Role: !If [NotHasLambdaRole, !GetAtt FunctionRole.Arn, !Ref LambdaRole]

--- a/athena-elasticsearch/Dockerfile
+++ b/athena-elasticsearch/Dockerfile
@@ -1,12 +1,14 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 17
+ARG JAVA_VERSION=17
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
 ARG JAVA_TOOL_OPTIONS=""
-# Set the JAVA_TOOL_OPTIONS environment variable for Java 17
-ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
+# Set the JAVA_TOOL_OPTIONS environment variable for Java 17.
+# Additional JVM options (e.g., for JDK 25: -Darrow.allocation.manager.type=Unsafe)
+# can be passed and will be included along with these defaults.
+ENV JAVA_TOOL_OPTIONS="--add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation ${JAVA_TOOL_OPTIONS}"
 
 # Copy function code and runtime dependencies from Maven layout
 COPY target/athena-elasticsearch-2022.47.1.jar ${LAMBDA_TASK_ROOT}

--- a/athena-elasticsearch/athena-elasticsearch-package.yaml
+++ b/athena-elasticsearch/athena-elasticsearch-package.yaml
@@ -101,11 +101,12 @@ Resources:
           query_timeout_cluster: !Ref QueryTimeoutCluster
           query_timeout_search: !Ref QueryTimeoutSearch
           query_scroll_timeout: !Ref QueryScrollTimeout
+          JAVA_TOOL_OPTIONS: --add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation
       FunctionName: !Sub "${AthenaCatalogName}"
       Handler: "com.amazonaws.athena.connectors.elasticsearch.ElasticsearchCompositeHandler"
       CodeUri: "./target/athena-elasticsearch-2022.47.1.jar"
       Description: "The Elasticsearch Lambda Connector provides Athena users the ability to query data stored on Elasticsearch clusters."
-      Runtime: java11
+      Runtime: java17
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       PermissionsBoundary: !If [ HasPermissionsBoundary, !Ref PermissionsBoundaryARN, !Ref "AWS::NoValue" ]

--- a/athena-elasticsearch/pom.xml
+++ b/athena-elasticsearch/pom.xml
@@ -105,13 +105,6 @@
             <artifactId>httpclient</artifactId>
             <version>${apache.httpclient.version}</version>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/org.mockito/mockito-core -->
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
         <!-- https://mvnrepository.com/artifact/junit/junit -->
         <dependency>
             <groupId>junit</groupId>

--- a/athena-example/athena-example.yaml
+++ b/athena-example/athena-example.yaml
@@ -52,11 +52,12 @@ Resources:
           spill_bucket: !Ref SpillBucket
           spill_prefix: !Ref SpillPrefix
           data_bucket: !Ref DataBucket
+          JAVA_TOOL_OPTIONS: --add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation
       FunctionName: !Sub "${AthenaCatalogName}"
       Handler: "com.amazonaws.athena.connectors.example.ExampleCompositeHandler"
       CodeUri: "./target/athena-example-2022.47.1.jar"
       Description: "A guided example for writing and deploying your own federated Amazon Athena connector for a custom source."
-      Runtime: java11
+      Runtime: java17
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       Policies:

--- a/athena-federation-sdk/athena-federation-sdk.yaml
+++ b/athena-federation-sdk/athena-federation-sdk.yaml
@@ -45,11 +45,12 @@ Resources:
           disable_spill_encryption: !Ref DisableSpillEncryption
           spill_bucket: !Ref SpillBucket
           spill_prefix: !Ref SpillPrefix
+          JAVA_TOOL_OPTIONS: --add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation
       FunctionName: !Ref AthenaCatalogName
       Handler: "com.amazonaws.athena.connector.lambda.examples.ExampleCompositeHandler"
       CodeUri: "./target/aws-athena-federation-sdk-2022.47.1-withdep.jar"
       Description: "This connector enables Amazon Athena to communicate with a randomly generated data source."
-      Runtime: java11
+      Runtime: java17
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       Policies:

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/handlers/CompositeHandlerTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/handlers/CompositeHandlerTest.java
@@ -87,11 +87,14 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 @RunWith(Enclosed.class)
 public class CompositeHandlerTest {
@@ -115,40 +118,40 @@ public class CompositeHandlerTest {
 
         allocator = new BlockAllocatorImpl();
         objectMapper = ObjectMapperFactory.create(allocator);
-        mockMetadataHandler = mock(MetadataHandler.class);
-        mockRecordHandler = mock(RecordHandler.class);
+        mockMetadataHandler = mock(MetadataHandler.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
+        mockRecordHandler = mock(RecordHandler.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
         mockUserDefinedFunctionHandler = mock(UserDefinedFunctionHandler.class);
 
         schemaForRead = SchemaBuilder.newBuilder()
                 .addField("col1", new ArrowType.Int(32, true))
                 .build();
 
-        when(mockMetadataHandler.doGetTableLayout(nullable(BlockAllocatorImpl.class), nullable(GetTableLayoutRequest.class)))
-                .thenReturn(new GetTableLayoutResponse("catalog",
-                        new TableName("schema", "table"),
-                        BlockUtils.newBlock(allocator, "col1", Types.MinorType.BIGINT.getType(), 1L)));
+        doReturn(new GetTableLayoutResponse("catalog",
+                new TableName("schema", "table"),
+                BlockUtils.newBlock(allocator, "col1", Types.MinorType.BIGINT.getType(), 1L)))
+                .when(mockMetadataHandler).doGetTableLayout(nullable(BlockAllocatorImpl.class), nullable(GetTableLayoutRequest.class));
 
-        when(mockMetadataHandler.doListTables(nullable(BlockAllocatorImpl.class), nullable(ListTablesRequest.class)))
-                .thenReturn(new ListTablesResponse("catalog",
-                        Collections.singletonList(new TableName("schema", "table")), null));
+        doReturn(new ListTablesResponse("catalog",
+                Collections.singletonList(new TableName("schema", "table")), null))
+                .when(mockMetadataHandler).doListTables(nullable(BlockAllocatorImpl.class), nullable(ListTablesRequest.class));
 
-        when(mockMetadataHandler.doGetTable(nullable(BlockAllocatorImpl.class), nullable(GetTableRequest.class)))
-                .thenReturn(new GetTableResponse("catalog",
-                        new TableName("schema", "table"),
-                        SchemaBuilder.newBuilder().addStringField("col1").build()));
+        doReturn(new GetTableResponse("catalog",
+                new TableName("schema", "table"),
+                SchemaBuilder.newBuilder().addStringField("col1").build()))
+                .when(mockMetadataHandler).doGetTable(nullable(BlockAllocatorImpl.class), nullable(GetTableRequest.class));
 
-        when(mockMetadataHandler.doListSchemaNames(nullable(BlockAllocatorImpl.class), nullable(ListSchemasRequest.class)))
-                .thenReturn(new ListSchemasResponse("catalog", Collections.singleton("schema1")));
+        doReturn(new ListSchemasResponse("catalog", Collections.singleton("schema1")))
+                .when(mockMetadataHandler).doListSchemaNames(nullable(BlockAllocatorImpl.class), nullable(ListSchemasRequest.class));
 
-        when(mockMetadataHandler.doGetSplits(nullable(BlockAllocatorImpl.class), nullable(GetSplitsRequest.class)))
-                .thenReturn(new GetSplitsResponse("catalog", Split.newBuilder(null, null).build()));
+        doReturn(new GetSplitsResponse("catalog", Split.newBuilder(null, null).build()))
+                .when(mockMetadataHandler).doGetSplits(nullable(BlockAllocatorImpl.class), nullable(GetSplitsRequest.class));
 
-        when(mockMetadataHandler.doPing(nullable(PingRequest.class)))
-                .thenReturn(new PingResponse("catalog", "queryId", "type", 23, 2));
+        doReturn(new PingResponse("catalog", "queryId", "type", 23, 2))
+                .when(mockMetadataHandler).doPing(nullable(PingRequest.class));
 
-        when(mockRecordHandler.doReadRecords(nullable(BlockAllocatorImpl.class), nullable(ReadRecordsRequest.class)))
-                .thenReturn(new ReadRecordsResponse("catalog",
-                        BlockUtils.newEmptyBlock(allocator, "col", new ArrowType.Int(32, true))));
+        doReturn(new ReadRecordsResponse("catalog",
+                BlockUtils.newEmptyBlock(allocator, "col", new ArrowType.Int(32, true))))
+                .when(mockRecordHandler).doReadRecords(nullable(BlockAllocatorImpl.class), nullable(ReadRecordsRequest.class));
 
         compositeHandler = new CompositeHandler(mockMetadataHandler, mockRecordHandler);
     }
@@ -282,12 +285,11 @@ public class CompositeHandlerTest {
                 5
         );
 
-        when(mockMetadataHandler.doListTables(any(BlockAllocator.class), eq(expectedRequest)))
-                .thenReturn(new ListTablesResponse(
-                        "testCatalog",
-                        Collections.singletonList(new TableName("testSchema", "testTable")),
-                        null
-                ));
+        doReturn(new ListTablesResponse(
+                "testCatalog",
+                Collections.singletonList(new TableName("testSchema", "testTable")),
+                null))
+                .when(mockMetadataHandler).doListTables(any(BlockAllocator.class), eq(expectedRequest));
 
         compositeHandler.handleRequest(inputStream, outputStream, mockContext);
 

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/security/KmsEncryptionProviderTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/security/KmsEncryptionProviderTest.java
@@ -21,7 +21,7 @@ package com.amazonaws.athena.connector.lambda.security;
 
 import com.amazonaws.encryptionsdk.AwsCrypto;
 import com.amazonaws.encryptionsdk.CryptoMaterialsManager;
-import com.amazonaws.encryptionsdk.CryptoResult;;
+import com.amazonaws.encryptionsdk.CryptoResult;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.cache.Cache;

--- a/athena-gcs/Dockerfile
+++ b/athena-gcs/Dockerfile
@@ -1,12 +1,14 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 17
+ARG JAVA_VERSION=17
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
 ARG JAVA_TOOL_OPTIONS=""
-# Set the JAVA_TOOL_OPTIONS environment variable for Java 17
-ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
+# Set the JAVA_TOOL_OPTIONS environment variable for Java 17.
+# Additional JVM options (e.g., for JDK 25: -Darrow.allocation.manager.type=Unsafe)
+# can be passed and will be included along with these defaults.
+ENV JAVA_TOOL_OPTIONS="--add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation ${JAVA_TOOL_OPTIONS}"
 
 # Copy function code and runtime dependencies from Maven layout
 COPY target/athena-gcs.zip ${LAMBDA_TASK_ROOT}

--- a/athena-gcs/pom.xml
+++ b/athena-gcs/pom.xml
@@ -109,18 +109,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>logs</artifactId>
             <version>${aws-cdk.version}</version>

--- a/athena-google-bigquery/Dockerfile
+++ b/athena-google-bigquery/Dockerfile
@@ -1,12 +1,14 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 17
+ARG JAVA_VERSION=17
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
 ARG JAVA_TOOL_OPTIONS=""
-# Set the JAVA_TOOL_OPTIONS environment variable for Java 17
-ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
+# Set the JAVA_TOOL_OPTIONS environment variable for Java 17.
+# Additional JVM options (e.g., for JDK 25: -Darrow.allocation.manager.type=Unsafe)
+# can be passed and will be included along with these defaults.
+ENV JAVA_TOOL_OPTIONS="--add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation ${JAVA_TOOL_OPTIONS}"
 
 # Copy function code and runtime dependencies from Maven layout
 COPY target/athena-google-bigquery-2022.47.1.jar ${LAMBDA_TASK_ROOT}

--- a/athena-google-bigquery/pom.xml
+++ b/athena-google-bigquery/pom.xml
@@ -82,12 +82,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>ST4</artifactId>
             <version>${antlr.st4.version}</version>

--- a/athena-hbase/Dockerfile
+++ b/athena-hbase/Dockerfile
@@ -1,12 +1,14 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 17
+ARG JAVA_VERSION=17
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
 ARG JAVA_TOOL_OPTIONS=""
-# Set the JAVA_TOOL_OPTIONS environment variable for Java 17
-ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
+# Set the JAVA_TOOL_OPTIONS environment variable for Java 17.
+# Additional JVM options (e.g., for JDK 25: -Darrow.allocation.manager.type=Unsafe)
+# can be passed and will be included along with these defaults.
+ENV JAVA_TOOL_OPTIONS="--add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation ${JAVA_TOOL_OPTIONS}"
 
 # Copy function code and runtime dependencies from Maven layout
 COPY target/athena-hbase-2022.47.1.jar ${LAMBDA_TASK_ROOT}

--- a/athena-hbase/athena-hbase-package.yaml
+++ b/athena-hbase/athena-hbase-package.yaml
@@ -84,11 +84,12 @@ Resources:
           kerberos_config_files_s3_reference: !Ref KerberosConfigFilesS3Reference
           principal_name: !Ref PrincipalName
           hbase_rpc_protection: !Ref HbaseRpcProtection
+          JAVA_TOOL_OPTIONS: --add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation
       FunctionName: !Ref AthenaCatalogName
       Handler: "com.amazonaws.athena.connectors.hbase.HbaseCompositeHandler"
       CodeUri: "./target/athena-hbase-2022.47.1.jar"
       Description: "Enables Amazon Athena to communicate with HBase, making your HBase data accessible via SQL"
-      Runtime: java11
+      Runtime: java17
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       PermissionsBoundary: !If [ HasPermissionsBoundary, !Ref PermissionsBoundaryARN, !Ref "AWS::NoValue" ]

--- a/athena-hortonworks-hive/Dockerfile
+++ b/athena-hortonworks-hive/Dockerfile
@@ -1,12 +1,14 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 17
+ARG JAVA_VERSION=17
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
 ARG JAVA_TOOL_OPTIONS=""
-# Set the JAVA_TOOL_OPTIONS environment variable for Java 17
-ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
+# Set the JAVA_TOOL_OPTIONS environment variable for Java 17.
+# Additional JVM options (e.g., for JDK 25: -Darrow.allocation.manager.type=Unsafe)
+# can be passed and will be included along with these defaults.
+ENV JAVA_TOOL_OPTIONS="--add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation ${JAVA_TOOL_OPTIONS}"
 
 # Copy function code and runtime dependencies from Maven layout
 COPY target/athena-hortonworks-hive-2022.47.1.jar ${LAMBDA_TASK_ROOT}

--- a/athena-hortonworks-hive/athena-hortonworks-hive-package.yaml
+++ b/athena-hortonworks-hive/athena-hortonworks-hive-package.yaml
@@ -68,11 +68,12 @@ Resources:
           spill_bucket: !Ref SpillBucket
           spill_prefix: !Ref SpillPrefix
           default: !Ref DefaultConnectionString
+          JAVA_TOOL_OPTIONS: --add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.hortonworks.HiveMuxCompositeHandler"
       CodeUri: "./target/athena-hortonworks-hive-2022.47.1.jar"
       Description: "Enables Amazon Athena to communicate with Hortonworks Hive using JDBC"
-      Runtime: java11
+      Runtime: java17
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       PermissionsBoundary: !If [ HasPermissionsBoundary, !Ref PermissionsBoundaryARN, !Ref "AWS::NoValue" ]

--- a/athena-hortonworks-hive/pom.xml
+++ b/athena-hortonworks-hive/pom.xml
@@ -46,18 +46,6 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/rds -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/athena-jdbc/pom.xml
+++ b/athena-jdbc/pom.xml
@@ -163,12 +163,6 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>

--- a/athena-kafka/Dockerfile
+++ b/athena-kafka/Dockerfile
@@ -1,12 +1,14 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 17
+ARG JAVA_VERSION=17
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
 ARG JAVA_TOOL_OPTIONS=""
-# Set the JAVA_TOOL_OPTIONS environment variable for Java 17
-ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
+# Set the JAVA_TOOL_OPTIONS environment variable for Java 17.
+# Additional JVM options (e.g., for JDK 25: -Darrow.allocation.manager.type=Unsafe)
+# can be passed and will be included along with these defaults.
+ENV JAVA_TOOL_OPTIONS="--add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation ${JAVA_TOOL_OPTIONS}"
 
 # Copy function code and runtime dependencies from Maven layout
 COPY target/athena-kafka-2022.47.1.jar ${LAMBDA_TASK_ROOT}

--- a/athena-kafka/athena-kafka-package.yaml
+++ b/athena-kafka/athena-kafka-package.yaml
@@ -100,11 +100,12 @@ Resources:
           kafka_endpoint: !Ref KafkaEndpoint
           schema_registry_url: !Ref SchemaRegistryUrl
           auth_type: !Ref AuthType
+          JAVA_TOOL_OPTIONS: --add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.kafka.KafkaCompositeHandler"
       CodeUri: "./target/athena-kafka-2022.47.1.jar"
       Description: "Enables Amazon Athena to communicate with Kafka clusters"
-      Runtime: java11
+      Runtime: java17
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       Role: !If [NotHasLambdaRole, !GetAtt FunctionRole.Arn, !Ref LambdaRoleARN]

--- a/athena-kafka/pom.xml
+++ b/athena-kafka/pom.xml
@@ -94,23 +94,6 @@
             <artifactId>guava</artifactId>
             <version>${guava.version}</version>
         </dependency>
-        <!--
-          This is purposefully using a legacy version because these tests
-          rely on powermock and it will break on a later version.
-          Eventually we should fix the test code to not rely on powermock.
-        -->
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>

--- a/athena-msk/Dockerfile
+++ b/athena-msk/Dockerfile
@@ -1,12 +1,14 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 17
+ARG JAVA_VERSION=17
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
 ARG JAVA_TOOL_OPTIONS=""
-# Set the JAVA_TOOL_OPTIONS environment variable for Java 17
-ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
+# Set the JAVA_TOOL_OPTIONS environment variable for Java 17.
+# Additional JVM options (e.g., for JDK 25: -Darrow.allocation.manager.type=Unsafe)
+# can be passed and will be included along with these defaults.
+ENV JAVA_TOOL_OPTIONS="--add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation ${JAVA_TOOL_OPTIONS}"
 
 # Copy function code and runtime dependencies from Maven layout
 COPY target/athena-msk-2022.47.1.jar ${LAMBDA_TASK_ROOT}

--- a/athena-msk/athena-msk-package.yaml
+++ b/athena-msk/athena-msk-package.yaml
@@ -96,11 +96,12 @@ Resources:
           certificates_s3_reference: !Ref CertificatesS3Reference
           kafka_endpoint: !Ref KafkaEndpoint
           auth_type: !Ref AuthType
+          JAVA_TOOL_OPTIONS: --add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.msk.AmazonMskCompositeHandler"
       CodeUri: "./target/athena-msk-2022.47.1.jar"
       Description: "Enables Amazon Athena to communicate with MSK clusters"
-      Runtime: java11
+      Runtime: java17
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       Role: !If [NotHasLambdaRole, !GetAtt FunctionRole.Arn, !Ref LambdaRoleARN]

--- a/athena-msk/pom.xml
+++ b/athena-msk/pom.xml
@@ -148,18 +148,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
             <version>2022.47.1</version>

--- a/athena-mysql/Dockerfile
+++ b/athena-mysql/Dockerfile
@@ -1,12 +1,14 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 17
+ARG JAVA_VERSION=17
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
 ARG JAVA_TOOL_OPTIONS=""
-# Set the JAVA_TOOL_OPTIONS environment variable for Java 17
-ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
+# Set the JAVA_TOOL_OPTIONS environment variable for Java 17.
+# Additional JVM options (e.g., for JDK 25: -Darrow.allocation.manager.type=Unsafe)
+# can be passed and will be included along with these defaults.
+ENV JAVA_TOOL_OPTIONS="--add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation ${JAVA_TOOL_OPTIONS}"
 
 # Copy function code and runtime dependencies from Maven layout
 COPY target/athena-mysql-2022.47.1.jar ${LAMBDA_TASK_ROOT}

--- a/athena-mysql/athena-mysql-package.yaml
+++ b/athena-mysql/athena-mysql-package.yaml
@@ -70,11 +70,12 @@ Resources:
           spill_bucket: !Ref SpillBucket
           spill_prefix: !Ref SpillPrefix
           default: !Ref DefaultConnectionString
+          JAVA_TOOL_OPTIONS: --add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.mysql.MySqlMuxCompositeHandler"
       CodeUri: "./target/athena-mysql-2022.47.1.jar"
       Description: "Enables Amazon Athena to communicate with MySQL using JDBC"
-      Runtime: java11
+      Runtime: java17
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       Role: !If [NotHasLambdaRole, !GetAtt FunctionRole.Arn, !Ref LambdaRoleARN]

--- a/athena-neptune/Dockerfile
+++ b/athena-neptune/Dockerfile
@@ -1,12 +1,14 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 17
+ARG JAVA_VERSION=17
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
 ARG JAVA_TOOL_OPTIONS=""
-# Set the JAVA_TOOL_OPTIONS environment variable for Java 17
-ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
+# Set the JAVA_TOOL_OPTIONS environment variable for Java 17.
+# Additional JVM options (e.g., for JDK 25: -Darrow.allocation.manager.type=Unsafe)
+# can be passed and will be included along with these defaults.
+ENV JAVA_TOOL_OPTIONS="--add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation ${JAVA_TOOL_OPTIONS}"
 
 # Copy function code and runtime dependencies from Maven layout
 COPY target/athena-neptune-2022.47.1.jar ${LAMBDA_TASK_ROOT}

--- a/athena-neptune/athena-neptune-package.yaml
+++ b/athena-neptune/athena-neptune-package.yaml
@@ -95,11 +95,12 @@ Resources:
           neptune_graphtype: !Ref NeptuneGraphType
           SERVICE_REGION: !Ref AWS::Region
           enable_caseinsensitivematch: !Ref EnableCaseInsensitiveMatch
+          JAVA_TOOL_OPTIONS: --add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation
       FunctionName: !Ref AthenaCatalogName
       Handler: "com.amazonaws.athena.connectors.neptune.NeptuneCompositeHandler"
       CodeUri: "./target/athena-neptune-2022.47.1.jar"
       Description: "Enables Amazon Athena to communicate with Neptune, making your Neptune graph data accessible via SQL."
-      Runtime: java11
+      Runtime: java17
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       PermissionsBoundary: !If [ HasPermissionsBoundary, !Ref PermissionsBoundaryARN, !Ref "AWS::NoValue" ]

--- a/athena-oracle/Dockerfile
+++ b/athena-oracle/Dockerfile
@@ -1,12 +1,14 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 17
+ARG JAVA_VERSION=17
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
-# Argument for Java tool options
+# Argument for Java tool options, defaulting to an empty string
 ARG JAVA_TOOL_OPTIONS=""
 # Set the JAVA_TOOL_OPTIONS environment variable for Java 17 and always include default truststore to avoid SSL handshake issues
-ENV JAVA_TOOL_OPTIONS="-Djavax.net.ssl.trustStore=/var/lang/lib/security/cacerts ${JAVA_TOOL_OPTIONS}"
+# Additional JVM options (e.g., for JDK 25: -Darrow.allocation.manager.type=Unsafe)
+# can be passed and will be included along with these defaults.
+ENV JAVA_TOOL_OPTIONS="-Djavax.net.ssl.trustStore=/var/lang/lib/security/cacerts --add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation ${JAVA_TOOL_OPTIONS}"
 
 # Install necessary tools
 RUN yum update -y

--- a/athena-oracle/athena-oracle-package.yaml
+++ b/athena-oracle/athena-oracle-package.yaml
@@ -81,11 +81,12 @@ Resources:
           spill_prefix: !Ref SpillPrefix
           default: !Ref DefaultConnectionString
           is_FIPS_Enabled: !Ref IsFIPSEnabled
+          JAVA_TOOL_OPTIONS: "-Djavax.net.ssl.trustStore=/var/lang/lib/security/cacerts --add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation"
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.oracle.OracleMuxCompositeHandler"
       CodeUri: "./target/athena-oracle-2022.47.1.jar"
       Description: "Enables Amazon Athena to communicate with ORACLE using JDBC"
-      Runtime: java11
+      Runtime: java17
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       Role: !If [NotHasLambdaRole, !GetAtt FunctionRole.Arn, !Ref LambdaRoleARN]

--- a/athena-oracle/pom.xml
+++ b/athena-oracle/pom.xml
@@ -53,18 +53,6 @@
             <version>${aws-cdk.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/athena-postgresql/Dockerfile
+++ b/athena-postgresql/Dockerfile
@@ -1,12 +1,14 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 17
+ARG JAVA_VERSION=17
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
 ARG JAVA_TOOL_OPTIONS=""
-# Set the JAVA_TOOL_OPTIONS environment variable for Java 17
-ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
+# Set the JAVA_TOOL_OPTIONS environment variable for Java 17.
+# Additional JVM options (e.g., for JDK 25: -Darrow.allocation.manager.type=Unsafe)
+# can be passed and will be included along with these defaults.
+ENV JAVA_TOOL_OPTIONS="--add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation ${JAVA_TOOL_OPTIONS}"
 
 # Copy function code and runtime dependencies from Maven layout
 COPY target/athena-postgresql-2022.47.1.jar ${LAMBDA_TASK_ROOT}

--- a/athena-postgresql/athena-postgresql-package.yaml
+++ b/athena-postgresql/athena-postgresql-package.yaml
@@ -80,11 +80,12 @@ Resources:
           spill_prefix: !Ref SpillPrefix
           default: !Ref DefaultConnectionString
           default_scale: !Ref DefaultScale
+          JAVA_TOOL_OPTIONS: --add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation
       FunctionName: !Ref LambdaFunctionName
       Handler: !Sub "com.amazonaws.athena.connectors.postgresql.${CompositeHandler}"
       CodeUri: "./target/athena-postgresql-2022.47.1.jar"
       Description: "Enables Amazon Athena to communicate with PostgreSQL using JDBC"
-      Runtime: java11
+      Runtime: java17
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       Role: !If [NotHasLambdaRole, !GetAtt FunctionRole.Arn, !Ref LambdaRoleARN]

--- a/athena-postgresql/pom.xml
+++ b/athena-postgresql/pom.xml
@@ -34,12 +34,6 @@
             <artifactId>postgresql</artifactId>
             <version>42.7.11</version>
         </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/rds -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/athena-redis/Dockerfile
+++ b/athena-redis/Dockerfile
@@ -1,12 +1,14 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 17
+ARG JAVA_VERSION=17
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
 ARG JAVA_TOOL_OPTIONS=""
-# Set the JAVA_TOOL_OPTIONS environment variable for Java 17
-ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
+# Set the JAVA_TOOL_OPTIONS environment variable for Java 17.
+# Additional JVM options (e.g., for JDK 25: -Darrow.allocation.manager.type=Unsafe)
+# can be passed and will be included along with these defaults.
+ENV JAVA_TOOL_OPTIONS="--add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation ${JAVA_TOOL_OPTIONS}"
 
 # Copy function code and runtime dependencies from Maven layout
 COPY target/athena-redis-2022.47.1.jar ${LAMBDA_TASK_ROOT}

--- a/athena-redis/athena-redis-package.yaml
+++ b/athena-redis/athena-redis-package.yaml
@@ -80,11 +80,12 @@ Resources:
           qpt_ssl: !Ref QPTConnectionSSL
           qpt_cluster: !Ref QPTConnectionCluster
           qpt_db_number: !Ref QPTConnectionDBNumber
+          JAVA_TOOL_OPTIONS: --add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation
       FunctionName: !Ref AthenaCatalogName
       Handler: "com.amazonaws.athena.connectors.redis.RedisCompositeHandler"
       CodeUri: "./target/athena-redis-2022.47.1.jar"
       Description: "Enables Amazon Athena to communicate with Redis, making your Redis data accessible via SQL"
-      Runtime: java11
+      Runtime: java17
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       PermissionsBoundary: !If [ HasPermissionsBoundary, !Ref PermissionsBoundaryARN, !Ref "AWS::NoValue" ]

--- a/athena-redshift/Dockerfile
+++ b/athena-redshift/Dockerfile
@@ -1,12 +1,14 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 17
+ARG JAVA_VERSION=17
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
 ARG JAVA_TOOL_OPTIONS=""
-# Set the JAVA_TOOL_OPTIONS environment variable for Java 17
-ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
+# Set the JAVA_TOOL_OPTIONS environment variable for Java 17.
+# Additional JVM options (e.g., for JDK 25: -Darrow.allocation.manager.type=Unsafe)
+# can be passed and will be included along with these defaults.
+ENV JAVA_TOOL_OPTIONS="--add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation ${JAVA_TOOL_OPTIONS}"
 
 # Copy function code and runtime dependencies from Maven layout
 COPY target/athena-redshift-2022.47.1.jar ${LAMBDA_TASK_ROOT}

--- a/athena-redshift/athena-redshift-package.yaml
+++ b/athena-redshift/athena-redshift-package.yaml
@@ -78,11 +78,12 @@ Resources:
           spill_prefix: !Ref SpillPrefix
           default: !Ref DefaultConnectionString
           kms_key_id: !If [HasKMSKeyId, !Ref KMSKeyId, !Ref "AWS::NoValue"]
+          JAVA_TOOL_OPTIONS: --add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.redshift.RedshiftMuxCompositeHandler"
       CodeUri: "./target/athena-redshift-2022.47.1.jar"
       Description: "Enables Amazon Athena to communicate with Redshift using JDBC"
-      Runtime: java11
+      Runtime: java17
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       Role: !If [NotHasLambdaRole, !GetAtt FunctionRole.Arn, !Ref LambdaRole]

--- a/athena-redshift/pom.xml
+++ b/athena-redshift/pom.xml
@@ -27,12 +27,6 @@
             <version>2.2.6</version>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
             <version>2022.47.1</version>

--- a/athena-saphana/Dockerfile
+++ b/athena-saphana/Dockerfile
@@ -1,12 +1,14 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 17
+ARG JAVA_VERSION=17
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
 ARG JAVA_TOOL_OPTIONS=""
-# Set the JAVA_TOOL_OPTIONS environment variable for Java 17
-ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
+# Set the JAVA_TOOL_OPTIONS environment variable for Java 17.
+# Additional JVM options (e.g., for JDK 25: -Darrow.allocation.manager.type=Unsafe)
+# can be passed and will be included along with these defaults.
+ENV JAVA_TOOL_OPTIONS="--add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation ${JAVA_TOOL_OPTIONS}"
 
 # Copy function code and runtime dependencies from Maven layout
 COPY target/athena-saphana.zip ${LAMBDA_TASK_ROOT}

--- a/athena-saphana/pom.xml
+++ b/athena-saphana/pom.xml
@@ -47,23 +47,6 @@
             <version>${aws-cdk.version}</version>
             <scope>test</scope>
         </dependency>
-        <!--
-          This is purposefully using a legacy version because these tests
-          rely on powermock and it will break on a later version.
-          Eventually we should fix the test code to not rely on powermock.
-        -->
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>

--- a/athena-snowflake/Dockerfile
+++ b/athena-snowflake/Dockerfile
@@ -1,12 +1,14 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 17
+ARG JAVA_VERSION=17
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
 ARG JAVA_TOOL_OPTIONS=""
-# Set the JAVA_TOOL_OPTIONS environment variable for Java 17
-ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
+# Set the JAVA_TOOL_OPTIONS environment variable for Java 17.
+# Additional JVM options (e.g., for JDK 25: -Darrow.allocation.manager.type=Unsafe)
+# can be passed and will be included along with these defaults.
+ENV JAVA_TOOL_OPTIONS="--add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation ${JAVA_TOOL_OPTIONS}"
 
 # Copy function code and runtime dependencies from Maven layout
 COPY target/athena-snowflake.zip ${LAMBDA_TASK_ROOT}

--- a/athena-snowflake/pom.xml
+++ b/athena-snowflake/pom.xml
@@ -92,23 +92,6 @@
             <version>${aws-cdk.version}</version>
             <scope>test</scope>
         </dependency>
-        <!--
-          This is purposefully using a legacy version because these tests
-          rely on powermock and it will break on a later version.
-          Eventually we should fix the test code to not rely on powermock.
-        -->
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeRecordHandler.java
+++ b/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeRecordHandler.java
@@ -288,7 +288,7 @@ public class SnowflakeRecordHandler extends JdbcRecordHandler
                 0,
                 srcValidity,
                 0,
-                BitVectorHelper.getValidityBufferSize(rowCount)
+                BitVectorHelper.getValidityBufferSizeFromCount(rowCount)
         );
 
         // finalized the actual value, without this vector will see no data.

--- a/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeRecordHandler.java
+++ b/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeRecordHandler.java
@@ -288,7 +288,7 @@ public class SnowflakeRecordHandler extends JdbcRecordHandler
                 0,
                 srcValidity,
                 0,
-                BitVectorHelper.getValidityBufferSizeFromCount(rowCount)
+                BitVectorHelper.getValidityBufferSize(rowCount)
         );
 
         // finalized the actual value, without this vector will see no data.

--- a/athena-sqlserver/Dockerfile
+++ b/athena-sqlserver/Dockerfile
@@ -1,12 +1,14 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 17
+ARG JAVA_VERSION=17
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
-# Argument for Java tool options for ssl
-ARG JAVA_TOOL_OPTIONS="-Djavax.net.ssl.trustStore=/var/lang/lib/security/cacerts"
-# Set the JAVA_TOOL_OPTIONS environment variable for Java 17
-ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
+# Argument for Java tool options, defaulting to an empty string
+ARG JAVA_TOOL_OPTIONS=""
+# Set the JAVA_TOOL_OPTIONS environment variable for Java 17 and always include default truststore to avoid SSL handshake issues
+# Additional JVM options (e.g., for JDK 25: -Darrow.allocation.manager.type=Unsafe)
+# can be passed and will be included along with these defaults.
+ENV JAVA_TOOL_OPTIONS="-Djavax.net.ssl.trustStore=/var/lang/lib/security/cacerts --add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation ${JAVA_TOOL_OPTIONS}"
 # Install necessary tools
 RUN yum update -y
 RUN yum install -y curl perl openssl11

--- a/athena-sqlserver/athena-sqlserver-package.yaml
+++ b/athena-sqlserver/athena-sqlserver-package.yaml
@@ -75,11 +75,12 @@ Resources:
           spill_bucket: !Ref SpillBucket
           spill_prefix: !Ref SpillPrefix
           default: !Ref DefaultConnectionString
+          JAVA_TOOL_OPTIONS: "-Djavax.net.ssl.trustStore=/var/lang/lib/security/cacerts --add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation"
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.sqlserver.SqlServerMuxCompositeHandler"
       CodeUri: "./target/athena-sqlserver-2022.47.1.jar"
       Description: "Enables Amazon Athena to communicate with SQLSERVER using JDBC"
-      Runtime: java11
+      Runtime: java17
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       Role: !If [NotHasLambdaRole, !GetAtt FunctionRole.Arn, !Ref LambdaRoleARN]

--- a/athena-sqlserver/pom.xml
+++ b/athena-sqlserver/pom.xml
@@ -52,29 +52,6 @@
             <version>${aws-cdk.version}</version>
             <scope>test</scope>
         </dependency>
-        <!--
-          This is purposefully using a legacy version because these tests
-          rely on powermock and it will break on a later version.
-          Eventually we should fix the test code to not rely on powermock.
-        -->
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <version>2.0.9</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/athena-synapse/Dockerfile
+++ b/athena-synapse/Dockerfile
@@ -1,12 +1,14 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 17
+ARG JAVA_VERSION=17
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
 ARG JAVA_TOOL_OPTIONS=""
-# Set the JAVA_TOOL_OPTIONS environment variable for Java 17
-ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
+# Set the JAVA_TOOL_OPTIONS environment variable for Java 17.
+# Additional JVM options (e.g., for JDK 25: -Darrow.allocation.manager.type=Unsafe)
+# can be passed and will be included along with these defaults.
+ENV JAVA_TOOL_OPTIONS="--add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation ${JAVA_TOOL_OPTIONS}"
 
 # Copy function code and runtime dependencies from Maven layout
 COPY target/athena-synapse-2022.47.1.jar ${LAMBDA_TASK_ROOT}

--- a/athena-synapse/athena-synapse-package.yaml
+++ b/athena-synapse/athena-synapse-package.yaml
@@ -77,11 +77,12 @@ Resources:
           spill_bucket: !Ref SpillBucket
           spill_prefix: !Ref SpillPrefix
           default: !Ref DefaultConnectionString
+          JAVA_TOOL_OPTIONS: --add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.synapse.SynapseMuxCompositeHandler"
       CodeUri: "./target/athena-synapse-2022.47.1.jar"
       Description: "Enables Amazon Athena to communicate with SYNPASE using JDBC"
-      Runtime: java11
+      Runtime: java17
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       Role: !If [NotHasLambdaRole, !GetAtt FunctionRole.Arn, !Ref LambdaRoleARN]

--- a/athena-synapse/pom.xml
+++ b/athena-synapse/pom.xml
@@ -79,23 +79,6 @@
             <version>${aws-cdk.version}</version>
             <scope>test</scope>
         </dependency>
-        <!--
-          This is purposefully using a legacy version because these tests
-          rely on powermock and it will break on a later version.
-          Eventually we should fix the test code to not rely on powermock.
-        -->
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/athena-teradata/Dockerfile
+++ b/athena-teradata/Dockerfile
@@ -1,12 +1,14 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 17
+ARG JAVA_VERSION=17
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
 ARG JAVA_TOOL_OPTIONS=""
-# Set the JAVA_TOOL_OPTIONS environment variable for Java 17
-ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
+# Set the JAVA_TOOL_OPTIONS environment variable for Java 17.
+# Additional JVM options (e.g., for JDK 25: -Darrow.allocation.manager.type=Unsafe)
+# can be passed and will be included along with these defaults.
+ENV JAVA_TOOL_OPTIONS="--add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation ${JAVA_TOOL_OPTIONS}"
 
 # Copy function code and runtime dependencies from Maven layout
 COPY target/athena-teradata-2022.47.1.jar ${LAMBDA_TASK_ROOT}

--- a/athena-teradata/athena-teradata-package.yaml
+++ b/athena-teradata/athena-teradata-package.yaml
@@ -73,11 +73,12 @@ Resources:
           spill_prefix: !Ref SpillPrefix
           default: !Ref DefaultConnectionString
           partitioncount: !Ref PartitionCount
+          JAVA_TOOL_OPTIONS: --add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.teradata.TeradataMuxCompositeHandler"
       CodeUri: "./target/athena-teradata-2022.47.1.jar"
       Description: "Enables Amazon Athena to communicate with Teradata using JDBC"
-      Runtime: java11
+      Runtime: java17
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       PermissionsBoundary: !If [ HasPermissionsBoundary, !Ref PermissionsBoundaryARN, !Ref "AWS::NoValue" ]

--- a/athena-teradata/pom.xml
+++ b/athena-teradata/pom.xml
@@ -48,18 +48,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.teradata.jdbc</groupId>
             <artifactId>terajdbc</artifactId>
             <version>20.00.00.56</version>

--- a/athena-timestream/Dockerfile
+++ b/athena-timestream/Dockerfile
@@ -1,12 +1,14 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 17
+ARG JAVA_VERSION=17
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
 ARG JAVA_TOOL_OPTIONS=""
-# Set the JAVA_TOOL_OPTIONS environment variable for Java 17
-ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
+# Set the JAVA_TOOL_OPTIONS environment variable for Java 17.
+# Additional JVM options (e.g., for JDK 25: -Darrow.allocation.manager.type=Unsafe)
+# can be passed and will be included along with these defaults.
+ENV JAVA_TOOL_OPTIONS="--add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation ${JAVA_TOOL_OPTIONS}"
 
 # Copy function code and runtime dependencies from Maven layout
 COPY target/athena-timestream-2022.47.1.jar ${LAMBDA_TASK_ROOT}

--- a/athena-timestream/athena-timestream-package.yaml
+++ b/athena-timestream/athena-timestream-package.yaml
@@ -51,11 +51,12 @@ Resources:
           disable_spill_encryption: !Ref DisableSpillEncryption
           spill_bucket: !Ref SpillBucket
           spill_prefix: !Ref SpillPrefix
+          JAVA_TOOL_OPTIONS: --add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation
       FunctionName: !Ref AthenaCatalogName
       Handler: "com.amazonaws.athena.connectors.timestream.TimestreamCompositeHandler"
       CodeUri: "./target/athena-timestream-2022.47.1.jar"
       Description: "Enables Amazon Athena to communicate with Amazon Timestream, making your time series data accessible from Athena."
-      Runtime: java11
+      Runtime: java17
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       PermissionsBoundary: !If [ HasPermissionsBoundary, !Ref PermissionsBoundaryARN, !Ref "AWS::NoValue" ]

--- a/athena-timestream/pom.xml
+++ b/athena-timestream/pom.xml
@@ -85,12 +85,6 @@
             <version>${log4j2Version}</version>
             <scope>runtime</scope>
         </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/athena-tpcds/Dockerfile
+++ b/athena-tpcds/Dockerfile
@@ -1,12 +1,14 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 17
+ARG JAVA_VERSION=17
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
 ARG JAVA_TOOL_OPTIONS=""
-# Set the JAVA_TOOL_OPTIONS environment variable for Java 17
-ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
+# Set the JAVA_TOOL_OPTIONS environment variable for Java 17.
+# Additional JVM options (e.g., for JDK 25: -Darrow.allocation.manager.type=Unsafe)
+# can be passed and will be included along with these defaults.
+ENV JAVA_TOOL_OPTIONS="--add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation ${JAVA_TOOL_OPTIONS}"
 
 # Copy function code and runtime dependencies from Maven layout
 COPY target/athena-tpcds-2022.47.1.jar ${LAMBDA_TASK_ROOT}

--- a/athena-tpcds/athena-tpcds-package.yaml
+++ b/athena-tpcds/athena-tpcds-package.yaml
@@ -52,11 +52,12 @@ Resources:
           disable_spill_encryption: !Ref DisableSpillEncryption
           spill_bucket: !Ref SpillBucket
           spill_prefix: !Ref SpillPrefix
+          JAVA_TOOL_OPTIONS: --add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation
       FunctionName: !Ref AthenaCatalogName
       Handler: "com.amazonaws.athena.connectors.tpcds.TPCDSCompositeHandler"
       CodeUri: "./target/athena-tpcds-2022.47.1.jar"
       Description: "This connector enables Amazon Athena to communicate with a randomly generated TPC-DS data source."
-      Runtime: java11
+      Runtime: java17
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       PermissionsBoundary: !If [ HasPermissionsBoundary, !Ref PermissionsBoundaryARN, !Ref "AWS::NoValue" ]

--- a/athena-udfs/Dockerfile
+++ b/athena-udfs/Dockerfile
@@ -1,12 +1,14 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 17
+ARG JAVA_VERSION=17
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
 ARG JAVA_TOOL_OPTIONS=""
-# Set the JAVA_TOOL_OPTIONS environment variable for Java 17
-ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
+# Set the JAVA_TOOL_OPTIONS environment variable for Java 17.
+# Additional JVM options (e.g., for JDK 25: -Darrow.allocation.manager.type=Unsafe)
+# can be passed and will be included along with these defaults.
+ENV JAVA_TOOL_OPTIONS="--add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation ${JAVA_TOOL_OPTIONS}"
 
 # Copy function code and runtime dependencies from Maven layout
 COPY target/athena-udfs-2022.47.1.jar ${LAMBDA_TASK_ROOT}

--- a/athena-udfs/athena-udfs-package.yaml
+++ b/athena-udfs/athena-udfs-package.yaml
@@ -38,11 +38,14 @@ Resources:
   ConnectorConfig:
     Type: 'AWS::Serverless::Function'
     Properties:
+      Environment:
+        Variables:
+          JAVA_TOOL_OPTIONS: --add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation
       FunctionName: !Ref LambdaFunctionName
       Handler: "com.amazonaws.athena.connectors.udfs.AthenaUDFHandler"
       CodeUri: "./target/athena-udfs-2022.47.1.jar"
       Description: "This connector enables Amazon Athena to leverage common UDFs made available via Lambda."
-      Runtime: java11
+      Runtime: java17
       Timeout: !Ref LambdaTimeout
       MemorySize: !Ref LambdaMemory
       PermissionsBoundary: !If [ HasPermissionsBoundary, !Ref PermissionsBoundaryARN, !Ref "AWS::NoValue" ]

--- a/athena-vertica/Dockerfile
+++ b/athena-vertica/Dockerfile
@@ -1,12 +1,14 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 17
+ARG JAVA_VERSION=17
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
 ARG JAVA_TOOL_OPTIONS=""
-# Set the JAVA_TOOL_OPTIONS environment variable for Java 17
-ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
+# Set the JAVA_TOOL_OPTIONS environment variable for Java 17.
+# Additional JVM options (e.g., for JDK 25: -Darrow.allocation.manager.type=Unsafe)
+# can be passed and will be included along with these defaults.
+ENV JAVA_TOOL_OPTIONS="--add-opens=java.base/java.nio=ALL-UNNAMED -XX:-TieredCompilation ${JAVA_TOOL_OPTIONS}"
 
 # Copy function code and runtime dependencies from Maven layout
 COPY target/athena-vertica-2022.47.1.jar ${LAMBDA_TASK_ROOT}

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <jsii.version>1.138.0</jsii.version>
         <!--- to meet engine version 2.0.7-->
         <slf4j-log4j.version>2.0.18</slf4j-log4j.version>
-        <mockito.version>4.11.0</mockito.version>
+        <mockito.version>5.18.0</mockito.version>
         <junit.version>4.13.2</junit.version>
         <jqwik.version>1.10.1</jqwik.version>
         <assertj.version>3.27.7</assertj.version>
@@ -567,6 +567,50 @@
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <version>${surefire.failsafe.version}</version>
                         <configuration>
+                            <forkCount>3C</forkCount>
+                            <reuseForks>false</reuseForks>
+                            <includes>
+                                <include>*IntegTest</include>
+                            </includes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>jdk25</id>
+            <activation>
+                <jdk>25</jdk>
+            </activation>
+            <properties>
+                <maven.compiler.release>25</maven.compiler.release>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.arrow</groupId>
+                    <artifactId>arrow-memory-unsafe</artifactId>
+                    <version>${apache.arrow.version}</version>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>${surefire.failsafe.version}</version>
+                        <configuration>
+                            <argLine>${argLine} -Darrow.allocation.manager.type=Unsafe --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED</argLine>
+                            <excludes>
+                                <exclude>*IntegTest</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>${surefire.failsafe.version}</version>
+                        <configuration>
+                            <argLine>${argLine} -Darrow.allocation.manager.type=Unsafe --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED</argLine>
                             <forkCount>3C</forkCount>
                             <reuseForks>false</reuseForks>
                             <includes>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.release>11</maven.compiler.release>
+        <maven.compiler.release>17</maven.compiler.release>
         <maven.compiler.plugin.version>3.15.0</maven.compiler.plugin.version>
         <!--- to meet engine version 1.12.533-->
         <aws-sdk-v2.version>2.46.17</aws-sdk-v2.version>
@@ -502,6 +502,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${surefire.failsafe.version}</version>
                 <configuration>
+                    <argLine>${argLine} --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED</argLine>
                     <excludes>
                         <exclude>*IntegTest</exclude>
                     </excludes>
@@ -512,6 +513,7 @@
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>${surefire.failsafe.version}</version>
                 <configuration>
+                    <argLine>${argLine} --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED</argLine>
                     <forkCount>3C</forkCount>
                     <reuseForks>false</reuseForks>
                     <includes>
@@ -541,12 +543,12 @@
             </properties>
         </profile>
         <profile>
-            <id>java17</id>
+            <id>java11</id>
             <activation>
-                <jdk>17</jdk>
+                <jdk>11</jdk>
             </activation>
             <properties>
-                <maven.compiler.release>17</maven.compiler.release>
+                <maven.compiler.release>11</maven.compiler.release>
             </properties>
             <build>
                 <plugins>
@@ -555,7 +557,6 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <version>${surefire.failsafe.version}</version>
                         <configuration>
-                            <argLine>${argLine} --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED</argLine>
                             <excludes>
                                 <exclude>*IntegTest</exclude>
                             </excludes>
@@ -566,7 +567,6 @@
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <version>${surefire.failsafe.version}</version>
                         <configuration>
-                            <argLine>${argLine} --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED</argLine>
                             <forkCount>3C</forkCount>
                             <reuseForks>false</reuseForks>
                             <includes>


### PR DESCRIPTION
*Description of changes:*

- Updated all connectors to target Java 17.
- Added build support for Java 25.
- Conducted functional and performance testing on Java 17 for Oracle, PostgreSQL, BigQuery, DocDB connectors.
- Conducted functional testing on Java 25 for DB2, Snowflake, BigQuery, Timestream connectors.

Please find attached test documents for reference.
[POSTGRES_PERFORMANCE_TEST_JDK17.xlsx](https://github.com/user-attachments/files/26308503/POSTGRES_PERFORMANCE_TEST_JDK17.xlsx)
[DOCDB-PERFORMANCE_TEST_JDK17.xlsx](https://github.com/user-attachments/files/26308505/DOCDB-PERFORMANCE_TEST_JDK17.xlsx)
[BIGQUERY-PERFORMANCE_TEST_JDK17.xlsx](https://github.com/user-attachments/files/26308506/BIGQUERY-PERFORMANCE_TEST_JDK17.xlsx)
[ORACLE_PERFORMANCE_TEST_JDK17.xlsx](https://github.com/user-attachments/files/26308507/ORACLE_PERFORMANCE_TEST_JDK17.xlsx)
[ORACLE_FUNCTIONAL_TEST_JDK17_2026-03-27.xlsx](https://github.com/user-attachments/files/26308508/ORACLE_FUNCTIONAL_TEST_JDK17_2026-03-27.xlsx)
[POSTGRES_FUNCTIONAL_TEST_JDK17_2026-03-27.xlsx](https://github.com/user-attachments/files/26308509/POSTGRES_FUNCTIONAL_TEST_JDK17_2026-03-27.xlsx)
[BIGQUERY_FUNCTIONAL_TEST_JDK17_2026-03-27.xlsx](https://github.com/user-attachments/files/26308511/BIGQUERY_FUNCTIONAL_TEST_JDK17_2026-03-27.xlsx)
[DOCDB_FUNCTIONAL_TEST_JDK17_2026-03-27.xlsx](https://github.com/user-attachments/files/26308512/DOCDB_FUNCTIONAL_TEST_JDK17_2026-03-27.xlsx)
[DB2_FUNCTIONAL_TEST_JDK25_2026-03-25.xlsx](https://github.com/user-attachments/files/26308514/DB2_FUNCTIONAL_TEST_JDK25_2026-03-25.xlsx)
[SNOWFLAKE_FUNCTIONAL_TEST_JDK25_2026-03-25.xlsx](https://github.com/user-attachments/files/26308515/SNOWFLAKE_FUNCTIONAL_TEST_JDK25_2026-03-25.xlsx)
[TIMESTREAM_FUNCTIONAL_TEST_JDK25_2026-03-26.xlsx](https://github.com/user-attachments/files/26308516/TIMESTREAM_FUNCTIONAL_TEST_JDK25_2026-03-26.xlsx)
[BIGQUERY_FUNCTIONAL_TEST_JDK25_2026-03-26.xlsx](https://github.com/user-attachments/files/26308517/BIGQUERY_FUNCTIONAL_TEST_JDK25_2026-03-26.xlsx)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
