### PR TITLE
S3BlockSpiller: emit Arrow stats as S3 user-metadata on spill

### DIFF
--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/S3BlockSpiller.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/S3BlockSpiller.java
@@ -82,6 +82,22 @@ public class S3BlockSpiller
     private static final String SPILL_QUEUE_CAPACITY = "SPILL_QUEUE_CAPACITY";
 
     private static final String SPILL_PUT_REQUEST_HEADERS_ENV = "spill_put_request_headers";
+
+    //S3 user-metadata key for the number of Arrow rows in the spilled block.
+    //Returned by HeadObject as the HTTP header `x-amz-meta-x-arrow-row-count`, allowing
+    //readers (e.g. SupportsReportStatistics) to obtain row counts without GetObject + decrypt.
+    static final String SPILL_METADATA_ROW_COUNT = "x-arrow-row-count";
+
+    //S3 user-metadata key for the in-memory Arrow buffer size (sum of FieldVector.getBufferSize()
+    //across all columns). This is the uncompressed/unencrypted size and is what stats consumers
+    //should treat as `sizeInBytes` -- distinct from the S3 object's contentLength which reflects
+    //the post-encryption byte count.
+    static final String SPILL_METADATA_BYTE_SIZE = "x-arrow-byte-size";
+
+    //S3 user-metadata key for the number of top-level columns in the spilled Block's schema.
+    //Lets readers cheaply detect schema-width drift without parsing the schema. Same value for
+    //every spill produced by a given spiller instance.
+    static final String SPILL_METADATA_NUM_COLUMNS = "x-arrow-num-columns";
     //Used to write to S3
     private final S3Client amazonS3;
     //Used to optionally encrypt Blocks.
@@ -379,7 +395,14 @@ public class S3BlockSpiller
             PutObjectRequest.Builder requestBuilder = PutObjectRequest.builder()
                     .bucket(spillLocation.getBucket())
                     .key(spillLocation.getKey())
-                    .contentLength((long) bytes.length);
+                    .contentLength((long) bytes.length)
+                    // S3 user-defined metadata: row count, uncompressed Arrow size, and column
+                    // count are exposed as `x-amz-meta-x-arrow-*` HTTP headers on HeadObject so
+                    // readers can size splits without GetObject + decrypt.
+                    .metadata(Map.of(
+                            SPILL_METADATA_ROW_COUNT, Integer.toString(block.getRowCount()),
+                            SPILL_METADATA_BYTE_SIZE, Long.toString(block.getSize()),
+                            SPILL_METADATA_NUM_COLUMNS, Integer.toString(schema.getFields().size())));
 
             // Set request headers via overrideConfiguration instead of metadata
             createRequestOverrideConfig().ifPresent(requestBuilder::overrideConfiguration);

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/data/S3BlockSpillerTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/data/S3BlockSpillerTest.java
@@ -220,8 +220,11 @@ public class S3BlockSpillerTest
         assertEquals("arn:aws:kms:us-east-1:123456789012:key/test-key-id", 
                 overrideConfig.headers().get("x-amz-server-side-encryption-aws-kms-key-id").get(0));
 
-        // Verify headers are NOT in metadata
-        assertTrue("Metadata should be null or empty, not contain headers", capturedRequest.metadata().isEmpty());
+        // Verify SSE-KMS request headers are NOT in user-metadata (they belong in overrideConfiguration)
+        assertFalse("SSE-KMS header should not appear in user-metadata",
+                capturedRequest.metadata().containsKey("x-amz-server-side-encryption"));
+        assertFalse("SSE-KMS key-id header should not appear in user-metadata",
+                capturedRequest.metadata().containsKey("x-amz-server-side-encryption-aws-kms-key-id"));
     }
 
     @Test
@@ -237,8 +240,9 @@ public class S3BlockSpillerTest
         assertFalse("Request should not have overrideConfiguration when no headers configured", 
                 capturedRequest.overrideConfiguration().isPresent());
 
