### PR TITLE
Remove shaded jar from container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,44 +38,44 @@ RUN echo "Trust store content is: " && \
     done
 
 # Set the connector version to use
-ARG VERSION=2022.47.1
+ARG JAR_VERSION=2022.47.1
 
 # Copy all jar files from their respective target directories into the Lambda task root.
-# Notice how we substitute the version using ${VERSION}.
+# Notice how we substitute the version using ${JAR_VERSION}.
 COPY \
-  athena-aws-cmdb/target/athena-aws-cmdb-${VERSION}.jar \
-  athena-clickhouse/target/athena-clickhouse-${VERSION}.jar \
-  athena-cloudera-hive/target/athena-cloudera-hive-${VERSION}.jar \
-  athena-cloudera-impala/target/athena-cloudera-impala-${VERSION}.jar \
-  athena-cloudwatch/target/athena-cloudwatch-${VERSION}.jar \
-  athena-cloudwatch-metrics/target/athena-cloudwatch-metrics-${VERSION}.jar \
-  athena-datalakegen2/target/athena-datalakegen2-${VERSION}.jar \
-  athena-db2/target/athena-db2-${VERSION}.jar \
-  athena-db2-as400/target/athena-db2-as400-${VERSION}.jar \
-  athena-docdb/target/athena-docdb-${VERSION}.jar \
-  athena-dynamodb/target/athena-dynamodb-${VERSION}.jar \
-  athena-elasticsearch/target/athena-elasticsearch-${VERSION}.jar \
+  athena-aws-cmdb/target/athena-aws-cmdb-${JAR_VERSION}.jar \
+  athena-clickhouse/target/athena-clickhouse-${JAR_VERSION}.jar \
+  athena-cloudera-hive/target/athena-cloudera-hive-${JAR_VERSION}.jar \
+  athena-cloudera-impala/target/athena-cloudera-impala-${JAR_VERSION}.jar \
+  athena-cloudwatch/target/athena-cloudwatch-${JAR_VERSION}.jar \
+  athena-cloudwatch-metrics/target/athena-cloudwatch-metrics-${JAR_VERSION}.jar \
+  athena-datalakegen2/target/athena-datalakegen2-${JAR_VERSION}.jar \
+  athena-db2/target/athena-db2-${JAR_VERSION}.jar \
+  athena-db2-as400/target/athena-db2-as400-${JAR_VERSION}.jar \
+  athena-docdb/target/athena-docdb-${JAR_VERSION}.jar \
+  athena-dynamodb/target/athena-dynamodb-${JAR_VERSION}.jar \
+  athena-elasticsearch/target/athena-elasticsearch-${JAR_VERSION}.jar \
   athena-gcs/target/athena-gcs.zip \
-  athena-google-bigquery/target/athena-google-bigquery-${VERSION}.jar \
-  athena-hbase/target/athena-hbase-${VERSION}.jar \
-  athena-hortonworks-hive/target/athena-hortonworks-hive-${VERSION}.jar \
-  athena-kafka/target/athena-kafka-${VERSION}.jar \
-  athena-msk/target/athena-msk-${VERSION}.jar \
-  athena-mysql/target/athena-mysql-${VERSION}.jar \
-  athena-neptune/target/athena-neptune-${VERSION}.jar \
-  athena-oracle/target/athena-oracle-${VERSION}.jar \
-  athena-postgresql/target/athena-postgresql-${VERSION}.jar \
-  athena-redis/target/athena-redis-${VERSION}.jar \
-  athena-redshift/target/athena-redshift-${VERSION}.jar \
+  athena-google-bigquery/target/athena-google-bigquery-${JAR_VERSION}.jar \
+  athena-hbase/target/athena-hbase-${JAR_VERSION}.jar \
+  athena-hortonworks-hive/target/athena-hortonworks-hive-${JAR_VERSION}.jar \
+  athena-kafka/target/athena-kafka-${JAR_VERSION}.jar \
+  athena-msk/target/athena-msk-${JAR_VERSION}.jar \
+  athena-mysql/target/athena-mysql-${JAR_VERSION}.jar \
+  athena-neptune/target/athena-neptune-${JAR_VERSION}.jar \
+  athena-oracle/target/athena-oracle-${JAR_VERSION}.jar \
+  athena-postgresql/target/athena-postgresql-${JAR_VERSION}.jar \
+  athena-redis/target/athena-redis-${JAR_VERSION}.jar \
+  athena-redshift/target/athena-redshift-${JAR_VERSION}.jar \
   athena-saphana/target/athena-saphana.zip \
   athena-snowflake/target/athena-snowflake.zip \
-  athena-sqlserver/target/athena-sqlserver-${VERSION}.jar \
-  athena-synapse/target/athena-synapse-${VERSION}.jar \
-  athena-teradata/target/athena-teradata-${VERSION}.jar \
-  athena-timestream/target/athena-timestream-${VERSION}.jar \
-  athena-tpcds/target/athena-tpcds-${VERSION}.jar \
-  athena-udfs/target/athena-udfs-${VERSION}.jar \
-  athena-vertica/target/athena-vertica-${VERSION}.jar \
+  athena-sqlserver/target/athena-sqlserver-${JAR_VERSION}.jar \
+  athena-synapse/target/athena-synapse-${JAR_VERSION}.jar \
+  athena-teradata/target/athena-teradata-${JAR_VERSION}.jar \
+  athena-timestream/target/athena-timestream-${JAR_VERSION}.jar \
+  athena-tpcds/target/athena-tpcds-${JAR_VERSION}.jar \
+  athena-udfs/target/athena-udfs-${JAR_VERSION}.jar \
+  athena-vertica/target/athena-vertica-${JAR_VERSION}.jar \
   ${LAMBDA_TASK_ROOT}/
 
 # Run a shell loop to iterate over all jar/zip files and extract each one.

--- a/athena-aws-cmdb/Dockerfile
+++ b/athena-aws-cmdb/Dockerfile
@@ -1,6 +1,18 @@
 # Argument for Java version, defaulting to 11.al2023-x86_64
 ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
+FROM public.ecr.aws/lambda/java:${JAVA_VERSION} AS builder
+
+# Argument for JAR version
+ARG JAR_VERSION=2022.47.1
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-aws-cmdb-${JAR_VERSION}.jar /app/
+
+# Unpack the JAR and then remove it
+WORKDIR /app
+RUN jar xf athena-aws-cmdb-${JAR_VERSION}.jar && rm -f athena-aws-cmdb-${JAR_VERSION}.jar
+
+# Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
@@ -8,10 +20,8 @@ ARG JAVA_TOOL_OPTIONS=""
 # Set the JAVA_TOOL_OPTIONS environment variable for Java 17
 ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
 
