### PR TITLE
fix wrong custom kms arn - using request override configuration

### DIFF
--- a/athena-docdb/src/main/java/com/amazonaws/athena/connectors/docdb/DocDBMetadataHandler.java
+++ b/athena-docdb/src/main/java/com/amazonaws/athena/connectors/docdb/DocDBMetadataHandler.java
@@ -417,7 +417,7 @@ public class DocDBMetadataHandler
 
         //Since our connector does not support parallel reads we return a fixed split.
         return new GetSplitsResponse(request.getCatalogName(),
-                Split.newBuilder(spillLocation, makeEncryptionKey())
+                Split.newBuilder(spillLocation, makeEncryptionKey(getRequestOverrideConfig(request)))
                         .add(DOCDB_CONN_STR, getConnStr(request))
                         .build());
     }

--- a/athena-elasticsearch/src/main/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchMetadataHandler.java
+++ b/athena-elasticsearch/src/main/java/com/amazonaws/athena/connectors/elasticsearch/ElasticsearchMetadataHandler.java
@@ -371,7 +371,7 @@ public class ElasticsearchMetadataHandler
         Set<Split> splits = Arrays.stream(indexResponse.getIndices())
                 .flatMap(index -> getShardsIDsFromES(client, index) // get all shards for an index.
                         .stream()
-                        .map(shardId -> new Split(makeSpillLocation(request), makeEncryptionKey(), ImmutableMap.of(SECRET_USERNAME, username, SECRET_PASSWORD, password, domain, endpoint, SHARD_KEY, SHARD_VALUE + shardId.toString(), INDEX_KEY, index))) // make split for each (index + shardId) combination
+                        .map(shardId -> new Split(makeSpillLocation(request), makeEncryptionKey(getRequestOverrideConfig(request)), ImmutableMap.of(SECRET_USERNAME, username, SECRET_PASSWORD, password, domain, endpoint, SHARD_KEY, SHARD_VALUE + shardId.toString(), INDEX_KEY, index))) // make split for each (index + shardId) combination
                 )
                 .collect(Collectors.toSet());
 

