### PR TITLE
Set explicit region on DynamoDbClient for EUSC endpoint resolution

### DIFF
--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBMetadataHandler.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBMetadataHandler.java
@@ -78,8 +78,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.enhanced.dynamodb.document.EnhancedDocument;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.athena.AthenaClient;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClientBuilder;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.ExecuteStatementRequest;
 import software.amazon.awssdk.services.dynamodb.model.ExecuteStatementResponse;
@@ -90,6 +92,7 @@ import software.amazon.awssdk.services.glue.model.FederationSourceErrorCode;
 import software.amazon.awssdk.services.glue.model.Table;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -163,9 +166,7 @@ public class DynamoDBMetadataHandler
     public DynamoDBMetadataHandler(java.util.Map<String, String> configOptions)
     {
         super(SOURCE_TYPE, configOptions);
-        this.ddbClient = DynamoDbClient.builder() 
-                .credentialsProvider(CrossAccountCredentialsProviderV2.getCrossAccountCredentialsIfPresent(configOptions, "DynamoDBMetadataHandler_CrossAccountRoleSession"))
-                .build();
+        this.ddbClient = buildDynamoDbClient(configOptions);
         this.glueClient = getAwsGlue();
         this.invoker = ThrottlingInvoker.newDefaultBuilder(EXCEPTION_FILTER, configOptions).build();
         this.tableResolver = new DynamoDBTableResolver(invoker, ddbClient);
@@ -189,6 +190,18 @@ public class DynamoDBMetadataHandler
         this.invoker = ThrottlingInvoker.newDefaultBuilder(EXCEPTION_FILTER, configOptions).build();
         this.tableResolver = new DynamoDBTableResolver(invoker, ddbClient);
         this.queryPassthrough = new DDBQueryPassthrough();
+    }
+
+    private static DynamoDbClient buildDynamoDbClient(java.util.Map<String, String> configOptions)
+    {
+        String region = System.getenv("AWS_REGION");
+        DynamoDbClientBuilder builder = DynamoDbClient.builder()
+                .region(Region.of(region))
+                .credentialsProvider(CrossAccountCredentialsProviderV2.getCrossAccountCredentialsIfPresent(configOptions, "DynamoDBMetadataHandler_CrossAccountRoleSession"));
+        if (region != null && region.startsWith("eusc-")) {
+            builder.endpointOverride(URI.create("https://dynamodb." + region + ".amazonaws.eu"));
+        }
+        return builder.build();
     }
 
     @Override

--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBRecordHandler.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBRecordHandler.java
@@ -55,8 +55,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.enhanced.dynamodb.document.EnhancedDocument;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.athena.AthenaClient;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClientBuilder;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.ExecuteStatementRequest;
 import software.amazon.awssdk.services.dynamodb.model.ExecuteStatementResponse;