-# Copy function code and runtime dependencies from Maven layout
-COPY target/athena-aws-cmdb-2022.47.1.jar ${LAMBDA_TASK_ROOT}
-# Unpack the jar
-RUN jar xf athena-aws-cmdb-2022.47.1.jar
+# Copy the extracted contents from the builder stage to the Lambda task root directory
+COPY --from=builder /app/ ${LAMBDA_TASK_ROOT}/
 
 # Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
 # No need to specify here (already defined in .yaml file)

--- a/athena-clickhouse/Dockerfile
+++ b/athena-clickhouse/Dockerfile
@@ -1,6 +1,18 @@
 # Argument for Java version, defaulting to 11.al2023-x86_64
 ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
+FROM public.ecr.aws/lambda/java:${JAVA_VERSION} AS builder
+
+# Argument for JAR version
+ARG JAR_VERSION=2022.47.1
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-clickhouse-${JAR_VERSION}.jar /app/
+
+# Unpack the JAR and then remove it
+WORKDIR /app
+RUN jar xf athena-clickhouse-${JAR_VERSION}.jar && rm -f athena-clickhouse-${JAR_VERSION}.jar
+
+# Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
@@ -8,10 +20,8 @@ ARG JAVA_TOOL_OPTIONS=""
 # Set the JAVA_TOOL_OPTIONS environment variable for Java 17
 ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
 
-# Copy function code and runtime dependencies from Maven layout
-COPY target/athena-clickhouse-2022.47.1.jar ${LAMBDA_TASK_ROOT}
-# Unpack the jar
-RUN jar xf athena-clickhouse-2022.47.1.jar
+# Copy the extracted contents from the builder stage to the Lambda task root directory
+COPY --from=builder /app/ ${LAMBDA_TASK_ROOT}/
 
 # Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
 # No need to specify here (already defined in .yaml file because legacy and connections use different)

--- a/athena-cloudera-hive/Dockerfile
+++ b/athena-cloudera-hive/Dockerfile
@@ -1,6 +1,18 @@
 # Argument for Java version, defaulting to 11.al2023-x86_64
 ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
+FROM public.ecr.aws/lambda/java:${JAVA_VERSION} AS builder
+
+# Argument for JAR version
+ARG JAR_VERSION=2022.47.1
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-cloudera-hive-${JAR_VERSION}.jar /app/
+
+# Unpack the JAR and then remove it
+WORKDIR /app
+RUN jar xf athena-cloudera-hive-${JAR_VERSION}.jar && rm -f athena-cloudera-hive-${JAR_VERSION}.jar
+
+# Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
@@ -8,10 +20,8 @@ ARG JAVA_TOOL_OPTIONS=""
 # Set the JAVA_TOOL_OPTIONS environment variable for Java 17
 ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
 
-# Copy function code and runtime dependencies from Maven layout
-COPY target/athena-cloudera-hive-2022.47.1.jar ${LAMBDA_TASK_ROOT}
-# Unpack the jar
-RUN jar xf athena-cloudera-hive-2022.47.1.jar
+# Copy the extracted contents from the builder stage to the Lambda task root directory
+COPY --from=builder /app/ ${LAMBDA_TASK_ROOT}/
 
 # Command can be overwritten by providing a different command in the template directly.
 # No need to specify here (already defined in .yaml file because legacy and connections use different)

--- a/athena-cloudera-impala/Dockerfile
+++ b/athena-cloudera-impala/Dockerfile
@@ -1,6 +1,18 @@
 # Argument for Java version, defaulting to 11.al2023-x86_64
 ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
+FROM public.ecr.aws/lambda/java:${JAVA_VERSION} AS builder
+
+# Argument for JAR version
+ARG JAR_VERSION=2022.47.1
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-cloudera-impala-${JAR_VERSION}.jar /app/
+
+# Unpack the JAR and then remove it
+WORKDIR /app
+RUN jar xf athena-cloudera-impala-${JAR_VERSION}.jar && rm -f athena-cloudera-impala-${JAR_VERSION}.jar
+
+# Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
@@ -8,10 +20,8 @@ ARG JAVA_TOOL_OPTIONS=""
 # Set the JAVA_TOOL_OPTIONS environment variable for Java 17
 ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
 
-# Copy function code and runtime dependencies from Maven layout
-COPY target/athena-cloudera-impala-2022.47.1.jar ${LAMBDA_TASK_ROOT}
-# Unpack the jar
-RUN jar xf athena-cloudera-impala-2022.47.1.jar
+# Copy the extracted contents from the builder stage to the Lambda task root directory
+COPY --from=builder /app/ ${LAMBDA_TASK_ROOT}/
 
 # Command can be overwritten by providing a different command in the template directly.
 # No need to specify here (already defined in .yaml file because legacy and connections use different)

--- a/athena-cloudwatch-metrics/Dockerfile
+++ b/athena-cloudwatch-metrics/Dockerfile
@@ -1,6 +1,18 @@
 # Argument for Java version, defaulting to 11.al2023-x86_64
 ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
+FROM public.ecr.aws/lambda/java:${JAVA_VERSION} AS builder
+
+# Argument for JAR version
+ARG JAR_VERSION=2022.47.1
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-cloudwatch-metrics-${JAR_VERSION}.jar /app/
+
+# Unpack the JAR and then remove it
+WORKDIR /app
+RUN jar xf athena-cloudwatch-metrics-${JAR_VERSION}.jar && rm -f athena-cloudwatch-metrics-${JAR_VERSION}.jar
+
+# Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
@@ -8,10 +20,8 @@ ARG JAVA_TOOL_OPTIONS=""
 # Set the JAVA_TOOL_OPTIONS environment variable for Java 17
 ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
 
-# Copy function code and runtime dependencies from Maven layout
-COPY target/athena-cloudwatch-metrics-2022.47.1.jar ${LAMBDA_TASK_ROOT}
-# Unpack the jar
-RUN jar xf athena-cloudwatch-metrics-2022.47.1.jar
+# Copy the extracted contents from the builder stage to the Lambda task root directory
+COPY --from=builder /app/ ${LAMBDA_TASK_ROOT}/
 
 # Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
 # No need to specify here (already defined in .yaml file)

--- a/athena-cloudwatch/Dockerfile
+++ b/athena-cloudwatch/Dockerfile
@@ -1,6 +1,18 @@
 # Argument for Java version, defaulting to 11.al2023-x86_64
 ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
+FROM public.ecr.aws/lambda/java:${JAVA_VERSION} AS builder
+
+# Argument for JAR version
+ARG JAR_VERSION=2022.47.1
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-cloudwatch-${JAR_VERSION}.jar /app/
+
+# Unpack the JAR and then remove it
+WORKDIR /app
+RUN jar xf athena-cloudwatch-${JAR_VERSION}.jar && rm -f athena-cloudwatch-${JAR_VERSION}.jar
+
+# Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
@@ -8,10 +20,8 @@ ARG JAVA_TOOL_OPTIONS=""
 # Set the JAVA_TOOL_OPTIONS environment variable for Java 17
 ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
 
