### PR TITLE
StringTemplate enhancement – BigQuery Connector

### DIFF
--- a/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryFederationExpressionParser.java
+++ b/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryFederationExpressionParser.java
@@ -49,8 +49,6 @@ import static com.amazonaws.athena.connector.lambda.domain.predicate.expression.
  */
 public class BigQueryFederationExpressionParser extends FederationExpressionParser
 {
-    private static final String quoteCharacter = "'";
-
     public String writeArrayConstructorClause(List<String> arguments)
     {
         return BigQuerySqlUtils.renderTemplate("comma_separated_list_with_parentheses", Map.of("items", arguments));
@@ -96,6 +94,12 @@ public class BigQueryFederationExpressionParser extends FederationExpressionPars
         return mapFunctionToDataSourceSyntax(functionName, functionCallExpression.getType(), arguments);
     }
 
+    @Override
+    public String parseVariableExpression(VariableExpression variableExpression)
+    {
+        return BigQuerySqlUtils.backtickQuotedIdentifier(variableExpression.getColumnName());
+    }
+
     public String parseConstantExpression(ConstantExpression constantExpression)
     {
         Block values = constantExpression.getValues();
@@ -112,7 +116,7 @@ public class BigQueryFederationExpressionParser extends FederationExpressionPars
                 || constantExpression.getType().equals(ArrowType.LargeUtf8.INSTANCE)
                 || fieldReader.getMinorType().equals(Types.MinorType.DATEDAY)) {
             constants = constants.stream()
-                    .map(val -> quoteCharacter + val + quoteCharacter)
+                    .map(BigQuerySqlUtils::singleQuotedStringLiteral)
                     .collect(Collectors.toList());
         }
 

--- a/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQuerySqlUtils.java
+++ b/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQuerySqlUtils.java
@@ -37,10 +37,12 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Utilities that help with Sql operations using StringTemplate.
+ * Utilities that help with Sql operations using StringTemplate, and escaping for dynamic SQL fragments.
  */
 public class BigQuerySqlUtils
 {
+    private static final String SQL_SINGLE_QUOTE = "'";
+    private static final String BIGQUERY_QUOTE_CHAR = "`";
     private static final BigQueryQueryFactory queryFactory = new BigQueryQueryFactory();
     private static final Logger logger = LoggerFactory.getLogger(BigQuerySqlUtils.class);
 
@@ -112,5 +114,29 @@ public class BigQuerySqlUtils
         params.forEach(template::add);
         
         return template.render().trim();
+    }
+
+    /**
+     * Escape a value for use inside a BigQuery single-quoted string literal (SQL standard: double each apostrophe).
+     */
+    public static String escapeForSingleQuotedStringLiteral(String value)
+    {
+        return value.replace(SQL_SINGLE_QUOTE, SQL_SINGLE_QUOTE + SQL_SINGLE_QUOTE);
+    }
+
+    /**
+     * A BigQuery Standard SQL single-quoted string literal for the given value.
+     */
+    public static String singleQuotedStringLiteral(String value)
+    {
+        return SQL_SINGLE_QUOTE + escapeForSingleQuotedStringLiteral(value) + SQL_SINGLE_QUOTE;
+    }
+
+    /**
+     * BigQuery Standard SQL backtick-quoted identifier; escape backslash and backtick inside the identifier.
+     */
+    public static String backtickQuotedIdentifier(String identifier)
+    {
+        return BIGQUERY_QUOTE_CHAR + identifier.replace("\\", "\\\\").replace(BIGQUERY_QUOTE_CHAR, "\\" + BIGQUERY_QUOTE_CHAR) + BIGQUERY_QUOTE_CHAR;
     }
 }

