### PR TITLE
Dependabot snowflake build issue fix

### DIFF
--- a/athena-snowflake/pom.xml
+++ b/athena-snowflake/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>net.snowflake</groupId>
             <artifactId>snowflake-jdbc</artifactId>
-            <version>3.28.0</version>
+            <version>4.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>

--- a/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeConstants.java
+++ b/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeConstants.java
@@ -30,7 +30,7 @@ public final class SnowflakeConstants
      * JDBC related config
      */
     public static final String SNOWFLAKE_NAME = "snowflake";
-    public static final String SNOWFLAKE_DRIVER_CLASS = "com.snowflake.client.jdbc.SnowflakeDriver";
+    public static final String SNOWFLAKE_DRIVER_CLASS = "net.snowflake.client.api.driver.SnowflakeDriver";
     public static final int SNOWFLAKE_DEFAULT_PORT = 1025;
     public static final Map<String, String> JDBC_PROPERTIES = ImmutableMap.of("databaseTerm", "SCHEMA", "CLIENT_RESULT_COLUMN_CASE_INSENSITIVE", "true");
     /**

--- a/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMetadataHandler.java
+++ b/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMetadataHandler.java
@@ -62,7 +62,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import net.snowflake.client.jdbc.SnowflakeSQLException;
+import net.snowflake.client.api.exception.SnowflakeSQLException;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.ArrowType;

--- a/athena-snowflake/src/test/java/com/amazonaws/athena/connectors/snowflake/connection/SnowflakeConnectionFactoryTest.java
+++ b/athena-snowflake/src/test/java/com/amazonaws/athena/connectors/snowflake/connection/SnowflakeConnectionFactoryTest.java
@@ -74,7 +74,7 @@ public class SnowflakeConnectionFactoryTest
         properties.put("test.property", "test.value");
 
         when(mockDatabaseConnectionConfig.getJdbcConnectionString()).thenReturn("jdbc:snowflake://test.snowflakecomputing.com");
-        when(mockDatabaseConnectionInfo.getDriverClassName()).thenReturn("com.snowflake.client.jdbc.SnowflakeDriver");
+        when(mockDatabaseConnectionInfo.getDriverClassName()).thenReturn("net.snowflake.client.api.driver.SnowflakeDriver");
 
         connectionFactory = new SnowflakeConnectionFactory(mockDatabaseConnectionConfig, properties, mockDatabaseConnectionInfo);
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

**https://github.com/awslabs/aws-athena-query-federation/pull/3379** proposes upgrading net.snowflake:snowflake-jdbc from 3.28.0 to 4.1.0 in athena-snowflake/pom.xml.
However, the athena-snowflake module does not compile against Snowflake JDBC 4.x without additional changes. Snowflake’s JDBC 4.x public API moved several types that this connector still referenced from their 3.x package locations.
Without updating the code:

Compilation fails due to missing classes such as SnowflakeSQLException under net.snowflake.client.jdbc.
At runtime, HikariCP risks throwing ClassNotFoundException if the JDBC driver class name continues to reference the old 3.x driver class.
Please find the attached functional test documentation.
[SNOWFLAKE_FUNCTIONAL_TEST_2026-04-17.xlsx](https://github.com/user-attachments/files/26834485/SNOWFLAKE_FUNCTIONAL_TEST_2026-04-17.xlsx)


Please refer this snowflake Doc for above changes : https://docs.snowflake.com/en/developer-guide/jdbc/jdbc-migration


This pull request updates the code to align with the Snowflake JDBC 4.x API, ensuring successful compilation and correct runtime behavior.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
