### PR TITLE
Downgrade Gremlin to Neptune-compatible version and fix CVEs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,7 @@ updates:
       - dependency-name: "com.google.api.grpc:grpc-google-cloud-bigquerystorage-v1"
       - dependency-name: "io.grpc:grpc-api"
       - dependency-name: "software.amazon.msk:aws-msk-iam-auth"
+      - dependency-name: "org.apache.tinkerpop:*"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/athena-federation-integ-test/pom.xml
+++ b/athena-federation-integ-test/pom.xml
@@ -106,7 +106,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${fasterxml.jackson.version}</version>
+            <version>${fasterxml.jackson.annotations.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/athena-kafka/pom.xml
+++ b/athena-kafka/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${fasterxml.jackson.version}</version>
+            <version>${fasterxml.jackson.annotations.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/athena-msk/pom.xml
+++ b/athena-msk/pom.xml
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${fasterxml.jackson.version}</version>
+            <version>${fasterxml.jackson.annotations.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/athena-neptune/pom.xml
+++ b/athena-neptune/pom.xml
@@ -10,7 +10,7 @@
     <version>2022.47.1</version>
     <properties>
         <!-- make sure gremlin driver version stays within the Neptune supported range -->
-        <gremlinDriverVersion>3.8.1</gremlinDriverVersion>
+        <gremlinDriverVersion>3.7.3</gremlinDriverVersion>
         <neptune.sigv4.signer.version>3.1.0</neptune.sigv4.signer.version>
     </properties>
     <dependencyManagement>
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-configuration2</artifactId>
-            <version>2.14.0</version>
+            <version>2.15.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.commons</groupId>

--- a/athena-neptune/pom.xml
+++ b/athena-neptune/pom.xml
@@ -9,7 +9,8 @@
     <artifactId>athena-neptune</artifactId>
     <version>2022.47.1</version>
     <properties>
-        <!-- make sure gremlin driver version stays within the Neptune supported range -->
+        <!-- make sure gremlin driver version stays within the Neptune supported range
+             https://docs.aws.amazon.com/neptune/latest/userguide/access-graph-gremlin.html -->
         <gremlinDriverVersion>3.7.3</gremlinDriverVersion>
         <neptune.sigv4.signer.version>3.1.0</neptune.sigv4.signer.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,8 @@
         <testng.version>7.12.0</testng.version>
          <!--- to meet engine version 2.12.6 -->
         <fasterxml.jackson.version>2.21.1</fasterxml.jackson.version>
+        <!-- jackson-annotations does not publish patch versions -->
+        <fasterxml.jackson.annotations.version>2.21</fasterxml.jackson.annotations.version>
         <surefire.failsafe.version>3.5.5</surefire.failsafe.version>
         <log4j2Version>2.26.0</log4j2Version>
         <apache.arrow.version>18.3.0</apache.arrow.version>
@@ -227,7 +229,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.21</version>
+            <version>${fasterxml.jackson.annotations.version}</version>
         </dependency>
         <dependency>
             <groupId>net.jqwik</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <!-- for redshift iam auth still using sdkv1 -->
         <aws-sdk.version>1.12.797</aws-sdk.version>
         <aws.lambda-java-core.version>1.2.2</aws.lambda-java-core.version>
-        <aws.lambda-java-log4j2.version>1.6.2</aws.lambda-java-log4j2.version>
+        <aws.lambda-java-log4j2.version>1.6.4</aws.lambda-java-log4j2.version>
         <aws-cdk.version>1.204.0</aws-cdk.version>
         <jsii.version>1.129.0</jsii.version>
         <!--- to meet engine version 2.0.7-->
@@ -29,7 +29,7 @@
         <assertj.version>3.27.7</assertj.version>
         <testng.version>7.12.0</testng.version>
          <!--- to meet engine version 2.12.6 -->
-        <fasterxml.jackson.version>2.19.2</fasterxml.jackson.version>
+        <fasterxml.jackson.version>2.21.1</fasterxml.jackson.version>
         <surefire.failsafe.version>3.5.5</surefire.failsafe.version>
         <log4j2Version>2.26.0</log4j2Version>
         <apache.arrow.version>18.3.0</apache.arrow.version>
@@ -227,7 +227,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${fasterxml.jackson.version}</version>
+            <version>2.21</version>
         </dependency>
         <dependency>
             <groupId>net.jqwik</groupId>


### PR DESCRIPTION
**Summary**

- Downgrade Gremlin driver to 3.7.3 (Neptune 1.4.x max supported TinkerPop version)
- Fix CVEs 

**Changes**

| Dependency | From | To | CVE |
|---|---|---|---|
| `gremlin-driver` | 3.8.1 | 3.7.3 | [Neptune compatibility](https://docs.aws.amazon.com/neptune/latest/userguide/access-graph-gremlin.html) |
| `jackson-core`/`jackson-databind` | 2.19.2 | 2.21.1 | [GHSA-72hv-8253-57qq](https://github.com/advisories/GHSA-72hv-8253-57qq) |
| `jackson-annotations` | 2.19.2 | 2.21 | (aligned with jackson-core) |
| `aws-lambda-java-log4j2` | 1.6.2 | 1.6.4 | [CVE-2026-34478](https://nvd.nist.gov/vuln/detail/CVE-2026-34478), [CVE-2026-34480](https://nvd.nist.gov/vuln/detail/CVE-2026-34480) |
| `commons-configuration2` | 2.14.0 | 2.15.0 | [CVE-2026-45205](https://scout.docker.com/vulnerabilities/id/CVE-2026-45205) |

**Dependabot configuration:**
- Added `org.apache.tinkerpop:*` to the dependabot ignore list. TinkerPop versions are pinned to Neptune's supported range and must not be auto-bumped — upgrades require verifying Neptune engine compatibility first.