--- a/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQuerySqlUtils.java
+++ b/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQuerySqlUtils.java
@@ -117,11 +117,11 @@ public class BigQuerySqlUtils
     }
 
     /**
-     * Escape a value for use inside a BigQuery single-quoted string literal (SQL standard: double each apostrophe).
+     * Escape a value for use inside a BigQuery single-quoted string literal (BigQuery: backslash escaping).
      */
     public static String escapeForSingleQuotedStringLiteral(String value)
     {
-        return value.replace(SQL_SINGLE_QUOTE, SQL_SINGLE_QUOTE + SQL_SINGLE_QUOTE);
+        return value.replace("\\", "\\\\").replace(SQL_SINGLE_QUOTE, "\\" + SQL_SINGLE_QUOTE);
     }
 
     /**

--- a/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryStorageApiUtils.java
+++ b/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryStorageApiUtils.java
@@ -49,6 +49,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import static com.amazonaws.athena.connectors.google.bigquery.BigQuerySqlUtils.backtickQuotedIdentifier;
 import static org.apache.arrow.vector.types.pojo.ArrowType.ArrowTypeID.Utf8;
 
 /**
@@ -58,15 +59,8 @@ public class BigQueryStorageApiUtils
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(BigQueryStorageApiUtils.class);
 
-    private static final String BIGQUERY_QUOTE_CHAR = "\"";
-
     private BigQueryStorageApiUtils()
     {
-    }
-
-    private static String quote(final String identifier)
-    {
-        return BIGQUERY_QUOTE_CHAR + identifier + BIGQUERY_QUOTE_CHAR;
     }
 
     private static List<String> toConjuncts(List<Field> columns, Constraints constraints)
@@ -94,17 +88,17 @@ public class BigQueryStorageApiUtils
 
         if (valueSet instanceof SortedRangeSet) {
             if (valueSet.isNone() && valueSet.isNullAllowed()) {
-                return BigQuerySqlUtils.renderTemplate("null_predicate", Map.of("columnName", columnName, "isNull", true));
+                return BigQuerySqlUtils.renderTemplate("null_predicate", Map.of("columnName", backtickQuotedIdentifier(columnName), "isNull", true));
             }
 
             if (valueSet.isNullAllowed()) {
-                disjuncts.add(BigQuerySqlUtils.renderTemplate("null_predicate", Map.of("columnName", columnName, "isNull", true)));
+                disjuncts.add(BigQuerySqlUtils.renderTemplate("null_predicate", Map.of("columnName", backtickQuotedIdentifier(columnName), "isNull", true)));
             }
 
             Range rangeSpan = ((SortedRangeSet) valueSet).getSpan();
 
             if (!valueSet.isNullAllowed() && rangeSpan.getLow().isLowerUnbounded() && rangeSpan.getHigh().isUpperUnbounded()) {
-                return BigQuerySqlUtils.renderTemplate("null_predicate", Map.of("columnName", columnName, "isNull", false));
+                return BigQuerySqlUtils.renderTemplate("null_predicate", Map.of("columnName", backtickQuotedIdentifier(columnName), "isNull", false));
             }
 
             for (Range range : valueSet.getRanges().getOrderedRanges()) {
@@ -154,10 +148,12 @@ public class BigQueryStorageApiUtils
             else if (singleValues.size() > 1) {
                 List<String> val = new ArrayList<>();
                 for (Object value : singleValues) {
-                    val.add(((type.getTypeID().equals(Utf8) || type.getTypeID().equals(ArrowType.ArrowTypeID.Date)) ? quote(getValueForWhereClause(columnName, value, type).getValue()) : getValueForWhereClause(columnName, value, type).getValue()));
+                    val.add(((type.getTypeID().equals(Utf8) || type.getTypeID().equals(ArrowType.ArrowTypeID.Date))
+                            ? BigQuerySqlUtils.singleQuotedStringLiteral(getValueForWhereClause(columnName, value, type).getValue())
+                            : getValueForWhereClause(columnName, value, type).getValue()));
                 }
                 disjuncts.add(BigQuerySqlUtils.renderTemplate("storage_api_in_predicate", 
-                    Map.of("columnName", columnName, "placeholderList", val)));
+                    Map.of("columnName", backtickQuotedIdentifier(columnName), "placeholderList", val)));
             }
         }
 
@@ -166,12 +162,12 @@ public class BigQueryStorageApiUtils
 
     private static String toPredicate(String columnName, String operator, Object value, ArrowType type)
     {
-        String formattedValue = (type.getTypeID().equals(Utf8) || type.getTypeID().equals(ArrowType.ArrowTypeID.Date)) ? 
-                               quote(getValueForWhereClause(columnName, value, type).getValue()) :
-                getValueForWhereClause(columnName, value, type).getValue();
-        
+        String formattedValue = (type.getTypeID().equals(Utf8) || type.getTypeID().equals(ArrowType.ArrowTypeID.Date))
+                ? BigQuerySqlUtils.singleQuotedStringLiteral(getValueForWhereClause(columnName, value, type).getValue())
+                : getValueForWhereClause(columnName, value, type).getValue();
+
         return BigQuerySqlUtils.renderTemplate("storage_api_comparison_predicate", 
-                Map.of("columnName", columnName, "operator", operator, "value", formattedValue));
+                Map.of("columnName", backtickQuotedIdentifier(columnName), "operator", operator, "value", formattedValue));
     }
 
     //Gets the representation of a value that can be used in a where clause, ie String values need to be quoted, numeric doesn't.

--- a/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/query/BigQueryPredicateBuilder.java
+++ b/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/query/BigQueryPredicateBuilder.java
@@ -40,6 +40,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static com.amazonaws.athena.connectors.google.bigquery.BigQuerySqlUtils.backtickQuotedIdentifier;
+
 public class BigQueryPredicateBuilder
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(BigQueryPredicateBuilder.class);
@@ -73,17 +75,17 @@ public class BigQueryPredicateBuilder
 
         if (valueSet instanceof SortedRangeSet) {
             if (valueSet.isNone() && valueSet.isNullAllowed()) {
-                return BigQuerySqlUtils.renderTemplate("null_predicate", Map.of("columnName", columnName, "isNull", true));
+                return BigQuerySqlUtils.renderTemplate("null_predicate", Map.of("columnName", backtickQuotedIdentifier(columnName), "isNull", true));
             }
 
             if (valueSet.isNullAllowed()) {
-                disjuncts.add(BigQuerySqlUtils.renderTemplate("null_predicate", Map.of("columnName", columnName, "isNull", true)));
+                disjuncts.add(BigQuerySqlUtils.renderTemplate("null_predicate", Map.of("columnName", backtickQuotedIdentifier(columnName), "isNull", true)));
             }
 
             Range rangeSpan = ((SortedRangeSet) valueSet).getSpan();
 
             if (!valueSet.isNullAllowed() && rangeSpan.getLow().isLowerUnbounded() && rangeSpan.getHigh().isUpperUnbounded()) {
-                return BigQuerySqlUtils.renderTemplate("null_predicate", Map.of("columnName", columnName, "isNull", false));
+                return BigQuerySqlUtils.renderTemplate("null_predicate", Map.of("columnName", backtickQuotedIdentifier(columnName), "isNull", false));
             }
 
             for (Range range : valueSet.getRanges().getOrderedRanges()) {
@@ -96,11 +98,11 @@ public class BigQueryPredicateBuilder
                         switch (range.getLow().getBound()) {
                             case ABOVE:
                                 parameterValues.add(BigQueryStorageApiUtils.getValueForWhereClause(columnName, range.getLow().getValue(), type));
-                                rangeConjuncts.add(BigQuerySqlUtils.renderTemplate("comparison_predicate", Map.of("columnName", columnName, "operator", ">")));
+                                rangeConjuncts.add(BigQuerySqlUtils.renderTemplate("comparison_predicate", Map.of("columnName", backtickQuotedIdentifier(columnName), "operator", ">")));
                                 break;
                             case EXACTLY:
                                 parameterValues.add(BigQueryStorageApiUtils.getValueForWhereClause(columnName, range.getLow().getValue(), type));
-                                rangeConjuncts.add(BigQuerySqlUtils.renderTemplate("comparison_predicate", Map.of("columnName", columnName, "operator", ">=")));
+                                rangeConjuncts.add(BigQuerySqlUtils.renderTemplate("comparison_predicate", Map.of("columnName", backtickQuotedIdentifier(columnName), "operator", ">=")));
                                 break;
                             case BELOW:
                                 throw new IllegalArgumentException("Low marker should never use BELOW bound");
@@ -114,11 +116,11 @@ public class BigQueryPredicateBuilder
                                 throw new IllegalArgumentException("High marker should never use ABOVE bound");
                             case EXACTLY:
                                 parameterValues.add(BigQueryStorageApiUtils.getValueForWhereClause(columnName, range.getHigh().getValue(), type));
-                                rangeConjuncts.add(BigQuerySqlUtils.renderTemplate("comparison_predicate", Map.of("columnName", columnName, "operator", "<=")));
+                                rangeConjuncts.add(BigQuerySqlUtils.renderTemplate("comparison_predicate", Map.of("columnName", backtickQuotedIdentifier(columnName), "operator", "<=")));
                                 break;
                             case BELOW:
                                 parameterValues.add(BigQueryStorageApiUtils.getValueForWhereClause(columnName, range.getHigh().getValue(), type));
-                                rangeConjuncts.add(BigQuerySqlUtils.renderTemplate("comparison_predicate", Map.of("columnName", columnName, "operator", "<")));
+                                rangeConjuncts.add(BigQuerySqlUtils.renderTemplate("comparison_predicate", Map.of("columnName", backtickQuotedIdentifier(columnName), "operator", "<")));
                                 break;
                             default:
                                 throw new AssertionError("Unhandled bound: " + range.getHigh().getBound());
@@ -133,14 +135,14 @@ public class BigQueryPredicateBuilder
             // Add back all of the possible single values either as an equality or an IN predicate
             if (singleValues.size() == 1) {
                 parameterValues.add(BigQueryStorageApiUtils.getValueForWhereClause(columnName, Iterables.getOnlyElement(singleValues), type));
-                disjuncts.add(BigQuerySqlUtils.renderTemplate("comparison_predicate", Map.of("columnName", columnName, "operator", "=")));
+                disjuncts.add(BigQuerySqlUtils.renderTemplate("comparison_predicate", Map.of("columnName", backtickQuotedIdentifier(columnName), "operator", "=")));
             }
             else if (singleValues.size() > 1) {
                 for (Object value : singleValues) {
                     parameterValues.add(BigQueryStorageApiUtils.getValueForWhereClause(columnName, value, type));
                 }
                 List<String> placeholders = Collections.nCopies(singleValues.size(), "?");
-                disjuncts.add(BigQuerySqlUtils.renderTemplate("in_predicate", Map.of("columnName", columnName, "counts", placeholders)));
+                disjuncts.add(BigQuerySqlUtils.renderTemplate("in_predicate", Map.of("columnName", backtickQuotedIdentifier(columnName), "counts", placeholders)));
             }
         }
 

--- a/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/query/BigQueryQueryBuilder.java
+++ b/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/query/BigQueryQueryBuilder.java
@@ -22,6 +22,7 @@ package com.amazonaws.athena.connectors.google.bigquery.query;
 import com.amazonaws.athena.connector.lambda.domain.TableName;
 import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
 import com.amazonaws.athena.connector.lambda.domain.predicate.OrderByField;
+import com.amazonaws.athena.connectors.google.bigquery.BigQuerySqlUtils;
 import com.google.cloud.bigquery.QueryParameterValue;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
@@ -36,7 +37,6 @@ public class BigQueryQueryBuilder
 {
     private static final String TEMPLATE_NAME = "select_query";
     private static final String TEMPLATE_FIELD = "builder";
-    private static final String BIGQUERY_QUOTE_CHAR = "`";
     
     private final ST query;
     private List<String> projection;
@@ -104,16 +104,6 @@ public class BigQueryQueryBuilder
         return projection;
     }
 
-    public String getSchemaName()
-    {
-        return schemaName;
-    }
-
-    public String getTableName()
-    {
-        return tableName;
-    }
-
     public List<String> getConjuncts()
     {
         return conjuncts;
@@ -129,6 +119,27 @@ public class BigQueryQueryBuilder
         return limitClause;
     }
 
+    /**
+     * Projection column names as backtick-quoted BigQuery identifiers (for StringTemplate).
+     */
+    public List<String> getEscapedProjection()
+    {
+        if (projection == null) {
+            return null;
+        }
+        return projection.stream().map(BigQuerySqlUtils::backtickQuotedIdentifier).collect(Collectors.toList());
+    }
+
+    public String getEscapedSchemaRef()
+    {
+        return BigQuerySqlUtils.backtickQuotedIdentifier(schemaName);
+    }
+
+    public String getEscapedTableRef()
+    {
+        return BigQuerySqlUtils.backtickQuotedIdentifier(tableName);
+    }
+
     public String build()
     {
         Validate.notNull(schemaName, "schemaName can not be null.");
@@ -137,11 +148,6 @@ public class BigQueryQueryBuilder
 
         query.add(TEMPLATE_FIELD, this);
         return query.render().trim();
-    }
-
-    private static String quote(final String identifier)
-    {
-        return BIGQUERY_QUOTE_CHAR + identifier + BIGQUERY_QUOTE_CHAR;
     }
 
     private static String extractOrderByClause(Constraints constraints)
