### PR TITLE
 StringTemplate enhancement – Vertica Connector

### DIFF
--- a/athena-vertica/src/main/java/com/amazonaws/athena/connectors/vertica/VerticaMetadataHandler.java
+++ b/athena-vertica/src/main/java/com/amazonaws/athena/connectors/vertica/VerticaMetadataHandler.java
@@ -45,6 +45,7 @@ import com.amazonaws.athena.connectors.jdbc.connection.JdbcConnectionFactory;
 import com.amazonaws.athena.connectors.jdbc.manager.JDBCUtil;
 import com.amazonaws.athena.connectors.jdbc.manager.JdbcMetadataHandler;
 import com.amazonaws.athena.connectors.jdbc.qpt.JdbcQueryPassthrough;
+import com.amazonaws.athena.connectors.vertica.query.PredicateBuilder;
 import com.amazonaws.athena.connectors.vertica.query.QueryFactory;
 import com.amazonaws.athena.connectors.vertica.query.VerticaExportQueryBuilder;
 import com.google.common.collect.ImmutableMap;
@@ -55,7 +56,6 @@ import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.stringtemplate.v4.ST;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -465,12 +465,10 @@ public class VerticaMetadataHandler
     }
 
     private void testAccess(Connection conn, TableName table) {
-        ST simpleTestSqlST = new ST("SELECT * FROM <schemaName>.<tableName> Limit 1;");
-        simpleTestSqlST.add("schemaName", table.getSchemaName());
-        simpleTestSqlST.add("tableName", table.getTableName());
+        String sql = "SELECT * FROM " + PredicateBuilder.getFromClauseWithSplit(table.getSchemaName(), table.getTableName()) + " LIMIT 1";
         logger.info("Checking if the user has access to {}.{}", table.getSchemaName(), table.getTableName());
         try {
-            PreparedStatement testAccessSql = conn.prepareStatement(simpleTestSqlST.render());
+            PreparedStatement testAccessSql = conn.prepareStatement(sql);
             ResultSet resultSet = testAccessSql.executeQuery();
         } catch (Exception e) {
             if (e.getMessage().contains("Permission denied")) {

--- a/athena-vertica/src/main/java/com/amazonaws/athena/connectors/vertica/query/PredicateBuilder.java
+++ b/athena-vertica/src/main/java/com/amazonaws/athena/connectors/vertica/query/PredicateBuilder.java
@@ -30,17 +30,12 @@ import com.google.common.collect.Iterables;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.commons.lang3.Validate;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
 public class PredicateBuilder {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(PredicateBuilder.class);
-    private final String quoteCharacters = "\"";
 
     private PredicateBuilder() {}
 

--- a/athena-vertica/src/main/java/com/amazonaws/athena/connectors/vertica/query/PredicateBuilder.java
+++ b/athena-vertica/src/main/java/com/amazonaws/athena/connectors/vertica/query/PredicateBuilder.java
@@ -34,7 +34,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
@@ -72,16 +71,16 @@ public class PredicateBuilder {
 
         if (valueSet instanceof SortedRangeSet){
             if (valueSet.isNone() && valueSet.isNullAllowed()) {
-                return String.format("(%s IS NULL)", columnName);
+                return String.format("(%s IS NULL)", quote(columnName));
             }
 
             if (valueSet.isNullAllowed()) {
-                disjuncts.add(String.format("(%s IS NULL)", columnName));
+                disjuncts.add(String.format("(%s IS NULL)", quote(columnName)));
             }
 
             Range rangeSpan = ((SortedRangeSet) valueSet).getSpan();
             if (!valueSet.isNullAllowed() && rangeSpan.getLow().isLowerUnbounded() && rangeSpan.getHigh().isUpperUnbounded()) {
-                return String.format("(%s IS NOT NULL)", columnName);
+                return String.format("(%s IS NOT NULL)", quote(columnName));
             }
 
             for (Range range : valueSet.getRanges().getOrderedRanges()) {
@@ -199,7 +198,7 @@ public class PredicateBuilder {
         }
     }
 
-    protected static String getFromClauseWithSplit(String schema, String table)
+    public static String getFromClauseWithSplit(String schema, String table)
     {
         StringBuilder tableName = new StringBuilder();
         if (!Strings.isNullOrEmpty(schema))

--- a/athena-vertica/src/main/java/com/amazonaws/athena/connectors/vertica/query/VerticaExportQueryBuilder.java
+++ b/athena-vertica/src/main/java/com/amazonaws/athena/connectors/vertica/query/VerticaExportQueryBuilder.java
@@ -26,8 +26,6 @@ import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.commons.lang3.Validate;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.stringtemplate.v4.ST;
 
 import java.math.BigDecimal;
@@ -40,11 +38,9 @@ import java.util.List;
 import java.util.Map;
 
 public class VerticaExportQueryBuilder {
-    private static final Logger LOGGER = LoggerFactory.getLogger(VerticaExportQueryBuilder.class);
     private static final String TEMPLATE_NAME = "templateVerticaExportQuery";
     private static final String QPT_TEMPLATE_NAME = "templateVerticaExportQPTQuery";
     private static final String TEMPLATE_FIELD = "builder";
-    private static final String QUOTE_CHARS = "\"";
     private final ST query;
     private String s3ExportBucket;
     private String table;

--- a/athena-vertica/src/main/java/com/amazonaws/athena/connectors/vertica/query/VerticaExportQueryBuilder.java
+++ b/athena-vertica/src/main/java/com/amazonaws/athena/connectors/vertica/query/VerticaExportQueryBuilder.java
@@ -117,7 +117,7 @@ public class VerticaExportQueryBuilder {
                 colN.append(castedField).append(",");
             }
             else {
-                colN.append(f.getName()).append(",");
+                colN.append(PredicateBuilder.quote(f.getName())).append(",");
             }
         }
         this.colNames = colN.deleteCharAt(colN.length() - 1).toString();
@@ -185,7 +185,7 @@ public class VerticaExportQueryBuilder {
                     sqlTemplate.add(colName, LocalDateTime.parse(typeAndValue.getValue().toString()).atZone(BlockUtils.UTC_ZONE_ID).toInstant().toEpochMilli());
                     break;
                 case VARCHAR:
-                    String val = "'" + typeAndValue.getValue() + "'";
+                    String val = "'" + escapeSqlStringLiteral(typeAndValue.getValue().toString()) + "'";
                     sqlTemplate.add(colName, val);
                     break;
                 case VARBINARY:
@@ -203,9 +203,13 @@ public class VerticaExportQueryBuilder {
 
     protected String castTimestamp(String name)
     {
-        ST castFieldST = new ST("CAST(<name> AS VARCHAR) AS <name>");
-        castFieldST.add("name", name);
-        return castFieldST.render();
+        String quotedColumnName = PredicateBuilder.quote(name);
+        return "CAST(" + quotedColumnName + " AS VARCHAR) AS " + quotedColumnName;
+    }
+
+    private static String escapeSqlStringLiteral(String value)
+    {
+        return value.replace("'", "''");
     }
 
     //build the Vertica SQL to set the AWS Region
@@ -214,9 +218,7 @@ public class VerticaExportQueryBuilder {
         if (awsRegion == null || awsRegion.equals("")) { 
             awsRegion = "us-east-1"; 
         }
-        ST regionST=  new ST("ALTER SESSION SET AWSRegion='<defaultRegion>'") ;
-        regionST.add("defaultRegion", awsRegion);
-        return regionST.render();
+        return "ALTER SESSION SET AWSRegion='" + escapeSqlStringLiteral(awsRegion) + "'";
     }
 
     public String getS3ExportBucket(){return s3ExportBucket;}

--- a/athena-vertica/src/test/java/com/amazonaws/athena/connectors/vertica/VerticaMetadataHandlerTest.java
+++ b/athena-vertica/src/test/java/com/amazonaws/athena/connectors/vertica/VerticaMetadataHandlerTest.java
@@ -385,8 +385,8 @@ public class VerticaMetadataHandlerTest extends TestBase
         String s3ExportBucket = "s3://testS3Bucket";
         String expectedExportSql = String.format(
                 "EXPORT TO PARQUET(directory = 's3://s3://testS3Bucket/%s', Compression='snappy', fileSizeMB=16, rowGroupSizeMB=16) " +
-                        "AS SELECT bit_col,tinyint_col,smallint_col,int_col,bigint_col,float_col,double_col,decimal_col," +
-                        "varchar_col,preparedStmt,queryId,awsRegionSql " +
+                        "AS SELECT \"bit_col\",\"tinyint_col\",\"smallint_col\",\"int_col\",\"bigint_col\",\"float_col\",\"double_col\",\"decimal_col\"," +
+                        "\"varchar_col\",\"preparedStmt\",\"queryId\",\"awsRegionSql\" " +
                         "FROM \"schema1\".\"table1\" " +
                         "WHERE (\"bit_col\" = 1 ) AND (\"tinyint_col\" = 127 ) AND (\"smallint_col\" = 32767 ) AND (\"int_col\" = 1000 ) " +
                         "AND (\"bigint_col\" = 1000000 ) AND (\"float_col\" = 3.14 ) AND (\"double_col\" = 3.14159 ) " +
@@ -693,7 +693,7 @@ public class VerticaMetadataHandlerTest extends TestBase
                 actualSql.indexOf("', Compression"));
         String expectedExportSql = "EXPORT TO PARQUET(directory = 's3://testS3Bucket/" +
                 actualQueryID + "', Compression='snappy', fileSizeMB=16, rowGroupSizeMB=16) " +
-                "AS SELECT id,name " +
+                "AS SELECT \"id\",\"name\" " +
                 "FROM \"testSchema\".\"testTable1\" " +
                 "WHERE (\"id\" IN (1,2,3))";
 
@@ -716,9 +716,9 @@ public class VerticaMetadataHandlerTest extends TestBase
                 actualSql.indexOf("', Compression"));
         String expectedExportSql = "EXPORT TO PARQUET(directory = 's3://testS3Bucket/" +
                 actualQueryID + "', Compression='snappy', fileSizeMB=16, rowGroupSizeMB=16) " +
-                "AS SELECT nullable_field " +
+                "AS SELECT \"nullable_field\" " +
                 "FROM \"testSchema\".\"testTable1\" " +
-                "WHERE ((nullable_field IS NULL) OR \"nullable_field\" = 'test' )";
+                "WHERE ((\"nullable_field\" IS NULL) OR \"nullable_field\" = 'test' )";
 
         Assert.assertEquals(expectedExportSql, actualSql);
     }
@@ -739,7 +739,7 @@ public class VerticaMetadataHandlerTest extends TestBase
                 actualSql.indexOf("', Compression"));
         String expectedExportSql = "EXPORT TO PARQUET(directory = 's3://testS3Bucket/" +
                 actualQueryID + "', Compression='snappy', fileSizeMB=16, rowGroupSizeMB=16) " +
-                "AS SELECT name " +
+                "AS SELECT \"name\" " +
                 "FROM \"testSchema\".\"testTable1\" " +
                 "WHERE ((\"name\" >= 'test'  AND \"name\" < 'tesu' ))";
 
@@ -783,7 +783,7 @@ public class VerticaMetadataHandlerTest extends TestBase
         // Construct expected SQL with actual query ID
         String expectedExportSql = "EXPORT TO PARQUET(directory = 's3://testS3Bucket/" +
                 actualQueryID + "', Compression='snappy', fileSizeMB=16, rowGroupSizeMB=16) " +
-                "AS SELECT id,status,price,category " +
+                "AS SELECT \"id\",\"status\",\"price\",\"category\" " +
                 "FROM \"testSchema\".\"testTable1\" " +
                 "WHERE (\"id\" IN (1,2,3,4,5)) AND ((\"status\" > 'A'  AND \"status\" <= 'Z' )) AND ((\"price\" >= 100  AND \"price\" <= 1000 )) AND (\"category\" IN ('books','electronics'))";
 
@@ -818,9 +818,9 @@ public class VerticaMetadataHandlerTest extends TestBase
         // Construct expected SQL with actual query ID
         String expectedExportSql = "EXPORT TO PARQUET(directory = 's3://testS3Bucket/" +
                 actualQueryID + "', Compression='snappy', fileSizeMB=16, rowGroupSizeMB=16) " +
-                "AS SELECT id,nullable_name,nullable_score,required_field " +
+                "AS SELECT \"id\",\"nullable_name\",\"nullable_score\",\"required_field\" " +
                 "FROM \"testSchema\".\"testTable1\" " +
-                "WHERE ((\"id\" > 0 )) AND ((nullable_name IS NULL) OR \"nullable_name\" = 'test' ) AND ((\"nullable_score\" >= 0  AND \"nullable_score\" < 100 )) AND (required_field IS NOT NULL)";
+                "WHERE ((\"id\" > 0 )) AND ((\"nullable_name\" IS NULL) OR \"nullable_name\" = 'test' ) AND ((\"nullable_score\" >= 0  AND \"nullable_score\" < 100 )) AND (\"required_field\" IS NOT NULL)";
 
         Assert.assertEquals(expectedExportSql, actualSql);
 
@@ -859,7 +859,7 @@ public class VerticaMetadataHandlerTest extends TestBase
         // Construct expected SQL with actual query ID
         String expectedExportSql = "EXPORT TO PARQUET(directory = 's3://testS3Bucket/" +
                 actualQueryID + "', Compression='snappy', fileSizeMB=16, rowGroupSizeMB=16) " +
-                "AS SELECT score,grade,age,department " +
+                "AS SELECT \"score\",\"grade\",\"age\",\"department\" " +
                 "FROM \"testSchema\".\"testTable1\" " +
                 "WHERE ((\"score\" > 85 )) AND ((\"grade\" <= 'B' )) AND ((\"age\" >= 18  AND \"age\" < 65 )) AND (\"department\" IN ('engineering','marketing','sales'))";
 
@@ -884,7 +884,7 @@ public class VerticaMetadataHandlerTest extends TestBase
         // Construct expected SQL with actual query ID (no WHERE clause for empty constraints)
         String expectedExportSql = "EXPORT TO PARQUET(directory = 's3://testS3Bucket/" +
                 actualQueryID + "', Compression='snappy', fileSizeMB=16, rowGroupSizeMB=16) " +
-                "AS SELECT field1,field2 " +
+                "AS SELECT \"field1\",\"field2\" " +
                 "FROM \"testSchema\".\"testTable1\"";
 
         Assert.assertEquals(expectedExportSql, actualSql);

--- a/athena-vertica/src/test/java/com/amazonaws/athena/connectors/vertica/query/PredicateBuilderTest.java
+++ b/athena-vertica/src/test/java/com/amazonaws/athena/connectors/vertica/query/PredicateBuilderTest.java
@@ -73,6 +73,27 @@ public class PredicateBuilderTest {
     public void quote_SimpleName_ReturnsQuotedString() {
         assertEquals("\"simpleName\"", PredicateBuilder.quote("simpleName"));
     }
+    
+    @Test
+    public void quote_NameContainsApostrophe_ReturnsDoubleQuotedIdentifier() {
+        assertEquals("\"O'Brien\"", PredicateBuilder.quote("O'Brien"));
+        assertEquals("\"host-keE37's-test\"", PredicateBuilder.quote("host-keE37's-test"));
+    }
+
+    @Test
+    public void quote_NameContainsDoubleQuote_DoublesDoubleQuote() {
+        assertEquals("\"a\"\"b\"", PredicateBuilder.quote("a\"b"));
+    }
+
+    @Test
+    public void quote_NameContainsMultipleDoubleQuotes_DoublesEach() {
+        assertEquals("\"a\"\"\"\"b\"", PredicateBuilder.quote("a\"\"b"));
+    }
+
+    @Test
+    public void quote_NameContainsApostropheAndDoubleQuote_EscapesOnlyDoubleQuotes() {
+        assertEquals("\"O'Brien\"\"nick\"", PredicateBuilder.quote("O'Brien\"nick"));
+    }
 
     @Test
     public void getFromClauseWithSplit_SchemaAndTable_ReturnsQualifiedTableName() {

--- a/athena-vertica/src/test/java/com/amazonaws/athena/connectors/vertica/query/PredicateBuilderTest.java
+++ b/athena-vertica/src/test/java/com/amazonaws/athena/connectors/vertica/query/PredicateBuilderTest.java
@@ -165,7 +165,7 @@ public class PredicateBuilderTest {
         Constraints constraints = createConstraints(ImmutableMap.of("col1", inValues(col1Int.getType(), true, 10, 20)));
         List<String> conjuncts = PredicateBuilder.toConjuncts(schema.getFields(), constraints, accumulator);
         assertEquals(1, conjuncts.size());
-        assertEquals("((col1 IS NULL) OR \"col1\" IN (<col1_0>,<col1_1>))", conjuncts.get(0));
+        assertEquals("((\"col1\" IS NULL) OR \"col1\" IN (<col1_0>,<col1_1>))", conjuncts.get(0));
         assertEquals(2, accumulator.size());
         assertEquals(10, accumulator.get("col1_0").getValue());
         assertEquals(20, accumulator.get("col1_1").getValue());
@@ -197,7 +197,7 @@ public class PredicateBuilderTest {
         Constraints constraints = createConstraints(ImmutableMap.of("col2", isNullOnly(col2Varchar.getType())));
         List<String> conjuncts = PredicateBuilder.toConjuncts(schema.getFields(), constraints, accumulator);
         assertEquals(1, conjuncts.size());
-        assertEquals("(col2 IS NULL)", conjuncts.get(0));
+        assertEquals("(\"col2\" IS NULL)", conjuncts.get(0));
         assertTrue(accumulator.isEmpty());
     }
 
@@ -206,7 +206,7 @@ public class PredicateBuilderTest {
         Constraints constraints = createConstraints(ImmutableMap.of("col3", isNotNullOnly(col3Double.getType())));
         List<String> conjuncts = PredicateBuilder.toConjuncts(schema.getFields(), constraints, accumulator);
         assertEquals(1, conjuncts.size());
-        assertEquals("(col3 IS NOT NULL)", conjuncts.get(0));
+        assertEquals("(\"col3\" IS NOT NULL)", conjuncts.get(0));
         assertTrue(accumulator.isEmpty());
     }
 

--- a/athena-vertica/src/test/java/com/amazonaws/athena/connectors/vertica/query/VerticaExportQueryBuilderTest.java
+++ b/athena-vertica/src/test/java/com/amazonaws/athena/connectors/vertica/query/VerticaExportQueryBuilderTest.java
@@ -87,7 +87,7 @@ public class VerticaExportQueryBuilderTest {
         mockSchema(new String[]{"id", "name"});
 
         builder.withColumns(resultSet, schema);
-        assertEquals("id,name", builder.getColNames());
+        assertEquals("\"id\",\"name\"", builder.getColNames());
     }
 
     @Test
@@ -96,7 +96,7 @@ public class VerticaExportQueryBuilderTest {
         mockSchema(new String[]{"id", "created_at"});
 
         builder.withColumns(resultSet, schema);
-        assertEquals("id,CAST(created_at AS VARCHAR) AS created_at", builder.getColNames());
+        assertEquals("\"id\",CAST(\"created_at\" AS VARCHAR) AS \"created_at\"", builder.getColNames());
     }
 
     @Test


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR enhances stringTemplate through the following improvements:

- **Identifiers (schema, table, column):**  
  All identifiers are now consistently wrapped in double quotes (`"schema"."table"`).

- **String literals (VARCHAR and similar):**  
  Filter values embedded in SQL have single quotes properly escaped.
  
Please find the attached functional test documentation.
  [VERTICA_FUNCTIONAL_TEST_2026-04-07.xlsx](https://github.com/user-attachments/files/26537402/VERTICA_FUNCTIONAL_TEST_2026-04-07.xlsx)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
