### PR TITLE
fix: insert partition predicates before FETCH/ORDER BY/LIMIT in Calci…

### DIFF
--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcSplitQueryBuilder.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcSplitQueryBuilder.java
@@ -79,6 +79,9 @@ public abstract class JdbcSplitQueryBuilder
 
     private static final Pattern WHERE_PATTERN = Pattern.compile("\\bWHERE\\b", Pattern.CASE_INSENSITIVE);
 
+    private static final Pattern TRAILING_CLAUSES_PATTERN = Pattern.compile(
+            "\\s+(FETCH\\s|ORDER\\s+BY\\s|LIMIT\\s|OFFSET\\s)", Pattern.CASE_INSENSITIVE);
+
     private static final int MILLIS_SHIFT = 12;
 
     private final String quoteCharacters;
@@ -467,7 +470,7 @@ public abstract class JdbcSplitQueryBuilder
             RelDataType tableSchema = SubstraitSqlUtils.getTableSchemaFromSubstraitPlan(base64EncodedPlan, sqlDialect);
             SubstraitAccumulatorVisitor visitor = new SubstraitAccumulatorVisitor(accumulator, tableSchema);
             SqlNode parameterizedNode = visitor.visit(root);
-            
+
             LOGGER.debug("CalciteSql parameterized sql with dialect {}: {}", sqlDialect.toString(), parameterizedNode.toSqlString(sqlDialect).getSql());
             LOGGER.debug("CalciteSql parameters: {}", accumulator.toString());
 
@@ -475,7 +478,15 @@ public abstract class JdbcSplitQueryBuilder
             List<String> splitClauses = getPartitionWhereClauses(split);
             if (!splitClauses.isEmpty()) {
                 String splitWhere = String.join(" AND ", splitClauses);
-                sql = WHERE_PATTERN.matcher(sql).find() ? sql + " AND " + splitWhere : sql + " WHERE " + splitWhere;
+                String conjunction = WHERE_PATTERN.matcher(sql).find() ? " AND " : " WHERE ";
+                java.util.regex.Matcher trailingMatcher = TRAILING_CLAUSES_PATTERN.matcher(sql);
+                if (trailingMatcher.find()) {
+                    int insertPos = trailingMatcher.start();
+                    sql = sql.substring(0, insertPos) + conjunction + splitWhere + sql.substring(insertPos);
+                }
+                else {
+                    sql = sql + conjunction + splitWhere;
+                }
             }
             PreparedStatement statement = jdbcConnection.prepareStatement(sql);
             ParameterMetaData metaData = statement.getParameterMetaData();

--- a/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcSplitQueryBuilderTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcSplitQueryBuilderTest.java
@@ -88,6 +88,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import org.mockito.ArgumentCaptor;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -1357,4 +1358,49 @@ public class JdbcSplitQueryBuilderTest
         verify(mockConnection).prepareStatement(contains("`testdb`.`users`"));
         verify(mockConnection).prepareStatement(contains("`age` > ?"));
     }