@@ -154,7 +160,7 @@ public class BigQueryQueryBuilder
                 .map(orderByField -> {
                     String ordering = orderByField.getDirection().isAscending() ? "ASC" : "DESC";
                     String nullsHandling = orderByField.getDirection().isNullsFirst() ? "NULLS FIRST" : "NULLS LAST";
-                    return quote(orderByField.getColumnName()) + " " + ordering + " " + nullsHandling;
+                    return BigQuerySqlUtils.backtickQuotedIdentifier(orderByField.getColumnName()) + " " + ordering + " " + nullsHandling;
                 })
                 .collect(Collectors.joining(", "));
     }

--- a/athena-google-bigquery/src/main/resources/BigQuery.stg
+++ b/athena-google-bigquery/src/main/resources/BigQuery.stg
@@ -9,7 +9,7 @@ test_template() ::= <%
  *@return A SQL query that can be executed by BigQuery.
  */
 select_query(builder) ::= <%
-    SELECT <if(builder.projection)><builder.projection:{col|`<col>`}; separator=","><else>null<endif> from `<builder.schemaName>`.`<builder.tableName>`<if(builder.conjuncts)> WHERE <builder.conjuncts:{conjunct|<conjunct>}; separator=" AND "><endif><if(builder.orderByClause)> <builder.orderByClause><endif><if(builder.limitClause)> <builder.limitClause><endif>
+    SELECT <if(builder.projection)><builder.escapedProjection; separator=","><else>null<endif> from <builder.escapedSchemaRef>.<builder.escapedTableRef><if(builder.conjuncts)> WHERE <builder.conjuncts:{conjunct|<conjunct>}; separator=" AND "><endif><if(builder.orderByClause)> <builder.orderByClause><endif><if(builder.limitClause)> <builder.limitClause><endif>
 %>
 
 /**
@@ -20,7 +20,7 @@ select_query(builder) ::= <%
  *@return A comparison predicate like `column` > ?
  */
 comparison_predicate(columnName, operator) ::= <%
