### PR TITLE
[athena-neptune] Bump commons-configuration2 to 2.15.0 and jackson to 2.21.1

### DIFF
--- a/athena-federation-integ-test/pom.xml
+++ b/athena-federation-integ-test/pom.xml
@@ -106,7 +106,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${fasterxml.jackson.version}</version>
+            <version>${fasterxml.jackson-annotations.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/athena-kafka/pom.xml
+++ b/athena-kafka/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${fasterxml.jackson.version}</version>
+            <version>${fasterxml.jackson-annotations.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/athena-msk/pom.xml
+++ b/athena-msk/pom.xml
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${fasterxml.jackson.version}</version>
+            <version>${fasterxml.jackson-annotations.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/athena-neptune/pom.xml
+++ b/athena-neptune/pom.xml
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-configuration2</artifactId>
-            <version>2.14.0</version>
+            <version>2.15.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,8 @@
         <jqwik.version>1.9.3</jqwik.version>
         <assertj.version>3.27.7</assertj.version>
         <testng.version>7.12.0</testng.version>
-         <!--- to meet engine version 2.12.6 -->
-        <fasterxml.jackson.version>2.19.2</fasterxml.jackson.version>
+        <fasterxml.jackson.version>2.21.1</fasterxml.jackson.version>
+        <fasterxml.jackson-annotations.version>2.21</fasterxml.jackson-annotations.version>
         <surefire.failsafe.version>3.5.5</surefire.failsafe.version>
         <log4j2Version>2.26.0</log4j2Version>
         <apache.arrow.version>18.3.0</apache.arrow.version>
@@ -227,7 +227,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${fasterxml.jackson.version}</version>
+            <version>${fasterxml.jackson-annotations.version}</version>
         </dependency>
         <dependency>
             <groupId>net.jqwik</groupId>


### PR DESCRIPTION
Bumps two dependencies to current upstream patch releases.

| Component | From | To |
|---|---|---|
| `org.apache.commons:commons-configuration2` | 2.14.0 | 2.15.0 |
| Jackson modules (`fasterxml.jackson.version`) | 2.19.2 | 2.21.1 |

`jackson-annotations` stopped publishing patch versions at 2.20, so it is pinned via a new `${fasterxml.jackson-annotations.version}=2.21` property (mirroring upstream `com.fasterxml.jackson:jackson-bom:2.21.1`). The four module poms that reference jackson-annotations explicitly are updated to use the new property.

Files changed: `pom.xml`, `athena-neptune/pom.xml`, `athena-federation-integ-test/pom.xml`, `athena-msk/pom.xml`, `athena-kafka/pom.xml`.

### Supersedes

- #3437, #3444 — Dependabot `commons-configuration2` 2.14.0 → 2.15.0 (open)
- #3243, #3301 — Dependabot Jackson 2.19.2 → 2.21.x (closed un-merged; could not resolve `jackson-annotations:2.21.x`)