-# Copy function code and runtime dependencies from Maven layout
-COPY target/athena-cloudwatch-2022.47.1.jar ${LAMBDA_TASK_ROOT}
-# Unpack the jar
-RUN jar xf athena-cloudwatch-2022.47.1.jar
+# Copy the extracted contents from the builder stage to the Lambda task root directory
+COPY --from=builder /app/ ${LAMBDA_TASK_ROOT}/
 
 # Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
 # No need to specify here (already defined in .yaml file)

--- a/athena-datalakegen2/Dockerfile
+++ b/athena-datalakegen2/Dockerfile
@@ -1,6 +1,18 @@
 # Argument for Java version, defaulting to 11.al2023-x86_64
 ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
+FROM public.ecr.aws/lambda/java:${JAVA_VERSION} AS builder
+
+# Argument for JAR version
+ARG JAR_VERSION=2022.47.1
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-datalakegen2-${JAR_VERSION}.jar /app/
+
+# Unpack the JAR and then remove it
+WORKDIR /app
+RUN jar xf athena-datalakegen2-${JAR_VERSION}.jar && rm -f athena-datalakegen2-${JAR_VERSION}.jar
+
+# Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
@@ -8,10 +20,8 @@ ARG JAVA_TOOL_OPTIONS=""
 # Set the JAVA_TOOL_OPTIONS environment variable for Java 17
 ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
 
-# Copy function code and runtime dependencies from Maven layout
-COPY target/athena-datalakegen2-2022.47.1.jar ${LAMBDA_TASK_ROOT}
-# Unpack the jar
-RUN jar xf athena-datalakegen2-2022.47.1.jar
+# Copy the extracted contents from the builder stage to the Lambda task root directory
+COPY --from=builder /app/ ${LAMBDA_TASK_ROOT}/
 
 # Command can be overwritten by providing a different command in the template directly.
 # No need to specify here (already defined in .yaml file because legacy and connections use different)

--- a/athena-db2-as400/Dockerfile
+++ b/athena-db2-as400/Dockerfile
@@ -1,6 +1,18 @@
 # Argument for Java version, defaulting to 11.al2023-x86_64
 ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
+FROM public.ecr.aws/lambda/java:${JAVA_VERSION} AS builder
+
+# Argument for JAR version
+ARG JAR_VERSION=2022.47.1
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-db2-as400-${JAR_VERSION}.jar /app/
+
+# Unpack the JAR and then remove it
+WORKDIR /app
+RUN jar xf athena-db2-as400-${JAR_VERSION}.jar && rm -f athena-db2-as400-${JAR_VERSION}.jar
+
+# Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
@@ -8,10 +20,8 @@ ARG JAVA_TOOL_OPTIONS=""
 # Set the JAVA_TOOL_OPTIONS environment variable for Java 17
 ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
 
-# Copy function code and runtime dependencies from Maven layout
-COPY target/athena-db2-as400-2022.47.1.jar ${LAMBDA_TASK_ROOT}
-# Unpack the jar
-RUN jar xf athena-db2-as400-2022.47.1.jar
+# Copy the extracted contents from the builder stage to the Lambda task root directory
+COPY --from=builder /app/ ${LAMBDA_TASK_ROOT}/
 
 # Command can be overwritten by providing a different command in the template directly.
 # No need to specify here (already defined in .yaml file because legacy and connections use different)

--- a/athena-db2/Dockerfile
+++ b/athena-db2/Dockerfile
@@ -1,6 +1,18 @@
 # Argument for Java version, defaulting to 11.al2023-x86_64
 ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
+FROM public.ecr.aws/lambda/java:${JAVA_VERSION} AS builder
+
+# Argument for JAR version
+ARG JAR_VERSION=2022.47.1
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-db2-${JAR_VERSION}.jar /app/
+
+# Unpack the JAR and then remove it
+WORKDIR /app
+RUN jar xf athena-db2-${JAR_VERSION}.jar && rm -f athena-db2-${JAR_VERSION}.jar
+
+# Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
@@ -8,10 +20,8 @@ ARG JAVA_TOOL_OPTIONS=""
 # Set the JAVA_TOOL_OPTIONS environment variable for Java 17
 ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
 
-# Copy function code and runtime dependencies from Maven layout
-COPY target/athena-db2-2022.47.1.jar ${LAMBDA_TASK_ROOT}
-# Unpack the jar
-RUN jar xf athena-db2-2022.47.1.jar
+# Copy the extracted contents from the builder stage to the Lambda task root directory
+COPY --from=builder /app/ ${LAMBDA_TASK_ROOT}/
 
 # Command can be overwritten by providing a different command in the template directly.
 # No need to specify here (already defined in .yaml file because legacy and connections use different)

--- a/athena-docdb/Dockerfile
+++ b/athena-docdb/Dockerfile
@@ -1,6 +1,18 @@
 # Argument for Java version, defaulting to 11.al2023-x86_64
 ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
+FROM public.ecr.aws/lambda/java:${JAVA_VERSION} AS builder
+
+# Argument for JAR version
+ARG JAR_VERSION=2022.47.1
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-docdb-${JAR_VERSION}.jar /app/
+
+# Unpack the JAR and then remove it
+WORKDIR /app
+RUN jar xf athena-docdb-${JAR_VERSION}.jar && rm -f athena-docdb-${JAR_VERSION}.jar
+
+# Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options
@@ -11,15 +23,6 @@ ENV JAVA_TOOL_OPTIONS="-Djavax.net.ssl.trustStore=/var/lang/lib/security/cacerts
 # Install necessary tools
 RUN dnf update -y
 RUN dnf install -y perl openssl
-
-# Copy function code and runtime dependencies from Maven layout
-COPY target/athena-docdb-2022.47.1.jar ${LAMBDA_TASK_ROOT}
-
-# Unpack the jar
-RUN jar xf athena-docdb-2022.47.1.jar
-
-# Clean up JAR
-RUN rm ${LAMBDA_TASK_ROOT}/athena-docdb-2022.47.1.jar
 
 # Set up environment variables
 ENV truststore=/var/lang/lib/security/cacerts
@@ -46,6 +49,9 @@ RUN echo "Trust store content is: " && \
         expiry=$(keytool -list -v -keystore "$truststore" -storepass ${storepassword} -alias "${alias}" | grep Valid | perl -ne 'if(/until: (.*?)\n/) { print "$1\n"; }'); \
         echo " Certificate ${alias} expires in '$expiry'"; \
     done