-    `<columnName>` <operator> ?
+    <columnName> <operator> ?
 %>
 
 /**
@@ -31,7 +31,7 @@ comparison_predicate(columnName, operator) ::= <%
  *@return An IN predicate like column IN (?,?)
  */
 in_predicate(columnName, counts) ::= <%
-    `<columnName>` IN (<counts:{c|?}; separator=",">)
+    <columnName> IN (<counts:{c|?}; separator=",">)
 %>
 
 /**

--- a/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryFederationExpressionParserTest.java
+++ b/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryFederationExpressionParserTest.java
@@ -39,10 +39,9 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.sql.Date;
+import java.time.LocalDate;
 import java.util.Collection;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static com.amazonaws.athena.connector.lambda.domain.predicate.expression.ConstantExpression.DEFAULT_CONSTANT_EXPRESSION_BLOCK_NAME;
@@ -52,8 +51,6 @@ public class BigQueryFederationExpressionParserTest
 {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BigQueryFederationExpressionParserTest.class);
-    private static final String COLUMN_QUOTE_CHAR = "\"";
-    private static final String CONSTANT_QUOTE_CHAR = "'";
     private static final String INPUT_ARGUMENT1 = "110";
     private static final String INPUT_ARGUMENT2 = "120";
 
@@ -101,18 +98,28 @@ public class BigQueryFederationExpressionParserTest
                         rawStrings), new ArrowType.Utf8()
         );
 
-        List<String> quotedStrings = rawStrings.stream().map(str -> CONSTANT_QUOTE_CHAR + str + CONSTANT_QUOTE_CHAR).collect(Collectors.toList());
+        List<String> quotedStrings = rawStrings.stream()
+                .map(str -> BigQuerySqlUtils.singleQuotedStringLiteral((String) str))
+                .collect(Collectors.toList());
         String expected = Joiner.on(",").join(quotedStrings);
         String actual = bigQueryExpressionParser.parseConstantExpression(listOfStrings);
         assertEquals(expected, actual);
     }
 
+    @Test
+    public void testParseConstantExpression_stringWithApostropheIsEscaped()
+    {
+        ConstantExpression irishName = new ConstantExpression(
+                BlockUtils.newBlock(blockAllocator, DEFAULT_CONSTANT_EXPRESSION_BLOCK_NAME, ArrowType.Utf8.INSTANCE,
+                        ImmutableList.of("O'Brien")), ArrowType.Utf8.INSTANCE);
+        assertEquals("'O''Brien'", bigQueryExpressionParser.parseConstantExpression(irishName));
+    }
 
     @Test
     public void testParseVariableExpression()
     {
         VariableExpression colThree = new VariableExpression("colThree", intType);
-        assertEquals(bigQueryExpressionParser.parseVariableExpression(colThree),  "colThree" );
+        assertEquals(bigQueryExpressionParser.parseVariableExpression(colThree), "`colThree`");
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -248,7 +255,7 @@ public class BigQueryFederationExpressionParserTest
                 StandardFunctions.LESS_THAN_OPERATOR_FUNCTION_NAME.getFunctionName(),
                 ltArguments);
 
-        assertEquals("((colOne + colThree) < 10)", bigQueryExpressionParser.parseFunctionCallExpression((FunctionCallExpression) fullExpression));
+        assertEquals("((`colOne` + `colThree`) < 10)", bigQueryExpressionParser.parseFunctionCallExpression((FunctionCallExpression) fullExpression));
     }
 
     // (colOne + colTwo > colThree) AND (colFour IN ("banana", "dragonfruit"))
@@ -328,8 +335,9 @@ public class BigQueryFederationExpressionParserTest
         // colOne + colThree < 10
         VariableExpression colOne = new VariableExpression("colOne", new ArrowType.Date(DateUnit.DAY));
 
+        long epochDay = LocalDate.of(2020, 1, 5).toEpochDay();
         Block b = BlockUtils.newBlock(blockAllocator, DEFAULT_CONSTANT_EXPRESSION_BLOCK_NAME, new ArrowType.Date(DateUnit.DAY),
-                ImmutableList.of(TimeUnit.MILLISECONDS.toDays(Date.valueOf("2020-01-05").getTime())));
+                ImmutableList.of(epochDay));
         ConstantExpression dateConstantExpression = new ConstantExpression(b, new ArrowType.Int(32, true));
 
 
@@ -338,17 +346,16 @@ public class BigQueryFederationExpressionParserTest
                 StandardFunctions.GREATER_THAN_OPERATOR_FUNCTION_NAME.getFunctionName(),
                 ImmutableList.of(colOne, dateConstantExpression));
 
-        String s = bigQueryExpressionParser.parseFunctionCallExpression((FunctionCallExpression) gtFunctionCall);
-        assertEquals("(colOne > '2020-01-05')", bigQueryExpressionParser.parseFunctionCallExpression((FunctionCallExpression) gtFunctionCall));
+        assertEquals("(`colOne` > '2020-01-05')", bigQueryExpressionParser.parseFunctionCallExpression((FunctionCallExpression) gtFunctionCall));
     }
 
     private String quoteColumn(String columnName)
     {
-        return columnName;
+        return BigQuerySqlUtils.backtickQuotedIdentifier(columnName);
     }
 
     private String quoteConstant(String constant)
     {
-        return CONSTANT_QUOTE_CHAR + constant + CONSTANT_QUOTE_CHAR;
+        return BigQuerySqlUtils.singleQuotedStringLiteral(constant);
     }
 }

--- a/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryFederationExpressionParserTest.java
+++ b/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryFederationExpressionParserTest.java
@@ -112,7 +112,7 @@ public class BigQueryFederationExpressionParserTest
         ConstantExpression irishName = new ConstantExpression(
                 BlockUtils.newBlock(blockAllocator, DEFAULT_CONSTANT_EXPRESSION_BLOCK_NAME, ArrowType.Utf8.INSTANCE,
                         ImmutableList.of("O'Brien")), ArrowType.Utf8.INSTANCE);
-        assertEquals("'O''Brien'", bigQueryExpressionParser.parseConstantExpression(irishName));
+        assertEquals("'O\\'Brien'", bigQueryExpressionParser.parseConstantExpression(irishName));
     }
 
     @Test

--- a/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQuerySqlUtilsTest.java
+++ b/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQuerySqlUtilsTest.java
@@ -19,14 +19,22 @@
  */
 package com.amazonaws.athena.connectors.google.bigquery;
 