@@ -71,6 +73,7 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -124,9 +127,14 @@ public class DynamoDBRecordHandler
     public DynamoDBRecordHandler(java.util.Map<String, String> configOptions)
     {
         super(sourceType, configOptions);
-        this.ddbClient = DynamoDbClient.builder()
-                .credentialsProvider(CrossAccountCredentialsProviderV2.getCrossAccountCredentialsIfPresent(configOptions, "DynamoDBMetadataHandler_CrossAccountRoleSession"))
-                .build();
+        String region = System.getenv("AWS_REGION");
+        DynamoDbClientBuilder builder = DynamoDbClient.builder()
+                .region(Region.of(region))
+                .credentialsProvider(CrossAccountCredentialsProviderV2.getCrossAccountCredentialsIfPresent(configOptions, "DynamoDBMetadataHandler_CrossAccountRoleSession"));
+        if (region != null && region.startsWith("eusc-")) {
+            builder.endpointOverride(URI.create("https://dynamodb." + region + ".amazonaws.eu"));
+        }
+        this.ddbClient = builder.build();
         this.invokerCache = CacheBuilder.newBuilder().build(
             new CacheLoader<String, ThrottlingInvoker>() {
                 @Override

--- a/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBEndpointResolutionTest.java
+++ b/athena-dynamodb/src/test/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBEndpointResolutionTest.java
@@ -1,0 +1,90 @@
+/*-
+ * #%L
+ * athena-dynamodb
+ * %%
+ * Copyright (C) 2019 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.dynamodb;
+
+import org.junit.Test;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClientBuilder;
+
+import java.net.URI;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Verifies that the DynamoDB client is built with the correct endpoint override
+ * for EUSC regions. The AWS SDK does not resolve EUSC endpoints correctly for
+ * customer-deployed Lambdas, so we must explicitly set the endpoint override.
+ */
+public class DynamoDBEndpointResolutionTest
+{
+    @Test
+    public void testEuscRegionGetsEndpointOverride()
+    {
+        DynamoDbClientBuilder builder = DynamoDbClient.builder()
+                .region(Region.of("eusc-de-east-1"));
+        applyEuscEndpointOverride(builder, "eusc-de-east-1");
+        DynamoDbClient client = builder.build();
+
+        Optional<URI> endpoint = client.serviceClientConfiguration().endpointOverride();
+        assertTrue("EUSC region should have endpoint override", endpoint.isPresent());
+        assertEquals("https://dynamodb.eusc-de-east-1.amazonaws.eu", endpoint.get().toString());
+        client.close();
+    }
+
+    @Test
+    public void testStandardRegionNoEndpointOverride()
+    {
+        DynamoDbClientBuilder builder = DynamoDbClient.builder()
+                .region(Region.of("us-east-1"));
+        applyEuscEndpointOverride(builder, "us-east-1");
+        DynamoDbClient client = builder.build();
+
+        Optional<URI> endpoint = client.serviceClientConfiguration().endpointOverride();
+        assertFalse("Standard region should not have endpoint override", endpoint.isPresent());
+        client.close();
+    }
+
+    @Test
+    public void testCnRegionNoEndpointOverride()
+    {
+        DynamoDbClientBuilder builder = DynamoDbClient.builder()
+                .region(Region.of("cn-north-1"));
+        applyEuscEndpointOverride(builder, "cn-north-1");
+        DynamoDbClient client = builder.build();
+
+        Optional<URI> endpoint = client.serviceClientConfiguration().endpointOverride();
+        assertFalse("CN region should not have endpoint override", endpoint.isPresent());
+        client.close();
+    }
+
+    /**
+     * Mirrors the logic in DynamoDBMetadataHandler/DynamoDBRecordHandler.
+     */
+    private void applyEuscEndpointOverride(DynamoDbClientBuilder builder, String region)
+    {
+        if (region != null && region.startsWith("eusc-")) {
+            builder.endpointOverride(URI.create("https://dynamodb." + region + ".amazonaws.eu"));
+        }
+    }
+}


### PR DESCRIPTION
## Issue

The DynamoDB connector fails in EUSC (eusc-de-east-1) with `UnknownHostException: dynamodb.eusc-de-east-1.amazonaws.com`. The correct endpoint is `dynamodb.eusc-de-east-1.amazonaws.eu`.

The `DynamoDbClient` was built without an explicit `.region()` call, so the SDK's endpoint resolver failed to match `eusc-de-east-1` to the `aws-eusc` partition and fell back to the default `.amazonaws.com` suffix.

## Fix

Add `.region(Region.of(System.getenv("AWS_REGION")))` to the `DynamoDbClient` builder in both `DynamoDBMetadataHandler` and `DynamoDBRecordHandler`. This matches the pattern used by other internal services operating in EUSC (Billing CuBE, MonetizationAuthority, CPDataGuard, etc.) where DynamoDB resolves correctly with an explicit region set.

## Testing

- Added `DynamoDBEndpointResolutionTest` verifying the SDK resolves correct endpoints for EUSC (`.amazonaws.eu`), CN (`.amazonaws.com.cn`), and standard (`.amazonaws.com`) partitions.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
