### PR TITLE
Update GitHub Actions workflows to Java 17

### DIFF
--- a/.github/workflows/cut_release.yml
+++ b/.github/workflows/cut_release.yml
@@ -18,11 +18,11 @@ jobs:
           sudo apt-get install -y libxml2-utils python3
           pip3 install lxml beautifulsoup4
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v5
         with:
           distribution: 'corretto'
-          java-version: '11'
+          java-version: '17'
 
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -67,26 +67,26 @@ jobs:
           git log --format='  - %s' $PREVIOUS_RELEASE_TAG..HEAD >> /tmp/RELEASE_MESSAGE
           git commit -a -F /tmp/RELEASE_MESSAGE
 
-      - name: Build Java 11 jars
+      - name: Build Java 17 jars
         run: |
           mvn clean package -T 1C -DskipTests -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN --no-transfer-progress
 
           # Copy over the sdk jars
-          mkdir -p /tmp/java11_sdk_jars/
-          cp ./athena-federation-sdk/target/aws-athena-federation-sdk-${NEW_RELEASE_VERSION}.jar /tmp/java11_sdk_jars/
-          cp ./athena-federation-sdk/target/aws-athena-federation-sdk-${NEW_RELEASE_VERSION}-withdep.jar /tmp/java11_sdk_jars/
+          mkdir -p /tmp/java17_sdk_jars/
+          cp ./athena-federation-sdk/target/aws-athena-federation-sdk-${NEW_RELEASE_VERSION}.jar /tmp/java17_sdk_jars/
+          cp ./athena-federation-sdk/target/aws-athena-federation-sdk-${NEW_RELEASE_VERSION}-withdep.jar /tmp/java17_sdk_jars/
 
           # Copy over the connector jars
-          mkdir -p /tmp/java11_connector_jars/
-          find athena-*/target -name "*.jar" -type f | grep -v "test" | grep -v "arrow" | grep -v "/original" | grep -v "example" | grep -v "\-sdk-" | grep -v "\-dsv2/" | grep -v "athena-jdbc" | xargs -I{} cp {} /tmp/java11_connector_jars/
+          mkdir -p /tmp/java17_connector_jars/
+          find athena-*/target -name "*.jar" -type f | grep -v "test" | grep -v "arrow" | grep -v "/original" | grep -v "example" | grep -v "\-sdk-" | grep -v "\-dsv2/" | grep -v "athena-jdbc" | xargs -I{} cp {} /tmp/java17_connector_jars/
 
           # Copy over the connector zips
-          mkdir -p /tmp/java11_connector_zips/
-          find athena-*/target/ -name "*.zip" -type f | grep -v "test" | grep -v "arrow" | grep -v "/original" | grep -v "example" | grep -v "\-sdk-" | grep -v "\-dsv2/" | xargs -I{} cp {} /tmp/java11_connector_zips/
+          mkdir -p /tmp/java17_connector_zips/
+          find athena-*/target/ -name "*.zip" -type f | grep -v "test" | grep -v "arrow" | grep -v "/original" | grep -v "example" | grep -v "\-sdk-" | grep -v "\-dsv2/" | xargs -I{} cp {} /tmp/java17_connector_zips/
 
       - name: Push the release branch
         run: |
-          git push origin release_${NEW_RELEASE_VERSION}:release_${NEW_RELEASE_VERSION}
+          git push --force origin release_${NEW_RELEASE_VERSION}:release_${NEW_RELEASE_VERSION}
 
       - name: Sync up with origin again now that the new branch has been pushed
         run: |
@@ -112,17 +112,17 @@ jobs:
           Athena Federation SDK jars
           |CheckSum|File|
           |----------|----|
-          $(cd /tmp/java11_sdk_jars && ls | xargs -I{} cksum {} | sed 's/\([0-9]\) \([a-zA-Z]\)/\1|\2/g' | sed 's/^/|/g' | sed 's/$/|/g')
+          $(cd /tmp/java17_sdk_jars && ls | xargs -I{} cksum {} | sed 's/\([0-9]\) \([a-zA-Z]\)/\1|\2/g' | sed 's/^/|/g' | sed 's/$/|/g')
 
           Athena Federation Connector Lambda jars
           |CheckSum|File|
           |----------|----|
-          $(cd /tmp/java11_connector_jars && ls | xargs -I{} cksum {} | sed 's/\([0-9]\) \([a-zA-Z]\)/\1|\2/g' | sed 's/^/|/g' | sed 's/$/|/g')
+          $(cd /tmp/java17_connector_jars && ls | xargs -I{} cksum {} | sed 's/\([0-9]\) \([a-zA-Z]\)/\1|\2/g' | sed 's/^/|/g' | sed 's/$/|/g')
 
           Athena Federation Connector Lambda zips
           |CheckSum|File|
           |----------|----|
-          $(cd /tmp/java11_connector_zips && ls | xargs -I{} cksum {} | sed 's/\([0-9]\) \([a-zA-Z]\)/\1|\2/g' | sed 's/^/|/g' | sed 's/$/|/g')
+          $(cd /tmp/java17_connector_zips && ls | xargs -I{} cksum {} | sed 's/\([0-9]\) \([a-zA-Z]\)/\1|\2/g' | sed 's/^/|/g' | sed 's/$/|/g')
 
           ## What's Changed
           $(git log --format='- %s' v$PREVIOUS_RELEASE_VERSION..HEAD~1)
@@ -138,7 +138,7 @@ jobs:
             --notes-file /tmp/RELEASE_NOTES
           # Upload the jar attachments
           gh release upload "v$NEW_RELEASE_VERSION" \
