### PR TITLE
  StringTemplate enhancement  – Timestream Connector

### DIFF
--- a/athena-timestream/src/main/java/com/amazonaws/athena/connectors/timestream/query/DescribeTableQueryBuilder.java
+++ b/athena-timestream/src/main/java/com/amazonaws/athena/connectors/timestream/query/DescribeTableQueryBuilder.java
@@ -57,14 +57,14 @@ public class DescribeTableQueryBuilder
         return this;
     }
 
-    public String getDatabaseName()
+    public String getQuotedDatabaseName()
     {
-        return databaseName;
+        return PredicateBuilder.quoteColumn(databaseName);
     }
 
-    public String getTableName()
+    public String getQuotedTableName()
     {
-        return tableName;
+        return PredicateBuilder.quoteColumn(tableName);
     }
 
     public String build()

--- a/athena-timestream/src/main/java/com/amazonaws/athena/connectors/timestream/query/PredicateBuilder.java
+++ b/athena-timestream/src/main/java/com/amazonaws/athena/connectors/timestream/query/PredicateBuilder.java
@@ -78,16 +78,16 @@ public class PredicateBuilder
 
         if (valueSet instanceof SortedRangeSet) {
             if (valueSet.isNone() && valueSet.isNullAllowed()) {
-                return String.format("(%s IS NULL)", columnName);
+                return String.format("(%s IS NULL)", quoteColumn(columnName));
             }
 
             if (valueSet.isNullAllowed()) {
-                disjuncts.add(String.format("(%s IS NULL)", columnName));
+                disjuncts.add(String.format("(%s IS NULL)", quoteColumn(columnName)));
             }
 
             Range rangeSpan = ((SortedRangeSet) valueSet).getSpan();
             if (!valueSet.isNullAllowed() && rangeSpan.getLow().isLowerUnbounded() && rangeSpan.getHigh().isUpperUnbounded()) {
-                return String.format("(%s IS NOT NULL)", columnName);
+                return String.format("(%s IS NOT NULL)", quoteColumn(columnName));
             }
 
             for (Range range : valueSet.getRanges().getOrderedRanges()) {
@@ -157,19 +157,24 @@ public class PredicateBuilder
         return quoteColumn(columnName) + " " + operator + " " + quoteValue(value, type);
     }
 
-    private static String quoteColumn(String name)
+    static String quoteColumn(String name)
     {
-        return "\"" + name + "\"";
+        String escaped = name.replace("\"", "\"\"");
+        return "\"" + escaped + "\"";
+    }
+    
+    static String escapeSqlStringLiteral(String value)
+    {
+        return value.replace("'", "''");
     }
 
     private static String quoteValue(Object value, ArrowType type)
     {
-        //TODO: add escaping
         switch (Types.getMinorTypeForArrowType(type)) {
             case VARCHAR:
-                return "\'" + value + "\'";
+                return "'" + escapeSqlStringLiteral(String.valueOf(value)) + "'";
             case DATEMILLI:
-                return "\'" + ((LocalDateTime) value).format(TIMESTAMP_FORMATTER) + "\'";
+                return "'" + ((LocalDateTime) value).format(TIMESTAMP_FORMATTER) + "'";
             default:
                 return String.valueOf(value);
         }

--- a/athena-timestream/src/main/java/com/amazonaws/athena/connectors/timestream/query/SelectQueryBuilder.java
+++ b/athena-timestream/src/main/java/com/amazonaws/athena/connectors/timestream/query/SelectQueryBuilder.java
@@ -63,7 +63,9 @@ public class SelectQueryBuilder
 
     public SelectQueryBuilder withProjection(Schema schema)
     {
-        this.projection = schema.getFields().stream().map(next -> next.getName()).collect(Collectors.toList());
+        this.projection = schema.getFields().stream()
+                .map(field -> PredicateBuilder.quoteColumn(field.getName()))
+                .collect(Collectors.toList());
         this.viewText = schema.getCustomMetadata().get(viewTextPropertyName);
         return this;
     }
@@ -83,21 +85,21 @@ public class SelectQueryBuilder
         this.conjucts = PredicateBuilder.buildConjucts(constraints);
         return this;
     }
-
-    public String getTableName()
+    
+    public String getQuotedDatabaseName()
     {
-        return tableName;
+        return PredicateBuilder.quoteColumn(databaseName);
+    }
+    
+    public String getQuotedTableName()
+    {
+        return PredicateBuilder.quoteColumn(tableName);
     }
 
     public SelectQueryBuilder withTableName(String tableName)
     {
         this.tableName = tableName;
         return this;
-    }
-
-    public String getDatabaseName()
-    {
-        return databaseName;
     }
 
     public SelectQueryBuilder withDatabaseName(String databaseName)
@@ -108,7 +110,7 @@ public class SelectQueryBuilder
 
     public String build()
     {
-        Validate.notNull(databaseName, "tableName can not be null.");
+        Validate.notNull(databaseName, "databaseName can not be null.");
         Validate.notNull(tableName, "tableName can not be null.");
         Validate.notNull(projection, "projection can not be null.");
         Validate.notEmpty(projection, "projection can not be empty.");

--- a/athena-timestream/src/main/resources/Timestream.stg
+++ b/athena-timestream/src/main/resources/Timestream.stg
@@ -9,7 +9,7 @@ test_template() ::= <%
  *@return A query that be used to describe a TimeStream table.
  */
 describe_table(builder) ::= <%
-    DESCRIBE "<builder.databaseName>"."<builder.tableName>"
+    DESCRIBE <builder.quotedDatabaseName>.<builder.quotedTableName>
 %>
 
 select_query(builder) ::= <%
@@ -21,7 +21,7 @@ select_query(builder) ::= <%
         <first(builder.projection): {next_col | <next_col>}>
         <rest(builder.projection): {next_col | , <next_col>}><\ >
     <\n>FROM<\ ><\n>
-        <if(builder.viewText)>t1<else>"<builder.databaseName>"."<builder.tableName>"<endif><\ ><\n>
+        <if(builder.viewText)>t1<else><builder.quotedDatabaseName>.<builder.quotedTableName><endif><\ ><\n>
     <if(builder.conjucts)>
     WHERE<\ >
         <first(builder.conjucts): {next_conjuct | <next_conjuct>}>

--- a/athena-timestream/src/test/java/com/amazonaws/athena/connectors/timestream/TimestreamRecordHandlerTest.java
+++ b/athena-timestream/src/test/java/com/amazonaws/athena/connectors/timestream/TimestreamRecordHandlerTest.java
@@ -196,7 +196,7 @@ public class TimestreamRecordHandlerTest
             throws Exception
     {
         int numRowsGenerated = 1_000;
-        String expectedQuery = "SELECT measure_name, measure_value::double, az, time, hostname, region FROM \"my_schema\".\"my_table\" WHERE (\"az\" IN ('us-east-1a','us-east-1b'))";
+        String expectedQuery = "SELECT \"measure_name\", \"measure_value::double\", \"az\", \"time\", \"hostname\", \"region\" FROM \"my_schema\".\"my_table\" WHERE (\"az\" IN ('us-east-1a','us-east-1b'))";
 
         QueryResponse mockResult = makeMockQueryResult(schemaForRead, numRowsGenerated);
         when(mockClient.query(nullable(QueryRequest.class)))
@@ -251,7 +251,7 @@ public class TimestreamRecordHandlerTest
     public void doReadRecordsSpill()
             throws Exception
     {
-        String expectedQuery = "SELECT measure_name, measure_value::double, az, time, hostname, region FROM \"my_schema\".\"my_table\" WHERE (\"az\" IN ('us-east-1a','us-east-1b'))";
+        String expectedQuery = "SELECT \"measure_name\", \"measure_value::double\", \"az\", \"time\", \"hostname\", \"region\" FROM \"my_schema\".\"my_table\" WHERE (\"az\" IN ('us-east-1a','us-east-1b'))";
 
         QueryResponse mockResult = makeMockQueryResult(schemaForRead, 100_000);
         when(mockClient.query(nullable(QueryRequest.class)))
@@ -325,7 +325,7 @@ public class TimestreamRecordHandlerTest
                         DEFAULT_SCHEMA + "\".\"" + TEST_TABLE + "\" group by measure_name, az")
                 .build();
 
-        String expectedQuery = "WITH t1 AS ( select measure_name, az,sum(\"measure_value::double\") as value, count(*) as num_samples from \"my_schema\".\"my_table\" group by measure_name, az )  SELECT measure_name, az, value, num_samples FROM t1 WHERE (\"az\" IN ('us-east-1a','us-east-1b'))";
+        String expectedQuery = "WITH t1 AS ( select measure_name, az,sum(\"measure_value::double\") as value, count(*) as num_samples from \"my_schema\".\"my_table\" group by measure_name, az )  SELECT \"measure_name\", \"az\", \"value\", \"num_samples\" FROM t1 WHERE (\"az\" IN ('us-east-1a','us-east-1b'))";
 
         QueryResponse mockResult = makeMockQueryResult(schemaForReadView, 1_000);
         when(mockClient.query(nullable(QueryRequest.class)))
@@ -392,7 +392,7 @@ public class TimestreamRecordHandlerTest
                 .addMetadata(VIEW_METADATA_FIELD, "select az, hostname, region,  CREATE_TIME_SERIES(time, measure_value::double) as cpu_utilization from \"" + DEFAULT_SCHEMA + "\".\"" + TEST_TABLE + "\" WHERE measure_name = 'cpu_utilization' GROUP BY measure_name, az, hostname, region")
                 .build();
 
-        String expectedQuery = "WITH t1 AS ( select az, hostname, region,  CREATE_TIME_SERIES(time, measure_value::double) as cpu_utilization from \"my_schema\".\"my_table\" WHERE measure_name = 'cpu_utilization' GROUP BY measure_name, az, hostname, region )  SELECT region, az, hostname, cpu_utilization FROM t1 WHERE (\"az\" IN ('us-east-1a','us-east-1b'))";
+        String expectedQuery = "WITH t1 AS ( select az, hostname, region,  CREATE_TIME_SERIES(time, measure_value::double) as cpu_utilization from \"my_schema\".\"my_table\" WHERE measure_name = 'cpu_utilization' GROUP BY measure_name, az, hostname, region )  SELECT \"region\", \"az\", \"hostname\", \"cpu_utilization\" FROM t1 WHERE (\"az\" IN ('us-east-1a','us-east-1b'))";
 
         QueryResponse mockResult = makeMockQueryResult(schemaForReadView, 1_000);
         when(mockClient.query(nullable(QueryRequest.class)))
@@ -447,7 +447,7 @@ public class TimestreamRecordHandlerTest
     {
 
         int numRows = 10;
-        String expectedQuery = "SELECT measure_name, measure_value::double, az, time, hostname, region FROM \"my_schema\".\"my_table\" WHERE (\"az\" IN ('us-east-1a'))";
+        String expectedQuery = "SELECT \"measure_name\", \"measure_value::double\", \"az\", \"time\", \"hostname\", \"region\" FROM \"my_schema\".\"my_table\" WHERE (\"az\" IN ('us-east-1a'))";
 
         QueryResponse mockResult = makeMockQueryResult(schemaForRead, numRows, numRows, false);
         when(mockClient.query(nullable(QueryRequest.class)))

--- a/athena-timestream/src/test/java/com/amazonaws/athena/connectors/timestream/query/PredicateBuilderTest.java
+++ b/athena-timestream/src/test/java/com/amazonaws/athena/connectors/timestream/query/PredicateBuilderTest.java
@@ -1,0 +1,204 @@
+/*-
+ * #%L
+ * athena-timestream
+ * %%
+ * Copyright (C) 2019 - 2026 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.timestream.query;
+
+import com.amazonaws.athena.connector.lambda.data.BlockAllocator;
+import com.amazonaws.athena.connector.lambda.data.BlockAllocatorImpl;
+import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
+import com.amazonaws.athena.connector.lambda.domain.predicate.EquatableValueSet;
+import com.amazonaws.athena.connector.lambda.domain.predicate.Range;
+import com.amazonaws.athena.connector.lambda.domain.predicate.SortedRangeSet;
+import com.amazonaws.athena.connector.lambda.domain.predicate.ValueSet;
+import com.amazonaws.athena.connector.lambda.exceptions.AthenaConnectorException;
+import com.google.common.collect.ImmutableList;
+import org.apache.arrow.vector.types.Types;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class PredicateBuilderTest
+{
+    private BlockAllocator allocator;
+    
+    @Before
+    public void setUp()
+    {
+        allocator = new BlockAllocatorImpl();
+    }
+
+    @After
+    public void tearDown()
+    {
+        allocator.close();
+    }
+
+    @Test
+    public void quoteColumn_columnName_wrapsInDoubleQuotes()
+    {
+        assertEquals("\"measure_name\"", PredicateBuilder.quoteColumn("measure_name"));
+    }
+
+    @Test
+    public void quoteColumn_doubleQuoteInName_escapedByDoubling()
+    {
+        assertEquals("\"a\"\"b\"", PredicateBuilder.quoteColumn("a\"b"));
+    }
+    
+    @Test
+    public void escapeSqlStringLiteral_valueContainsApostrophe_doublesApostrophe()
+    {
+        assertEquals("O''Brien", PredicateBuilder.escapeSqlStringLiteral("O'Brien"));
+    }
+
+    @Test
+    public void buildConjucts_equatableVarcharWithApostrophe_escapesLiteralsInInClause()
+    {
+        List<String> conjuncts = PredicateBuilder.buildConjucts(constraints("region",
+                EquatableValueSet.newBuilder(allocator, Types.MinorType.VARCHAR.getType(), true, true)
+                        .add("us-east-1")
+                        .add("O'Brien")
+                        .build()));
+        assertEquals(1, conjuncts.size());
+        assertEquals("(\"region\" IN ('us-east-1','O''Brien'))", conjuncts.get(0));
+    }
+
+    @Test
+    public void buildConjucts_sortedRangeVarcharSingleValueWithApostrophe_escapesLiteralInEquality()
+    {
+        List<String> conjuncts = PredicateBuilder.buildConjucts(constraints("hostname",
+                SortedRangeSet.copyOf(Types.MinorType.VARCHAR.getType(),
+                        ImmutableList.of(Range.equal(allocator, Types.MinorType.VARCHAR.getType(), "host-keE37's-test")),
+                        false)));
+        assertEquals(1, conjuncts.size());
+        assertEquals("(\"hostname\" = 'host-keE37''s-test')", conjuncts.get(0));
+    }
+
+    @Test
+    public void buildConjucts_intGreaterThanRange_returnsComparisonConjunct()
+    {
+        List<String> conjuncts = PredicateBuilder.buildConjucts(constraints("col1",
+                SortedRangeSet.copyOf(Types.MinorType.INT.getType(),
+                        ImmutableList.of(Range.greaterThan(allocator, Types.MinorType.INT.getType(), 1)), false)));
+        assertEquals(1, conjuncts.size());
+        assertEquals("((\"col1\" > 1))", conjuncts.get(0));
+    }
+
+    @Test
+    public void buildConjucts_columnNameContainsDoubleQuote_outputsEscapedQuotedIdentifier()
+    {
+        String columnWithQuote = "evil\" OR 1=1 --";
+        List<String> conjuncts = PredicateBuilder.buildConjucts(constraints(columnWithQuote,
+                EquatableValueSet.newBuilder(allocator, Types.MinorType.VARCHAR.getType(), true, true)
+                        .add("x")
+                        .build()));
+        assertEquals(1, conjuncts.size());
+        assertTrue(conjuncts.get(0).contains("\"evil\"\" OR 1=1 --\""));
+        assertTrue(conjuncts.get(0).contains("'x'"));
+    }
+
+    @Test
+    public void buildConjucts_dateMilliGreaterThanRange_formatsTimestampWithNanosecondPrecision()
+    {
+        LocalDateTime ts = LocalDateTime.of(2024, 4, 5, 9, 31, 12, 142000000);
+        List<String> conjuncts = PredicateBuilder.buildConjucts(constraints("time0",
+                SortedRangeSet.copyOf(Types.MinorType.DATEMILLI.getType(),
+                        ImmutableList.of(Range.greaterThan(allocator, Types.MinorType.DATEMILLI.getType(), ts)), false)));
+        assertEquals(1, conjuncts.size());
+        assertEquals("((\"time0\" > '2024-04-05 09:31:12.142000000'))", conjuncts.get(0));
+    }
+
+    @Test
+    public void buildConjucts_onlyNullSortedRangeSet_returnsIsNullPredicate()
+    {
+        List<String> conjuncts = PredicateBuilder.buildConjucts(constraints("col",
+                SortedRangeSet.onlyNull(Types.MinorType.INT.getType())));
+        assertEquals(1, conjuncts.size());
+        assertEquals("(\"col\" IS NULL)", conjuncts.get(0));
+    }
+
+    @Test
+    public void buildConjucts_notNullSortedRangeSet_returnsIsNotNullPredicate()
+    {
+        List<String> conjuncts = PredicateBuilder.buildConjucts(constraints("col",
+                SortedRangeSet.notNull(allocator, Types.MinorType.INT.getType())));
+        assertEquals(1, conjuncts.size());
+        assertEquals("(\"col\" IS NOT NULL)", conjuncts.get(0));
+    }
+
+    @Test
+    public void buildConjucts_nullAllowedWithIntGreaterThan_returnsIsNullOrComparisonPredicate()
+    {
+        List<String> conjuncts = PredicateBuilder.buildConjucts(constraints("col",
+                SortedRangeSet.copyOf(Types.MinorType.INT.getType(),
+                        ImmutableList.of(Range.greaterThan(allocator, Types.MinorType.INT.getType(), 1)), true)));
+        assertEquals(1, conjuncts.size());
+        assertEquals("((\"col\" IS NULL) OR (\"col\" > 1))", conjuncts.get(0));
+    }
+
+    @Test
+    public void buildConjucts_emptySummary_returnsEmptyConjunctList()
+    {
+        assertTrue(PredicateBuilder.buildConjucts(constraints(Collections.emptyMap())).isEmpty());
+    }
+    
+    @Test(expected = AthenaConnectorException.class)
+    public void buildConjucts_sortedRangeSetNoneWithoutNull_throwsAthenaConnectorException()
+    {
+        PredicateBuilder.buildConjucts(constraints("col",
+                SortedRangeSet.none(Types.MinorType.INT.getType())));
+    }
+
+    @Test
+    public void buildConjucts_equatableValueSetEmpty_returnsInClauseWithNoLiterals()
+    {
+        EquatableValueSet empty = EquatableValueSet.newBuilder(allocator, Types.MinorType.VARCHAR.getType(), true, true)
+                .build();
+        List<String> conjuncts = PredicateBuilder.buildConjucts(constraints("c", empty));
+        assertEquals(1, conjuncts.size());
+        assertEquals("(\"c\" IN ())", conjuncts.get(0));
+    }
+
+    private static Constraints constraints(Map<String, ValueSet> summary)
+    {
+        return new Constraints(
+                summary,
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Constraints.DEFAULT_NO_LIMIT,
+                Collections.emptyMap(),
+                null);
+    }
+    
+    private static Constraints constraints(String column, ValueSet valueSet)
+    {
+        Map<String, ValueSet> summary = new LinkedHashMap<>();
+        summary.put(column, valueSet);
+        return constraints(summary);
+    }
+}

--- a/athena-timestream/src/test/java/com/amazonaws/athena/connectors/timestream/query/SelectQueryBuilderTest.java
+++ b/athena-timestream/src/test/java/com/amazonaws/athena/connectors/timestream/query/SelectQueryBuilderTest.java
@@ -66,7 +66,7 @@ public class SelectQueryBuilderTest
     {
         logger.info("build: enter");
 
-        String expected = "SELECT col1, col2, col3, col4 FROM \"myDatabase\".\"myTable\" WHERE (\"col4\" IN ('val1','val2')) AND ((\"col2\" < 1)) AND (\"col3\" IN (20000,10000)) AND ((\"col1\" > 1))";
+        String expected = "SELECT \"col1\", \"col2\", \"col3\", \"col4\" FROM \"myDatabase\".\"myTable\" WHERE (\"col4\" IN ('val1','val2')) AND ((\"col2\" < 1)) AND (\"col3\" IN (20000,10000)) AND ((\"col1\" > 1))";
 
         Map<String, ValueSet> constraintsMap = new HashMap<>();
         constraintsMap.put("col1", SortedRangeSet.copyOf(Types.MinorType.INT.getType(),
@@ -107,7 +107,7 @@ public class SelectQueryBuilderTest
     public void buildWithTime() {
         logger.info("build: enter");
 
-        String expected = "SELECT val FROM \"myDatabase\".\"myTable\" WHERE ((\"time1\" > '2024-04-05 09:31:12.000000000')) AND ((\"time0\" > '2024-04-05 09:31:12.142000000'))";
+        String expected = "SELECT \"val\" FROM \"myDatabase\".\"myTable\" WHERE ((\"time1\" > '2024-04-05 09:31:12.000000000')) AND ((\"time0\" > '2024-04-05 09:31:12.142000000'))";
 
         Map<String, ValueSet> constraintsMap = new HashMap<>();
         constraintsMap.put("time0", SortedRangeSet.copyOf(Types.MinorType.DATEMILLI.getType(),
@@ -139,7 +139,7 @@ public class SelectQueryBuilderTest
     {
         logger.info("build: buildWithView");
 
-        String expected = "WITH t1 AS ( SELECT col1 from test_table )  SELECT col1, col2, col3, col4 FROM t1 WHERE ((\"col2\" < 1)) AND ((\"col1\" > 1))";
+        String expected = "WITH t1 AS ( SELECT col1 from test_table )  SELECT \"col1\", \"col2\", \"col3\", \"col4\" FROM t1 WHERE ((\"col2\" < 1)) AND ((\"col1\" > 1))";
 
         Schema schema = SchemaBuilder.newBuilder()
                 //types shouldn't matter


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR enhances stringTemplate through the following improvements:
 
• **Identifiers (database, table, column)**: Wrapped in double quotes (e.g. "db"."table", "column").
• **String literals (VARCHAR)**: Filter values embedded in SQL have single quotes escaped .

Please find the attached functional test documentation.
[TIMESTREAM_FUNCTIONAL_TEST_2026-04-09.xlsx](https://github.com/user-attachments/files/26600089/TIMESTREAM_FUNCTIONAL_TEST_2026-04-09.xlsx)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