--- a/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryMetadataHandler.java
+++ b/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryMetadataHandler.java
@@ -252,7 +252,7 @@ public class BigQueryMetadataHandler
         SpillLocation spillLocation = makeSpillLocation(request);
 
         return new GetSplitsResponse(request.getCatalogName(), Split.newBuilder(spillLocation,
-                makeEncryptionKey()).build());
+                makeEncryptionKey(getRequestOverrideConfig(request))).build());
     }
 
     /**

--- a/athena-mysql/src/main/java/com/amazonaws/athena/connectors/mysql/MySqlMetadataHandler.java
+++ b/athena-mysql/src/main/java/com/amazonaws/athena/connectors/mysql/MySqlMetadataHandler.java
@@ -220,7 +220,7 @@ public class MySqlMetadataHandler
 
             LOGGER.info("{}: Input partition is {}", getSplitsRequest.getQueryId(), locationReader.readText());
 
-            Split.Builder splitBuilder = Split.newBuilder(spillLocation, makeEncryptionKey())
+            Split.Builder splitBuilder = Split.newBuilder(spillLocation, makeEncryptionKey(getRequestOverrideConfig(getSplitsRequest)))
                     .add(BLOCK_PARTITION_COLUMN_NAME, String.valueOf(locationReader.readText()));
 
             if (getSplitsRequest.getIdentity().getConfigOptions() != null && getSplitsRequest.getIdentity().getConfigOptions().containsKey(EnvironmentConstants.CATALOG_CASING_FILTER)) {

--- a/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleMetadataHandler.java
+++ b/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleMetadataHandler.java
@@ -228,7 +228,7 @@ public class OracleMetadataHandler
 
             LOGGER.info("{}: Input partition is {}", getSplitsRequest.getQueryId(), partitionValue);
 
-            Split.Builder splitBuilder = Split.newBuilder(spillLocation, makeEncryptionKey())
+            Split.Builder splitBuilder = Split.newBuilder(spillLocation, makeEncryptionKey(getRequestOverrideConfig(getSplitsRequest)))
                     .add(BLOCK_PARTITION_COLUMN_NAME, partitionValue);
 
             if (getSplitsRequest.getIdentity().getConfigOptions() != null && getSplitsRequest.getIdentity().getConfigOptions().containsKey(EnvironmentConstants.CATALOG_CASING_FILTER)) {

--- a/athena-postgresql/src/main/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlMetadataHandler.java
+++ b/athena-postgresql/src/main/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlMetadataHandler.java
@@ -251,7 +251,7 @@ public class PostGreSqlMetadataHandler
                     //Every split must have a unique location if we wish to spill to avoid failures
                     SpillLocation spillLocation = makeSpillLocation(getSplitsRequest);
 
-                    Split.Builder splitBuilder = Split.newBuilder(spillLocation, makeEncryptionKey())
+                    Split.Builder splitBuilder = Split.newBuilder(spillLocation, makeEncryptionKey(getRequestOverrideConfig(getSplitsRequest)))
                             .add(BLOCK_PARTITION_SCHEMA_COLUMN_NAME, String.valueOf(partitionsSchemaFieldReader.readText()))
                             .add(BLOCK_PARTITION_COLUMN_NAME, String.valueOf(splitClause));
 
@@ -282,7 +282,7 @@ public class PostGreSqlMetadataHandler
                 SpillLocation spillLocation = makeSpillLocation(getSplitsRequest);
 
                 LOGGER.info("{}: Input partition is {}", getSplitsRequest.getQueryId(), String.valueOf(partitionsFieldReader.readText()));
-                Split.Builder splitBuilder = Split.newBuilder(spillLocation, makeEncryptionKey())
+                Split.Builder splitBuilder = Split.newBuilder(spillLocation, makeEncryptionKey(getRequestOverrideConfig(getSplitsRequest)))
                         .add(BLOCK_PARTITION_SCHEMA_COLUMN_NAME, String.valueOf(partitionsSchemaFieldReader.readText()))
                         .add(BLOCK_PARTITION_COLUMN_NAME, String.valueOf(partitionsFieldReader.readText()));
 

--- a/athena-saphana/src/main/java/com/amazonaws/athena/connectors/saphana/SaphanaMetadataHandler.java
+++ b/athena-saphana/src/main/java/com/amazonaws/athena/connectors/saphana/SaphanaMetadataHandler.java
@@ -299,7 +299,7 @@ public class SaphanaMetadataHandler extends JdbcMetadataHandler
             locationReader.setPosition(curPartition);
             SpillLocation spillLocation = makeSpillLocation(getSplitsRequest);
             LOGGER.debug("{}: Input partition is {}", getSplitsRequest.getQueryId(), locationReader.readText());
-            Split.Builder splitBuilder = Split.newBuilder(spillLocation, makeEncryptionKey())
+            Split.Builder splitBuilder = Split.newBuilder(spillLocation, makeEncryptionKey(getRequestOverrideConfig(getSplitsRequest)))
                     .add(SaphanaConstants.BLOCK_PARTITION_COLUMN_NAME, String.valueOf(locationReader.readText()));
             if (getSplitsRequest.getIdentity()
                     .getConfigOptions().containsKey(EnvironmentConstants.CATALOG_CASING_FILTER)) {

--- a/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMetadataHandler.java
+++ b/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMetadataHandler.java
@@ -365,7 +365,7 @@ public class SnowflakeMetadataHandler extends JdbcMetadataHandler
             locationReader.setPosition(curPartition);
             SpillLocation spillLocation = makeSpillLocation(getSplitsRequest);
             LOGGER.info("{}: Input partition is {}", getSplitsRequest.getQueryId(), locationReader.readText());
-            Split.Builder splitBuilder = Split.newBuilder(spillLocation, makeEncryptionKey())
+            Split.Builder splitBuilder = Split.newBuilder(spillLocation, makeEncryptionKey(getRequestOverrideConfig(getSplitsRequest)))
                     .add(BLOCK_PARTITION_COLUMN_NAME, String.valueOf(locationReader.readText()));
             splits.add(splitBuilder.build());
             if (splits.size() >= MAX_SPLITS_PER_REQUEST) {
@@ -442,7 +442,7 @@ public class SnowflakeMetadataHandler extends JdbcMetadataHandler
             LOGGER.debug("{} s3ObjectSummaries returned after executing on SnowFlake for queryId {}",
                     (long) s3ObjectSummaries.size(), queryId);
             for (S3Object objectSummary : s3ObjectSummaries) {
-                Split split = Split.newBuilder(makeSpillLocation(request), makeEncryptionKey())
+                Split split = Split.newBuilder(makeSpillLocation(request), makeEncryptionKey(getRequestOverrideConfig(request)))
                         .add(SNOWFLAKE_SPLIT_QUERY_ID, queryId)
                         .add(SNOWFLAKE_SPLIT_EXPORT_BUCKET, s3Uri.get().bucket().orElseThrow())
                         .add(SNOWFLAKE_SPLIT_OBJECT_KEY, objectSummary.key())
@@ -454,7 +454,7 @@ public class SnowflakeMetadataHandler extends JdbcMetadataHandler
         else {
             // Case when there is no data for copy into.
             LOGGER.debug("s3ObjectSummaries returned empty on SnowFlake for queryId {}", queryId);
-            Split split = Split.newBuilder(makeSpillLocation(request), makeEncryptionKey())
+            Split split = Split.newBuilder(makeSpillLocation(request), makeEncryptionKey(getRequestOverrideConfig(request)))
                     .add(SNOWFLAKE_SPLIT_QUERY_ID, queryId)
                     .add(SNOWFLAKE_SPLIT_EXPORT_BUCKET, s3Uri.get().bucket().orElseThrow())
                     .add(SNOWFLAKE_SPLIT_OBJECT_KEY, EMPTY_STRING)

--- a/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerMetadataHandler.java
+++ b/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerMetadataHandler.java
@@ -352,13 +352,13 @@ public class SqlServerMetadataHandler extends JdbcMetadataHandler
             // Included partition information to split if the table is partitioned
             if (partInfo.contains(":::")) {
                 String[] partInfoAr = partInfo.split(":::");
-                splitBuilder = Split.newBuilder(spillLocation, makeEncryptionKey())
+                splitBuilder = Split.newBuilder(spillLocation, makeEncryptionKey(getRequestOverrideConfig(getSplitsRequest)))
                         .add(PARTITION_NUMBER, partInfoAr[0])
                         .add(PARTITION_FUNCTION, partInfoAr[1])
                         .add(PARTITIONING_COLUMN, partInfoAr[2]);
             }
             else {
-                splitBuilder = Split.newBuilder(spillLocation, makeEncryptionKey())
+                splitBuilder = Split.newBuilder(spillLocation, makeEncryptionKey(getRequestOverrideConfig(getSplitsRequest)))
                         .add(PARTITION_NUMBER, partInfo);
             }
 

--- a/athena-teradata/src/main/java/com/amazonaws/athena/connectors/teradata/TeradataMetadataHandler.java
+++ b/athena-teradata/src/main/java/com/amazonaws/athena/connectors/teradata/TeradataMetadataHandler.java
@@ -326,7 +326,7 @@ public class TeradataMetadataHandler extends JdbcMetadataHandler
 
             LOGGER.info("{}: Input partition is {}", getSplitsRequest.getQueryId(), locationReader.readText());
 
-            Split.Builder splitBuilder = Split.newBuilder(spillLocation, makeEncryptionKey())
+            Split.Builder splitBuilder = Split.newBuilder(spillLocation, makeEncryptionKey(getRequestOverrideConfig(getSplitsRequest)))
                     .add(BLOCK_PARTITION_COLUMN_NAME, String.valueOf(locationReader.readText()));
 
             splits.add(splitBuilder.build());


### PR DESCRIPTION
…customer FAS.

*Issue #, if available:*
Currently, Athena managed connectors are taking customer KMS key `id` input as ways to generate EncryptionKey for spill locations, instead of the full ARN which includes account information. As such it requires connectors to correctly identify the identity from the caller, which is the customer FAS instead of Service Accounts. 

*Description of changes:*
By leveraging FAS directly from Federated Requests, following the same pattern from DDB, we will be able to use the customer credentials instead of service credentials to get the KMS key for encryption. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