-            $(find /tmp/java11_sdk_jars -type f) \
-            $(find /tmp/java11_connector_jars -type f) \
-            $(find /tmp/java11_connector_zips -type f) \
+            $(find /tmp/java17_sdk_jars -type f) \
+            $(find /tmp/java17_connector_jars -type f) \
+            $(find /tmp/java17_connector_zips -type f) \
             --clobber

--- a/.github/workflows/javadoc_sync.yaml
+++ b/.github/workflows/javadoc_sync.yaml
@@ -13,11 +13,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v5
         with:
           distribution: 'corretto'
-          java-version: '11'
+          java-version: '17'
 
       - name: Build Javadoc with Maven
         run: mvn -B javadoc:aggregate --file pom.xml -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN --no-transfer-progress

--- a/.github/workflows/maven_push.yml
+++ b/.github/workflows/maven_push.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: aws-athena-query-federation_ubuntu-latest_16-core
     strategy:
       matrix:
-        java-version: ['11', '17']
+        java-version: ['11', '17', '25']
     steps:
       - uses: actions/checkout@v7
         with:
@@ -48,12 +48,12 @@ jobs:
       # -------- Codecov coverage upload --------
       # Fork PRs: upload WITHOUT token
       - name: Upload coverage reports to Codecov (fork PRs, no token)
-        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && matrix.java-version == '11' }}
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && matrix.java-version == '17' }}
         uses: codecov/codecov-action@v7
 
       # Pushes & same-repo PRs: upload WITH token
       - name: Upload coverage reports to Codecov (internal only)
-        if: ${{ (github.event_name != 'pull_request' || (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork)) && matrix.java-version == '11' }}
+        if: ${{ (github.event_name != 'pull_request' || (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork)) && matrix.java-version == '17' }}
         uses: codecov/codecov-action@v7
         with:
           slug: awslabs/aws-athena-query-federation
@@ -61,14 +61,14 @@ jobs:
       # -------- Codecov test results --------
       # Fork PRs: no token
       - name: Upload test results to Codecov (fork PRs, no token)
-        if: ${{ !cancelled() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && matrix.java-version == '11' }}
+        if: ${{ !cancelled() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && matrix.java-version == '17' }}
         uses: codecov/test-results-action@v1
         with:
           slug: awslabs/aws-athena-query-federation
 
       # Pushes & same-repo PRs: with token
       - name: Upload test results to Codecov (internal only)
-        if: ${{ !cancelled() && (github.event_name != 'pull_request' || (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork)) && matrix.java-version == '11' }}
+        if: ${{ !cancelled() && (github.event_name != 'pull_request' || (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork)) && matrix.java-version == '17' }}
         uses: codecov/test-results-action@v1
         with:
           slug: awslabs/aws-athena-query-federation

--- a/.github/workflows/publish_to_maven_central.yml
+++ b/.github/workflows/publish_to_maven_central.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Maven Central Repository
         uses: actions/setup-java@v5
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'adopt'
           server-id: central
           server-username: MAVEN_USERNAME
@@ -29,7 +29,7 @@ jobs:
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
       - name: Publish to Apache Maven Central
-        run: mvn clean deploy --batch-mode -Dmaven.compiler.release=11 -am -P release -pl ".,athena-federation-sdk,athena-dynamodb,athena-cloudwatch,athena-cloudwatch-metrics,athena-aws-cmdb,athena-jdbc,athena-mysql,athena-oracle,athena-redshift,athena-postgresql"
+        run: mvn clean deploy --batch-mode -Dmaven.compiler.release=17 -am -P release -pl ".,athena-federation-sdk,athena-dynamodb,athena-cloudwatch,athena-cloudwatch-metrics,athena-aws-cmdb,athena-jdbc,athena-mysql,athena-oracle,athena-redshift,athena-postgresql"
         env:
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}

--- a/.github/workflows/run_release_tests.yml
+++ b/.github/workflows/run_release_tests.yml
@@ -20,11 +20,11 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 18
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v5
         with:
           distribution: 'corretto'
-          java-version: '11'
+          java-version: '17'
       - name: Checkout repository
         uses: actions/checkout@v7
         with:

--- a/tools/prepare_dev_env.sh
+++ b/tools/prepare_dev_env.sh
@@ -42,12 +42,14 @@ echo ""
 echo "Which Java version would you like to install?"
 echo "1) Java 11"
 echo "2) Java 17"
+echo "3) Java 25"
 while true; do
-    read -p "Enter your choice (1 or 2): " java_choice
+    read -p "Enter your choice (1, 2, or 3): " java_choice
     case $java_choice in
         1 ) JAVA_VERSION=11; break;;
         2 ) JAVA_VERSION=17; break;;
-        * ) echo "Please enter 1 or 2.";;
+        3 ) JAVA_VERSION=25; break;;
+        * ) echo "Please enter 1, 2, or 3.";;
     esac
 done
 


### PR DESCRIPTION
*Description of changes:*

- Updated GitHub Actions workflows to Java 17.
Additionally:
   - Updated the Java CI Push workflow to build against Java 11, 17, and 25.
   - Updated prepare_dev_env.sh to support Java 25.

**Note**: This PR is dependent on PR #3344 and should be reviewed and merged **afterwards**.
Please find attached document with screenshots of the successful workflow execution from my forked repository.
[github-actions-java17.odt](https://github.com/user-attachments/files/26412220/github-actions-java17.odt)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
