### PR TITLE
[athena-federation-sdk] Upgrade Apache Arrow to 19.0.0 for Netty 4.2.x compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <fasterxml.jackson.version>2.19.2</fasterxml.jackson.version>
         <surefire.failsafe.version>3.5.5</surefire.failsafe.version>
         <log4j2Version>2.26.0</log4j2Version>
-        <apache.arrow.version>18.3.0</apache.arrow.version>
+        <apache.arrow.version>19.0.0</apache.arrow.version>
         <guava.version>33.6.0-jre</guava.version>
         <protobuf3.version>3.25.5</protobuf3.version>
         <antlr.st4.version>4.3.4</antlr.st4.version>


### PR DESCRIPTION
## Problem

The `athena-federation-sdk` test suite fails completely when running on JDK 17 with the Netty 4.2.x BOM override already present in the parent `pom.xml`.

**Failure chain:**
```
NettyAllocationManager.<clinit>
  → PooledByteBufAllocatorL.<init>
  → UnsafeDirectLittleEndian.<init>(line 45)
  → DuplicatedByteBuf.memoryAddress()
  → EmptyByteBuf.memoryAddress()
  → UnsupportedOperationException
```

Arrow 18.3.0 was built against Netty 4.1.x. Its `arrow-memory-netty-buffer-patch` JAR contains a patched `UnsafeDirectLittleEndian` whose constructor calls `EmptyByteBuf.memoryAddress()`. In Netty 4.2.x, `EmptyByteBuf.hasMemoryAddress()` returns `false` when `sun.misc.Unsafe` direct-buffer access is unavailable (which occurs under JDK 17+ with restricted reflection), so `memoryAddress()` throws `UnsupportedOperationException`. This causes `ExceptionInInitializerError` in `NettyAllocationManager.<clinit>`, which cascades to `NoClassDefFoundError: RootAllocator` across all SDK tests (630 tests, 254 failures + 15 errors).

## Fix

Upgrade `apache.arrow.version` from `18.3.0` to `19.0.0`.

Arrow 19.0.0 was built against Netty 4.2.9.Final (`dep.netty-bom.version=4.2.9.Final` in `arrow-java-root-19.0.0.pom`). Its allocator initialization is compatible with Netty 4.2.x semantics.

**Change:** one property in the root `pom.xml`:
```xml
-<apache.arrow.version>18.3.0</apache.arrow.version>
+<apache.arrow.version>19.0.0</apache.arrow.version>
```

## Verification

| Scope | JDK | Arrow | Netty | Result |
|---|---|---|---|---|
| `athena-federation-sdk` tests | 17 | 18.3.0 | 4.2.13.Final | ❌ 254 failures, 15 errors |
| `athena-federation-sdk` tests | 17 | 19.0.0 | 4.2.13.Final | ✅ 630 tests, 0 failures |
| `athena-neptune` tests | 17 | 19.0.0 | 4.2.13.Final | ✅ same pass/fail as baseline (4 pre-existing errors unrelated to Arrow) |

The 4 pre-existing `athena-neptune` test errors (`NoClassDefFoundError: MetadataLoader`, `NoSuchMethodError: ImmutableMap$Builder.allowDuplicateKeys`) are present on `master` before this change and are unrelated to Arrow.
