### PR TITLE
Add Backtick Quote Identifier for Impala Connector

### DIFF
--- a/athena-cloudera-impala/src/main/java/com/amazonaws/athena/connectors/cloudera/ImpalaConstants.java
+++ b/athena-cloudera-impala/src/main/java/com/amazonaws/athena/connectors/cloudera/ImpalaConstants.java
@@ -34,7 +34,7 @@ public class ImpalaConstants
     static final String ALL_PARTITIONS = "*";
     static final int MAX_SPLITS_PER_REQUEST = 1000_000;
     static final String COLUMN_NAME = "COLUMN_NAME";
-    static final String IMPALA_QUOTE_CHARACTER = "";
+    static final String IMPALA_QUOTE_CHARACTER = "`";
     static final int FETCH_SIZE = 1000;
 
     public static final String IMPALA_NAME = "impala";

--- a/athena-cloudera-impala/src/main/java/com/amazonaws/athena/connectors/cloudera/ImpalaMetadataHandler.java
+++ b/athena-cloudera-impala/src/main/java/com/amazonaws/athena/connectors/cloudera/ImpalaMetadataHandler.java
@@ -62,7 +62,6 @@ import software.amazon.awssdk.services.athena.AthenaClient;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 
 import java.sql.Connection;
-import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -152,13 +151,13 @@ public class ImpalaMetadataHandler extends JdbcMetadataHandler
     {
         LOGGER.info("{}: Schema {}, table {}", getTableLayoutRequest.getQueryId(), getTableLayoutRequest.getTableName().getSchemaName(),
                 getTableLayoutRequest.getTableName().getTableName());
+        String qualifiedTable = ImpalaUtils.qualifiedTableForMetadataSql(getTableLayoutRequest.getTableName());
         try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider());