-import static org.junit.Assert.*;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.amazonaws.athena.connector.lambda.data.BlockAllocatorImpl;
 import com.amazonaws.athena.connector.lambda.domain.TableName;
-import com.amazonaws.athena.connector.lambda.domain.predicate.*;
+import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
+import com.amazonaws.athena.connector.lambda.domain.predicate.Marker;
+import com.amazonaws.athena.connector.lambda.domain.predicate.OrderByField;
+import com.amazonaws.athena.connector.lambda.domain.predicate.QueryPlan;
+import com.amazonaws.athena.connector.lambda.domain.predicate.Range;
+import com.amazonaws.athena.connector.lambda.domain.predicate.Ranges;
+import com.amazonaws.athena.connector.lambda.domain.predicate.SortedRangeSet;
+import com.amazonaws.athena.connector.lambda.domain.predicate.ValueSet;
 import com.google.cloud.bigquery.QueryParameterValue;
 import com.google.common.collect.ImmutableList;
 import org.apache.arrow.vector.types.DateUnit;
@@ -40,7 +48,11 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 import static com.amazonaws.athena.connector.lambda.domain.predicate.Constraints.DEFAULT_NO_LIMIT;
 import static com.amazonaws.athena.connectors.google.bigquery.BigQueryTestUtils.makeSchema;
