### PR TITLE
Add Backtick Quote Identifier for HIVE Connector

### DIFF
--- a/athena-cloudera-hive/src/main/java/com/amazonaws/athena/connectors/cloudera/HiveConstants.java
+++ b/athena-cloudera-hive/src/main/java/com/amazonaws/athena/connectors/cloudera/HiveConstants.java
@@ -33,7 +33,7 @@ public class HiveConstants
     static final String BLOCK_PARTITION_COLUMN_NAME = "partition";
     static final int MAX_SPLITS_PER_REQUEST = 1000_000;
     static final String COLUMN_NAME = "COLUMN_NAME";
-    static final String HIVE_QUOTE_CHARACTER = "";
+    static final String HIVE_QUOTE_CHARACTER = "`";
     static final int FETCH_SIZE = 1000;
     static final String ALL_PARTITIONS = "*";
     public static final String HIVE_NAME = "hive";

--- a/athena-cloudera-hive/src/main/java/com/amazonaws/athena/connectors/cloudera/HiveMetadataHandler.java
+++ b/athena-cloudera-hive/src/main/java/com/amazonaws/athena/connectors/cloudera/HiveMetadataHandler.java
@@ -63,7 +63,6 @@ import software.amazon.awssdk.services.athena.AthenaClient;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 
 import java.sql.Connection;
-import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -130,11 +129,17 @@ public class HiveMetadataHandler extends JdbcMetadataHandler
     {
         LOGGER.info("{}: Schema {}, table {}", getTableLayoutRequest.getQueryId(), getTableLayoutRequest.getTableName().getSchemaName(),
                 getTableLayoutRequest.getTableName().getTableName());
+        TableName table = getTableLayoutRequest.getTableName();
+        String qualifiedTable = HiveUtils.qualifiedTableForMetadataSql(table);
+        String describeSql = GET_METADATA_QUERY + qualifiedTable;
+        String showPartitionsSql = "show partitions " + qualifiedTable;
+        String showExtendedSql = "show table extended in "
+                + HiveUtils.quoteIdentifier(table.getSchemaName().toUpperCase())
+                + " like " + HiveUtils.likePatternLiteral(table.getTableName());
         try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider());