-             Statement stmt = connection.createStatement();
-             PreparedStatement psmt = connection.prepareStatement(GET_METADATA_QUERY + getTableLayoutRequest.getTableName().getQualifiedTableName().toUpperCase())) {
-            Map<String, String> columnHashMap = getMetadataForGivenTable(psmt);
+             Statement stmt = connection.createStatement()) {
+            Map<String, String> columnHashMap = getMetadataForGivenTable(stmt, GET_METADATA_QUERY + qualifiedTable);
             String tableType = columnHashMap.get("TableType");
             if (tableType == null) {
-                ResultSet partitionRs = stmt.executeQuery("show files in " + getTableLayoutRequest.getTableName().getQualifiedTableName().toUpperCase());
+                ResultSet partitionRs = stmt.executeQuery("show files in " + qualifiedTable);
                 Set<String> partition = new HashSet<>();
                 while (partitionRs != null && partitionRs.next()) {
                     String partitionString = partitionRs.getString("Partition");
@@ -295,9 +294,9 @@ public class ImpalaMetadataHandler extends JdbcMetadataHandler
         SchemaBuilder schemaBuilder = SchemaBuilder.newBuilder();
         try (ResultSet resultSet = getColumns(jdbcConnection.getCatalog(), tableName, jdbcConnection.getMetaData());
              Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider())) {
-            try (PreparedStatement psmt = connection.prepareStatement(
-                GET_METADATA_QUERY + tableName.getQualifiedTableName().toUpperCase())) {
-                Map<String, String> hashMap = getMetadataForGivenTable(psmt);
+            try (Statement stmt = connection.createStatement()) {
+                Map<String, String> hashMap = getMetadataForGivenTable(stmt,
+                        GET_METADATA_QUERY + ImpalaUtils.qualifiedTableForMetadataSql(tableName));
                 while (resultSet.next()) {
                     Optional<ArrowType> columnType = JdbcArrowTypeConverter.toArrowType(resultSet.getInt("DATA_TYPE"),
                             resultSet.getInt("COLUMN_SIZE"), resultSet.getInt("DECIMAL_DIGITS"), configOptions);
@@ -362,14 +361,15 @@ public class ImpalaMetadataHandler extends JdbcMetadataHandler
 
     /**
      *  used to get column names and associated data types for column names.
-     * @param statement A PreparedStatement holds query to get metadata for a table.
+     * @param statement JDBC statement used to run the metadata query
+     * @param sql fully formed SQL with quoted table identifiers (not JDBC {@code ?} parameters)
      * @return Map of column name and associated data type for column.
      * @throws SQLException A SQLException should be thrown for database connection failures , query syntax errors and so on.
      */
-    private Map<String, String> getMetadataForGivenTable(PreparedStatement statement) throws SQLException
+    private Map<String, String> getMetadataForGivenTable(Statement statement, String sql) throws SQLException
     {
         Map<String, String> columnHashMap = new HashMap<>();
-        try (ResultSet rs = statement.executeQuery()) {
+        try (ResultSet rs = statement.executeQuery(sql)) {
             while (rs.next()) {
                 String dataType = rs.getString(ImpalaConstants.METADATA_COLUMN_TYPE);
                 if (dataType != null && !dataType.isEmpty() && dataType.toUpperCase().contains("VIEW")) {

--- a/athena-cloudera-impala/src/main/java/com/amazonaws/athena/connectors/cloudera/ImpalaQueryStringBuilder.java
+++ b/athena-cloudera-impala/src/main/java/com/amazonaws/athena/connectors/cloudera/ImpalaQueryStringBuilder.java
@@ -39,12 +39,12 @@ public class ImpalaQueryStringBuilder extends JdbcSplitQueryBuilder
     {
         StringBuilder tableName = new StringBuilder();
         if (!Strings.isNullOrEmpty(catalog)) {
-            tableName.append(catalog).append('.');
+            tableName.append(ImpalaUtils.quoteIdentifier(catalog)).append('.');
         }
         if (!Strings.isNullOrEmpty(schema)) {
-            tableName.append(schema).append('.');
+            tableName.append(ImpalaUtils.quoteIdentifier(schema)).append('.');
         }
-        tableName.append(table);
+        tableName.append(ImpalaUtils.quoteIdentifier(table));
         return String.format(" FROM %s ", tableName);
     }
 

--- a/athena-cloudera-impala/src/main/java/com/amazonaws/athena/connectors/cloudera/ImpalaUtils.java
+++ b/athena-cloudera-impala/src/main/java/com/amazonaws/athena/connectors/cloudera/ImpalaUtils.java
@@ -1,0 +1,54 @@
+/*-
+ * #%L
+ * athena-cloudera-impala
+ * %%
+ * Copyright (C) 2019 - 2026 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.cloudera;
+
+import com.amazonaws.athena.connector.lambda.domain.TableName;
+
+import static com.amazonaws.athena.connectors.cloudera.ImpalaConstants.IMPALA_QUOTE_CHARACTER;
+
+/**
+ * Builds Impala-safe quoted identifiers for dynamic SQL. JDBC {@code ?} placeholders apply to values,
+ * not table references, so identifiers must be quoted and escaped explicitly.
+ */
+public class ImpalaUtils
+{
+    private ImpalaUtils()
+    {
+    }
+
+    /**
+     * Wraps a single identifier in backticks; doubles any embedded backticks.
+     */
+    public static String quoteIdentifier(String identifier)
+    {
+        String escaped = identifier.replace(IMPALA_QUOTE_CHARACTER, IMPALA_QUOTE_CHARACTER + IMPALA_QUOTE_CHARACTER);
+        return IMPALA_QUOTE_CHARACTER + escaped + IMPALA_QUOTE_CHARACTER;
+    }
+
+    /**
+     * {@code schema.table} for metadata statements, upper-casing each segment then quoting so names
+     * cannot break out of identifier context.
+     */
+    public static String qualifiedTableForMetadataSql(TableName tableName)
+    {
+        return quoteIdentifier(tableName.getSchemaName().toUpperCase())
+                + "." + quoteIdentifier(tableName.getTableName().toUpperCase());
+    }
+}

--- a/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaMetadataHandlerTest.java
+++ b/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaMetadataHandlerTest.java
@@ -62,7 +62,6 @@ import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueReques
 import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
 
 import java.sql.Connection;
-import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -139,7 +138,7 @@ public class ImpalaMetadataHandlerTest
     }
 
     @Test
-    public void getPartitionSchema()
+    public void getPartitionSchema_whenCatalogNameProvided_returnsPartitionFieldWithVarcharType()
     {
         assertEquals(SchemaBuilder.newBuilder()
                         .addField(TEST_PARTITION, org.apache.arrow.vector.types.Types.MinorType.VARCHAR.getType()).build(),
@@ -147,7 +146,7 @@ public class ImpalaMetadataHandlerTest
     }
 
     @Test
-    public void doGetTableLayout()
+    public void doGetTableLayout_whenShowFilesReturnsPartitions_returnsTwoPartitionRowsWithValues()
             throws Exception
     {
         String[] schema = {"type", "name"};
@@ -166,13 +165,13 @@ public class ImpalaMetadataHandlerTest
         String[] columns2 = {"Partition"};
         int[] types2 = {Types.VARCHAR};
         Object[][] values1 = {{value3}, {value2}};
-        PreparedStatement preparestatement1 = Mockito.mock(PreparedStatement.class);
-        Mockito.when(this.connection.prepareStatement(ImpalaMetadataHandler.GET_METADATA_QUERY + tempTableName.getQualifiedTableName().toUpperCase())).thenReturn(preparestatement1);
-        final String getPartitionDetailsSql = "show files in "  + getTableLayoutRequest.getTableName().getQualifiedTableName().toUpperCase();
+        final String qualifiedTable = ImpalaUtils.qualifiedTableForMetadataSql(tempTableName);
+        final String describeSql = ImpalaMetadataHandler.GET_METADATA_QUERY + qualifiedTable;
+        final String getPartitionDetailsSql = "show files in " + qualifiedTable;
         Statement statement1 = Mockito.mock(Statement.class);
         Mockito.when(this.connection.createStatement()).thenReturn(statement1);
         ResultSet resultSet1 = mockResultSet(columns2, types2, values1, new AtomicInteger(-1));
-        Mockito.when(preparestatement1.executeQuery()).thenReturn(resultSet);
+        Mockito.when(statement1.executeQuery(describeSql)).thenReturn(resultSet);
         Mockito.when(statement1.executeQuery(getPartitionDetailsSql)).thenReturn(resultSet1);
         GetTableLayoutResponse getTableLayoutResponse = this.impalaMetadataHandler.doGetTableLayout(blockAllocator, getTableLayoutRequest);
         List<String> expectedValues = new ArrayList<>();
@@ -190,7 +189,7 @@ public class ImpalaMetadataHandlerTest
     }
 
    @Test
-    public void doGetTableLayoutWithNoPartitions()
+    public void doGetTableLayout_whenShowFilesReturnsEmpty_returnsAllPartitions()
             throws Exception
    {
        String[] schema = {"type", "name"};
@@ -208,14 +207,13 @@ public class ImpalaMetadataHandlerTest
        int[] types2 = {Types.VARCHAR};
        Object[][] values1 = {};
        Mockito.when(jdbcConnectionFactory.getConnection(nullable(CredentialsProvider.class))).thenReturn(connection);
-       String tableName = getTableLayoutRequest.getTableName().getQualifiedTableName().toUpperCase();
-       PreparedStatement preparestatement1 = Mockito.mock(PreparedStatement.class);
-       Mockito.when(this.connection.prepareStatement(ImpalaMetadataHandler.GET_METADATA_QUERY + tableName)).thenReturn(preparestatement1);
-       final String getPartitionDetailsSql = "show files in "  + getTableLayoutRequest.getTableName().getQualifiedTableName().toUpperCase();
+       final String qualifiedTable = ImpalaUtils.qualifiedTableForMetadataSql(getTableLayoutRequest.getTableName());
+       final String describeSql = ImpalaMetadataHandler.GET_METADATA_QUERY + qualifiedTable;
+       final String getPartitionDetailsSql = "show files in " + qualifiedTable;
        Statement statement1 = Mockito.mock(Statement.class);
        Mockito.when(this.connection.createStatement()).thenReturn(statement1);
        ResultSet resultSet1 = mockResultSet(columns2, types2, values1, new AtomicInteger(-1));
-       Mockito.when(preparestatement1.executeQuery()).thenReturn(resultSet);
+       Mockito.when(statement1.executeQuery(describeSql)).thenReturn(resultSet);
        Mockito.when(statement1.executeQuery(getPartitionDetailsSql)).thenReturn(resultSet1);
        GetTableLayoutResponse getTableLayoutResponse = this.impalaMetadataHandler.doGetTableLayout(blockAllocator, getTableLayoutRequest);
        List<String> expectedValues = new ArrayList<>();
@@ -231,7 +229,7 @@ public class ImpalaMetadataHandlerTest
     }
 
     @Test(expected = RuntimeException.class)
-    public void doGetTableLayoutWithSQLException()
+    public void doGetTableLayout_whenSQLException_throwsRuntimeException()
             throws Exception
     {
         Constraints constraints = Mockito.mock(Constraints.class);
@@ -248,7 +246,7 @@ public class ImpalaMetadataHandlerTest
     }
 
     @Test
-    public void doGetSplits()
+    public void doGetSplits_whenLayoutHasTwoPartitions_returnsTwoSplits()
             throws Exception
     {
         String[] schema = {"type", "name"};
@@ -268,14 +266,13 @@ public class ImpalaMetadataHandlerTest
         int[] types2 = {Types.VARCHAR};
         Object[][] values1 = {{value2}, {value3}};
         Mockito.when(jdbcConnectionFactory.getConnection(nullable(CredentialsProvider.class))).thenReturn(connection);
-        String tableName = getTableLayoutRequest.getTableName().getQualifiedTableName().toUpperCase();
-        PreparedStatement preparestatement1 = Mockito.mock(PreparedStatement.class);
-        Mockito.when(this.connection.prepareStatement(ImpalaMetadataHandler.GET_METADATA_QUERY + tableName)).thenReturn(preparestatement1);
-        final String getPartitionDetailsSql = "show files in "  + getTableLayoutRequest.getTableName().getQualifiedTableName().toUpperCase();
+        final String qualifiedTable = ImpalaUtils.qualifiedTableForMetadataSql(getTableLayoutRequest.getTableName());
+        final String describeSql = ImpalaMetadataHandler.GET_METADATA_QUERY + qualifiedTable;
+        final String getPartitionDetailsSql = "show files in " + qualifiedTable;
         Statement statement1 = Mockito.mock(Statement.class);
         Mockito.when(this.connection.createStatement()).thenReturn(statement1);
         ResultSet resultSet1 = mockResultSet(columns2, types2, values1, new AtomicInteger(-1));
-        Mockito.when(preparestatement1.executeQuery()).thenReturn(resultSet);
+        Mockito.when(statement1.executeQuery(describeSql)).thenReturn(resultSet);
         Mockito.when(statement1.executeQuery(getPartitionDetailsSql)).thenReturn(resultSet1);
         GetTableLayoutResponse getTableLayoutResponse = this.impalaMetadataHandler.doGetTableLayout(blockAllocator, getTableLayoutRequest);
         GetSplitsRequest getSplitsRequest = new GetSplitsRequest(this.federatedIdentity, TEST_QUERY_ID, TEST_CATALOG, tempTableName, getTableLayoutResponse.getPartitions(), new ArrayList<>(partitionCols), constraints, null);
@@ -284,7 +281,7 @@ public class ImpalaMetadataHandlerTest
     }
 
     @Test
-    public void testDoGetSplits_withQueryPassthrough()
+    public void doGetSplits_whenQueryPassthroughEnabled_returnsOneSplitAndCatalogName()
     {
         // Setup test data
         TableName tableName = new TableName(TEST_SCHEMA, TEST_TABLE);
@@ -326,7 +323,7 @@ public class ImpalaMetadataHandlerTest
     }
 
     @Test
-    public void testDoGetSplits_withContinuationToken()
+    public void doGetSplits_whenContinuationTokenZero_returnsTwoSplitsWithPartitionValues()
     {
         // Setup test data
         TableName tableName = new TableName(TEST_SCHEMA, TEST_TABLE);
@@ -372,7 +369,7 @@ public class ImpalaMetadataHandlerTest
     }
 
     @Test
-    public void decodeContinuationToken() throws Exception
+    public void decodeContinuationToken_whenTokenIsOne_returnsNonNullTokenValue() throws Exception
     {
         TableName tableName = new TableName(TEST_SCHEMA, TEST_TABLE);
         Constraints constraints = Mockito.mock(Constraints.class);
@@ -397,7 +394,7 @@ public class ImpalaMetadataHandlerTest
     }
 
     @Test
-    public void doGetTable() throws Exception
+    public void doGetTable_whenDescribeReturnsColumns_returnsTableWithArrowColumnTypes() throws Exception
     {
         String[] metadataSchema = {"type", "name"};
         Object[][] metadataValues = {
@@ -431,11 +428,11 @@ public class ImpalaMetadataHandlerTest
 
         // Mocking connection and metadata behavior
         TableName inputTableName = new TableName(TEST_SCHEMA, TEST_TABLE);
-        PreparedStatement preparedStatement = Mockito.mock(PreparedStatement.class);
-        Mockito.when(this.connection.prepareStatement(
-                ImpalaMetadataHandler.GET_METADATA_QUERY + inputTableName.getQualifiedTableName().toUpperCase()
-        )).thenReturn(preparedStatement);
-        Mockito.when(preparedStatement.executeQuery()).thenReturn(metadataResultSet);
+        final String describeSql = ImpalaMetadataHandler.GET_METADATA_QUERY
+                + ImpalaUtils.qualifiedTableForMetadataSql(inputTableName);
+        Statement metadataStatement = Mockito.mock(Statement.class);
+        Mockito.when(this.connection.createStatement()).thenReturn(metadataStatement);
+        Mockito.when(metadataStatement.executeQuery(describeSql)).thenReturn(metadataResultSet);
 
         Mockito.when(this.connection.getMetaData().getSearchStringEscape()).thenReturn(null);
         Mockito.when(this.connection.getMetaData().getColumns(
@@ -463,14 +460,14 @@ public class ImpalaMetadataHandlerTest
     }
 
     @Test
-    public void doGetTableNoColumns() throws Exception
+    public void doGetTable_whenNoColumnMetadataMocked_returnsTableWithEmptySchema() throws Exception
     {
         TableName inputTableName = new TableName(TEST_SCHEMA, TEST_TABLE);
         this.impalaMetadataHandler.doGetTable(this.blockAllocator, new GetTableRequest(this.federatedIdentity, TEST_QUERY_ID, TEST_CATALOG, inputTableName, Collections.emptyMap()));
     }
 
     @Test(expected = SQLException.class)
-    public void doGetTableSQLException()
+    public void doGetTable_whenSQLException_throwsSQLException()
             throws Exception
     {
         TableName inputTableName = new TableName(TEST_SCHEMA, TEST_TABLE);
@@ -480,7 +477,7 @@ public class ImpalaMetadataHandlerTest
     }
 
     @Test
-    public void testDoGetDataSourceCapabilities()
+    public void doGetDataSourceCapabilities_whenStandardCapabilitiesRequest_returnsFilterTopNAndLimitPushdownSubTypes()
     {
         GetDataSourceCapabilitiesRequest request = new GetDataSourceCapabilitiesRequest(federatedIdentity, TEST_QUERY_ID, TEST_CATALOG);
         GetDataSourceCapabilitiesResponse response = impalaMetadataHandler.doGetDataSourceCapabilities(blockAllocator, request);
@@ -531,7 +528,7 @@ public class ImpalaMetadataHandlerTest
     }
 
     @Test
-    public void testDoGetTableLayout_withViewTable() throws Exception
+    public void doGetTableLayout_whenTableTypeIsView_returnsAllPartitions() throws Exception
     {
         // Setup metadata with VIEW table type
         String[] schema = {"type", "name"};
@@ -546,9 +543,11 @@ public class ImpalaMetadataHandlerTest
         GetTableLayoutRequest getTableLayoutRequest = new GetTableLayoutRequest(this.federatedIdentity, TEST_QUERY_ID,
                 TEST_CATALOG, tempTableName, constraints, partitionSchema, partitionCols);
 
-        PreparedStatement preparestatement1 = Mockito.mock(PreparedStatement.class);
-        Mockito.when(this.connection.prepareStatement(ImpalaMetadataHandler.GET_METADATA_QUERY + tempTableName.getQualifiedTableName().toUpperCase())).thenReturn(preparestatement1);
-        Mockito.when(preparestatement1.executeQuery()).thenReturn(resultSet);
+        final String describeSql = ImpalaMetadataHandler.GET_METADATA_QUERY
+                + ImpalaUtils.qualifiedTableForMetadataSql(tempTableName);
+        Statement statement1 = Mockito.mock(Statement.class);
+        Mockito.when(this.connection.createStatement()).thenReturn(statement1);
+        Mockito.when(statement1.executeQuery(describeSql)).thenReturn(resultSet);
 
         GetTableLayoutResponse getTableLayoutResponse = this.impalaMetadataHandler.doGetTableLayout(blockAllocator, getTableLayoutRequest);
 

--- a/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaQueryStringBuilderTest.java
+++ b/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaQueryStringBuilderTest.java
@@ -40,10 +40,10 @@ public class ImpalaQueryStringBuilderTest
 	Split split;
 	
 	@Test
-	public void testQueryBuilder()
+	public void getFromClauseWithSplit_whenCatalogSchemaTableProvided_returnsBacktickQuotedFromClause()
 	{
-	    String expectedFrom1 = " FROM default.schema.table ";
-	    String expectedFrom2 = " FROM default.table ";
+	    String expectedFrom1 = " FROM `default`.`schema`.`table` ";
+	    String expectedFrom2 = " FROM `default`.`table` ";
 		ImpalaQueryStringBuilder builder = new ImpalaQueryStringBuilder(IMPALA_QUOTE_CHARACTER, new ImpalaFederationExpressionParser(IMPALA_QUOTE_CHARACTER));
 		String fromResult1 = builder.getFromClauseWithSplit("default", "schema", "table", split);
 		String fromResult2 = builder.getFromClauseWithSplit("default", "", "table", split);
@@ -52,7 +52,7 @@ public class ImpalaQueryStringBuilderTest
 	}
 
 	@Test
-	public void testGetPartitionWhereClauses_withAllPartitions()
+	public void getPartitionWhereClauses_whenAllPartitions_returnsEmptyList()
 	{
 		Mockito.when(split.getProperty(ImpalaConstants.BLOCK_PARTITION_COLUMN_NAME)).thenReturn("*");
 

--- a/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaRecordHandlerTest.java
+++ b/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaRecordHandlerTest.java
@@ -176,10 +176,7 @@ public class ImpalaRecordHandlerTest
         when(this.connection.prepareStatement(nullable(String.class))).thenReturn(expectedPreparedStatement);
         PreparedStatement preparedStatement = this.impalaRecordHandler.buildSplitSql(this.connection, TEST_CATALOG, tableName, schema, constraints, split);
         Assert.assertEquals(expectedPreparedStatement, preparedStatement);
-        Date expectedDate = new Date(120, 0, 5);
-        Assert.assertEquals(expectedPreparedStatement, preparedStatement);
-        verify(preparedStatement, Mockito.times(1))
-                .setDate(1, expectedDate);
+        verify(preparedStatement, Mockito.times(1)).setDate(Mockito.eq(1), Mockito.any(Date.class));
     }
 
     @Test
@@ -366,7 +363,7 @@ public class ImpalaRecordHandlerTest
                 null
         );
 
-        String expectedSql = "SELECT id, name, age, salary, department, is_active, created_date, updated_timestamp, amount FROM testSchema.testTable  WHERE (id IN (?,?,?,?,?)) AND ((age >= ? AND age <= ?)) AND ((salary > ?)) AND (department = ?) AND (is_active = ?) AND (amount = ?) AND p0";
+        String expectedSql = "SELECT `id`, `name`, `age`, `salary`, `department`, `is_active`, `created_date`, `updated_timestamp`, `amount` FROM `testSchema`.`testTable`  WHERE (`id` IN (?,?,?,?,?)) AND ((`age` >= ? AND `age` <= ?)) AND ((`salary` > ?)) AND (`department` = ?) AND (`is_active` = ?) AND (`amount` = ?) AND p0";
 
         PreparedStatement expectedPreparedStatement = executeAndVerifySqlGeneration(tableName, schema, split, constraints, expectedSql);
 
@@ -385,7 +382,7 @@ public class ImpalaRecordHandlerTest
     }
 
     @Test
-    public void testBuildSplitSqlWithOrderByAndLimit()
+    public void buildSplitSql_whenOrderByAndLimit_generatesBacktickQuotedSql()
             throws SQLException
     {
         TableName tableName = new TableName(TEST_SCHEMA, TEST_TABLE);
@@ -414,7 +411,7 @@ public class ImpalaRecordHandlerTest
                 null
         );
 
-        String expectedSql = "SELECT id, name, salary FROM testSchema.testTable  WHERE p0 ORDER BY salary DESC NULLS LAST LIMIT 10";
+        String expectedSql = "SELECT `id`, `name`, `salary` FROM `testSchema`.`testTable`  WHERE p0 ORDER BY `salary` DESC NULLS LAST LIMIT 10";
 
         executeAndVerifySqlGeneration(tableName, schema, split, constraints, expectedSql);
     }
@@ -453,7 +450,7 @@ public class ImpalaRecordHandlerTest
                 null
         );
 
-        String expectedSql = "SELECT id, name, salary, department FROM testSchema.testTable  WHERE ((salary > ?)) AND (department = ?) AND p0 ORDER BY salary DESC NULLS LAST LIMIT 5";
+        String expectedSql = "SELECT `id`, `name`, `salary`, `department` FROM `testSchema`.`testTable`  WHERE ((`salary` > ?)) AND (`department` = ?) AND p0 ORDER BY `salary` DESC NULLS LAST LIMIT 5";
 
         PreparedStatement expectedPreparedStatement = executeAndVerifySqlGeneration(tableName, schema, split, constraints, expectedSql);
 
@@ -498,7 +495,7 @@ public class ImpalaRecordHandlerTest
                 null
         );
 
-        String expectedSql = "SELECT created_date, updated_timestamp FROM testSchema.testTable  WHERE (created_date = ?) AND (updated_timestamp = ?) AND p0";
+        String expectedSql = "SELECT `created_date`, `updated_timestamp` FROM `testSchema`.`testTable`  WHERE (`created_date` = ?) AND (`updated_timestamp` = ?) AND p0";
 
         PreparedStatement expectedPreparedStatement = executeAndVerifySqlGeneration(tableName, schema, split, constraints, expectedSql);
 
@@ -508,7 +505,7 @@ public class ImpalaRecordHandlerTest
     }
 
     @Test
-    public void testBuildSplitSqlWithNullConstraints()
+    public void buildSplitSql_whenNullConstraints_generatesBacktickQuotedSql()
             throws SQLException
     {
         TableName tableName = new TableName(TEST_SCHEMA, TEST_TABLE);
@@ -535,13 +532,13 @@ public class ImpalaRecordHandlerTest
                 null
         );
 
-        String expectedSql = "SELECT name FROM testSchema.testTable  WHERE (name IS NULL) AND p0";
+        String expectedSql = "SELECT `name` FROM `testSchema`.`testTable`  WHERE (`name` IS NULL) AND p0";
 
         executeAndVerifySqlGeneration(tableName, schema, split, constraints, expectedSql);
     }
 
     @Test
-    public void testBuildSplitSqlWithEmptyConstraints()
+    public void buildSplitSql_whenEmptyConstraints_generatesBacktickQuotedSql()
             throws SQLException
     {
         TableName tableName = new TableName(TEST_SCHEMA, TEST_TABLE);
@@ -562,13 +559,13 @@ public class ImpalaRecordHandlerTest
                 null
         );
 
-        String expectedSql = "SELECT id FROM testSchema.testTable  WHERE p0";
+        String expectedSql = "SELECT `id` FROM `testSchema`.`testTable`  WHERE p0";
 
         executeAndVerifySqlGeneration(tableName, schema, split, constraints, expectedSql);
     }
 
     @Test
-    public void testBuildSplitSqlWithMultipleOrderByFields()
+    public void buildSplitSql_whenMultipleOrderByFields_generatesBacktickQuotedSql()
             throws SQLException
     {
         TableName tableName = new TableName(TEST_SCHEMA, TEST_TABLE);
@@ -600,7 +597,7 @@ public class ImpalaRecordHandlerTest
                 null
         );
 
-        String expectedSql = "SELECT department, salary, name FROM testSchema.testTable  WHERE p0 ORDER BY department ASC NULLS LAST, salary DESC NULLS FIRST, name ASC NULLS LAST";
+        String expectedSql = "SELECT `department`, `salary`, `name` FROM `testSchema`.`testTable`  WHERE p0 ORDER BY `department` ASC NULLS LAST, `salary` DESC NULLS FIRST, `name` ASC NULLS LAST";
 
         executeAndVerifySqlGeneration(tableName, schema, split, constraints, expectedSql);
     }

--- a/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaUtilsTest.java
+++ b/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaUtilsTest.java
@@ -1,0 +1,77 @@
+/*-
+ * #%L
+ * athena-cloudera-impala
+ * %%
+ * Copyright (C) 2019 - 2026 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.cloudera;
+
+import com.amazonaws.athena.connector.lambda.domain.TableName;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class ImpalaUtilsTest
+{
+    @Test
+    public void quoteIdentifier_whenNameIsSimple_returnsBacktickWrappedName()
+    {
+        assertEquals("`a`", ImpalaUtils.quoteIdentifier("a"));
+    }
+
+    @Test
+    public void quoteIdentifier_whenNameContainsBacktick_doublesEmbeddedBackticks()
+    {
+        assertEquals("`a``b`", ImpalaUtils.quoteIdentifier("a`b"));
+    }
+
+    @Test
+    public void quoteIdentifier_whenIdentifierIsEmpty_returnsQuotedEmptyIdentifier()
+    {
+        assertEquals("``", ImpalaUtils.quoteIdentifier(""));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void quoteIdentifier_whenIdentifierIsNull_throwsNullPointerException()
+    {
+        ImpalaUtils.quoteIdentifier(null);
+    }
+
+    @Test
+    public void qualifiedTableForMetadataSql_whenTableNameIsStandard_returnsQuotedQualifiedName()
+    {
+        TableName tableName = new TableName("testSchema", "testTable");
+        assertEquals("`TESTSCHEMA`.`TESTTABLE`", ImpalaUtils.qualifiedTableForMetadataSql(tableName));
+    }
+
+    @Test
+    public void qualifiedTableForMetadataSql_whenTableNameHasSpecialCharacters_keepsCharactersInsideQuotes()
+    {
+        TableName tableName = new TableName("demo_security", "test; INSERT INTO x VALUES (1);--");
+        String qualified = ImpalaUtils.qualifiedTableForMetadataSql(tableName);
+        assertEquals("`DEMO_SECURITY`.`TEST; INSERT INTO X VALUES (1);--`", qualified);
+        assertEquals("describe FORMATTED `DEMO_SECURITY`.`TEST; INSERT INTO X VALUES (1);--`",
+                ImpalaMetadataHandler.GET_METADATA_QUERY + qualified);
+        assertFalse(qualified.contains("`DEMO_SECURITY`.TEST;"));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void qualifiedTableForMetadataSql_whenTableNameIsNull_throwsNullPointerException()
+    {
+        ImpalaUtils.qualifiedTableForMetadataSql(null);
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Replaced PreparedStatement (no bind parameters) with Statement and backtick-quoted identifiers for metadata commands.

**Identifier quoting:** Schema, table, and column names are wrapped in backticks


Please find the attached functional test documentation.
[CLOUDERAIMPALA_FUNCTIONAL_TEST_2026-05-18.xlsx](https://github.com/user-attachments/files/28012982/CLOUDERAIMPALA_FUNCTIONAL_TEST_2026-05-18.xlsx)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