+
+# Copy the extracted contents from the builder stage to the Lambda task root directory
+COPY --from=builder /app/ ${LAMBDA_TASK_ROOT}/
 
 # Set the CMD to your handler
 # No need to specify here (already defined in .yaml file)

--- a/athena-dynamodb/Dockerfile
+++ b/athena-dynamodb/Dockerfile
@@ -1,6 +1,18 @@
 # Argument for Java version, defaulting to 11.al2023-x86_64
 ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
+FROM public.ecr.aws/lambda/java:${JAVA_VERSION} AS builder
+
+# Argument for JAR version
+ARG JAR_VERSION=2022.47.1
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-dynamodb-${JAR_VERSION}.jar /app/
+
+# Unpack the JAR and then remove it
+WORKDIR /app
+RUN jar xf athena-dynamodb-${JAR_VERSION}.jar && rm -f athena-dynamodb-${JAR_VERSION}.jar
+
+# Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Fix CVE-2025-14087: glib2 buffer underflow
@@ -14,7 +26,5 @@ ARG JAVA_TOOL_OPTIONS=""
 # Set the JAVA_TOOL_OPTIONS environment variable for Java 17
 ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
 
-# Copy function code and runtime dependencies from Maven layout
-COPY target/athena-dynamodb-2022.47.1.jar ${LAMBDA_TASK_ROOT}
-# Unpack the jar
-RUN jar xf athena-dynamodb-2022.47.1.jar
+# Copy the extracted contents from the builder stage to the Lambda task root directory
+COPY --from=builder /app/ ${LAMBDA_TASK_ROOT}/

--- a/athena-elasticsearch/Dockerfile
+++ b/athena-elasticsearch/Dockerfile
@@ -1,6 +1,18 @@
 # Argument for Java version, defaulting to 11.al2023-x86_64
 ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
+FROM public.ecr.aws/lambda/java:${JAVA_VERSION} AS builder
+
+# Argument for JAR version
+ARG JAR_VERSION=2022.47.1
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-elasticsearch-${JAR_VERSION}.jar /app/
+
+# Unpack the JAR and then remove it
+WORKDIR /app
+RUN jar xf athena-elasticsearch-${JAR_VERSION}.jar && rm -f athena-elasticsearch-${JAR_VERSION}.jar
+
+# Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
@@ -8,10 +20,8 @@ ARG JAVA_TOOL_OPTIONS=""
 # Set the JAVA_TOOL_OPTIONS environment variable for Java 17
 ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
 
-# Copy function code and runtime dependencies from Maven layout
-COPY target/athena-elasticsearch-2022.47.1.jar ${LAMBDA_TASK_ROOT}
-# Unpack the jar
-RUN jar xf athena-elasticsearch-2022.47.1.jar
+# Copy the extracted contents from the builder stage to the Lambda task root directory
+COPY --from=builder /app/ ${LAMBDA_TASK_ROOT}/
 
 # Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
 # No need to specify here (already defined in .yaml file)

--- a/athena-gcs/Dockerfile
+++ b/athena-gcs/Dockerfile
@@ -1,6 +1,16 @@
 # Argument for Java version, defaulting to 11.al2023-x86_64
 ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
+FROM public.ecr.aws/lambda/java:${JAVA_VERSION} AS builder
+
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-gcs.zip /app/
+
+# Unpack the archive and then remove it
+WORKDIR /app
+RUN jar xf athena-gcs.zip && rm -f athena-gcs.zip
+
+# Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
@@ -8,10 +18,8 @@ ARG JAVA_TOOL_OPTIONS=""
 # Set the JAVA_TOOL_OPTIONS environment variable for Java 17
 ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
 
-# Copy function code and runtime dependencies from Maven layout
-COPY target/athena-gcs.zip ${LAMBDA_TASK_ROOT}
-# Unpack the jar
-RUN jar xf athena-gcs.zip
+# Copy the extracted contents from the builder stage to the Lambda task root directory
+COPY --from=builder /app/ ${LAMBDA_TASK_ROOT}/
 
 # Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
 # No need to specify here (already defined in .yaml file)

--- a/athena-google-bigquery/Dockerfile
+++ b/athena-google-bigquery/Dockerfile
@@ -1,6 +1,18 @@
 # Argument for Java version, defaulting to 11.al2023-x86_64
 ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
+FROM public.ecr.aws/lambda/java:${JAVA_VERSION} AS builder
+
+# Argument for JAR version
+ARG JAR_VERSION=2022.47.1
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-google-bigquery-${JAR_VERSION}.jar /app/
+
+# Unpack the JAR and then remove it
+WORKDIR /app
+RUN jar xf athena-google-bigquery-${JAR_VERSION}.jar && rm -f athena-google-bigquery-${JAR_VERSION}.jar
+
+# Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
@@ -8,10 +20,8 @@ ARG JAVA_TOOL_OPTIONS=""
 # Set the JAVA_TOOL_OPTIONS environment variable for Java 17
 ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
 
-# Copy function code and runtime dependencies from Maven layout
-COPY target/athena-google-bigquery-2022.47.1.jar ${LAMBDA_TASK_ROOT}
-# Unpack the jar
-RUN jar xf athena-google-bigquery-2022.47.1.jar
+# Copy the extracted contents from the builder stage to the Lambda task root directory
+COPY --from=builder /app/ ${LAMBDA_TASK_ROOT}/
 
 # Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
 # No need to specify here (already defined in .yaml file)

--- a/athena-hbase/Dockerfile
+++ b/athena-hbase/Dockerfile
@@ -1,6 +1,18 @@
 # Argument for Java version, defaulting to 11.al2023-x86_64
 ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
+FROM public.ecr.aws/lambda/java:${JAVA_VERSION} AS builder
+
+# Argument for JAR version
+ARG JAR_VERSION=2022.47.1
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-hbase-${JAR_VERSION}.jar /app/
+
+# Unpack the JAR and then remove it
+WORKDIR /app
+RUN jar xf athena-hbase-${JAR_VERSION}.jar && rm -f athena-hbase-${JAR_VERSION}.jar
+
+# Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
@@ -8,10 +20,8 @@ ARG JAVA_TOOL_OPTIONS=""
 # Set the JAVA_TOOL_OPTIONS environment variable for Java 17
 ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
 
-# Copy function code and runtime dependencies from Maven layout
-COPY target/athena-hbase-2022.47.1.jar ${LAMBDA_TASK_ROOT}
-# Unpack the jar
-RUN jar xf athena-hbase-2022.47.1.jar
+# Copy the extracted contents from the builder stage to the Lambda task root directory
+COPY --from=builder /app/ ${LAMBDA_TASK_ROOT}/
 
 # Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
 # No need to specify here (already defined in .yaml file)

