### PR TITLE
Remove Transitive Dependency kotlin-stdlib-common from athena-msk.

### DIFF
--- a/athena-msk/pom.xml
+++ b/athena-msk/pom.xml
@@ -29,11 +29,6 @@
             </dependency>
             <dependency>
                 <groupId>org.jetbrains.kotlin</groupId>
-                <artifactId>kotlin-stdlib-common</artifactId>
-                <version>2.0.21</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-stdlib-jdk8</artifactId>
                 <version>2.4.0</version>
             </dependency>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Dependabot PR [#3422 ](https://github.com/awslabs/aws-athena-query-federation/pull/3422)proposes upgrading kotlin-stdlib-common from 2.0.21 to 2.3.21 in athena-msk/pom.xml. However, the build fails because the JAR is unavailable on Maven Central from version 2.1.x onwards.

Since kotlin-stdlib-common is a transitive dependency pulled in via schema-registry-serde , we have removed this dependency with no functional impact.
PFA functional testing documentation for reference.
[MSK_FUNCTIONAL_TEST_2026-05-18.xlsx](https://github.com/user-attachments/files/27957282/MSK_FUNCTIONAL_TEST_2026-05-18.xlsx)




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