@@ -114,8 +126,8 @@ public class BigQuerySqlUtilsTest
                 QueryParameterValue.bool(true),
                 QueryParameterValue.int64(10), QueryParameterValue.int64(1000000));
         String expectedSql = "SELECT `integerRange`,`isNullRange`,`isNotNullRange`,`stringRange`,`booleanRange`,`integerInRange` from `schema`.`table` " +
-                "WHERE integerRange IS NULL OR `integerRange` > ? AND `integerRange` < ? " +
-                "AND isNullRange IS NULL AND isNotNullRange IS NOT NULL " +
+                "WHERE `integerRange` IS NULL OR `integerRange` > ? AND `integerRange` < ? " +
+                "AND `isNullRange` IS NULL AND `isNotNullRange` IS NOT NULL " +
                 "AND `stringRange` >= ? AND `stringRange` < ? " +
                 "AND `booleanRange` = ? " +
                 "AND `integerInRange` IN (?,?)";
@@ -197,7 +209,7 @@ public class BigQuerySqlUtilsTest
         constraintMap.put("emptyCol", emptyStringSet);
         List<QueryParameterValue> expectedParams = ImmutableList.of(QueryParameterValue.string(""));
         String expectedSql = "SELECT `nullCol`,`nonNullCol`,`emptyCol` from `schema`.`table` " +
-                "WHERE nullCol IS NULL AND nonNullCol IS NOT NULL AND `emptyCol` = ?";
+                "WHERE `nullCol` IS NULL AND `nonNullCol` IS NOT NULL AND `emptyCol` = ?";
         Constraints constraints = getConstraints(constraintMap, Collections.emptyList(), DEFAULT_NO_LIMIT);
         executeAndVerify(constraints, makeSchema(constraintMap), expectedParams, expectedSql);
     }
@@ -517,6 +529,24 @@ public class BigQuerySqlUtilsTest
         assertTrue(result.contains("SELECT ID"));
         assertTrue(result.contains("FROM MY_DATASET.SERVICE_REQUESTS_NO_NOISE"));
         assertTrue(result.contains("WHERE ID IN (100.0000, 200.0000) AND NOT IS_ACTIVE"));
+    }
+    
+
+
+    @Test
+    public void singleQuotedStringLiteral_doublesApostrophe()
+    {
+        assertEquals("'a'", BigQuerySqlUtils.singleQuotedStringLiteral("a"));
+        assertEquals("'O''Brien'", BigQuerySqlUtils.singleQuotedStringLiteral("O'Brien"));
+        assertEquals("''''", BigQuerySqlUtils.singleQuotedStringLiteral("'"));
+    }
+
+    @Test
+    public void backtickQuotedIdentifier_escapesBacktickAndBackslash()
+    {
+        assertEquals("`col`", BigQuerySqlUtils.backtickQuotedIdentifier("col"));
+        assertEquals("`a\\`b`", BigQuerySqlUtils.backtickQuotedIdentifier("a`b"));
+        assertEquals("`c\\\\d`", BigQuerySqlUtils.backtickQuotedIdentifier("c\\d"));
     }
 
     private Constraints getConstraints(Map<String, ValueSet> constraintMap, List<OrderByField> orderByFields, long limit) {

--- a/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQuerySqlUtilsTest.java
+++ b/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQuerySqlUtilsTest.java
@@ -22,6 +22,7 @@ package com.amazonaws.athena.connectors.google.bigquery;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -49,6 +50,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;

--- a/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQuerySqlUtilsTest.java
+++ b/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQuerySqlUtilsTest.java
@@ -536,11 +536,12 @@ public class BigQuerySqlUtilsTest
 
 
     @Test
-    public void singleQuotedStringLiteral_doublesApostrophe()
+    public void singleQuotedStringLiteral_escapesBackslashAndApostrophe()
     {
         assertEquals("'a'", BigQuerySqlUtils.singleQuotedStringLiteral("a"));
-        assertEquals("'O''Brien'", BigQuerySqlUtils.singleQuotedStringLiteral("O'Brien"));
-        assertEquals("''''", BigQuerySqlUtils.singleQuotedStringLiteral("'"));
+        assertEquals("'O\\'Brien'", BigQuerySqlUtils.singleQuotedStringLiteral("O'Brien"));
+        assertEquals("'\\''", BigQuerySqlUtils.singleQuotedStringLiteral("'"));
+        assertEquals("'foo\\\\'", BigQuerySqlUtils.singleQuotedStringLiteral("foo\\"));
     }
 
     @Test

--- a/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryStorageApiUtilsTest.java
+++ b/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryStorageApiUtilsTest.java
@@ -115,7 +115,7 @@ public class BigQueryStorageApiUtilsTest
                     "selected_fields: \"stringRange\"\n" +
                     "selected_fields: \"booleanRange\"\n" +
                     "selected_fields: \"integerInRange\"\n" +
-                    "row_restriction: \"integerRange IS NULL OR integerRange > 10 AND integerRange < 20 AND isNullRange IS NULL AND isNotNullRange IS NOT NULL AND stringRange >= \\\"a_low\\\" AND stringRange < \\\"z_high\\\" AND booleanRange = true AND integerInRange IN (10,1000000)\"\n", option.toString());
+                    "row_restriction: \"`integerRange` IS NULL OR `integerRange` > 10 AND `integerRange` < 20 AND `isNullRange` IS NULL AND `isNotNullRange` IS NOT NULL AND `stringRange` >= \\'a_low\\' AND `stringRange` < \\'z_high\\' AND `booleanRange` = true AND `integerInRange` IN (10,1000000)\"\n", option.toString());
         }
     }
 