--- a/athena-hortonworks-hive/Dockerfile
+++ b/athena-hortonworks-hive/Dockerfile
@@ -1,6 +1,18 @@
 # Argument for Java version, defaulting to 11.al2023-x86_64
 ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
+FROM public.ecr.aws/lambda/java:${JAVA_VERSION} AS builder
+
+# Argument for JAR version
+ARG JAR_VERSION=2022.47.1
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-hortonworks-hive-${JAR_VERSION}.jar /app/
+
+# Unpack the JAR and then remove it
+WORKDIR /app
+RUN jar xf athena-hortonworks-hive-${JAR_VERSION}.jar && rm -f athena-hortonworks-hive-${JAR_VERSION}.jar
+
+# Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
@@ -8,10 +20,8 @@ ARG JAVA_TOOL_OPTIONS=""
 # Set the JAVA_TOOL_OPTIONS environment variable for Java 17
 ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
 
-# Copy function code and runtime dependencies from Maven layout
-COPY target/athena-hortonworks-hive-2022.47.1.jar ${LAMBDA_TASK_ROOT}
-# Unpack the jar
-RUN jar xf athena-hortonworks-hive-2022.47.1.jar
+# Copy the extracted contents from the builder stage to the Lambda task root directory
+COPY --from=builder /app/ ${LAMBDA_TASK_ROOT}/
 
 # Command can be overwritten by providing a different command in the template directly.
 # No need to specify here (already defined in .yaml file because legacy and connections use different)

--- a/athena-kafka/Dockerfile
+++ b/athena-kafka/Dockerfile
@@ -1,6 +1,18 @@
 # Argument for Java version, defaulting to 11.al2023-x86_64
 ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
+FROM public.ecr.aws/lambda/java:${JAVA_VERSION} AS builder
+
+# Argument for JAR version
+ARG JAR_VERSION=2022.47.1
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-kafka-${JAR_VERSION}.jar /app/
+
+# Unpack the JAR and then remove it
+WORKDIR /app
+RUN jar xf athena-kafka-${JAR_VERSION}.jar && rm -f athena-kafka-${JAR_VERSION}.jar
+
+# Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
@@ -8,10 +20,8 @@ ARG JAVA_TOOL_OPTIONS=""
 # Set the JAVA_TOOL_OPTIONS environment variable for Java 17
 ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
 
-# Copy function code and runtime dependencies from Maven layout
-COPY target/athena-kafka-2022.47.1.jar ${LAMBDA_TASK_ROOT}
-# Unpack the jar
-RUN jar xf athena-kafka-2022.47.1.jar
+# Copy the extracted contents from the builder stage to the Lambda task root directory
+COPY --from=builder /app/ ${LAMBDA_TASK_ROOT}/
 
 # Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
 # No need to specify here (already defined in .yaml file)

--- a/athena-msk/Dockerfile
+++ b/athena-msk/Dockerfile
@@ -1,6 +1,18 @@
 # Argument for Java version, defaulting to 11.al2023-x86_64
 ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
+FROM public.ecr.aws/lambda/java:${JAVA_VERSION} AS builder
+
+# Argument for JAR version
+ARG JAR_VERSION=2022.47.1
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-msk-${JAR_VERSION}.jar /app/
+
+# Unpack the JAR and then remove it
+WORKDIR /app
+RUN jar xf athena-msk-${JAR_VERSION}.jar && rm -f athena-msk-${JAR_VERSION}.jar
+
+# Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
@@ -8,10 +20,8 @@ ARG JAVA_TOOL_OPTIONS=""
 # Set the JAVA_TOOL_OPTIONS environment variable for Java 17
 ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
 
-# Copy function code and runtime dependencies from Maven layout
-COPY target/athena-msk-2022.47.1.jar ${LAMBDA_TASK_ROOT}
-# Unpack the jar
-RUN jar xf athena-msk-2022.47.1.jar
+# Copy the extracted contents from the builder stage to the Lambda task root directory
+COPY --from=builder /app/ ${LAMBDA_TASK_ROOT}/
 
 # Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
 # No need to specify here (already defined in .yaml file)

--- a/athena-mysql/Dockerfile
+++ b/athena-mysql/Dockerfile
@@ -1,6 +1,18 @@
 # Argument for Java version, defaulting to 11.al2023-x86_64
 ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
+FROM public.ecr.aws/lambda/java:${JAVA_VERSION} AS builder
+
+# Argument for JAR version
+ARG JAR_VERSION=2022.47.1
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-mysql-${JAR_VERSION}.jar /app/
+
+# Unpack the JAR and then remove it
+WORKDIR /app
+RUN jar xf athena-mysql-${JAR_VERSION}.jar && rm -f athena-mysql-${JAR_VERSION}.jar
+
+# Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
@@ -8,10 +20,8 @@ ARG JAVA_TOOL_OPTIONS=""
 # Set the JAVA_TOOL_OPTIONS environment variable for Java 17
 ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
 
-# Copy function code and runtime dependencies from Maven layout
-COPY target/athena-mysql-2022.47.1.jar ${LAMBDA_TASK_ROOT}
-# Unpack the jar
-RUN jar xf athena-mysql-2022.47.1.jar
+# Copy the extracted contents from the builder stage to the Lambda task root directory
+COPY --from=builder /app/ ${LAMBDA_TASK_ROOT}/
 
 # Command can be overwritten by providing a different command in the template directly.
 # No need to specify here (already defined in .yaml file because legacy and connections use different)

--- a/athena-neptune/Dockerfile
+++ b/athena-neptune/Dockerfile
@@ -1,6 +1,18 @@
 # Argument for Java version, defaulting to 11.al2023-x86_64
 ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
+FROM public.ecr.aws/lambda/java:${JAVA_VERSION} AS builder
+
+# Argument for JAR version
+ARG JAR_VERSION=2022.47.1
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-neptune-${JAR_VERSION}.jar /app/
+
+# Unpack the JAR and then remove it
+WORKDIR /app
+RUN jar xf athena-neptune-${JAR_VERSION}.jar && rm -f athena-neptune-${JAR_VERSION}.jar
+
+# Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
@@ -8,10 +20,8 @@ ARG JAVA_TOOL_OPTIONS=""
 # Set the JAVA_TOOL_OPTIONS environment variable for Java 17
 ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
 
-# Copy function code and runtime dependencies from Maven layout
-COPY target/athena-neptune-2022.47.1.jar ${LAMBDA_TASK_ROOT}
-# Unpack the jar
-RUN jar xf athena-neptune-2022.47.1.jar
+# Copy the extracted contents from the builder stage to the Lambda task root directory
+COPY --from=builder /app/ ${LAMBDA_TASK_ROOT}/
 
 # Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
 # No need to specify here (already defined in .yaml file)

