### PR TITLE
Fix Codecov not updating on master.

### DIFF
--- a/.github/workflows/maven_push.yml
+++ b/.github/workflows/maven_push.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           cancel_others: 'true'
           concurrent_skipping: 'same_content_newer'
-          do_not_skip: '["workflow_dispatch", "schedule", "merge_group", "pull_request"]'
+          do_not_skip: '["workflow_dispatch", "schedule", "merge_group", "pull_request", "push"]'
 
   build:
     needs: pre_job
@@ -28,6 +28,8 @@ jobs:
         java-version: ['11', '17']
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v5
         with:


### PR DESCRIPTION
*Issue #, if available:*
Codecov was not reflecting the latest commits on the master branch because the GitHub Actions push workflow for merge commits was frequently skipped.

*Description of changes:*
- Added `"push"` to `do_not_skip` in `.github/workflows/maven_push.yml` so pushes to the default branch (including merge commits) are not skipped by `fkirc/skip-duplicate-actions`. This ensures the build job (including Codecov upload) runs for merge commits and updates Codecov’s master view.  

- Set `fetch-depth: 0` on `actions/checkout` so the job has full git history. This helps Codecov correctly resolve commits (including merge commits).  
  Reference: [Codecov docs — Environment specific requirements](https://docs.codecov.com/docs/environment-specific-requirements)  

PFA analysis document for reference.
[codecov_commit_issue.docx](https://github.com/user-attachments/files/27008880/codecov_commit_issue.docx)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