--- a/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryStorageApiUtilsTest.java
+++ b/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryStorageApiUtilsTest.java
@@ -20,11 +20,9 @@
 package com.amazonaws.athena.connectors.google.bigquery;
 
 import com.amazonaws.athena.connector.lambda.data.BlockAllocatorImpl;
-import com.amazonaws.athena.connector.lambda.exceptions.AthenaConnectorException;
 import com.amazonaws.athena.connector.lambda.domain.predicate.*;
-import com.google.cloud.bigquery.QueryParameterValue;
 import com.google.cloud.bigquery.storage.v1.ReadSession;
-import com.google.common.collect.ImmutableList;
+import org.apache.arrow.vector.types.DateUnit;
 import org.apache.arrow.vector.types.FloatingPointPrecision;
 import org.apache.arrow.vector.types.TimeUnit;
 import org.apache.arrow.vector.types.pojo.ArrowType;
@@ -93,11 +91,6 @@ public class BigQueryStorageApiUtilsTest
         constraintMap.put("booleanRange", booleanRangeSet);
         constraintMap.put("integerInRange", integerInRangeSet);
 
-        final List<QueryParameterValue> expectedParameterValues = ImmutableList.of(QueryParameterValue.int64(10), QueryParameterValue.int64(20),
-                QueryParameterValue.string("a_low"), QueryParameterValue.string("z_high"),
-                QueryParameterValue.bool(true),
-                QueryParameterValue.int64(10), QueryParameterValue.int64(1000000));
-
         try (Constraints constraints = new Constraints(constraintMap, Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null)) {
             List<String> fields = new ArrayList<>();
             for (Field field : makeSchema(constraintMap).getFields()) {
@@ -116,6 +109,80 @@ public class BigQueryStorageApiUtilsTest
                     "selected_fields: \"booleanRange\"\n" +
                     "selected_fields: \"integerInRange\"\n" +
                     "row_restriction: \"`integerRange` IS NULL OR `integerRange` > 10 AND `integerRange` < 20 AND `isNullRange` IS NULL AND `isNotNullRange` IS NOT NULL AND `stringRange` >= \\'a_low\\' AND `stringRange` < \\'z_high\\' AND `booleanRange` = true AND `integerInRange` IN (10,1000000)\"\n", option.toString());
+        }
+    }
+
+    @Test
+    public void testSetConstraints_MultiValueStringIn_UsesSingleQuotedLiteralsInInList()
+    {
+        Map<String, ValueSet> constraintMap = new LinkedHashMap<>();
+        ValueSet stringInSet = SortedRangeSet.newBuilder(STRING_TYPE, false)
+                .add(Range.equal(allocator, STRING_TYPE, "alpha"))
+                .add(Range.equal(allocator, STRING_TYPE, "beta"))
+                .build();
+        constraintMap.put("status", stringInSet);
+
+        try (Constraints constraints = new Constraints(constraintMap, Collections.emptyList(), Collections.emptyList(),
+                DEFAULT_NO_LIMIT, Collections.emptyMap(), null)) {
+            Schema schema = makeSchema(constraintMap);
+            ReadSession.TableReadOptions.Builder optionsBuilder = ReadSession.TableReadOptions.newBuilder()
+                    .addSelectedFields("status");
+            ReadSession.TableReadOptions.Builder option =
+                    BigQueryStorageApiUtils.setConstraints(optionsBuilder, schema, constraints, false);
+            String rowRestriction = option.build().getRowRestriction();
+            assertTrue(rowRestriction.contains("`status` IN ("));
+            assertTrue(rowRestriction.contains("'alpha'"));
+            assertTrue(rowRestriction.contains("'beta'"));
+        }
+    }
+
+    @Test
+    public void testSetConstraints_MultiValueDateIn_UsesSingleQuotedLiteralsInInList()
+    {
+        ArrowType dateDay = new ArrowType.Date(DateUnit.DAY);
+        Map<String, ValueSet> constraintMap = new LinkedHashMap<>();
+        ValueSet dateInSet = SortedRangeSet.newBuilder(dateDay, false)
+                .add(Range.equal(allocator, dateDay, 0L))
+                .add(Range.equal(allocator, dateDay, 1L))
+                .build();
+        constraintMap.put("event_day", dateInSet);
+
+        try (Constraints constraints = new Constraints(constraintMap, Collections.emptyList(), Collections.emptyList(),
+                DEFAULT_NO_LIMIT, Collections.emptyMap(), null)) {
+            Schema schema = makeSchema(constraintMap);
+            ReadSession.TableReadOptions.Builder optionsBuilder = ReadSession.TableReadOptions.newBuilder()
+                    .addSelectedFields("event_day");
+            ReadSession.TableReadOptions.Builder option =
+                    BigQueryStorageApiUtils.setConstraints(optionsBuilder, schema, constraints, false);
+            String rowRestriction = option.build().getRowRestriction();
+            assertTrue(rowRestriction.contains("`event_day` IN ("));
+            assertTrue(rowRestriction.contains("'1970-01-01'"));
+            assertTrue(rowRestriction.contains("'1970-01-02'"));
+        }
+    }
+
+    @Test
+    public void testSetConstraints_DateRangeComparison_UsesSingleQuotedLiterals()
+    {
+        ArrowType dateDay = new ArrowType.Date(DateUnit.DAY);
+        Map<String, ValueSet> constraintMap = new LinkedHashMap<>();
+        ValueSet dateRange = SortedRangeSet.newBuilder(dateDay, false)
+                .add(new Range(Marker.exactly(allocator, dateDay, 5L), Marker.below(allocator, dateDay, 10L)))
+                .build();
+        constraintMap.put("event_day", dateRange);
+
+        try (Constraints constraints = new Constraints(constraintMap, Collections.emptyList(), Collections.emptyList(),
+                DEFAULT_NO_LIMIT, Collections.emptyMap(), null)) {
+            Schema schema = makeSchema(constraintMap);
+            ReadSession.TableReadOptions.Builder optionsBuilder = ReadSession.TableReadOptions.newBuilder()
+                    .addSelectedFields("event_day");
+            ReadSession.TableReadOptions.Builder option =
+                    BigQueryStorageApiUtils.setConstraints(optionsBuilder, schema, constraints, false);
+            String rowRestriction = option.build().getRowRestriction();
+            assertTrue(rowRestriction.contains("`event_day` >="));
+            assertTrue(rowRestriction.contains("`event_day` <"));
+            assertTrue(rowRestriction.contains("'1970-01-06'"));
+            assertTrue(rowRestriction.contains("'1970-01-11'"));
         }
     }
 