--- a/athena-oracle/Dockerfile
+++ b/athena-oracle/Dockerfile
@@ -1,6 +1,18 @@
 # Argument for Java version, defaulting to 11.al2023-x86_64
 ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
+FROM public.ecr.aws/lambda/java:${JAVA_VERSION} AS builder
+
+# Argument for JAR version
+ARG JAR_VERSION=2022.47.1
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-oracle-${JAR_VERSION}.jar /app/
+
+# Unpack the JAR and then remove it
+WORKDIR /app
+RUN jar xf athena-oracle-${JAR_VERSION}.jar && rm -f athena-oracle-${JAR_VERSION}.jar
+
+# Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options
@@ -38,13 +50,8 @@ RUN echo "Trust store content is: " && \
         echo " Certificate ${alias} expires in '$expiry'"; \
     done
 
-# Copy function code and runtime dependencies from Maven layout
-COPY target/athena-oracle-2022.47.1.jar ${LAMBDA_TASK_ROOT}
-# Unpack the jar
-RUN jar xf athena-oracle-2022.47.1.jar
-
-# Clean up JAR
-RUN rm ${LAMBDA_TASK_ROOT}/athena-oracle-2022.47.1.jar
+# Copy the extracted contents from the builder stage to the Lambda task root directory
+COPY --from=builder /app/ ${LAMBDA_TASK_ROOT}/
 
 # Command can be overwritten by providing a different command in the template directly.
 # No need to specify here (already defined in .yaml file because legacy and connections use different)

--- a/athena-redis/Dockerfile
+++ b/athena-redis/Dockerfile
@@ -1,6 +1,18 @@
 # Argument for Java version, defaulting to 11.al2023-x86_64
 ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
+FROM public.ecr.aws/lambda/java:${JAVA_VERSION} AS builder
+
+# Argument for JAR version
+ARG JAR_VERSION=2022.47.1
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-redis-${JAR_VERSION}.jar /app/
+
+# Unpack the JAR and then remove it
+WORKDIR /app
+RUN jar xf athena-redis-${JAR_VERSION}.jar && rm -f athena-redis-${JAR_VERSION}.jar
+
+# Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
@@ -8,10 +20,8 @@ ARG JAVA_TOOL_OPTIONS=""
 # Set the JAVA_TOOL_OPTIONS environment variable for Java 17
 ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
 
-# Copy function code and runtime dependencies from Maven layout
-COPY target/athena-redis-2022.47.1.jar ${LAMBDA_TASK_ROOT}
-# Unpack the jar
-RUN jar xf athena-redis-2022.47.1.jar
+# Copy the extracted contents from the builder stage to the Lambda task root directory
+COPY --from=builder /app/ ${LAMBDA_TASK_ROOT}/
 
 # Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
 # No need to specify here (already defined in .yaml file)

--- a/athena-redshift/Dockerfile
+++ b/athena-redshift/Dockerfile
@@ -1,6 +1,18 @@
 # Argument for Java version, defaulting to 11.al2023-x86_64
 ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
+FROM public.ecr.aws/lambda/java:${JAVA_VERSION} AS builder
+
+# Argument for JAR version
+ARG JAR_VERSION=2022.47.1
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-redshift-${JAR_VERSION}.jar /app/
+
+# Unpack the JAR and then remove it
+WORKDIR /app
+RUN jar xf athena-redshift-${JAR_VERSION}.jar && rm -f athena-redshift-${JAR_VERSION}.jar
+
+# Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
@@ -8,10 +20,8 @@ ARG JAVA_TOOL_OPTIONS=""
 # Set the JAVA_TOOL_OPTIONS environment variable for Java 17
 ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
 
-# Copy function code and runtime dependencies from Maven layout
-COPY target/athena-redshift-2022.47.1.jar ${LAMBDA_TASK_ROOT}
-# Unpack the jar
-RUN jar xf athena-redshift-2022.47.1.jar
+# Copy the extracted contents from the builder stage to the Lambda task root directory
+COPY --from=builder /app/ ${LAMBDA_TASK_ROOT}/
 
 # Command can be overwritten by providing a different command in the template directly.
 # No need to specify here (already defined in .yaml file because legacy and connections use different)

--- a/athena-saphana/Dockerfile
+++ b/athena-saphana/Dockerfile
@@ -1,6 +1,16 @@
 # Argument for Java version, defaulting to 11.al2023-x86_64
 ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
+FROM public.ecr.aws/lambda/java:${JAVA_VERSION} AS builder
+
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-saphana.zip /app/
+
+# Unpack the archive and then remove it
+WORKDIR /app
+RUN jar xf athena-saphana.zip && rm -f athena-saphana.zip
+
+# Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
@@ -8,10 +18,8 @@ ARG JAVA_TOOL_OPTIONS=""
 # Set the JAVA_TOOL_OPTIONS environment variable for Java 17
 ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
 
-# Copy function code and runtime dependencies from Maven layout
-COPY target/athena-saphana.zip ${LAMBDA_TASK_ROOT}
-# Unpack the jar
-RUN jar xf athena-saphana.zip
+# Copy the extracted contents from the builder stage to the Lambda task root directory
+COPY --from=builder /app/ ${LAMBDA_TASK_ROOT}/
 
 # Command can be overwritten by providing a different command in the template directly.
 # No need to specify here (already defined in .yaml file because legacy and connections use different)

--- a/athena-snowflake/Dockerfile
+++ b/athena-snowflake/Dockerfile
@@ -1,6 +1,16 @@
 # Argument for Java version, defaulting to 11.al2023-x86_64
 ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
+FROM public.ecr.aws/lambda/java:${JAVA_VERSION} AS builder
+
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-snowflake.zip /app/
+
+# Unpack the archive and then remove it
+WORKDIR /app
+RUN jar xf athena-snowflake.zip && rm -f athena-snowflake.zip
+
+# Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
@@ -8,10 +18,8 @@ ARG JAVA_TOOL_OPTIONS=""
 # Set the JAVA_TOOL_OPTIONS environment variable for Java 17
 ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
 
-# Copy function code and runtime dependencies from Maven layout
-COPY target/athena-snowflake.zip ${LAMBDA_TASK_ROOT}
-# Unpack the jar
-RUN jar xf athena-snowflake.zip
+# Copy the extracted contents from the builder stage to the Lambda task root directory
+COPY --from=builder /app/ ${LAMBDA_TASK_ROOT}/
 
 # Command can be overwritten by providing a different command in the template directly.
 # No need to specify here (already defined in .yaml file because legacy and connections use different)

--- a/athena-sqlserver/Dockerfile
+++ b/athena-sqlserver/Dockerfile
@@ -1,6 +1,18 @@
 # Argument for Java version, defaulting to 11.al2023-x86_64
 ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