-             Statement stmt = connection.createStatement();
-             PreparedStatement psmt = connection.prepareStatement(GET_METADATA_QUERY + getTableLayoutRequest.getTableName().getQualifiedTableName().toUpperCase())) {
+             Statement stmt = connection.createStatement()) {
             boolean isTablePartitioned = false;
-            ResultSet partitionResultset = stmt.executeQuery("show table extended in " + getTableLayoutRequest.getTableName().getSchemaName() + " like " + getTableLayoutRequest.getTableName().getTableName().toUpperCase());
+            ResultSet partitionResultset = stmt.executeQuery(showExtendedSql);
             while (partitionResultset != null && partitionResultset.next()) {
                 String partExists = partitionResultset.getString(1);
                 if (partExists.toUpperCase().contains("PARTITIONED")) {
@@ -146,13 +151,13 @@ public class HiveMetadataHandler extends JdbcMetadataHandler
             }
             LOGGER.debug("isTablePartitioned:" + isTablePartitioned);
              if (isTablePartitioned) {
-                 ResultSet partitionRs = stmt.executeQuery("show partitions " + getTableLayoutRequest.getTableName().getQualifiedTableName().toUpperCase());
+                 ResultSet partitionRs = stmt.executeQuery(showPartitionsSql);
                  Set<String> partition = new HashSet<>();
                  while (partitionRs != null && partitionRs.next()) {
                      partition.add(partitionRs.getString("Partition"));
                  }
                  if (!partition.isEmpty()) {
-                     Map<String, String> columnHashMap = getMetadataForGivenTable(psmt);
+                     Map<String, String> columnHashMap = getMetadataForGivenTable(stmt, describeSql);
                      addPartitions(partition, columnHashMap, blockWriter);
                  }
              }
@@ -306,8 +311,9 @@ public class HiveMetadataHandler extends JdbcMetadataHandler
         SchemaBuilder schemaBuilder = SchemaBuilder.newBuilder();
         try (ResultSet resultSet = getColumns(jdbcConnection.getCatalog(), tableName, jdbcConnection.getMetaData());
                 Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider())) {
-            try (PreparedStatement psmt = connection.prepareStatement(GET_METADATA_QUERY + tableName.getQualifiedTableName().toUpperCase())) {
-                Map<String, String> meteHashMap = getMetadataForGivenTable(psmt);
+            try (Statement stmt = connection.createStatement()) {
+                Map<String, String> meteHashMap = getMetadataForGivenTable(stmt,
+                        GET_METADATA_QUERY + HiveUtils.qualifiedTableForMetadataSql(tableName));
                 while (resultSet.next()) {
                     Optional<ArrowType> columnType = JdbcArrowTypeConverter.toArrowType(resultSet.getInt("DATA_TYPE"),
                             resultSet.getInt("COLUMN_SIZE"), resultSet.getInt("DECIMAL_DIGITS"), configOptions);
@@ -368,14 +374,15 @@ public class HiveMetadataHandler extends JdbcMetadataHandler
 
     /**
      *  used to get column names and associated data types for column names.
-     * @param statement A PreparedStatement holds query to get metadata for a table.
+     * @param statement JDBC statement used to run the metadata query
+     * @param sql fully formed SQL with quoted table identifiers (not JDBC {@code ?} parameters)
      * @return Map of column name and associated data type for column.
      * @throws SQLException A SQLException should be thrown for database connection failures , query syntax errors and so on.
      */
-    private Map<String, String> getMetadataForGivenTable(PreparedStatement statement) throws SQLException
+    private Map<String, String> getMetadataForGivenTable(Statement statement, String sql) throws SQLException
     {
         Map<String, String> columnHashMap = new HashMap<>();
-        try (ResultSet rs = statement.executeQuery()) {
+        try (ResultSet rs = statement.executeQuery(sql)) {
             while (rs.next()) {
                 String dataType = rs.getString(HiveConstants.METADATA_COLUMN_TYPE);
                 if (dataType != null && !dataType.isEmpty()) {

--- a/athena-cloudera-hive/src/main/java/com/amazonaws/athena/connectors/cloudera/HiveQueryStringBuilder.java
+++ b/athena-cloudera-hive/src/main/java/com/amazonaws/athena/connectors/cloudera/HiveQueryStringBuilder.java
@@ -42,12 +42,12 @@ public class HiveQueryStringBuilder extends JdbcSplitQueryBuilder
     {
         StringBuilder tableName = new StringBuilder();
         if (!Strings.isNullOrEmpty(catalogName)) {
-            tableName.append(catalogName).append('.');
+            tableName.append(HiveUtils.quoteIdentifier(catalogName)).append('.');
         }
         if (!Strings.isNullOrEmpty(schema)) {
-            tableName.append(schema).append('.');
+            tableName.append(HiveUtils.quoteIdentifier(schema)).append('.');
         }
-        tableName.append(table);
+        tableName.append(HiveUtils.quoteIdentifier(table));
         return String.format(" FROM %s ", tableName);
     }
 

--- a/athena-cloudera-hive/src/main/java/com/amazonaws/athena/connectors/cloudera/HiveUtils.java
+++ b/athena-cloudera-hive/src/main/java/com/amazonaws/athena/connectors/cloudera/HiveUtils.java
@@ -20,6 +20,8 @@
 package com.amazonaws.athena.connectors.cloudera;
 
 import com.amazonaws.athena.connector.lambda.domain.TableName;
+import org.apache.calcite.sql.SqlDialect;
+import org.apache.calcite.sql.dialect.HiveSqlDialect;
 
 import static com.amazonaws.athena.connectors.cloudera.HiveConstants.HIVE_QUOTE_CHARACTER;
 
@@ -29,6 +31,8 @@ import static com.amazonaws.athena.connectors.cloudera.HiveConstants.HIVE_QUOTE_
  */
 public class HiveUtils
 {
+    private static final SqlDialect HIVE_SQL_DIALECT = HiveSqlDialect.DEFAULT;
+
     private HiveUtils()
     {
     }
@@ -53,12 +57,14 @@ public class HiveUtils
     }
 
     /**
-     * Single-quoted pattern for {@code SHOW TABLE EXTENDED IN ... LIKE '...'}. Hive uses {@code *}
-     * (not {@code %}) as the wildcard in {@code SHOW} commands; valid table names do not include
-     * wildcards, so only single quotes are escaped and the name is upper-cased to match prior behavior.
+     * Single-quoted pattern for {@code SHOW TABLE EXTENDED IN ... LIKE '...'}. Hive string literals
+     * accept both quote-doubling and C-style backslash escapes. Backslashes are escaped first, then
+     * {@link HiveSqlDialect#quoteStringLiteral(String)} applies Hive dialect quoting rules. The name
+     * is upper-cased to match prior connector behavior.
      */
     public static String likePatternLiteral(String pattern)
     {
-        return "'" + pattern.replace("'", "''").toUpperCase() + "'";
+        String escaped = pattern.toUpperCase().replace("\\", "\\\\");
+        return HIVE_SQL_DIALECT.quoteStringLiteral(escaped);
     }
 }

--- a/athena-cloudera-hive/src/main/java/com/amazonaws/athena/connectors/cloudera/HiveUtils.java
+++ b/athena-cloudera-hive/src/main/java/com/amazonaws/athena/connectors/cloudera/HiveUtils.java
@@ -1,0 +1,64 @@
+/*-
+ * #%L
+ * athena-cloudera-hive
+ * %%
+ * Copyright (C) 2019 - 2026 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.cloudera;
+
+import com.amazonaws.athena.connector.lambda.domain.TableName;
+
+import static com.amazonaws.athena.connectors.cloudera.HiveConstants.HIVE_QUOTE_CHARACTER;
+
+/**
+ * Builds Hive-safe quoted identifiers for dynamic SQL. JDBC {@code ?} placeholders apply to values,
+ * not table references, so identifiers must be quoted and escaped explicitly.
+ */
+public class HiveUtils
+{
+    private HiveUtils()
+    {
+    }
+
+    /**
+     * Wraps a single identifier in backticks; doubles any embedded backticks.
+     */
+    public static String quoteIdentifier(String identifier)
+    {
+        String escaped = identifier.replace(HIVE_QUOTE_CHARACTER, HIVE_QUOTE_CHARACTER + HIVE_QUOTE_CHARACTER);
+        return HIVE_QUOTE_CHARACTER + escaped + HIVE_QUOTE_CHARACTER;
+    }
+
+    /**
+     * {@code schema.table} for metadata statements, upper-casing each segment then quoting so names
+     * cannot break out of identifier context.
+     */
+    public static String qualifiedTableForMetadataSql(TableName tableName)
+    {
+        return quoteIdentifier(tableName.getSchemaName().toUpperCase())
+                + "." + quoteIdentifier(tableName.getTableName().toUpperCase());
+    }
+
+    /**
+     * Single-quoted pattern for {@code SHOW TABLE EXTENDED IN ... LIKE '...'}. Hive uses {@code *}
+     * (not {@code %}) as the wildcard in {@code SHOW} commands; valid table names do not include
+     * wildcards, so only single quotes are escaped and the name is upper-cased to match prior behavior.
+     */
+    public static String likePatternLiteral(String pattern)
+    {
+        return "'" + pattern.replace("'", "''").toUpperCase() + "'";
+    }
+}

--- a/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveMetadataHandlerTest.java
+++ b/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveMetadataHandlerTest.java
@@ -51,7 +51,6 @@ import com.google.common.collect.ImmutableMap;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -63,7 +62,6 @@ import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueReques
 import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
 
 import java.sql.Connection;
-import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -137,7 +135,7 @@ public class HiveMetadataHandlerTest
     }
 
     @Test
-    public void getPartitionSchema()
+    public void getPartitionSchema_whenCatalogNameProvided_returnsPartitionFieldWithVarcharType()
     {
         assertEquals(SchemaBuilder.newBuilder()
                         .addField("partition", org.apache.arrow.vector.types.Types.MinorType.VARCHAR.getType()).build(),
@@ -145,7 +143,7 @@ public class HiveMetadataHandlerTest
     }
 
     @Test
-    public void doGetTableLayout()
+    public void doGetTableLayout_whenShowPartitionsReturnsPartitions_returnsTwoPartitionRowsWithValues()
             throws Exception
     {
         String[] schema = {"data_type", "col_name"};
@@ -169,15 +167,16 @@ public class HiveMetadataHandlerTest
         Object[][] values4 = {{"PARTITIONED:true"}};
         ResultSet resultSet2 = mockResultSet(columns3, types3, values4, new AtomicInteger(-1));
         Mockito.when(jdbcConnectionFactory.getConnection(nullable(CredentialsProvider.class))).thenReturn(connection);
-        String tableName = getTableLayoutRequest.getTableName().getQualifiedTableName().toUpperCase();
-        PreparedStatement preparestatement1 = Mockito.mock(PreparedStatement.class);
-        Mockito.when(this.connection.prepareStatement(HiveMetadataHandler.GET_METADATA_QUERY + tableName)).thenReturn(preparestatement1);
-        final String getPartitionExistsSql = "show table extended in " + getTableLayoutRequest.getTableName().getSchemaName() + " like "  + getTableLayoutRequest.getTableName().getTableName().toUpperCase();
-        final String getPartitionDetailsSql = "show partitions "  + getTableLayoutRequest.getTableName().getQualifiedTableName().toUpperCase();
+        final String qualifiedTable = HiveUtils.qualifiedTableForMetadataSql(getTableLayoutRequest.getTableName());
+        final String describeSql = HiveMetadataHandler.GET_METADATA_QUERY + qualifiedTable;
+        final String getPartitionExistsSql = "show table extended in "
+                + HiveUtils.quoteIdentifier(getTableLayoutRequest.getTableName().getSchemaName().toUpperCase())
+                + " like " + HiveUtils.likePatternLiteral(getTableLayoutRequest.getTableName().getTableName());
+        final String getPartitionDetailsSql = "show partitions " + qualifiedTable;
         Statement statement1 = Mockito.mock(Statement.class);
         Mockito.when(this.connection.createStatement()).thenReturn(statement1);
         ResultSet resultSet1 = mockResultSet(columns2, types2, values1, new AtomicInteger(-1));
-        Mockito.when(preparestatement1.executeQuery()).thenReturn(resultSet);
+        Mockito.when(statement1.executeQuery(describeSql)).thenReturn(resultSet);
         Mockito.when(statement1.executeQuery(getPartitionDetailsSql)).thenReturn(resultSet1);
         Mockito.when(statement1.executeQuery(getPartitionExistsSql)).thenReturn(resultSet2);
         Mockito.when(resultSet2.getString(1)).thenReturn("PARTITIONED:true");
@@ -197,7 +196,7 @@ public class HiveMetadataHandlerTest
     }
 
     @Test
-    public void doGetTableLayoutWithNoPartitions()
+    public void doGetTableLayout_whenShowPartitionsReturnsEmpty_returnsAllPartitionsRow()
             throws Exception
     {
         String[] schema = {"data_type", "col_name"};
@@ -215,13 +214,13 @@ public class HiveMetadataHandlerTest
         int[] types2 = {Types.VARCHAR};
         Object[][] values1 = {};
         Mockito.when(jdbcConnectionFactory.getConnection(nullable(CredentialsProvider.class))).thenReturn(connection);
-        PreparedStatement preparestatement1 = Mockito.mock(PreparedStatement.class);
-        Mockito.when(this.connection.prepareStatement(HiveMetadataHandler.GET_METADATA_QUERY + tempTableName.getQualifiedTableName())).thenReturn(preparestatement1);
-        final String getPartitionDetailsSql = "show partitions "  + getTableLayoutRequest.getTableName().getQualifiedTableName().toUpperCase();
+        final String qualifiedTable = HiveUtils.qualifiedTableForMetadataSql(getTableLayoutRequest.getTableName());
+        final String describeSql = HiveMetadataHandler.GET_METADATA_QUERY + qualifiedTable;
+        final String getPartitionDetailsSql = "show partitions " + qualifiedTable;
         Statement statement1 = Mockito.mock(Statement.class);
         Mockito.when(this.connection.createStatement()).thenReturn(statement1);
         ResultSet resultSet1 = mockResultSet(columns2, types2, values1, new AtomicInteger(-1));
-        Mockito.when(preparestatement1.executeQuery()).thenReturn(resultSet);
+        Mockito.when(statement1.executeQuery(describeSql)).thenReturn(resultSet);
         Mockito.when(statement1.executeQuery(getPartitionDetailsSql)).thenReturn(resultSet1);
         GetTableLayoutResponse getTableLayoutResponse = this.hiveMetadataHandler.doGetTableLayout(blockAllocator, getTableLayoutRequest);
         List<String> expectedValues = new ArrayList<>();
@@ -237,7 +236,7 @@ public class HiveMetadataHandlerTest
     }
 
     @Test(expected = RuntimeException.class)
-    public void doGetTableLayoutWithSQLException()
+    public void doGetTableLayout_whenSQLException_throwsRuntimeException()
             throws Exception
     {
         Constraints constraints = Mockito.mock(Constraints.class);
@@ -255,7 +254,7 @@ public class HiveMetadataHandlerTest
     }
 
     @Test
-    public void doGetSplits()
+    public void doGetSplits_whenLayoutHasTwoPartitions_returnsTwoSplits()
             throws Exception
     {
         String[] schema = {"data_type", "col_name"};
@@ -279,15 +278,16 @@ public class HiveMetadataHandlerTest
         int[] types2 = {Types.VARCHAR};
         Object[][] values1 = {{value2}, {value3}};
         Mockito.when(jdbcConnectionFactory.getConnection(nullable(CredentialsProvider.class))).thenReturn(connection);
-        String tableName = getTableLayoutRequest.getTableName().getQualifiedTableName().toUpperCase();
-        PreparedStatement preparestatement1 = Mockito.mock(PreparedStatement.class);
-        Mockito.when(this.connection.prepareStatement(HiveMetadataHandler.GET_METADATA_QUERY + tableName)).thenReturn(preparestatement1);
-        final String getPartitionExistsSql = "show table extended in " + getTableLayoutRequest.getTableName().getSchemaName() + " like "  + getTableLayoutRequest.getTableName().getTableName().toUpperCase();
-        final String getPartitionDetailsSql = "show partitions "  + getTableLayoutRequest.getTableName().getQualifiedTableName().toUpperCase();
+        final String qualifiedTable = HiveUtils.qualifiedTableForMetadataSql(getTableLayoutRequest.getTableName());
+        final String describeSql = HiveMetadataHandler.GET_METADATA_QUERY + qualifiedTable;
+        final String getPartitionExistsSql = "show table extended in "
+                + HiveUtils.quoteIdentifier(getTableLayoutRequest.getTableName().getSchemaName().toUpperCase())
+                + " like " + HiveUtils.likePatternLiteral(getTableLayoutRequest.getTableName().getTableName());
+        final String getPartitionDetailsSql = "show partitions " + qualifiedTable;
         Statement statement1 = Mockito.mock(Statement.class);
         Mockito.when(this.connection.createStatement()).thenReturn(statement1);
         ResultSet resultSet1 = mockResultSet(columns2, types2, values1, new AtomicInteger(-1));
-        Mockito.when(preparestatement1.executeQuery()).thenReturn(resultSet);
+        Mockito.when(statement1.executeQuery(describeSql)).thenReturn(resultSet);
         Mockito.when(statement1.executeQuery(getPartitionDetailsSql)).thenReturn(resultSet1);
         Mockito.when(statement1.executeQuery(getPartitionExistsSql)).thenReturn(resultSet2);
         Mockito.when(resultSet2.getString(1)).thenReturn("PARTITIONED:true");
@@ -299,7 +299,7 @@ public class HiveMetadataHandlerTest
     }
 
     @Test
-    public void doGetSplits_WithQueryPassthrough_ReturnsPassthroughSplit() {
+    public void doGetSplits_whenQueryPassthroughEnabled_returnsOneSplitWithQueryProperty() {
         TableName tableName = new TableName(TEST_SCHEMA, TEST_TABLE);
         Schema partitionSchema = this.hiveMetadataHandler.getPartitionSchema(CATALOG_NAME);
         Set<String> partitionCols = partitionSchema.getFields().stream()
@@ -338,7 +338,7 @@ public class HiveMetadataHandlerTest
     }
 
     @Test
-    public void doGetSplits_WithContinuationToken_ReturnsSplitsFromToken() {
+    public void doGetSplits_whenContinuationTokenZero_returnsTwoSplitsWithPartitionValues() {
         TableName tableName = new TableName(TEST_SCHEMA, TEST_TABLE);
         Schema partitionSchema = this.hiveMetadataHandler.getPartitionSchema(CATALOG_NAME);
         Set<String> partitionCols = partitionSchema.getFields().stream()
@@ -378,7 +378,7 @@ public class HiveMetadataHandlerTest
     }
 
     @Test
-    public void decodeContinuationToken_WithValidToken_DecodesToken() throws Exception {
+    public void decodeContinuationToken_whenTokenIsOne_returnsNonNullTokenValue() throws Exception {
         TableName tableName = new TableName(TEST_SCHEMA, TEST_TABLE);
         Constraints constraints = Mockito.mock(Constraints.class);
         Schema partitionSchema = this.hiveMetadataHandler.getPartitionSchema(CATALOG_NAME);
@@ -402,7 +402,7 @@ public class HiveMetadataHandlerTest
     }
 
     @Test
-    public void doGetTable()
+    public void doGetTable_whenDescribeReturnsColumns_returnsTableWithArrowColumnTypes()
             throws Exception
     {
         String[] schema = {"data_type", "col_name"};
@@ -418,9 +418,11 @@ public class HiveMetadataHandlerTest
                 {Types.OTHER, 12, "case_unsupported", 0, 0}};
         ResultSet resultSet1 = mockResultSet(schema1, values1, new AtomicInteger(-1));
         TableName inputTableName = new TableName(TEST_SCHEMA, TEST_TABLE);
-        PreparedStatement preparestatement1 = Mockito.mock(PreparedStatement.class);
-        Mockito.when(this.connection.prepareStatement(HiveMetadataHandler.GET_METADATA_QUERY + inputTableName.getQualifiedTableName().toUpperCase())).thenReturn(preparestatement1);
-        Mockito.when(preparestatement1.executeQuery()).thenReturn(resultSet);
+        final String describeSql = HiveMetadataHandler.GET_METADATA_QUERY
+                + HiveUtils.qualifiedTableForMetadataSql(inputTableName);
+        Statement metadataStatement = Mockito.mock(Statement.class);
+        Mockito.when(this.connection.createStatement()).thenReturn(metadataStatement);
+        Mockito.when(metadataStatement.executeQuery(describeSql)).thenReturn(resultSet);
         Mockito.when(this.connection.getMetaData().getSearchStringEscape()).thenReturn(null);
         Mockito.when(this.connection.getMetaData().getColumns(CATALOG_NAME, inputTableName.getSchemaName(), inputTableName.getTableName(), null)).thenReturn(resultSet1);
         Mockito.when(this.connection.getCatalog()).thenReturn(CATALOG_NAME);
@@ -441,14 +443,14 @@ public class HiveMetadataHandlerTest
     }
 
     @Test
-    public void doGetTableNoColumns() throws Exception
+    public void doGetTable_whenJdbcReturnsNoColumns_returnsTableWithEmptySchema() throws Exception
     {
         TableName inputTableName = new TableName(TEST_SCHEMA, TEST_TABLE);
         this.hiveMetadataHandler.doGetTable(blockAllocator, new GetTableRequest(this.federatedIdentity, QUERY_ID, CATALOG_NAME, inputTableName, Collections.emptyMap()));
     }
 
     @Test(expected = SQLException.class)
-    public void doGetTableSQLException() throws Exception {
+    public void doGetTable_whenSQLException_throwsSQLException() throws Exception {
         TableName inputTableName = new TableName(TEST_SCHEMA, TEST_TABLE);
         Mockito.when(this.connection.getMetaData().getColumns(nullable(String.class), nullable(String.class), nullable(String.class), nullable(String.class)))
                 .thenThrow(new SQLException());
@@ -456,7 +458,7 @@ public class HiveMetadataHandlerTest
     }
 
     @Test
-    public void doGetDataSourceCapabilities_WithValidRequest_ReturnsCapabilities() {
+    public void doGetDataSourceCapabilities_whenCapabilitiesRequestedForCatalog_returnsFilterComplexTopNAndLimitPushdownSubTypes() {
         GetDataSourceCapabilitiesRequest request = new GetDataSourceCapabilitiesRequest(federatedIdentity, QUERY_ID, CATALOG_NAME);
         GetDataSourceCapabilitiesResponse response = hiveMetadataHandler.doGetDataSourceCapabilities(blockAllocator, request);
 

--- a/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveQueryStringBuilderTest.java
+++ b/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveQueryStringBuilderTest.java
@@ -39,10 +39,10 @@ public class HiveQueryStringBuilderTest
 	Split split;
 	
 	@Test
-	public void getFromClauseWithSplit_WithDifferentSchemas_ReturnsCorrectFromClause()
+	public void getFromClauseWithSplit_whenCatalogSchemaTableProvided_returnsBacktickQuotedFromClause()
 	{
-	    String expectedFrom1 = " FROM default.schema.table ";
-	    String expectedFrom2 = " FROM default.table ";
+	    String expectedFrom1 = " FROM `default`.`schema`.`table` ";
+	    String expectedFrom2 = " FROM `default`.`table` ";
 		HiveQueryStringBuilder builder = new HiveQueryStringBuilder(HIVE_QUOTE_CHARACTER, new HiveFederationExpressionParser(HIVE_QUOTE_CHARACTER));
 		String fromResult1 = builder.getFromClauseWithSplit("default", "schema", "table", split);
 		String fromResult2 = builder.getFromClauseWithSplit("default", "", "table", split);
@@ -51,7 +51,7 @@ public class HiveQueryStringBuilderTest
 	}
 
 	@Test
-	public void getPartitionWhereClauses_WithAllPartitions_ReturnsEmptyList()
+	public void getPartitionWhereClauses_whenAllPartitions_returnsEmptyList()
 	{
 		Mockito.when(split.getProperty(HiveConstants.BLOCK_PARTITION_COLUMN_NAME)).thenReturn("*");
 		

--- a/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveRecordHandlerTest.java
+++ b/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveRecordHandlerTest.java
@@ -107,7 +107,7 @@ public class HiveRecordHandlerTest
     private static final String TEST_COL4 = "testCol4";
     private static final String PARTITION_PROPERTY = "partition";
     private static final String PARTITION_VALUE = "p0";
-    private static final String QPT_TEST_QUERY = "SELECT * FROM testSchema.testTable WHERE testCol1 = 1";
+    private static final String QPT_TEST_QUERY = "SELECT * FROM `testSchema`.`testTable` WHERE testCol1 = 1";
     private static final String QPT_SCHEMA_FUNCTION_NAME_VALUE = "system.query";
     private static final String QPT_NAME_PROPERTY = "name";
     private static final String QPT_SCHEMA_PROPERTY = "schema";
@@ -362,7 +362,7 @@ public class HiveRecordHandlerTest
     }
 
     @Test
-    public void buildSplitSql_WithComplexConstraints_ReturnsPreparedStatement()
+    public void buildSplitSql_whenComplexConstraints_generatesBacktickQuotedSql()
             throws SQLException
     {
         TableName tableName = new TableName(TEST_SCHEMA, TEST_TABLE);
@@ -410,7 +410,7 @@ public class HiveRecordHandlerTest
                 null
         );
 
-        String expectedSql = "SELECT id, name, age, salary, department, is_active, created_date, updated_timestamp, amount FROM testSchema.testTable  WHERE (id IN (?,?,?,?,?)) AND ((age >= ? AND age <= ?)) AND ((salary > ?)) AND (department = ?) AND (is_active = ?) AND (amount = ?) AND p0";
+        String expectedSql = "SELECT `id`, `name`, `age`, `salary`, `department`, `is_active`, `created_date`, `updated_timestamp`, `amount` FROM `testSchema`.`testTable`  WHERE (`id` IN (?,?,?,?,?)) AND ((`age` >= ? AND `age` <= ?)) AND ((`salary` > ?)) AND (`department` = ?) AND (`is_active` = ?) AND (`amount` = ?) AND p0";
 
         PreparedStatement expectedPreparedStatement = executeAndVerifySqlGeneration(tableName, schema, split, constraints, expectedSql);
 
@@ -429,7 +429,7 @@ public class HiveRecordHandlerTest
     }
 
     @Test
-    public void buildSplitSql_WithOrderByAndLimit_ReturnsPreparedStatement()
+    public void buildSplitSql_whenOrderByAndLimit_generatesBacktickQuotedSql()
             throws SQLException
     {
         TableName tableName = new TableName(TEST_SCHEMA, TEST_TABLE);
@@ -458,13 +458,13 @@ public class HiveRecordHandlerTest
                 null
         );
 
-        String expectedSql = "SELECT id, name, salary FROM testSchema.testTable  WHERE p0 ORDER BY salary DESC NULLS LAST LIMIT 10";
+        String expectedSql = "SELECT `id`, `name`, `salary` FROM `testSchema`.`testTable`  WHERE p0 ORDER BY `salary` DESC NULLS LAST LIMIT 10";
 
         executeAndVerifySqlGeneration(tableName, schema, split, constraints, expectedSql);
     }
 
     @Test
-    public void buildSplitSql_WithTopNQuery_ReturnsPreparedStatement()
+    public void buildSplitSql_whenTopNQuery_generatesBacktickQuotedSql()
             throws SQLException
     {
         TableName tableName = new TableName(TEST_SCHEMA, TEST_TABLE);
@@ -497,7 +497,7 @@ public class HiveRecordHandlerTest
                 null
         );
 
-        String expectedSql = "SELECT id, name, salary, department FROM testSchema.testTable  WHERE ((salary > ?)) AND (department = ?) AND p0 ORDER BY salary DESC NULLS LAST LIMIT 5";
+        String expectedSql = "SELECT `id`, `name`, `salary`, `department` FROM `testSchema`.`testTable`  WHERE ((`salary` > ?)) AND (`department` = ?) AND p0 ORDER BY `salary` DESC NULLS LAST LIMIT 5";
 
         PreparedStatement expectedPreparedStatement = executeAndVerifySqlGeneration(tableName, schema, split, constraints, expectedSql);
 
@@ -507,7 +507,7 @@ public class HiveRecordHandlerTest
     }
 
     @Test
-    public void buildSplitSql_WithDateConstraints_ReturnsPreparedStatement()
+    public void buildSplitSql_whenDateConstraints_generatesBacktickQuotedSql()
             throws SQLException
     {
         TableName tableName = new TableName(TEST_SCHEMA, TEST_TABLE);
@@ -542,7 +542,7 @@ public class HiveRecordHandlerTest
                 null
         );
 
-        String expectedSql = "SELECT created_date, updated_timestamp FROM testSchema.testTable  WHERE (created_date = ?) AND (updated_timestamp = cast(? as timestamp)) AND p0";
+        String expectedSql = "SELECT `created_date`, `updated_timestamp` FROM `testSchema`.`testTable`  WHERE (`created_date` = ?) AND (`updated_timestamp` = cast(? as timestamp)) AND p0";
 
         PreparedStatement expectedPreparedStatement = executeAndVerifySqlGeneration(tableName, schema, split, constraints, expectedSql);
 
@@ -552,7 +552,7 @@ public class HiveRecordHandlerTest
     }
 
     @Test
-    public void buildSplitSql_WithNullConstraints_ReturnsPreparedStatement()
+    public void buildSplitSql_whenNullConstraints_generatesBacktickQuotedSql()
             throws SQLException
     {
         TableName tableName = new TableName(TEST_SCHEMA, TEST_TABLE);
@@ -579,13 +579,13 @@ public class HiveRecordHandlerTest
                 null
         );
 
-        String expectedSql = "SELECT name FROM testSchema.testTable  WHERE (name IS NULL) AND p0";
+        String expectedSql = "SELECT `name` FROM `testSchema`.`testTable`  WHERE (`name` IS NULL) AND p0";
 
         executeAndVerifySqlGeneration(tableName, schema, split, constraints, expectedSql);
     }
 
     @Test
-    public void buildSplitSql_WithEmptyConstraints_ReturnsPreparedStatement()
+    public void buildSplitSql_whenEmptyConstraints_generatesBacktickQuotedSql()
             throws SQLException
     {
         TableName tableName = new TableName(TEST_SCHEMA, TEST_TABLE);
@@ -606,13 +606,13 @@ public class HiveRecordHandlerTest
                 null
         );
 
-        String expectedSql = "SELECT id FROM testSchema.testTable  WHERE p0";
+        String expectedSql = "SELECT `id` FROM `testSchema`.`testTable`  WHERE p0";
 
         executeAndVerifySqlGeneration(tableName, schema, split, constraints, expectedSql);
     }
 
     @Test
-    public void buildSplitSql_WithMultipleOrderByFields_ReturnsPreparedStatement()
+    public void buildSplitSql_whenMultipleOrderByFields_generatesBacktickQuotedSql()
             throws SQLException
     {
         TableName tableName = new TableName(TEST_SCHEMA, TEST_TABLE);
@@ -644,7 +644,7 @@ public class HiveRecordHandlerTest
                 null
         );
 
-        String expectedSql = "SELECT department, salary, name FROM testSchema.testTable  WHERE p0 ORDER BY department ASC NULLS LAST, salary DESC NULLS FIRST, name ASC NULLS LAST";
+        String expectedSql = "SELECT `department`, `salary`, `name` FROM `testSchema`.`testTable`  WHERE p0 ORDER BY `department` ASC NULLS LAST, `salary` DESC NULLS FIRST, `name` ASC NULLS LAST";
 
         executeAndVerifySqlGeneration(tableName, schema, split, constraints, expectedSql);
     }

--- a/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveUtilsTest.java
+++ b/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveUtilsTest.java
@@ -111,6 +111,36 @@ public class HiveUtilsTest
         assertEquals("'''; SELECT 1;--'", HiveUtils.likePatternLiteral("'; SELECT 1;--"));
     }
 
+    @Test
+    public void likePatternLiteral_whenPatternContainsBackslash_escapesBackslashBeforeQuoting()
+    {
+        String literal = HiveUtils.likePatternLiteral("test\\'; DROP TABLE x;--");
+        assertEquals("'TEST\\\\''; DROP TABLE X;--'", literal);
+        String showExtendedSql = "show table extended in `DEMO` like " + literal;
+        assertFalse(showExtendedSql.contains("like 'TEST';"));
+    }
+
+    @Test
+    public void likePatternLiteral_whenPatternContainsJavaEscapedQuote_hasSameOutputAsPlainQuote()
+    {
+        assertEquals("'TEST''; DROP TABLE X;--'", HiveUtils.likePatternLiteral("test\'; DROP TABLE x;--"));
+    }
+
+    @Test
+    public void likePatternLiteral_whenPatternContainsBackslashOnly_doublesBackslashes()
+    {
+        assertEquals("'A\\\\B'", HiveUtils.likePatternLiteral("a\\b"));
+    }
+
+    @Test
+    public void likePatternLiteral_whenPatternContainsHiveCStyleEscapes_doublesBackslashes() {
+        assertEquals("'QUOTE\\\\''ESCAPE'", HiveUtils.likePatternLiteral("quote\\'escape"));
+        assertEquals("'SLASH\\\\\\\\ESCAPE'", HiveUtils.likePatternLiteral("slash\\\\escape"));
+        assertEquals("'NEWLINE\\\\NESCAPE'", HiveUtils.likePatternLiteral("newline\\nescape"));
+        assertEquals("'TAB\\\\TESCAPE'", HiveUtils.likePatternLiteral("tab\\tescape"));
+    }
+
+   
     @Test(expected = NullPointerException.class)
     public void likePatternLiteral_whenPatternIsNull_throwsNullPointerException()
     {

--- a/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveUtilsTest.java
+++ b/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveUtilsTest.java
@@ -1,0 +1,119 @@
+/*-
+ * #%L
+ * athena-cloudera-hive
+ * %%
+ * Copyright (C) 2019 - 2026 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.cloudera;
+
+import com.amazonaws.athena.connector.lambda.domain.TableName;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class HiveUtilsTest
+{
+    @Test
+    public void quoteIdentifier_whenNameIsSimple_returnsBacktickWrappedName()
+    {
+        assertEquals("`a`", HiveUtils.quoteIdentifier("a"));
+    }
+
+    @Test
+    public void quoteIdentifier_whenNameContainsBacktick_doublesEmbeddedBackticks()
+    {
+        assertEquals("`a``b`", HiveUtils.quoteIdentifier("a`b"));
+    }
+
+    @Test
+    public void quoteIdentifier_whenIdentifierIsEmpty_returnsQuotedEmptyIdentifier()
+    {
+        assertEquals("``", HiveUtils.quoteIdentifier(""));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void quoteIdentifier_whenIdentifierIsNull_throwsNullPointerException()
+    {
+        HiveUtils.quoteIdentifier(null);
+    }
+
+    @Test
+    public void qualifiedTableForMetadataSql_whenTableNameIsStandard_returnsQuotedQualifiedName()
+    {
+        TableName tableName = new TableName("testSchema", "testTable");
+        assertEquals("`TESTSCHEMA`.`TESTTABLE`", HiveUtils.qualifiedTableForMetadataSql(tableName));
+    }
+
+    @Test
+    public void qualifiedTableForMetadataSql_whenTableNameHasSpecialCharacters_keepsCharactersInsideQuotes()
+    {
+        TableName tableName = new TableName("demo_security", "test; INSERT INTO x VALUES (1);--");
+        String qualified = HiveUtils.qualifiedTableForMetadataSql(tableName);
+        assertEquals("`DEMO_SECURITY`.`TEST; INSERT INTO X VALUES (1);--`", qualified);
+        assertEquals("describe `DEMO_SECURITY`.`TEST; INSERT INTO X VALUES (1);--`",
+                HiveMetadataHandler.GET_METADATA_QUERY + qualified);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void qualifiedTableForMetadataSql_whenTableNameIsNull_throwsNullPointerException()
+    {
+        HiveUtils.qualifiedTableForMetadataSql(null);
+    }
+
+    @Test
+    public void likePatternLiteral_whenPatternIsSimple_returnsUppercaseQuotedLiteral()
+    {
+        assertEquals("'TESTTABLE'", HiveUtils.likePatternLiteral("testTable"));
+    }
+
+    @Test
+    public void likePatternLiteral_whenPatternContainsSingleQuote_escapesSingleQuote()
+    {
+        assertEquals("'O''REILLY'", HiveUtils.likePatternLiteral("o'reilly"));
+    }
+
+    @Test
+    public void likePatternLiteral_whenPatternIsTableName_returnsUppercasedSecrets()
+    {
+        assertEquals("'SECRETS'", HiveUtils.likePatternLiteral("secrets"));
+    }
+
+    @Test
+    public void likePatternLiteral_whenPatternContainsSqlSuffix_staysInsideSingleQuotedLiteral()
+    {
+        String literal = HiveUtils.likePatternLiteral("test'; DROP TABLE x;--");
+        assertEquals("'TEST''; DROP TABLE X;--'", literal);
+        assertTrue(literal.startsWith("'"));
+        assertTrue(literal.endsWith("'"));
+        String showExtendedSql = "show table extended in `DEMO` like " + literal;
+        assertEquals("show table extended in `DEMO` like 'TEST''; DROP TABLE X;--'", showExtendedSql);
+        assertFalse(showExtendedSql.contains("like 'TEST';"));
+    }
+
+    @Test
+    public void likePatternLiteral_whenPatternIsQuoteOnlyPayload_returnsEscapedQuotedLiteral()
+    {
+        assertEquals("'''; SELECT 1;--'", HiveUtils.likePatternLiteral("'; SELECT 1;--"));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void likePatternLiteral_whenPatternIsNull_throwsNullPointerException()
+    {
+        HiveUtils.likePatternLiteral(null);
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Replaced PreparedStatement (no bind parameters) with Statement and backtick-quoted identifiers for metadata commands.

**Identifier quoting:** Schema, table, and column names are wrapped in backticks

**String literals:** Table names in SHOW TABLE EXTENDED ... LIKE '...' are single-quoted with escaped apostrophes (' → '') through likePatternLiteral.

Please find the attached functional test documentation.
[CLOUDERAHIVE_FUNCTIONAL_TEST_2026-05-18.xlsx](https://github.com/user-attachments/files/28013016/CLOUDERAHIVE_FUNCTIONAL_TEST_2026-05-18.xlsx)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