-        // Verify metadata is null or empty
-        assertTrue("Metadata should be null when no headers configured", capturedRequest.metadata().isEmpty());
+        // Spill stats metadata is always present even when no request headers are configured.
+        assertTrue("Spill stats metadata should always be set",
+                capturedRequest.metadata().containsKey(S3BlockSpiller.SPILL_METADATA_ROW_COUNT));
     }
 
     @Test
@@ -277,8 +281,39 @@ public class S3BlockSpillerTest
         
         assertEquals("Should have 3 headers", 3, overrideConfig.headers().size());
 
-        // Verify headers are NOT in metadata
-        assertTrue("Metadata should be null, not contain headers", capturedRequest.metadata().isEmpty());
+        // Verify SSE-KMS / storage-class request headers are NOT in user-metadata
+        assertFalse(capturedRequest.metadata().containsKey("x-amz-server-side-encryption"));
+        assertFalse(capturedRequest.metadata().containsKey("x-amz-server-side-encryption-aws-kms-key-id"));
+        assertFalse(capturedRequest.metadata().containsKey("x-amz-storage-class"));
+    }
+
+    @Test
+    public void spillTest_WritesArrowStatsMetadata()
+            throws IOException
+    {
+        // expected has 2 columns (col1 Int32, col2 Utf8) and rowCount=2 (set in @Before).
+        PutObjectRequest capturedRequest = executeSpillWithConfig(com.google.common.collect.ImmutableMap.of());
+
+        java.util.Map<String, String> meta = capturedRequest.metadata();
+
+        // Row count: matches expected.getRowCount()
+        assertEquals("x-arrow-row-count must reflect Block.getRowCount()",
+                Integer.toString(expected.getRowCount()),
+                meta.get(S3BlockSpiller.SPILL_METADATA_ROW_COUNT));
+
+        // Byte size: matches Block.getSize() (uncompressed Arrow buffer size, not encrypted bytes).
+        assertEquals("x-arrow-byte-size must reflect Block.getSize()",
+                Long.toString(expected.getSize()),
+                meta.get(S3BlockSpiller.SPILL_METADATA_BYTE_SIZE));
+
+        // Column count: schema has 2 fields (col1, col2)
+        assertEquals("x-arrow-num-columns must reflect Schema.getFields().size()",
+                Integer.toString(expected.getSchema().getFields().size()),
+                meta.get(S3BlockSpiller.SPILL_METADATA_NUM_COLUMNS));
+
+        // No unexpected metadata keys leaked in (e.g. SSE-KMS request headers).
+        assertEquals("Only the three x-arrow-* stats keys should be in user-metadata",
+                3, meta.size());
     }
 
     /**


### PR DESCRIPTION
Adds three user-defined metadata keys to every PutObject issued by S3BlockSpiller.write(Block):

  - x-arrow-row-count   : Block.getRowCount()
  - x-arrow-byte-size   : Block.getSize() (uncompressed Arrow buffer size)
  - x-arrow-num-columns : Schema.getFields().size()

These are returned by S3 HeadObject as `x-amz-meta-*` HTTP headers, allowing readers (e.g. SupportsReportStatistics) to obtain row counts and uncompressed sizes without GetObject + AES-GCM decrypt + Arrow deserialize. Previously row count required reading the full encrypted spill payload because DNA spill files are bare Arrow RecordBatch messages with no footer/index.

Costs:
  - Write side: trivial (values are already computed by the spiller)
  - Wire: ~50 bytes of x-amz-meta-* headers per object (well under the 2 KB S3 user-metadata cap)
  - Read side: enables a HEAD-only stats path; decrypt is unaffected because user-metadata is on the S3 object, not inside the encrypted payload

Tests:
  - New S3BlockSpillerTest#spillTest_WritesArrowStatsMetadata asserts all three keys are present with correct values and that no other keys leak into user-metadata.
  - Updated three existing header-tests: their stale "metadata is empty" assertions now verify the SSE-KMS request headers do not leak into user-metadata (preserving original intent).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