+
+    @Test
+    public void testPrepareStatementWithCalciteSql_PartitionClausesBeforeFetchNext_NoExistingWhere()
+            throws Exception
+    {
+        // SELECT * FROM "warehouse"."call_center" ORDER BY "cc_rec_start_date" LIMIT 100
+        String base64Plan = "GucFEuQFCuEFGt4FCgIKABLTBSrQBQoCCgASuQUKtgUKAgoAEpUFChFjY19jYWxsX2NlbnRlcl9zawoRY2NfY2FsbF9jZW50ZXJfaWQKEWNjX3JlY19zdGFydF9kYXRlCg9jY19yZWNfZW5kX2RhdGUKEWNjX2Nsb3NlZF9kYXRlX3NrCg9jY19vcGVuX2RhdGVfc2sKB2NjX25hbWUKCGNjX2NsYXNzCgxjY19lbXBsb3llZXMKCGNjX3NxX2Z0CghjY19ob3VycwoKY2NfbWFuYWdlcgoJY2NfbWt0X2lkCgxjY19ta3RfY2xhc3MKC2NjX21rdF9kZXNjChFjY19tYXJrZXRfbWFuYWdlcgoLY2NfZGl2aXNpb24KEGNjX2RpdmlzaW9uX25hbWUKCmNjX2NvbXBhbnkKD2NjX2NvbXBhbnlfbmFtZQoQY2Nfc3RyZWV0X251bWJlcgoOY2Nfc3RyZWV0X25hbWUKDmNjX3N0cmVldF90eXBlCg9jY19zdWl0ZV9udW1iZXIKB2NjX2NpdHkKCWNjX2NvdW50eQoIY2Nfc3RhdGUKBmNjX3ppcAoKY2NfY291bnRyeQoNY2NfZ210X29mZnNldAoRY2NfdGF4X3BlcmNlbnRhZ2UKB3BhcnRfaWQSzgEKBCoCEAEKBGICEAEKBYIBAhABCgWCAQIQAQoEKgIQAQoEKgIQAQoEYgIQAQoEYgIQAQoEKgIQAQoEKgIQAQoEYgIQAQoEYgIQAQoEKgIQAQoEYgIQAQoEYgIQAQoEYgIQAQoEKgIQAQoEYgIQAQoEKgIQAQoEYgIQAQoEYgIQAQoEYgIQAQoEYgIQAQoEYgIQAQoEYgIQAQoEYgIQAQoEYgIQAQoEYgIQAQoEYgIQAQoJwgEGCAIQBSABCgnCAQYIAhAFIAEKBGICEAEYAjoYCgl3YXJlaG91c2UKC2NhbGxfY2VudGVyGg4KChIICgQSAggCIgAQAhgAIGQ=";
+
+        QueryPlan queryPlan = mock(QueryPlan.class);
+        Constraints constraintsWithQueryPlan = mock(Constraints.class);
+        when(queryPlan.getSubstraitPlan()).thenReturn(base64Plan);
+        when(constraintsWithQueryPlan.getQueryPlan()).thenReturn(queryPlan);
+
+        builder.prepareStatementWithCalciteSql(mockConnection, constraintsWithQueryPlan, AnsiSqlDialect.DEFAULT, split);
+
+        ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+        verify(mockConnection).prepareStatement(sqlCaptor.capture());
+        String sql = sqlCaptor.getValue();
+        assertEquals("SELECT *\n"
+                + "FROM `warehouse`.`call_center` WHERE \"partition_col\" = '2024'\n"
+                + "ORDER BY `cc_rec_start_date`\n"
+                + "FETCH NEXT 100 ROWS ONLY", sql);
+    }
+
+    @Test
+    public void testPrepareStatementWithCalciteSql_PartitionClausesBeforeFetchNext_WithExistingWhere()
+            throws Exception
+    {
+        // SELECT * FROM "tpch"."lineitem" WHERE "l_returnflag" = 'R' LIMIT 50
+        String base64Plan = "ChsIARIXL2Z1bmN0aW9uc19ib29sZWFuLnlhbWwKHggCEhovZnVuY3Rpb25zX2NvbXBhcmlzb24ueWFtbBIOGgwIARoIYW5kOmJvb2wSFRoTCAIQARoNZXF1YWw6YW55X2FueRrUAxLRAwrOAxrLAwoCCgASwAMSvQMKAgoAEvkCCvYCCgIKABLdAgoKbF9vcmRlcmtleQoJbF9wYXJ0a2V5CglsX3N1cHBrZXkKDGxfbGluZW51bWJlcgoKbF9xdWFudGl0eQoPbF9leHRlbmRlZHByaWNlCgpsX2Rpc2NvdW50CgVsX3RheAoMbF9yZXR1cm5mbGFnCgxsX2xpbmVzdGF0dXMKCmxfc2hpcGRhdGUKDGxfY29tbWl0ZGF0ZQoNbF9yZWNlaXB0ZGF0ZQoObF9zaGlwaW5zdHJ1Y3QKCmxfc2hpcG1vZGUKCWxfY29tbWVudAoOcGFydGl0aW9uX25hbWUSfwoEKgIQAQoEKgIQAQoEKgIQAQoEKgIQAQoJwgEGCAIQDyABCgnCAQYIAhAPIAEKCcIBBggCEA8gAQoJwgEGCAIQDyABCgRiAhABCgRiAhABCgWCAQIQAQoFggECEAEKBYIBAhABCgRiAhABCgRiAhABCgRiAhABCgRiAhABGAI6EAoEdHBjaAoIbGluZWl0ZW0aOxo5GgQKAhABIiYaJBoiCAEaBAoCEAEiDBoKEggKBBICCAgiACIKGggKBmIBUpADASIJGgcKBQgBkAMBGAAgMg==";
+
+        QueryPlan queryPlan = mock(QueryPlan.class);
+        Constraints constraintsWithQueryPlan = mock(Constraints.class);
+        when(queryPlan.getSubstraitPlan()).thenReturn(base64Plan);
+        when(constraintsWithQueryPlan.getQueryPlan()).thenReturn(queryPlan);
+
+        builder.prepareStatementWithCalciteSql(mockConnection, constraintsWithQueryPlan, AnsiSqlDialect.DEFAULT, split);
+
+        ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+        verify(mockConnection).prepareStatement(sqlCaptor.capture());
+        String sql = sqlCaptor.getValue();
+        assertEquals("SELECT *\n"
+                + "FROM `tpch`.`lineitem`\n"
+                + "WHERE `l_returnflag` = ? AND \"partition_col\" = '2024'\n"
+                + "FETCH NEXT 50 ROWS ONLY", sql);    }
 }


### PR DESCRIPTION
Description:

Problem
When using the Calcite/Substrait SQL generation path in JDBC connectors (e.g., PostgreSQL, Oracle), partition predicates from split processing are appended to the end of the generated SQL. This produces invalid SQL when the query contains trailing clauses like ORDER BY, LIMIT, FETCH, or OFFSET:

-- Generated (INVALID):
SELECT * FROM users WHERE active = true ORDER BY id LIMIT 10 AND partition_key = 'p1'

This causes query failures for any partitioned table query that includes ordering or pagination.

Fix
Introduced a TRAILING_CLAUSES_PATTERN regex that detects FETCH, ORDER BY, LIMIT, or OFFSET clauses. Partition predicates are now inserted before these trailing 
clauses:

-- Generated (CORRECT):
SELECT * FROM users WHERE active = true AND partition_key = 'p1' ORDER BY id LIMIT 10

Testing
Added unit tests in JdbcSplitQueryBuilderTest covering:
• Queries with ORDER BY + partition predicates
• Queries with LIMIT/FETCH + partition predicates
• Queries without trailing clauses (existing behavior preserved)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