+FROM public.ecr.aws/lambda/java:${JAVA_VERSION} AS builder
+
+# Argument for JAR version
+ARG JAR_VERSION=2022.47.1
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-sqlserver-${JAR_VERSION}.jar /app/
+
+# Unpack the JAR and then remove it
+WORKDIR /app
+RUN jar xf athena-sqlserver-${JAR_VERSION}.jar && rm -f athena-sqlserver-${JAR_VERSION}.jar
+
+# Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options for ssl
@@ -36,11 +48,8 @@ RUN echo "Trust store content is: " && \
         echo " Certificate ${alias} expires in '$expiry'"; \
     done
 
-
-# Copy function code and runtime dependencies from Maven layout
-COPY target/athena-sqlserver-2022.47.1.jar ${LAMBDA_TASK_ROOT}
-# Unpack the jar
-RUN jar xf athena-sqlserver-2022.47.1.jar
+# Copy the extracted contents from the builder stage to the Lambda task root directory
+COPY --from=builder /app/ ${LAMBDA_TASK_ROOT}/
 
 # Command can be overwritten by providing a different command in the template directly.
 # No need to specify here (already defined in .yaml file because legacy and connections use different)

--- a/athena-synapse/Dockerfile
+++ b/athena-synapse/Dockerfile
@@ -1,6 +1,18 @@
 # Argument for Java version, defaulting to 11.al2023-x86_64
 ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
+FROM public.ecr.aws/lambda/java:${JAVA_VERSION} AS builder
+
+# Argument for JAR version
+ARG JAR_VERSION=2022.47.1
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-synapse-${JAR_VERSION}.jar /app/
+
+# Unpack the JAR and then remove it
+WORKDIR /app
+RUN jar xf athena-synapse-${JAR_VERSION}.jar && rm -f athena-synapse-${JAR_VERSION}.jar
+
+# Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
@@ -8,10 +20,8 @@ ARG JAVA_TOOL_OPTIONS=""
 # Set the JAVA_TOOL_OPTIONS environment variable for Java 17
 ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
 
-# Copy function code and runtime dependencies from Maven layout
-COPY target/athena-synapse-2022.47.1.jar ${LAMBDA_TASK_ROOT}
-# Unpack the jar
-RUN jar xf athena-synapse-2022.47.1.jar
+# Copy the extracted contents from the builder stage to the Lambda task root directory
+COPY --from=builder /app/ ${LAMBDA_TASK_ROOT}/
 
 # Command can be overwritten by providing a different command in the template directly.
 # No need to specify here (already defined in .yaml file because legacy and connections use different)

--- a/athena-teradata/Dockerfile
+++ b/athena-teradata/Dockerfile
@@ -1,6 +1,18 @@
 # Argument for Java version, defaulting to 11.al2023-x86_64
 ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
+FROM public.ecr.aws/lambda/java:${JAVA_VERSION} AS builder
+
+# Argument for JAR version
+ARG JAR_VERSION=2022.47.1
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-teradata-${JAR_VERSION}.jar /app/
+
+# Unpack the JAR and then remove it
+WORKDIR /app
+RUN jar xf athena-teradata-${JAR_VERSION}.jar && rm -f athena-teradata-${JAR_VERSION}.jar
+
+# Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
@@ -8,10 +20,8 @@ ARG JAVA_TOOL_OPTIONS=""
 # Set the JAVA_TOOL_OPTIONS environment variable for Java 17
 ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
 
-# Copy function code and runtime dependencies from Maven layout
-COPY target/athena-teradata-2022.47.1.jar ${LAMBDA_TASK_ROOT}
-# Unpack the jar
-RUN jar xf athena-teradata-2022.47.1.jar
+# Copy the extracted contents from the builder stage to the Lambda task root directory
+COPY --from=builder /app/ ${LAMBDA_TASK_ROOT}/
 
 # Command can be overwritten by providing a different command in the template directly.
 # No need to specify here (already defined in .yaml file because legacy and connections use different)

--- a/athena-timestream/Dockerfile
+++ b/athena-timestream/Dockerfile
@@ -1,6 +1,18 @@
 # Argument for Java version, defaulting to 11.al2023-x86_64
 ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
+FROM public.ecr.aws/lambda/java:${JAVA_VERSION} AS builder
+
+# Argument for JAR version
+ARG JAR_VERSION=2022.47.1
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-timestream-${JAR_VERSION}.jar /app/
+
+# Unpack the JAR and then remove it
+WORKDIR /app
+RUN jar xf athena-timestream-${JAR_VERSION}.jar && rm -f athena-timestream-${JAR_VERSION}.jar
+
+# Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
@@ -8,10 +20,8 @@ ARG JAVA_TOOL_OPTIONS=""
 # Set the JAVA_TOOL_OPTIONS environment variable for Java 17
 ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
 
-# Copy function code and runtime dependencies from Maven layout
-COPY target/athena-timestream-2022.47.1.jar ${LAMBDA_TASK_ROOT}
-# Unpack the jar
-RUN jar xf athena-timestream-2022.47.1.jar
+# Copy the extracted contents from the builder stage to the Lambda task root directory
+COPY --from=builder /app/ ${LAMBDA_TASK_ROOT}/
 
 # Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
 # No need to specify here (already defined in .yaml file)

--- a/athena-tpcds/Dockerfile
+++ b/athena-tpcds/Dockerfile
@@ -1,6 +1,18 @@
 # Argument for Java version, defaulting to 11.al2023-x86_64
 ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
+FROM public.ecr.aws/lambda/java:${JAVA_VERSION} AS builder
+
+# Argument for JAR version
+ARG JAR_VERSION=2022.47.1
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-tpcds-${JAR_VERSION}.jar /app/
+
+# Unpack the JAR and then remove it
+WORKDIR /app
+RUN jar xf athena-tpcds-${JAR_VERSION}.jar && rm -f athena-tpcds-${JAR_VERSION}.jar
+
+# Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
@@ -8,10 +20,8 @@ ARG JAVA_TOOL_OPTIONS=""
 # Set the JAVA_TOOL_OPTIONS environment variable for Java 17
 ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
 
-# Copy function code and runtime dependencies from Maven layout
-COPY target/athena-tpcds-2022.47.1.jar ${LAMBDA_TASK_ROOT}
-# Unpack the jar
-RUN jar xf athena-tpcds-2022.47.1.jar
+# Copy the extracted contents from the builder stage to the Lambda task root directory
+COPY --from=builder /app/ ${LAMBDA_TASK_ROOT}/
 
 # Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
 # No need to specify here (already defined in .yaml file)

--- a/athena-udfs/Dockerfile
+++ b/athena-udfs/Dockerfile
@@ -1,6 +1,18 @@
 # Argument for Java version, defaulting to 11.al2023-x86_64
 ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
