### PR TITLE
fix(athena-google-bigquery): Wrap REPEATED STRUCT sub-fields in Struct node in getChildFieldList

### DIFF
--- a/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryUtils.java
+++ b/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryUtils.java
@@ -32,6 +32,7 @@ import com.google.cloud.bigquery.DatasetId;
 import com.google.cloud.bigquery.FieldValue;
 import com.google.cloud.bigquery.LegacySQLTypeName;
 import com.google.cloud.bigquery.Table;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.sun.jna.platform.unix.LibC;
 import org.apache.arrow.vector.FieldVector;
@@ -210,7 +211,13 @@ public class BigQueryUtils
         if (null != field.getSubFields()) {
             for (com.google.cloud.bigquery.Field subField : field.getSubFields()) {
                 if (null != subField.getMode() && subField.getMode().name().equals("REPEATED")) {
-                    fieldList.add(new Field(subField.getName(), FieldType.nullable(Types.MinorType.LIST.getType()), getChildFieldList(subField)));
+                    if (subField.getType().getStandardType().name().equalsIgnoreCase("Struct")) {
+                        fieldList.add(new Field(subField.getName(), FieldType.nullable(Types.MinorType.LIST.getType()),
+                                ImmutableList.of(new Field(subField.getName(), FieldType.nullable(Types.MinorType.STRUCT.getType()), getChildFieldList(subField)))));
+                    }
+                    else {
+                        fieldList.add(new Field(subField.getName(), FieldType.nullable(Types.MinorType.LIST.getType()), getChildFieldList(subField)));
+                    }
                 }
                 else if (subField.getType().getStandardType().name().equalsIgnoreCase("Struct")) {
                     fieldList.add(new Field(subField.getName(), FieldType.nullable(Types.MinorType.STRUCT.getType()), getChildFieldList(subField)));

--- a/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryUtilsTest.java
+++ b/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryUtilsTest.java
@@ -211,6 +211,32 @@ public class BigQueryUtilsTest
         assertInstanceOf(ArrowType.Struct.class, nestedField.getType());
         assertEquals(2, nestedField.getChildren().size());
     }
+    @Test
+    public void testGetChildFieldListWithRepeatedStructSubField() {
+        // Simulate a REPEATED STRUCT sub-field (e.g. GA4 item_params nested inside a parent struct)
+        Field keyField = Field.of("key", LegacySQLTypeName.STRING);
+        Field valueField = Field.of("value", LegacySQLTypeName.STRING);
+        Field repeatedStructField = Field.newBuilder("item_params", LegacySQLTypeName.RECORD, keyField, valueField)
+                .setMode(Field.Mode.REPEATED).build();
+        Field parentStruct = Field.of("event", LegacySQLTypeName.RECORD,
+                Field.of("event_name", LegacySQLTypeName.STRING), repeatedStructField);
+
+        List<org.apache.arrow.vector.types.pojo.Field> result = BigQueryUtils.getChildFieldList(parentStruct);
+        assertNotNull(result);
+        assertEquals(2, result.size());
+
+        // The REPEATED STRUCT sub-field should be a List with 1 Struct child
+        org.apache.arrow.vector.types.pojo.Field itemParamsField = result.get(1);
+        assertEquals("item_params", itemParamsField.getName());
+        assertInstanceOf(org.apache.arrow.vector.types.pojo.ArrowType.List.class, itemParamsField.getType());
+        // Should have exactly 1 child (Struct wrapper), NOT 2 direct children
+        assertEquals(1, itemParamsField.getChildren().size());
+        org.apache.arrow.vector.types.pojo.Field structChild = itemParamsField.getChildren().get(0);
+        assertInstanceOf(ArrowType.Struct.class, structChild.getType());
+        assertEquals(2, structChild.getChildren().size());
+        assertEquals("key", structChild.getChildren().get(0).getName());
+        assertEquals("value", structChild.getChildren().get(1).getName());
+    }
 
     @Test
     public void testCoerceWithTimeVector() {


### PR DESCRIPTION
*Issue #, if available:*
Glue DNA metadata API got exception: `java.lang.IllegalArgumentException: Field: item_params contains 2 argument(s) [key: Utf8, value: Struct<string_value: Utf8, int_value: Int(64, true), float_value:
FloatingPoint(DOUBLE), double_value: FloatingPoint(DOUBLE)>]. Incompatible with List type, only 1 argument allowed.`

Description of changes:

getChildFieldList()` in `BigQueryUtils` did not wrap REPEATED STRUCT sub-fields in a Struct node. When a REPEATED RECORD field was nested inside another STRUCT (e.g. GA4 `item_params` inside an `event` struct), it placed the record's children directly under the List node, producing an invalid Arrow schema. This caused downstream consumers to fail with `IllegalArgumentException: Field contains N argument(s)... Incompatible with List type, only 1 argument allowed`.
The fix applies the same STRUCT wrapping pattern already used in `convertBigQuerySchema()` for top-level REPEATED STRUCT fields. 
Added unit test for nested REPEATED STRUCT sub-field.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
