### PR TITLE
Fix Vertica connection timeout issue due to resource leakage.

### DIFF
--- a/athena-vertica/src/main/java/com/amazonaws/athena/connectors/vertica/VerticaMetadataHandler.java
+++ b/athena-vertica/src/main/java/com/amazonaws/athena/connectors/vertica/VerticaMetadataHandler.java
@@ -104,6 +104,7 @@ public class VerticaMetadataHandler
     private static final String EMPTY_STRING = StringUtils.EMPTY;
     private static final String TABLE_SCHEMA = "TABLE_SCHEM";
     private static final String[] TABLE_TYPES = {"TABLE"};
+    private static final int VERTICA_STALE_CONNECTION_ERROR = 100023;
     private final QueryFactory queryFactory = new QueryFactory();
     private final VerticaSchemaUtils verticaSchemaUtils;
     private S3Client amazonS3;
@@ -153,12 +154,11 @@ public class VerticaMetadataHandler
             return new ListSchemasResponse(request.getCatalogName(), fetchSchemaNames());
         }
         catch (SQLException e) {
-            // VJDBC(100023) means a stale pooled connection was reused after a Lambda freeze/resume.
-            // Lambda freezes the JVM between requests; during that time Vertica may close its end of
-            // the idle pooled connection. When Lambda resumes, HikariCP hands back that dead connection
-            // and getTables() fails mid-protocol. Retry once to get a fresh connection.
-            if (e.getMessage() != null && e.getMessage().contains("100023")) {
-                logger.warn("doListSchemaNames: stale connection detected (VJDBC 100023), retrying with fresh connection");
+            // Error code 100023 indicates a stale pooled connection may have been
+            // reused after a Lambda freeze/resume cycle. Retry once to obtain a fresh connection.
+            if (e.getErrorCode() == VERTICA_STALE_CONNECTION_ERROR) {
+                logger.warn("doListSchemaNames: stale connection detected (errorCode={}), retrying with fresh connection",
+                        VERTICA_STALE_CONNECTION_ERROR);
                 return new ListSchemasResponse(request.getCatalogName(), fetchSchemaNames());
             }
             throw e;

--- a/athena-vertica/src/main/java/com/amazonaws/athena/connectors/vertica/VerticaMetadataHandler.java
+++ b/athena-vertica/src/main/java/com/amazonaws/athena/connectors/vertica/VerticaMetadataHandler.java
@@ -37,6 +37,7 @@ import com.amazonaws.athena.connector.lambda.metadata.GetTableRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableResponse;
 import com.amazonaws.athena.connector.lambda.metadata.ListSchemasRequest;
 import com.amazonaws.athena.connector.lambda.metadata.ListSchemasResponse;
+import com.amazonaws.athena.connector.lambda.exceptions.AthenaConnectorException;
 import com.amazonaws.athena.connector.lambda.metadata.optimizations.OptimizationSubType;
 import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionConfig;
 import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionInfo;
@@ -58,6 +59,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
+import software.amazon.awssdk.services.glue.model.ErrorDetails;
+import software.amazon.awssdk.services.glue.model.FederationSourceErrorCode;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.ListObjectsRequest;
 import software.amazon.awssdk.services.s3.model.ListObjectsResponse;
@@ -146,20 +149,37 @@ public class VerticaMetadataHandler
             throws Exception
     {
         logger.info("doListSchemaNames: {}", request.getCatalogName());
+        try {
+            return new ListSchemasResponse(request.getCatalogName(), fetchSchemaNames());
+        }
+        catch (SQLException e) {
+            // VJDBC(100023) means a stale pooled connection was reused after a Lambda freeze/resume.
+            // Lambda freezes the JVM between requests; during that time Vertica may close its end of
+            // the idle pooled connection. When Lambda resumes, HikariCP hands back that dead connection
+            // and getTables() fails mid-protocol. Retry once to get a fresh connection.
+            if (e.getMessage() != null && e.getMessage().contains("100023")) {
+                logger.warn("doListSchemaNames: stale connection detected (VJDBC 100023), retrying with fresh connection");
+                return new ListSchemasResponse(request.getCatalogName(), fetchSchemaNames());
+            }
+            throw e;
+        }
+    }
+
+    private List<String> fetchSchemaNames() throws Exception
+    {
         List<String> schemas = new ArrayList<>();
         try (Connection client = getJdbcConnectionFactory().getConnection(getCredentialProvider())) {
             DatabaseMetaData dbMetadata = client.getMetaData();
-            ResultSet rs  = dbMetadata.getTables(null, null, null, TABLE_TYPES);
-
+            ResultSet rs = dbMetadata.getTables(null, null, null, TABLE_TYPES);
             while (rs.next())
             {
-                if(!schemas.contains(rs.getString(TABLE_SCHEMA)))
+                if (!schemas.contains(rs.getString(TABLE_SCHEMA)))
                 {
                     schemas.add(rs.getString(TABLE_SCHEMA));
                 }
             }
         }
-        return new ListSchemasResponse(request.getCatalogName(), schemas);
+        return schemas;
     }
 
     protected ArrowType getArrayArrowTypeFromTypeName(String typeName, int precision, int scale)
@@ -229,16 +249,17 @@ public class VerticaMetadataHandler
     public GetTableResponse doGetTable(BlockAllocator allocator, GetTableRequest request) throws Exception
     {
         Set<String> partitionCols = new HashSet<>();
-        Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider());
+        try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider())) {
 
-        //build the schema as per columns in Vertica
-        Schema schema = verticaSchemaUtils.buildTableSchema(connection, request.getTableName());
+            //build the schema as per columns in Vertica
+            Schema schema = verticaSchemaUtils.buildTableSchema(connection, request.getTableName());
 
-        return new GetTableResponse(request.getCatalogName(),
-                request.getTableName(),
-                schema,
-                partitionCols
-        );
+            return new GetTableResponse(request.getCatalogName(),
+                    request.getTableName(),
+                    schema,
+                    partitionCols
+            );
+        }
     }
 
     /**
@@ -277,29 +298,26 @@ public class VerticaMetadataHandler
 
         String randomStr = UUID.randomUUID().toString();
         String queryID = request.getQueryId().replace("-","").concat(randomStr);
-
-        //Build the SQL query
-        Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider());
-
         // if  QPT get input query from Athena console
         //else old logic
 
         VerticaExportQueryBuilder queryBuilder = queryFactory.createVerticaExportQueryBuilder();
         String preparedSQLStmt;
 
-        if (!request.getTableName().getQualifiedTableName().equalsIgnoreCase(queryPassthrough.getFunctionSignature())) {
+        try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider())) {
+            if (!request.getTableName().getQualifiedTableName().equalsIgnoreCase(queryPassthrough.getFunctionSignature())) {
+                DatabaseMetaData dbMetadata = connection.getMetaData();
+                ResultSet definition = dbMetadata.getColumns(null, tableName.getSchemaName(), tableName.getTableName(), null);
 
-            DatabaseMetaData dbMetadata = connection.getMetaData();
-            ResultSet definition = dbMetadata.getColumns(null, tableName.getSchemaName(), tableName.getTableName(), null);
-
-            preparedSQLStmt = queryBuilder.withS3ExportBucket(s3ExportBucket)
-                    .withQueryID(queryID)
-                    .withColumns(definition, schemaName)
-                    .fromTable(tableName.getSchemaName(), tableName.getTableName())
-                    .withConstraints(constraints, schemaName)
-                    .build();
-        } else {
-            preparedSQLStmt = null;
+                preparedSQLStmt = queryBuilder.withS3ExportBucket(s3ExportBucket)
+                        .withQueryID(queryID)
+                        .withColumns(definition, schemaName)
+                        .fromTable(tableName.getSchemaName(), tableName.getTableName())
+                        .withConstraints(constraints, schemaName)
+                        .build();
+            } else {
+                preparedSQLStmt = null;
+            }
         }
 
         logger.info("Vertica Export Statement: {}", preparedSQLStmt);
@@ -334,93 +352,96 @@ public class VerticaMetadataHandler
     public GetSplitsResponse doGetSplits(BlockAllocator allocator, GetSplitsRequest request)
     {
         //ToDo: implement use of a continuation token to use in case of larger queries
-        Connection connection;
-        try {
-            connection = getJdbcConnectionFactory().getConnection(getCredentialProvider());
-        } catch (Exception e) {
-            throw new RuntimeException("connection failed ", e);
-        }
-        Set<Split> splits = new HashSet<>();
-        String exportBucket = getS3ExportBucket();
-        String queryId = request.getQueryId().replace("-","");
-        Constraints constraints  = request.getConstraints();
-        String s3ExportBucket = getS3ExportBucket();
-        String sqlStatement;
-        //testing if the user has access to the requested table
+        try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider())) {
+            Set<Split> splits = new HashSet<>();
+            String exportBucket = getS3ExportBucket();
+            String queryId = request.getQueryId().replace("-","");
+            Constraints constraints  = request.getConstraints();
+            String s3ExportBucket = getS3ExportBucket();
+            String sqlStatement;
+            //testing if the user has access to the requested table
 
-        FieldReader fieldReaderQid = request.getPartitions().getFieldReader("queryId");
-        String queryID  = fieldReaderQid.readText().toString();
+            FieldReader fieldReaderQid = request.getPartitions().getFieldReader("queryId");
+            String queryID  = fieldReaderQid.readText().toString();
 
-        //get the SQL statement which was created in getPartitions
-        FieldReader fieldReaderPS = request.getPartitions().getFieldReader("preparedStmt");
-        if (constraints.isQueryPassThrough()) {
-            String preparedSQL = buildQueryPassthroughSql(constraints);
+            //get the SQL statement which was created in getPartitions
+            FieldReader fieldReaderPS = request.getPartitions().getFieldReader("preparedStmt");
+            if (constraints.isQueryPassThrough()) {
+                String preparedSQL = buildQueryPassthroughSql(constraints);
 
-            VerticaExportQueryBuilder queryBuilder = queryFactory.createQptVerticaExportQueryBuilder();
-            sqlStatement = queryBuilder.withS3ExportBucket(s3ExportBucket)
-                    .withQueryID(queryID)
-                    .withPreparedStatementSQL(preparedSQL).build();
-            logger.info("Vertica Export Statement: {}", sqlStatement);
-        }
-        else {
-            testAccess(connection, request.getTableName());
-            sqlStatement = fieldReaderPS.readText().toString();
-        }
-        String catalogName = request.getCatalogName();
+                VerticaExportQueryBuilder queryBuilder = queryFactory.createQptVerticaExportQueryBuilder();
+                sqlStatement = queryBuilder.withS3ExportBucket(s3ExportBucket)
+                        .withQueryID(queryID)
+                        .withPreparedStatementSQL(preparedSQL).build();
+                logger.info("Vertica Export Statement: {}", sqlStatement);
+            }
+            else {
+                testAccess(connection, request.getTableName());
+                sqlStatement = fieldReaderPS.readText().toString();
+            }
+            String catalogName = request.getCatalogName();
 
-        FieldReader fieldReaderAwsRegion = request.getPartitions().getFieldReader("awsRegionSql");
-        String awsRegionSql  = fieldReaderAwsRegion.readText().toString();
+            FieldReader fieldReaderAwsRegion = request.getPartitions().getFieldReader("awsRegionSql");
+            String awsRegionSql  = fieldReaderAwsRegion.readText().toString();
 
-        // Split the string by the first occurrence of "/"
-        String[] s3ExportBucketPath = exportBucket.split(SEPARATOR, 2); // The '2' limits the split to 2 parts
-        String s3ExportBucketName;
-        String remainingPath;
+            // Split the string by the first occurrence of "/"
+            String[] s3ExportBucketPath = exportBucket.split(SEPARATOR, 2); // The '2' limits the split to 2 parts
+            String s3ExportBucketName;
+            String remainingPath;
 
-        if (s3ExportBucketPath.length == 2) {
-            s3ExportBucketName = s3ExportBucketPath[0];
-            remainingPath = s3ExportBucketPath[1] + SEPARATOR;
-        } else {
-            s3ExportBucketName = s3ExportBucket;
-            remainingPath = "";
-        }
-        String prefix = remainingPath + queryId;
+            if (s3ExportBucketPath.length == 2) {
+                s3ExportBucketName = s3ExportBucketPath[0];
+                remainingPath = s3ExportBucketPath[1] + SEPARATOR;
+            } else {
+                s3ExportBucketName = s3ExportBucket;
+                remainingPath = "";
+            }
+            String prefix = remainingPath + queryId;
 
-        List<S3Object> s3ObjectsList = getlistExportedObjects(s3ExportBucketName, prefix);
-        if (s3ObjectsList.isEmpty()) {
-            // Execute queries on Vertica if S3 export bucket does not contain objects for given queryId
-            executeQueriesOnVertica(connection, sqlStatement, awsRegionSql);
-            // Retrieve the S3 objects list for given queryId
-            s3ObjectsList = getlistExportedObjects(s3ExportBucketName, prefix);
-        }
+            List<S3Object> s3ObjectsList = getlistExportedObjects(s3ExportBucketName, prefix);
+            if (s3ObjectsList.isEmpty()) {
+                // Execute queries on Vertica if S3 export bucket does not contain objects for given queryId
+                executeQueriesOnVertica(connection, sqlStatement, awsRegionSql);
+                // Retrieve the S3 objects list for given queryId
+                s3ObjectsList = getlistExportedObjects(s3ExportBucketName, prefix);
+            }
 
-        Split split;
+            Split split;
 
-        // Create a split for each s3 object
-        if(!s3ObjectsList.isEmpty())
-        {
-            for (S3Object s3Object : s3ObjectsList)
+            // Create a split for each s3 object
+            if(!s3ObjectsList.isEmpty())
             {
+                for (S3Object s3Object : s3ObjectsList)
+                {
+                    split = Split.newBuilder(makeSpillLocation(request), makeEncryptionKey())
+                            .add(VERTICA_SPLIT_QUERY_ID, queryID)
+                            .add(VERTICA_SPLIT_EXPORT_BUCKET, s3ExportBucketName)
+                            .add(VERTICA_SPLIT_OBJECT_KEY, s3Object.key())
+                            .build();
+                    splits.add(split);
+
+                }
+                return new GetSplitsResponse(catalogName, splits);
+            }
+            else
+            {
+                //No records were exported by Vertica for the issued query, creating a "empty" split
+                logger.info("No records were exported by Vertica");
                 split = Split.newBuilder(makeSpillLocation(request), makeEncryptionKey())
                         .add(VERTICA_SPLIT_QUERY_ID, queryID)
-                        .add(VERTICA_SPLIT_EXPORT_BUCKET, s3ExportBucketName)
-                        .add(VERTICA_SPLIT_OBJECT_KEY, s3Object.key())
+                        .add(VERTICA_SPLIT_EXPORT_BUCKET, exportBucket)
+                        .add(VERTICA_SPLIT_OBJECT_KEY, EMPTY_STRING)
                         .build();
                 splits.add(split);
-
+                return new GetSplitsResponse(catalogName,split);
             }
-            return new GetSplitsResponse(catalogName, splits);
         }
-        else
-        {
-            //No records were exported by Vertica for the issued query, creating a "empty" split
-            logger.info("No records were exported by Vertica");
-            split = Split.newBuilder(makeSpillLocation(request), makeEncryptionKey())
-                    .add(VERTICA_SPLIT_QUERY_ID, queryID)
-                    .add(VERTICA_SPLIT_EXPORT_BUCKET, exportBucket)
-                    .add(VERTICA_SPLIT_OBJECT_KEY, EMPTY_STRING)
-                    .build();
-            splits.add(split);
-            return new GetSplitsResponse(catalogName,split);
+        catch (RuntimeException e) {
+            throw e;
+        }
+        catch (Exception e) {
+            throw new AthenaConnectorException("connection failed: " + e.getMessage(), e,
+                    ErrorDetails.builder().errorCode(FederationSourceErrorCode.INTERNAL_SERVICE_EXCEPTION.toString()).build());
         }
 
     }

--- a/athena-vertica/src/main/java/com/amazonaws/athena/connectors/vertica/VerticaMetadataHandler.java
+++ b/athena-vertica/src/main/java/com/amazonaws/athena/connectors/vertica/VerticaMetadataHandler.java
@@ -137,6 +137,33 @@ public class VerticaMetadataHandler
         this.verticaSchemaUtils = verticaSchemaUtils;
     }
 
+    @FunctionalInterface
+    private interface SqlSupplier<T>
+    {
+        T get() throws Exception;
+    }
+
+    /**
+     * Executes a JDBC-backed action, retrying once on Vertica error 100023, which indicates a
+     * stale pooled connection reused after a Lambda freeze/resume. The retry borrows a new
+     * connection, so it must be paired with try-with-resources cleanup (a leaked/unclosed
+     * connection would just be re-borrowed in the same broken state).
+     */
+    private <T> T withStaleConnectionRetry(SqlSupplier<T> action) throws Exception
+    {
+        try {
+            return action.get();
+        }
+        catch (SQLException e) {
+            if (e.getErrorCode() != VERTICA_STALE_CONNECTION_ERROR) {
+                throw e;
+            }
+            logger.warn("Stale connection detected (errorCode={}), retrying once with a fresh connection",
+                    VERTICA_STALE_CONNECTION_ERROR);
+            return action.get();
+        }
+    }
+
     /**
      * Used to get the list of schemas (aka databases) that this source contains.
      *
@@ -150,36 +177,19 @@ public class VerticaMetadataHandler
             throws Exception
     {
         logger.info("doListSchemaNames: {}", request.getCatalogName());
-        try {
-            return new ListSchemasResponse(request.getCatalogName(), fetchSchemaNames());
-        }
-        catch (SQLException e) {
-            // Error code 100023 indicates a stale pooled connection may have been
-            // reused after a Lambda freeze/resume cycle. Retry once to obtain a fresh connection.
-            if (e.getErrorCode() == VERTICA_STALE_CONNECTION_ERROR) {
-                logger.warn("doListSchemaNames: stale connection detected (errorCode={}), retrying with fresh connection",
-                        VERTICA_STALE_CONNECTION_ERROR);
-                return new ListSchemasResponse(request.getCatalogName(), fetchSchemaNames());
-            }
-            throw e;
-        }
-    }
-
-    private List<String> fetchSchemaNames() throws Exception
-    {
-        List<String> schemas = new ArrayList<>();
-        try (Connection client = getJdbcConnectionFactory().getConnection(getCredentialProvider())) {
-            DatabaseMetaData dbMetadata = client.getMetaData();
-            ResultSet rs = dbMetadata.getTables(null, null, null, TABLE_TYPES);
-            while (rs.next())
-            {
-                if (!schemas.contains(rs.getString(TABLE_SCHEMA)))
-                {
-                    schemas.add(rs.getString(TABLE_SCHEMA));
+        return withStaleConnectionRetry(() -> {
+            List<String> schemas = new ArrayList<>();
+            try (Connection client = getJdbcConnectionFactory().getConnection(getCredentialProvider())) {
+                DatabaseMetaData dbMetadata = client.getMetaData();
+                ResultSet rs = dbMetadata.getTables(null, null, null, TABLE_TYPES);
+                while (rs.next()) {
+                    if (!schemas.contains(rs.getString(TABLE_SCHEMA))) {
+                        schemas.add(rs.getString(TABLE_SCHEMA));
+                    }
                 }
             }
-        }
-        return schemas;
+            return new ListSchemasResponse(request.getCatalogName(), schemas);
+        });
     }
 
     protected ArrowType getArrayArrowTypeFromTypeName(String typeName, int precision, int scale)
@@ -208,24 +218,26 @@ public class VerticaMetadataHandler
         queryPassthrough.verify(getTableRequest.getQueryPassthroughArguments());
         String customerPassedQuery = getTableRequest.getQueryPassthroughArguments().get(JdbcQueryPassthrough.QUERY);
 
-        try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider())) {
-            PreparedStatement preparedStatement = connection.prepareStatement(customerPassedQuery);
-            ResultSetMetaData metadata = preparedStatement.getMetaData();
-            if (metadata == null) {
-                throw new UnsupportedOperationException("Query not supported: ResultSetMetaData not available for query: " + customerPassedQuery);
-            }
-            SchemaBuilder schemaBuilder = SchemaBuilder.newBuilder();
+        return withStaleConnectionRetry(() -> {
+            try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider())) {
+                PreparedStatement preparedStatement = connection.prepareStatement(customerPassedQuery);
+                ResultSetMetaData metadata = preparedStatement.getMetaData();
+                if (metadata == null) {
+                    throw new UnsupportedOperationException("Query not supported: ResultSetMetaData not available for query: " + customerPassedQuery);
+                }
+                SchemaBuilder schemaBuilder = SchemaBuilder.newBuilder();
 
-            for (int columnIndex = 1; columnIndex <= metadata.getColumnCount(); columnIndex++) {
-                String columnName = metadata.getColumnName(columnIndex);
-                String columnLabel = metadata.getColumnLabel(columnIndex);
-                columnName = columnName.equals(columnLabel) ? columnName : columnLabel;
-                convertToArrowType(schemaBuilder, columnName, metadata.getColumnTypeName(columnIndex));
-            }
+                for (int columnIndex = 1; columnIndex <= metadata.getColumnCount(); columnIndex++) {
+                    String columnName = metadata.getColumnName(columnIndex);
+                    String columnLabel = metadata.getColumnLabel(columnIndex);
+                    columnName = columnName.equals(columnLabel) ? columnName : columnLabel;
+                    convertToArrowType(schemaBuilder, columnName, metadata.getColumnTypeName(columnIndex));
+                }
 
-            Schema schema = schemaBuilder.build();
-            return new GetTableResponse(getTableRequest.getCatalogName(), getTableRequest.getTableName(), schema, Collections.emptySet());
-        }
+                Schema schema = schemaBuilder.build();
+                return new GetTableResponse(getTableRequest.getCatalogName(), getTableRequest.getTableName(), schema, Collections.emptySet());
+            }
+        });
     }
 
     @Override
@@ -248,18 +260,18 @@ public class VerticaMetadataHandler
     @Override
     public GetTableResponse doGetTable(BlockAllocator allocator, GetTableRequest request) throws Exception
     {
-        Set<String> partitionCols = new HashSet<>();
-        try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider())) {
-
-            //build the schema as per columns in Vertica
-            Schema schema = verticaSchemaUtils.buildTableSchema(connection, request.getTableName());
-
-            return new GetTableResponse(request.getCatalogName(),
-                    request.getTableName(),
-                    schema,
-                    partitionCols
-            );
-        }
+        return withStaleConnectionRetry(() -> {
+            Set<String> partitionCols = new HashSet<>();
+            try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider())) {
+                //build the schema as per columns in Vertica
+                Schema schema = verticaSchemaUtils.buildTableSchema(connection, request.getTableName());
+                return new GetTableResponse(request.getCatalogName(),
+                        request.getTableName(),
+                        schema,
+                        partitionCols
+                );
+            }
+        });
     }
 
     /**
@@ -302,23 +314,22 @@ public class VerticaMetadataHandler
         //else old logic
 
         VerticaExportQueryBuilder queryBuilder = queryFactory.createVerticaExportQueryBuilder();
-        String preparedSQLStmt;
+        String preparedSQLStmt = withStaleConnectionRetry(() -> {
+            try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider())) {
+                if (!request.getTableName().getQualifiedTableName().equalsIgnoreCase(queryPassthrough.getFunctionSignature())) {
+                    DatabaseMetaData dbMetadata = connection.getMetaData();
+                    ResultSet definition = dbMetadata.getColumns(null, tableName.getSchemaName(), tableName.getTableName(), null);
 
-        try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider())) {
-            if (!request.getTableName().getQualifiedTableName().equalsIgnoreCase(queryPassthrough.getFunctionSignature())) {
-                DatabaseMetaData dbMetadata = connection.getMetaData();
-                ResultSet definition = dbMetadata.getColumns(null, tableName.getSchemaName(), tableName.getTableName(), null);
-
-                preparedSQLStmt = queryBuilder.withS3ExportBucket(s3ExportBucket)
-                        .withQueryID(queryID)
-                        .withColumns(definition, schemaName)
-                        .fromTable(tableName.getSchemaName(), tableName.getTableName())
-                        .withConstraints(constraints, schemaName)
-                        .build();
-            } else {
-                preparedSQLStmt = null;
+                    return queryBuilder.withS3ExportBucket(s3ExportBucket)
+                            .withQueryID(queryID)
+                            .withColumns(definition, schemaName)
+                            .fromTable(tableName.getSchemaName(), tableName.getTableName())
+                            .withConstraints(constraints, schemaName)
+                            .build();
+                }
+                return null;
             }
-        }
+        });
 
         logger.info("Vertica Export Statement: {}", preparedSQLStmt);
         // Build the Set AWS Region SQL - Assumes using the default region provider chain
@@ -352,95 +363,99 @@ public class VerticaMetadataHandler
     public GetSplitsResponse doGetSplits(BlockAllocator allocator, GetSplitsRequest request)
     {
         //ToDo: implement use of a continuation token to use in case of larger queries
-        try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider())) {
-            Set<Split> splits = new HashSet<>();
-            String exportBucket = getS3ExportBucket();
-            String queryId = request.getQueryId().replace("-","");
-            Constraints constraints  = request.getConstraints();
-            String s3ExportBucket = getS3ExportBucket();
-            String sqlStatement;
-            //testing if the user has access to the requested table
+        try {
+            return withStaleConnectionRetry(() -> {
+                try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider())) {
+                    Set<Split> splits = new HashSet<>();
+                    String exportBucket = getS3ExportBucket();
+                    String queryId = request.getQueryId().replace("-","");
+                    Constraints constraints  = request.getConstraints();
+                    String s3ExportBucket = getS3ExportBucket();
+                    String sqlStatement;
+                    //testing if the user has access to the requested table
 
-            FieldReader fieldReaderQid = request.getPartitions().getFieldReader("queryId");
-            String queryID  = fieldReaderQid.readText().toString();
+                    FieldReader fieldReaderQid = request.getPartitions().getFieldReader("queryId");
+                    String queryID  = fieldReaderQid.readText().toString();
 
-            //get the SQL statement which was created in getPartitions
-            FieldReader fieldReaderPS = request.getPartitions().getFieldReader("preparedStmt");
-            if (constraints.isQueryPassThrough()) {
-                String preparedSQL = buildQueryPassthroughSql(constraints);
+                    //get the SQL statement which was created in getPartitions
+                    FieldReader fieldReaderPS = request.getPartitions().getFieldReader("preparedStmt");
+                    if (constraints.isQueryPassThrough()) {
+                        String preparedSQL = buildQueryPassthroughSql(constraints);
 
-                VerticaExportQueryBuilder queryBuilder = queryFactory.createQptVerticaExportQueryBuilder();
-                sqlStatement = queryBuilder.withS3ExportBucket(s3ExportBucket)
-                        .withQueryID(queryID)
-                        .withPreparedStatementSQL(preparedSQL).build();
-                logger.info("Vertica Export Statement: {}", sqlStatement);
-            }
-            else {
-                testAccess(connection, request.getTableName());
-                sqlStatement = fieldReaderPS.readText().toString();
-            }
-            String catalogName = request.getCatalogName();
+                        VerticaExportQueryBuilder queryBuilder = queryFactory.createQptVerticaExportQueryBuilder();
+                        sqlStatement = queryBuilder.withS3ExportBucket(s3ExportBucket)
+                                .withQueryID(queryID)
+                                .withPreparedStatementSQL(preparedSQL).build();
+                        logger.info("Vertica Export Statement: {}", sqlStatement);
+                    }
+                    else {
+                        testAccess(connection, request.getTableName());
+                        sqlStatement = fieldReaderPS.readText().toString();
+                    }
+                    String catalogName = request.getCatalogName();
 
-            FieldReader fieldReaderAwsRegion = request.getPartitions().getFieldReader("awsRegionSql");
-            String awsRegionSql  = fieldReaderAwsRegion.readText().toString();
+                    FieldReader fieldReaderAwsRegion = request.getPartitions().getFieldReader("awsRegionSql");
+                    String awsRegionSql  = fieldReaderAwsRegion.readText().toString();
 
-            // Split the string by the first occurrence of "/"
-            String[] s3ExportBucketPath = exportBucket.split(SEPARATOR, 2); // The '2' limits the split to 2 parts
-            String s3ExportBucketName;
-            String remainingPath;
+                    // Split the string by the first occurrence of "/"
+                    String[] s3ExportBucketPath = exportBucket.split(SEPARATOR, 2); // The '2' limits the split to 2 parts
+                    String s3ExportBucketName;
+                    String remainingPath;
 
-            if (s3ExportBucketPath.length == 2) {
-                s3ExportBucketName = s3ExportBucketPath[0];
-                remainingPath = s3ExportBucketPath[1] + SEPARATOR;
-            } else {
-                s3ExportBucketName = s3ExportBucket;
-                remainingPath = "";
-            }
-            String prefix = remainingPath + queryId;
+                    if (s3ExportBucketPath.length == 2) {
+                        s3ExportBucketName = s3ExportBucketPath[0];
+                        remainingPath = s3ExportBucketPath[1] + SEPARATOR;
+                    } else {
+                        s3ExportBucketName = s3ExportBucket;
+                        remainingPath = "";
+                    }
+                    String prefix = remainingPath + queryId;
 
-            List<S3Object> s3ObjectsList = getlistExportedObjects(s3ExportBucketName, prefix);
-            if (s3ObjectsList.isEmpty()) {
-                // Execute queries on Vertica if S3 export bucket does not contain objects for given queryId
-                executeQueriesOnVertica(connection, sqlStatement, awsRegionSql);
-                // Retrieve the S3 objects list for given queryId
-                s3ObjectsList = getlistExportedObjects(s3ExportBucketName, prefix);
-            }
+                    List<S3Object> s3ObjectsList = getlistExportedObjects(s3ExportBucketName, prefix);
+                    if (s3ObjectsList.isEmpty()) {
+                        // Execute queries on Vertica if S3 export bucket does not contain objects for given queryId
+                        executeQueriesOnVertica(connection, sqlStatement, awsRegionSql);
+                        // Retrieve the S3 objects list for given queryId
+                        s3ObjectsList = getlistExportedObjects(s3ExportBucketName, prefix);
+                    }
 
-            Split split;
+                    Split split;
 
-            // Create a split for each s3 object
-            if(!s3ObjectsList.isEmpty())
-            {
-                for (S3Object s3Object : s3ObjectsList)
-                {
-                    split = Split.newBuilder(makeSpillLocation(request), makeEncryptionKey())
-                            .add(VERTICA_SPLIT_QUERY_ID, queryID)
-                            .add(VERTICA_SPLIT_EXPORT_BUCKET, s3ExportBucketName)
-                            .add(VERTICA_SPLIT_OBJECT_KEY, s3Object.key())
-                            .build();
-                    splits.add(split);
+                    // Create a split for each s3 object
+                    if(!s3ObjectsList.isEmpty())
+                    {
+                        for (S3Object s3Object : s3ObjectsList)
+                        {
+                            split = Split.newBuilder(makeSpillLocation(request), makeEncryptionKey())
+                                    .add(VERTICA_SPLIT_QUERY_ID, queryID)
+                                    .add(VERTICA_SPLIT_EXPORT_BUCKET, s3ExportBucketName)
+                                    .add(VERTICA_SPLIT_OBJECT_KEY, s3Object.key())
+                                    .build();
+                            splits.add(split);
 
+                        }
+                        return new GetSplitsResponse(catalogName, splits);
+                    }
+                    else
+                    {
+                        //No records were exported by Vertica for the issued query, creating a "empty" split
+                        logger.info("No records were exported by Vertica");
+                        split = Split.newBuilder(makeSpillLocation(request), makeEncryptionKey())
+                                .add(VERTICA_SPLIT_QUERY_ID, queryID)
+                                .add(VERTICA_SPLIT_EXPORT_BUCKET, exportBucket)
+                                .add(VERTICA_SPLIT_OBJECT_KEY, EMPTY_STRING)
+                                .build();
+                        splits.add(split);
+                        return new GetSplitsResponse(catalogName,split);
+                    }
                 }
-                return new GetSplitsResponse(catalogName, splits);
-            }
-            else
-            {
-                //No records were exported by Vertica for the issued query, creating a "empty" split
-                logger.info("No records were exported by Vertica");
-                split = Split.newBuilder(makeSpillLocation(request), makeEncryptionKey())
-                        .add(VERTICA_SPLIT_QUERY_ID, queryID)
-                        .add(VERTICA_SPLIT_EXPORT_BUCKET, exportBucket)
-                        .add(VERTICA_SPLIT_OBJECT_KEY, EMPTY_STRING)
-                        .build();
-                splits.add(split);
-                return new GetSplitsResponse(catalogName,split);
-            }
+            });
         }
         catch (RuntimeException e) {
             throw e;
         }
         catch (Exception e) {
-            throw new AthenaConnectorException("connection failed: " + e.getMessage(), e,
+            throw new AthenaConnectorException("Failed to get splits: " + e.getMessage(), e,
                     ErrorDetails.builder().errorCode(FederationSourceErrorCode.INTERNAL_SERVICE_EXCEPTION.toString()).build());
         }
 

--- a/athena-vertica/src/test/java/com/amazonaws/athena/connectors/vertica/VerticaMetadataHandlerTest.java
+++ b/athena-vertica/src/test/java/com/amazonaws/athena/connectors/vertica/VerticaMetadataHandlerTest.java
@@ -970,10 +970,11 @@ public class VerticaMetadataHandlerTest extends TestBase
         AtomicInteger rowNumber = new AtomicInteger(-1);
         ResultSet resultSet = mockResultSet(schema, values, rowNumber);
 
-        // first connection is stale — throws VJDBC 100023 (Lambda freeze/resume scenario)
+        // first connection is stale — throws VJDBC error code 100023 (Lambda freeze/resume scenario)
+        // SQLException(reason, sqlState, vendorCode): vendorCode is what getErrorCode() returns
         Connection staleConnection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);
         Mockito.when(staleConnection.getMetaData().getTables(null, null, null, TABLE_TYPES))
-                .thenThrow(new SQLException("[Vertica][VJDBC](100023) Unexpected message type: RowDescription"));
+                .thenThrow(new SQLException("Unexpected message type: RowDescription", "S1000", 100023));
 
         // second connection is fresh — succeeds
         Connection freshConnection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);
@@ -996,8 +997,9 @@ public class VerticaMetadataHandlerTest extends TestBase
     @Test
     public void doListSchemaNames_NonStaleSQLException_NotRetried() throws Exception {
         Connection failingConnection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);
+        // error code 0 (any non-100023 code) must not trigger retry
         Mockito.when(failingConnection.getMetaData().getTables(null, null, null, TABLE_TYPES))
-                .thenThrow(new SQLException("Some other DB error"));
+                .thenThrow(new SQLException("Some other DB error", "S1000", 0));
 
         Mockito.when(jdbcConnectionFactory.getConnection(nullable(CredentialsProvider.class)))
                 .thenReturn(failingConnection);

--- a/athena-vertica/src/test/java/com/amazonaws/athena/connectors/vertica/VerticaMetadataHandlerTest.java
+++ b/athena-vertica/src/test/java/com/amazonaws/athena/connectors/vertica/VerticaMetadataHandlerTest.java
@@ -44,6 +44,7 @@ import com.amazonaws.athena.connector.lambda.metadata.ListTablesRequest;
 import com.amazonaws.athena.connector.lambda.metadata.ListTablesResponse;
 import com.amazonaws.athena.connector.lambda.metadata.MetadataRequestType;
 import com.amazonaws.athena.connector.lambda.metadata.MetadataResponse;
+import com.amazonaws.athena.connector.lambda.exceptions.AthenaConnectorException;
 import com.amazonaws.athena.connector.lambda.security.FederatedIdentity;
 import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionConfig;
 import com.amazonaws.athena.connectors.jdbc.connection.JdbcConnectionFactory;
@@ -78,6 +79,7 @@ import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -890,6 +892,164 @@ public class VerticaMetadataHandlerTest extends TestBase
         Assert.assertEquals(expectedExportSql, actualSql);
 
         logger.info("Empty constraints test - Generated SQL: {}", actualSql);
+    }
+    
+    @Test
+    public void doGetTable_WithValidSchema_ConnectionClosed() throws Exception {
+        Schema tableSchema = SchemaBuilder.newBuilder().addIntField("id").build();
+        Mockito.when(verticaSchemaUtils.buildTableSchema(connection, tableName)).thenReturn(tableSchema);
+
+        GetTableRequest request = new GetTableRequest(federatedIdentity, QUERY_ID, TEST_CATALOG, tableName, Collections.emptyMap());
+        verticaMetadataHandler.doGetTable(allocator, request);
+
+        // try-with-resources must call connection.close() exactly once
+        Mockito.verify(connection, Mockito.times(1)).close();
+    }
+
+    @Test
+    public void getPartitions_WithValidColumns_ConnectionClosed() throws Exception {
+        String[] schema = {TABLE_SCHEM, TABLE_NAME, COLUMN_NAME, TYPE_NAME};
+        Object[][] values = {{TEST_SCHEMA, TEST_TABLE, "id", "int"}};
+        int[] types = {Types.INTEGER};
+        AtomicInteger rowNumber = new AtomicInteger(-1);
+        ResultSet resultSet = mockResultSet(schema, types, values, rowNumber);
+
+        Mockito.when(connection.getMetaData().getColumns(null, TEST_SCHEMA, TEST_TABLE, null)).thenReturn(resultSet);
+        Mockito.lenient().when(queryFactory.createVerticaExportQueryBuilder())
+                .thenReturn(new VerticaExportQueryBuilder(new ST("templateVerticaExportQuery")));
+        Mockito.when(verticaMetadataHandlerMocked.getS3ExportBucket()).thenReturn(TEST_S3_BUCKET);
+
+        Schema tableSchema = SchemaBuilder.newBuilder().addIntField("id").build();
+        Set<String> partitionCols = new HashSet<>();
+
+        try (GetTableLayoutRequest req = new GetTableLayoutRequest(federatedIdentity, TEST_QUERY_ID, DEFAULT_CATALOG,
+                new TableName(TEST_SCHEMA, TEST_TABLE),
+                new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null),
+                tableSchema, partitionCols);
+             GetTableLayoutResponse res = verticaMetadataHandlerMocked.doGetTableLayout(allocator, req)) {
+            assertNotNull(res);
+        }
+
+        // connection.close() must be called (try-with-resources in getPartitions)
+        Mockito.verify(connection, Mockito.atLeastOnce()).close();
+    }
+
+    @Test
+    public void doGetSplits_WithValidPartitions_ConnectionClosed() throws Exception {
+        Schema schema = SchemaBuilder.newBuilder()
+                .addStringField("preparedStmt")
+                .addStringField(TEST_QUERY_ID)
+                .addStringField(AWS_REGION_SQL_FIELD)
+                .build();
+
+        Block partitions = allocator.createBlock(schema);
+        BlockUtils.setValue(partitions.getFieldVector("preparedStmt"), 0, TEST_VALUE);
+        BlockUtils.setValue(partitions.getFieldVector(TEST_QUERY_ID), 0, "123");
+        BlockUtils.setValue(partitions.getFieldVector(AWS_REGION_SQL_FIELD), 0, "us-west-2");
+
+        List<S3Object> objectList = new ArrayList<>();
+        objectList.add(S3Object.builder().key("testKey").build());
+        Mockito.when(verticaMetadataHandlerMocked.getS3ExportBucket()).thenReturn(TEST_S3_BUCKET);
+        Mockito.when(amazonS3.listObjects(nullable(ListObjectsRequest.class)))
+                .thenReturn(ListObjectsResponse.builder().contents(objectList).build());
+
+        GetSplitsRequest req = new GetSplitsRequest(federatedIdentity, TEST_QUERY_ID, "catalog_name",
+                new TableName("schema", "table_name"), partitions, Collections.emptyList(),
+                new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null), null);
+
+        verticaMetadataHandlerMocked.doGetSplits(allocator, req);
+
+        // connection.close() must be called (try-with-resources in doGetSplits)
+        Mockito.verify(connection, Mockito.times(1)).close();
+    }
+    
+    @Test
+    public void doListSchemaNames_StaleConnection_RetriesAndReturnsSchemas() throws Exception {
+        String[] schema = {"TABLE_SCHEM"};
+        Object[][] values = {{"testDB1"}};
+        AtomicInteger rowNumber = new AtomicInteger(-1);
+        ResultSet resultSet = mockResultSet(schema, values, rowNumber);
+
+        // first connection is stale — throws VJDBC 100023 (Lambda freeze/resume scenario)
+        Connection staleConnection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);
+        Mockito.when(staleConnection.getMetaData().getTables(null, null, null, TABLE_TYPES))
+                .thenThrow(new SQLException("[Vertica][VJDBC](100023) Unexpected message type: RowDescription"));
+
+        // second connection is fresh — succeeds
+        Connection freshConnection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);
+        Mockito.when(freshConnection.getMetaData().getTables(null, null, null, TABLE_TYPES)).thenReturn(resultSet);
+        Mockito.when(resultSet.next()).thenReturn(true).thenReturn(false);
+
+        Mockito.when(jdbcConnectionFactory.getConnection(nullable(CredentialsProvider.class)))
+                .thenReturn(staleConnection)
+                .thenReturn(freshConnection);
+
+        ListSchemasResponse response = verticaMetadataHandler.doListSchemaNames(allocator,
+                new ListSchemasRequest(federatedIdentity, QUERY_ID, TEST_CATALOG));
+
+        Assert.assertArrayEquals(new String[]{"testDB1"}, response.getSchemas().toArray());
+        // getConnection() must be called exactly twice: once for stale, once for retry
+        Mockito.verify(jdbcConnectionFactory, Mockito.times(2))
+                .getConnection(nullable(CredentialsProvider.class));
+    }
+
+    @Test
+    public void doListSchemaNames_NonStaleSQLException_NotRetried() throws Exception {
+        Connection failingConnection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);
+        Mockito.when(failingConnection.getMetaData().getTables(null, null, null, TABLE_TYPES))
+                .thenThrow(new SQLException("Some other DB error"));
+
+        Mockito.when(jdbcConnectionFactory.getConnection(nullable(CredentialsProvider.class)))
+                .thenReturn(failingConnection);
+
+        try {
+            verticaMetadataHandler.doListSchemaNames(allocator,
+                    new ListSchemasRequest(federatedIdentity, QUERY_ID, TEST_CATALOG));
+            fail("Expected SQLException");
+        } catch (SQLException e) {
+            assertEquals("Some other DB error", e.getMessage());
+        }
+
+        // getConnection() must be called only once — non-100023 errors must not trigger retry
+        Mockito.verify(jdbcConnectionFactory, Mockito.times(1))
+                .getConnection(nullable(CredentialsProvider.class));
+    }
+    
+    @Test
+    public void doGetSplits_CheckedExceptionFromGetConnection_WrappedAsConnectionFailed() throws Exception {
+        // A checked Exception thrown by getConnection() must be wrapped with "connection failed"
+        // to preserve the original error message contract.
+        JdbcConnectionFactory failingFactory = Mockito.mock(JdbcConnectionFactory.class);
+        Mockito.when(failingFactory.getConnection(nullable(CredentialsProvider.class)))
+                .thenThrow(new Exception("DB host unreachable"));
+
+        VerticaMetadataHandler handlerWithFailingFactory = new VerticaMetadataHandler(
+                databaseConnectionConfig, failingFactory,
+                com.google.common.collect.ImmutableMap.of(), amazonS3, verticaSchemaUtils);
+
+        Schema schema = SchemaBuilder.newBuilder()
+                .addStringField("preparedStmt")
+                .addStringField(TEST_QUERY_ID)
+                .addStringField(AWS_REGION_SQL_FIELD)
+                .build();
+
+        Block partitions = allocator.createBlock(schema);
+        BlockUtils.setValue(partitions.getFieldVector("preparedStmt"), 0, TEST_VALUE);
+        BlockUtils.setValue(partitions.getFieldVector(TEST_QUERY_ID), 0, "123");
+        BlockUtils.setValue(partitions.getFieldVector(AWS_REGION_SQL_FIELD), 0, "us-west-2");
+
+        GetSplitsRequest req = new GetSplitsRequest(federatedIdentity, TEST_QUERY_ID, "catalog_name",
+                new TableName("schema", "table_name"), partitions, Collections.emptyList(),
+                new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null), null);
+
+        try {
+            handlerWithFailingFactory.doGetSplits(allocator, req);
+            fail("Expected AthenaConnectorException");
+        } catch (AthenaConnectorException e) {
+            assertTrue("Checked exception must be wrapped as 'connection failed'",
+                    e.getMessage().contains("connection failed"));
+            assertEquals("Original cause must be preserved", "DB host unreachable", e.getCause().getMessage());
+        }
     }
 
     private Schema createTestSchema(String... columnSpecs)

--- a/athena-vertica/src/test/java/com/amazonaws/athena/connectors/vertica/VerticaMetadataHandlerTest.java
+++ b/athena-vertica/src/test/java/com/amazonaws/athena/connectors/vertica/VerticaMetadataHandlerTest.java
@@ -964,63 +964,8 @@ public class VerticaMetadataHandlerTest extends TestBase
     }
     
     @Test
-    public void doListSchemaNames_StaleConnection_RetriesAndReturnsSchemas() throws Exception {
-        String[] schema = {"TABLE_SCHEM"};
-        Object[][] values = {{"testDB1"}};
-        AtomicInteger rowNumber = new AtomicInteger(-1);
-        ResultSet resultSet = mockResultSet(schema, values, rowNumber);
-
-        // first connection is stale — throws VJDBC error code 100023 (Lambda freeze/resume scenario)
-        // SQLException(reason, sqlState, vendorCode): vendorCode is what getErrorCode() returns
-        Connection staleConnection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);
-        Mockito.when(staleConnection.getMetaData().getTables(null, null, null, TABLE_TYPES))
-                .thenThrow(new SQLException("Unexpected message type: RowDescription", "S1000", 100023));
-
-        // second connection is fresh — succeeds
-        Connection freshConnection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);
-        Mockito.when(freshConnection.getMetaData().getTables(null, null, null, TABLE_TYPES)).thenReturn(resultSet);
-        Mockito.when(resultSet.next()).thenReturn(true).thenReturn(false);
-
-        Mockito.when(jdbcConnectionFactory.getConnection(nullable(CredentialsProvider.class)))
-                .thenReturn(staleConnection)
-                .thenReturn(freshConnection);
-
-        ListSchemasResponse response = verticaMetadataHandler.doListSchemaNames(allocator,
-                new ListSchemasRequest(federatedIdentity, QUERY_ID, TEST_CATALOG));
-
-        Assert.assertArrayEquals(new String[]{"testDB1"}, response.getSchemas().toArray());
-        // getConnection() must be called exactly twice: once for stale, once for retry
-        Mockito.verify(jdbcConnectionFactory, Mockito.times(2))
-                .getConnection(nullable(CredentialsProvider.class));
-    }
-
-    @Test
-    public void doListSchemaNames_NonStaleSQLException_NotRetried() throws Exception {
-        Connection failingConnection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);
-        // error code 0 (any non-100023 code) must not trigger retry
-        Mockito.when(failingConnection.getMetaData().getTables(null, null, null, TABLE_TYPES))
-                .thenThrow(new SQLException("Some other DB error", "S1000", 0));
-
-        Mockito.when(jdbcConnectionFactory.getConnection(nullable(CredentialsProvider.class)))
-                .thenReturn(failingConnection);
-
-        try {
-            verticaMetadataHandler.doListSchemaNames(allocator,
-                    new ListSchemasRequest(federatedIdentity, QUERY_ID, TEST_CATALOG));
-            fail("Expected SQLException");
-        } catch (SQLException e) {
-            assertEquals("Some other DB error", e.getMessage());
-        }
-
-        // getConnection() must be called only once — non-100023 errors must not trigger retry
-        Mockito.verify(jdbcConnectionFactory, Mockito.times(1))
-                .getConnection(nullable(CredentialsProvider.class));
-    }
-    
-    @Test
-    public void doGetSplits_CheckedExceptionFromGetConnection_WrappedAsConnectionFailed() throws Exception {
-        // A checked Exception thrown by getConnection() must be wrapped with "connection failed"
-        // to preserve the original error message contract.
+    public void doGetSplits_CheckedExceptionFromGetConnection_WrappedAsFailedToGetSplits() throws Exception {
+        // A checked Exception thrown by getConnection() must be wrapped as AthenaConnectorException
         JdbcConnectionFactory failingFactory = Mockito.mock(JdbcConnectionFactory.class);
         Mockito.when(failingFactory.getConnection(nullable(CredentialsProvider.class)))
                 .thenThrow(new Exception("DB host unreachable"));
@@ -1048,10 +993,75 @@ public class VerticaMetadataHandlerTest extends TestBase
             handlerWithFailingFactory.doGetSplits(allocator, req);
             fail("Expected AthenaConnectorException");
         } catch (AthenaConnectorException e) {
-            assertTrue("Checked exception must be wrapped as 'connection failed'",
-                    e.getMessage().contains("connection failed"));
+            assertTrue("Checked exception must be wrapped as 'Failed to get splits'",
+                    e.getMessage().contains("Failed to get splits"));
             assertEquals("Original cause must be preserved", "DB host unreachable", e.getCause().getMessage());
         }
+    }
+
+    @Test
+    public void doListSchemaNames_StaleConnection_RetriesAndReturnsSchemas() throws Exception {
+        String[] schema = {"TABLE_SCHEM"};
+        Object[][] values = {{"testDB1"}};
+        AtomicInteger rowNumber = new AtomicInteger(-1);
+        ResultSet resultSet = mockResultSet(schema, values, rowNumber);
+
+        Connection staleConnection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);
+        Mockito.when(staleConnection.getMetaData().getTables(null, null, null, TABLE_TYPES))
+                .thenThrow(new SQLException("Unexpected message type: RowDescription", "S1000", 100023));
+
+        Connection freshConnection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);
+        Mockito.when(freshConnection.getMetaData().getTables(null, null, null, TABLE_TYPES)).thenReturn(resultSet);
+        Mockito.when(resultSet.next()).thenReturn(true).thenReturn(false);
+
+        Mockito.when(jdbcConnectionFactory.getConnection(nullable(CredentialsProvider.class)))
+                .thenReturn(staleConnection)
+                .thenReturn(freshConnection);
+
+        ListSchemasResponse response = verticaMetadataHandler.doListSchemaNames(allocator,
+                new ListSchemasRequest(federatedIdentity, QUERY_ID, TEST_CATALOG));
+
+        Assert.assertArrayEquals(new String[]{"testDB1"}, response.getSchemas().toArray());
+        Mockito.verify(jdbcConnectionFactory, Mockito.times(2))
+                .getConnection(nullable(CredentialsProvider.class));
+    }
+
+    @Test
+    public void doListSchemaNames_NonStaleSQLException_NotRetriedAndExceptionPropagates() throws Exception {
+        Connection failingConnection = Mockito.mock(Connection.class, Mockito.RETURNS_DEEP_STUBS);
+        Mockito.when(failingConnection.getMetaData().getTables(null, null, null, TABLE_TYPES))
+                .thenThrow(new SQLException("Some other DB error", "S1000", 0));
+
+        Mockito.when(jdbcConnectionFactory.getConnection(nullable(CredentialsProvider.class)))
+                .thenReturn(failingConnection);
+
+        try {
+            verticaMetadataHandler.doListSchemaNames(allocator,
+                    new ListSchemasRequest(federatedIdentity, QUERY_ID, TEST_CATALOG));
+            fail("Expected SQLException");
+        } catch (SQLException e) {
+            assertEquals("Some other DB error", e.getMessage());
+        }
+
+        Mockito.verify(jdbcConnectionFactory, Mockito.times(1))
+                .getConnection(nullable(CredentialsProvider.class));
+    }
+
+    @Test
+    public void doGetTable_StaleConnection_RetriesAndReturnsTable() throws Exception {
+        Schema tableSchema = SchemaBuilder.newBuilder().addIntField("id").build();
+
+        Mockito.when(jdbcConnectionFactory.getConnection(nullable(CredentialsProvider.class)))
+                .thenThrow(new SQLException("Unexpected message type: RowDescription", "S1000", 100023))
+                .thenReturn(connection);
+        Mockito.when(verticaSchemaUtils.buildTableSchema(connection, tableName)).thenReturn(tableSchema);
+
+        GetTableResponse response = verticaMetadataHandler.doGetTable(allocator,
+                new GetTableRequest(federatedIdentity, QUERY_ID, TEST_CATALOG, tableName, Collections.emptyMap()));
+
+        assertEquals(tableSchema, response.getSchema());
+        Mockito.verify(jdbcConnectionFactory, Mockito.times(2))
+                .getConnection(nullable(CredentialsProvider.class));
     }
 
     private Schema createTestSchema(String... columnSpecs)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
While testing the Vertica connector, we observed that after running some queries it throws a connection timeout error due to resource leakage. Fixed this by wrapping JDBC connections in try-with-resources to ensure connections are always closed and returned to the pool after use.
PFA Functional Testing and analysis document for reference.
[VERTICA_FUNCTIONAL_TEST_2026-05-26.xlsx](https://github.com/user-attachments/files/28254250/VERTICA_FUNCTIONAL_TEST_2026-05-26.xlsx)
[Vertica Connection Issue Analysis.docx](https://github.com/user-attachments/files/28877693/Vertica.Connection.Issue.Analysis.docx)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