+FROM public.ecr.aws/lambda/java:${JAVA_VERSION} AS builder
+
+# Argument for JAR version
+ARG JAR_VERSION=2022.47.1
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-udfs-${JAR_VERSION}.jar /app/
+
+# Unpack the JAR and then remove it
+WORKDIR /app
+RUN jar xf athena-udfs-${JAR_VERSION}.jar && rm -f athena-udfs-${JAR_VERSION}.jar
+
+# Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
@@ -8,10 +20,8 @@ ARG JAVA_TOOL_OPTIONS=""
 # Set the JAVA_TOOL_OPTIONS environment variable for Java 17
 ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
 
-# Copy function code and runtime dependencies from Maven layout
-COPY target/athena-udfs-2022.47.1.jar ${LAMBDA_TASK_ROOT}
-# Unpack the jar
-RUN jar xf athena-udfs-2022.47.1.jar
+# Copy the extracted contents from the builder stage to the Lambda task root directory
+COPY --from=builder /app/ ${LAMBDA_TASK_ROOT}/
 
 # Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
 # No need to specify here (already defined in .yaml file)

--- a/athena-vertica/Dockerfile
+++ b/athena-vertica/Dockerfile
@@ -1,6 +1,18 @@
 # Argument for Java version, defaulting to 11.al2023-x86_64
 ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
+FROM public.ecr.aws/lambda/java:${JAVA_VERSION} AS builder
+
+# Argument for JAR version
+ARG JAR_VERSION=2022.47.1
+# Copy function code and runtime dependencies from Maven layout
+COPY target/athena-vertica-${JAR_VERSION}.jar /app/
+
+# Unpack the JAR and then remove it
+WORKDIR /app
+RUN jar xf athena-vertica-${JAR_VERSION}.jar && rm -f athena-vertica-${JAR_VERSION}.jar
+
+# Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Argument for Java tool options, defaulting to an empty string
@@ -8,10 +20,8 @@ ARG JAVA_TOOL_OPTIONS=""
 # Set the JAVA_TOOL_OPTIONS environment variable for Java 17
 ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
 
-# Copy function code and runtime dependencies from Maven layout
-COPY target/athena-vertica-2022.47.1.jar ${LAMBDA_TASK_ROOT}
-# Unpack the jar
-RUN jar xf athena-vertica-2022.47.1.jar
+# Copy the extracted contents from the builder stage to the Lambda task root directory
+COPY --from=builder /app/ ${LAMBDA_TASK_ROOT}/
 
 # Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
 # No need to specify here (already defined in .yaml file)

--- a/tools/bump_versions/common.py
+++ b/tools/bump_versions/common.py
@@ -41,9 +41,7 @@ def update_yaml(yaml_files, new_version):
 
 def update_dockerfile(dockerfiles, new_version):
     for file in dockerfiles:
-        # Replace literal athena-*-X.Y.Z.jar (e.g. athena-mysql-2022.47.1.jar)
-        subprocess.run(["sed", "-i", f"s|\(athena-.*\)-[0-9]*\.[0-9]*\.[0-9]*\.jar|\\1-{new_version}.jar|g", file])
-        # Replace ARG JAR_VERSION=X.Y.Z (e.g. athena-postgresql Dockerfile uses this)
+        # Replace ARG JAR_VERSION=X.Y.Z
         subprocess.run(["sed", "-i", f"s/\\(ARG JAR_VERSION=\\)[0-9]*\\.[0-9]*\\.[0-9]*/\\1{new_version}/", file])
 
 

--- a/tools/bump_versions/common.py
+++ b/tools/bump_versions/common.py
@@ -41,6 +41,8 @@ def update_yaml(yaml_files, new_version):
 
 def update_dockerfile(dockerfiles, new_version):
     for file in dockerfiles:
+        # Replace literal athena-*-X.Y.Z.jar
+        subprocess.run(["sed", "-i", f"s|\(athena-.*\)-[0-9]*\.[0-9]*\.[0-9]*\.jar|\\1-{new_version}.jar|g", file])
         # Replace ARG JAR_VERSION=X.Y.Z
         subprocess.run(["sed", "-i", f"s/\\(ARG JAR_VERSION=\\)[0-9]*\\.[0-9]*\\.[0-9]*/\\1{new_version}/", file])
 


### PR DESCRIPTION
*Issue #, if available:*
#2410 

*Description of changes:*

This PR does below things:
 
- This change updates connector Dockerfiles so images unpack the connector JAR in a build stage and delete the JAR before copying the exploded contents into the Lambda runtime image. That avoids leaving the shaded JAR on disk in the final image. 
- The repo root Dockerfile is aligned by renaming ARG VERSION to ARG JAR_VERSION everywhere those paths are referenced. 
- The version-bump helper is simplified to only bump ARG JAR_VERSION, since connector Dockerfiles no longer embed literal athena-*-x.y.z.jar names.

Please find the attached functional test documents.
[BIGQUERY_FUNCTIONAL_TEST.xlsx](https://github.com/user-attachments/files/26378808/BIGQUERY_FUNCTIONAL_TEST.xlsx)
[CLICKHOUSE_FUNCTIONAL_TEST.xlsx](https://github.com/user-attachments/files/26378818/CLICKHOUSE_FUNCTIONAL_TEST.xlsx)
[CLOUDWATCH_FUNCTIONAL_TEST.xlsx](https://github.com/user-attachments/files/26378821/CLOUDWATCH_FUNCTIONAL_TEST.xlsx)
[DDB_FUNCTIONAL_TEST.xlsx](https://github.com/user-attachments/files/26378823/DDB_FUNCTIONAL_TEST.xlsx)
[GCS_FUNCTIONAL_TEST.xlsx](https://github.com/user-attachments/files/26378825/GCS_FUNCTIONAL_TEST.xlsx)
[ORACLE_FUNCTIONAL_TEST.xlsx](https://github.com/user-attachments/files/26378829/ORACLE_FUNCTIONAL_TEST.xlsx)
[Remove shaded jar testing for DocDB and SQLServer.docx](https://github.com/user-attachments/files/26378830/Remove.shaded.jar.testing.for.DocDB.and.SQLServer.docx)
[SNOWFLAKE_FUNCTIONAL_TEST.xlsx](https://github.com/user-attachments/files/26378831/SNOWFLAKE_FUNCTIONAL_TEST.xlsx)
[TERADATA_FUNCTIONAL_TEST.xlsx](https://github.com/user-attachments/files/26378833/TERADATA_FUNCTIONAL_TEST.xlsx)
[VERTICA_FUNCTIONAL_TEST.xlsx](https://github.com/user-attachments/files/26378835/VERTICA_FUNCTIONAL_TEST.xlsx)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
