### PR TITLE
fixed cryptography version conflict issue

### DIFF
--- a/athena_federation_testing/requirements.txt
+++ b/athena_federation_testing/requirements.txt
@@ -5,7 +5,7 @@ boto3==1.38.1
 botocore==1.38.1
 cachetools==5.5.2
 certifi==2025.1.31
-cffi==1.17.1
+cffi==2.0.0
 charset-normalizer==3.4.1
 cryptography==46.0.6
 Events==0.5
@@ -50,8 +50,8 @@ s3transfer==0.12.0
 scramp==1.4.6
 setuptools==80.9.0
 six==1.17.0
-snowflake-connector-python==3.14.1
-snowflake-sqlalchemy==1.7.3
+snowflake-connector-python==4.4.0
+snowflake-sqlalchemy==1.9.0
 sortedcontainers==2.4.0
 soupsieve==2.7
 SQLAlchemy==1.4.54


### PR DESCRIPTION
*Issue #, if available:

*Description of changes:*
During validation of PR #3346, running pip install -r requirements.txt failed due to a dependency conflict:

cryptography 46.0.6 requires cffi >= 2.0.0
snowflake-connector-python 3.14.1 requires cffi >= 1.9, < 2.0

To resolve this conflict, the following dependency upgrades were applied:
cffi upgarded to 2.0.0
snowflake-connector-python upgraded to 4.4.0
snowflake-sqlalchemy upgraded to 1.9.0

After these updates, pip install -r requirements.txt executed successfully.
The Snowflake and Postgresql  Resource were also validated using:
python testing_main.py --action test_glue  --resources snowflake --output_file_prefix Results_glue
python testing_main.py --action test_athena  --resources snowflake --output_file_prefix Results_athena
python testing_main.py --action test_athena --resources postgresql--output_file_prefix Results_athena
python testing_main.py --action test_glue --resources postgresql--output_file_prefix Results_glue

Please find the Results: 
[Results_glue_postgresql.xlsx](https://github.com/user-attachments/files/26972509/Results_glue_postgresql.xlsx)
[Results_glue_snowflake.xlsx](https://github.com/user-attachments/files/26972511/Results_glue_snowflake.xlsx)
[Results_athena_snowflake.xlsx](https://github.com/user-attachments/files/26972512/Results_athena_snowflake.xlsx)
[Results_athena_postgresql.xlsx](https://github.com/user-attachments/files/26972513/Results_athena_postgresql.xlsx)

Please find the validation Document: 
[Dependabot PRs Validation for Athena Federation Testing.docx](https://github.com/user-attachments/files/26973149/Dependabot.PRs.Validation.for.Athena.Federation.Testing.docx)





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