--- a/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryUtilsTest.java
+++ b/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryUtilsTest.java
@@ -302,7 +302,9 @@ public class BigQueryUtilsTest
         Object result = BigQueryUtils.getObjectFromFieldValue(FIELD_NAME, dateValue, dateField);
         assertNotNull(result);
         assertInstanceOf(Long.class, result);
-        assertEquals(19358L, result);
+        long expectedDays = java.util.concurrent.TimeUnit.MILLISECONDS.toDays(
+                new java.text.SimpleDateFormat("yyyy-MM-dd").parse("2023-01-01").getTime());
+        assertEquals(expectedDays, result);
     }
 
     @Test

--- a/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/query/BigQueryQueryBuilderTest.java
+++ b/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/query/BigQueryQueryBuilderTest.java
@@ -41,6 +41,7 @@ import java.util.List;
 import static com.amazonaws.athena.connector.lambda.domain.predicate.Constraints.DEFAULT_NO_LIMIT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class BigQueryQueryBuilderTest
@@ -90,6 +91,13 @@ public class BigQueryQueryBuilderTest
         
         assertNotNull("Template name should not be null", templateName);
         assertEquals("Template name should match", "select_query", templateName);
+    }
+
+    @Test
+    public void getEscapedProjection_ReturnsNullWhenProjectionNotSet()
+    {
+        BigQueryQueryBuilder builder = queryFactory.createQueryBuilder();
+        assertNull("getEscapedProjection should return null when withProjection was never called", builder.getEscapedProjection());
     }
 
     @Test

--- a/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/query/BigQueryQueryBuilderTest.java
+++ b/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/query/BigQueryQueryBuilderTest.java
@@ -170,8 +170,6 @@ public class BigQueryQueryBuilderTest
                 .withProjection(testSchema)
                 .withTableName(TEST_TABLE);
 
-        assertEquals("Schema name should match", TEST_SCHEMA_NAME, builder.getSchemaName());
-        assertEquals("Table name should match", TEST_TABLE_NAME, builder.getTableName());
         assertEquals("Projection should have correct number of columns", 4, builder.getProjection().size());
         assertTrue("Projection should contain id", builder.getProjection().contains(COLUMN_ID));
         assertTrue("Projection should contain name", builder.getProjection().contains(COLUMN_NAME));


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR enhances stringTemplate through the following improvements:
- **Identifier Quoting**: Schema, table, and column identifiers are now wrapped in backticks (e.g., `table_name`).
- **String literals**: All user-provided text and date values are now correctly escaped.

Please find the attached detailed description and functional test documentation.
[BIGQUERY_FUNCTIONAL_TEST.xlsx](https://github.com/user-attachments/files/26460393/BIGQUERY_FUNCTIONAL_TEST.xlsx)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
