### PR TITLE
Remove valueMap string-based validation for Gremlin QPT queries

### DIFF
--- a/athena-neptune/pom.xml
+++ b/athena-neptune/pom.xml
@@ -113,7 +113,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.tinkerpop</groupId>
-            <artifactId>gremlin-groovy</artifactId>
+            <artifactId>gremlin-language</artifactId>
             <version>${gremlinDriverVersion}</version>
             <exclusions>
                 <exclusion>

--- a/athena-neptune/src/main/java/com/amazonaws/athena/connectors/neptune/Constants.java
+++ b/athena-neptune/src/main/java/com/amazonaws/athena/connectors/neptune/Constants.java
@@ -52,7 +52,6 @@ public class Constants
    public static final String PREFIX_KEY = "prefix_";
    public static final int PREFIX_LEN = PREFIX_KEY.length();
 
-   public static final String GREMLIN_QUERY_SUPPORT_TYPE = "valueMap";
    public static final String RDF_COMPONENT_TYPE = "rdf";
    public static final String GREMLIN_QUERY_LIMIT = "limit(10)";
    public static final String SPARQL_QUERY_LIMIT = "limit 10";

--- a/athena-neptune/src/main/java/com/amazonaws/athena/connectors/neptune/NeptuneMetadataHandler.java
+++ b/athena-neptune/src/main/java/com/amazonaws/athena/connectors/neptune/NeptuneMetadataHandler.java
@@ -25,6 +25,7 @@ import com.amazonaws.athena.connector.lambda.data.BlockWriter;
 import com.amazonaws.athena.connector.lambda.domain.Split;
 import com.amazonaws.athena.connector.lambda.domain.TableName;
 import com.amazonaws.athena.connector.lambda.domain.spill.SpillLocation;
+import com.amazonaws.athena.connector.lambda.exceptions.AthenaConnectorException;
 import com.amazonaws.athena.connector.lambda.handlers.GlueMetadataHandler;
 import com.amazonaws.athena.connector.lambda.metadata.GetDataSourceCapabilitiesRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetDataSourceCapabilitiesResponse;
@@ -55,6 +56,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.athena.AthenaClient;
 import software.amazon.awssdk.services.glue.GlueClient;
+import software.amazon.awssdk.services.glue.model.ErrorDetails;
+import software.amazon.awssdk.services.glue.model.FederationSourceErrorCode;
 import software.amazon.awssdk.services.glue.model.GetTablesRequest;
 import software.amazon.awssdk.services.glue.model.GetTablesResponse;
 import software.amazon.awssdk.services.glue.model.Table;
@@ -125,6 +128,7 @@ public class NeptuneMetadataHandler extends GlueMetadataHandler
         super(glue, keyFactory, awsSecretsManager, athena, Constants.SOURCE_TYPE, spillBucket, spillPrefix, configOptions);
         this.glue = glue;
         this.glueDBName = configOptions.get("glue_database_name");
+        this.neptuneConnection = neptuneConnection;
     }
 
     @Override
@@ -314,15 +318,17 @@ public class NeptuneMetadataHandler extends GlueMetadataHandler
                 if (graphTraversalForSchema.hasNext()) {
                     Object responseObj = graphTraversalForSchema.next();
                     if (responseObj instanceof Map) {
-                        logger.info("NeptuneMetadataHandler doGetQueryPassthroughSchema gremlinQuery with valueMap");
+                        logger.info("NeptuneMetadataHandler doGetQueryPassthroughSchema gremlinQuery with Map-shaped result");
                         Map graphTraversalObj = (Map) responseObj;
                         schema = NeptuneSchemaUtils.getSchemaFromResults(graphTraversalObj, componentTypeValue, tableName);
                         return new GetTableResponse(request.getCatalogName(), tableNameObj, schema);
                     }
                     else {
-                        throw new RuntimeException("Unsupported gremlin query format: We are currently supporting only valueMap gremlin queries. " +
-                                "Please make sure you are using valueMap gremlin query. " +
-                                "Example for valueMap query is g.V().hasLabel(\\\"airport\\\").valueMap().limit(5)");
+                        throw new AthenaConnectorException(
+                                "Unsupported gremlin query result shape: inline passthrough requires each row to be a Map. " +
+                                        "Use terminal steps such as valueMap(), elementMap(), or project(...).by(...). " +
+                                        "Example: g.V().hasLabel(\\\"airport\\\").project(\\\"name\\\").by(values(\\\"name\\\"))",
+                                ErrorDetails.builder().errorCode(FederationSourceErrorCode.INVALID_INPUT_EXCEPTION.toString()).build());
                     }
                 }
                 else {

--- a/athena-neptune/src/main/java/com/amazonaws/athena/connectors/neptune/propertygraph/PropertyGraphHandler.java
+++ b/athena-neptune/src/main/java/com/amazonaws/athena/connectors/neptune/propertygraph/PropertyGraphHandler.java
@@ -35,7 +35,7 @@ import org.apache.arrow.util.VisibleForTesting;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.tinkerpop.gremlin.driver.Client;
 import org.apache.tinkerpop.gremlin.driver.Result;
-import org.apache.tinkerpop.gremlin.groovy.jsr223.GremlinGroovyScriptEngine;
+import org.apache.tinkerpop.gremlin.jsr223.GremlinLangScriptEngine;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.WithOptions;
@@ -197,9 +197,12 @@ public class PropertyGraphHandler
         }
     }
 
+    /**
+     * Parses a Gremlin query-passthrough string using the Gremlin language grammar (GremlinLangScriptEngine).
+     */
     public Object getResponseFromGremlinQuery(GraphTraversalSource graphTraversalSource, String gremlinQuery) throws ScriptException
     {
-        ScriptEngine engine = new GremlinGroovyScriptEngine();
+        ScriptEngine engine = new GremlinLangScriptEngine();
         Bindings bindings = engine.createBindings();
         bindings.put("g", graphTraversalSource);
         return engine.eval(gremlinQuery, bindings);

--- a/athena-neptune/src/main/java/com/amazonaws/athena/connectors/neptune/qpt/NeptuneGremlinQueryPassthrough.java
+++ b/athena-neptune/src/main/java/com/amazonaws/athena/connectors/neptune/qpt/NeptuneGremlinQueryPassthrough.java
@@ -21,7 +21,6 @@ package com.amazonaws.athena.connectors.neptune.qpt;
 
 import com.amazonaws.athena.connector.lambda.exceptions.AthenaConnectorException;
 import com.amazonaws.athena.connector.lambda.metadata.optimizations.querypassthrough.QueryPassthroughSignature;
-import com.amazonaws.athena.connectors.neptune.Constants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.glue.model.ErrorDetails;
@@ -84,11 +83,6 @@ public final class NeptuneGremlinQueryPassthrough implements QueryPassthroughSig
         // Verify no mixed operations (SPARQL and Gremlin in same request)
         if (engineQptArguments.containsKey(QUERY)) {
             throw new AthenaConnectorException("Mixed operations not supported: Cannot use both SPARQL query and Gremlin traverse in the same request", ErrorDetails.builder().errorCode(FederationSourceErrorCode.INVALID_INPUT_EXCEPTION.toString()).build());
-        }
-        else if (!engineQptArguments.get(TRAVERSE).contains(Constants.GREMLIN_QUERY_SUPPORT_TYPE)) {
-            throw new AthenaConnectorException("Unsupported gremlin query format: We are currently supporting only valueMap gremlin queries. " +
-                    "Please make sure you are using valueMap gremlin query. " +
-                    "Example for valueMap query is g.V().hasLabel(\\\"airport\\\").valueMap().limit(5)", ErrorDetails.builder().errorCode(FederationSourceErrorCode.INVALID_INPUT_EXCEPTION.toString()).build());
         }
     }
 }

--- a/athena-neptune/src/test/java/com/amazonaws/athena/connectors/neptune/NeptuneMetadataHandlerTest.java
+++ b/athena-neptune/src/test/java/com/amazonaws/athena/connectors/neptune/NeptuneMetadataHandlerTest.java
@@ -21,6 +21,7 @@ package com.amazonaws.athena.connectors.neptune;
 
 import com.amazonaws.athena.connector.lambda.data.BlockAllocatorImpl;
 import com.amazonaws.athena.connector.lambda.domain.TableName;
+import com.amazonaws.athena.connector.lambda.exceptions.AthenaConnectorException;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableResponse;
 import com.amazonaws.athena.connector.lambda.metadata.ListSchemasRequest;
@@ -29,6 +30,10 @@ import com.amazonaws.athena.connector.lambda.metadata.ListTablesRequest;
 import com.amazonaws.athena.connector.lambda.metadata.ListTablesResponse;
 import com.amazonaws.athena.connector.lambda.security.LocalKeyFactory;
 
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.structure.T;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -37,6 +42,7 @@ import org.mockito.Mock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.tinkerpop.gremlin.driver.Client;
 import software.amazon.awssdk.services.athena.AthenaClient;
 import software.amazon.awssdk.services.glue.GlueClient;
 import software.amazon.awssdk.services.glue.model.Column;
@@ -55,6 +61,11 @@ import java.util.Map;
 import static org.junit.Assert.*;
 
 import static com.amazonaws.athena.connector.lambda.metadata.ListTablesRequest.UNLIMITED_PAGE_SIZE_VALUE;
+import static com.amazonaws.athena.connector.lambda.metadata.optimizations.querypassthrough.QueryPassthroughSignature.SCHEMA_FUNCTION_NAME;
+import static com.amazonaws.athena.connectors.neptune.qpt.NeptuneGremlinQueryPassthrough.COLLECTION;
+import static com.amazonaws.athena.connectors.neptune.qpt.NeptuneGremlinQueryPassthrough.COMPONENT_TYPE;
+import static com.amazonaws.athena.connectors.neptune.qpt.NeptuneGremlinQueryPassthrough.DATABASE;
+import static com.amazonaws.athena.connectors.neptune.qpt.NeptuneGremlinQueryPassthrough.TRAVERSE;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -64,6 +75,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class NeptuneMetadataHandlerTest extends TestBase {
     private static final Logger logger = LoggerFactory.getLogger(NeptuneMetadataHandlerTest.class);
+    private static final String GREMLIN_QPT_FUNCTION = "system.traverse";
 
     @Mock
     private GlueClient glue;
@@ -170,6 +182,71 @@ public class NeptuneMetadataHandlerTest extends TestBase {
 
         logger.info("doGetTable - {}", res);
         logger.info("doGetTable - exit");
+    }
+
+    @Test
+    public void doGetQueryPassthroughSchema_withMapGremlinResult_returnsSchema() throws Exception
+    {
+        GraphTraversalSource graphTraversalSource = buildGremlinTestGraph();
+
+        Client client = mock(Client.class);
+        when(neptuneConnection.getNeptuneClientConnection()).thenReturn(client);
+        when(neptuneConnection.getTraversalSource(nullable(Client.class))).thenReturn(graphTraversalSource);
+
+        GetTableRequest request = buildGremlinQptRequest(
+                "g.V().project('name').by(values('name'))");
+
+        GetTableResponse response = handler.doGetQueryPassthroughSchema(allocator, request);
+
+        assertNotNull(response.getSchema());
+        assertFalse(response.getSchema().getFields().isEmpty());
+    }
+
+    @Test
+    public void doGetQueryPassthroughSchema_withNonMapGremlinResult_throwsAthenaConnectorException() throws Exception
+    {
+        GraphTraversalSource graphTraversalSource = buildGremlinTestGraph();
+
+        Client client = mock(Client.class);
+        when(neptuneConnection.getNeptuneClientConnection()).thenReturn(client);
+        when(neptuneConnection.getTraversalSource(nullable(Client.class))).thenReturn(graphTraversalSource);
+
+        GetTableRequest request = buildGremlinQptRequest("g.V().values('name')");
+
+        try {
+            handler.doGetQueryPassthroughSchema(allocator, request);
+            fail("Expected AthenaConnectorException");
+        }
+        catch (AthenaConnectorException e) {
+            assertTrue(e.getMessage().contains("Unsupported gremlin query result shape"));
+            assertTrue(e.getMessage().contains("Map"));
+        }
+    }
+
+    private GraphTraversalSource buildGremlinTestGraph()
+    {
+        try (TinkerGraph tinkerGraph = TinkerGraph.open()) {
+            Vertex vertex = tinkerGraph.addVertex(T.label, "airport");
+            vertex.property("name", "LAX");
+            return tinkerGraph.traversal();
+        }
+    }
+
+    private GetTableRequest buildGremlinQptRequest(String traverse)
+    {
+        Map<String, String> qptArguments = new HashMap<>();
+        qptArguments.put(SCHEMA_FUNCTION_NAME, GREMLIN_QPT_FUNCTION);
+        qptArguments.put(DATABASE, "testDb");
+        qptArguments.put(COLLECTION, "airport");
+        qptArguments.put(COMPONENT_TYPE, "vertex");
+        qptArguments.put(TRAVERSE, traverse);
+
+        return new GetTableRequest(
+                IDENTITY,
+                QUERY_ID,
+                DEFAULT_CATALOG,
+                new TableName("testDb", "airport"),
+                qptArguments);
     }
 
 }

--- a/athena-neptune/src/test/java/com/amazonaws/athena/connectors/neptune/propertygraph/PropertyGraphHandlerTest.java
+++ b/athena-neptune/src/test/java/com/amazonaws/athena/connectors/neptune/propertygraph/PropertyGraphHandlerTest.java
@@ -1,0 +1,92 @@
+/*-
+ * #%L
+ * athena-neptune
+ * %%
+ * Copyright (C) 2019 - 2026 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.neptune.propertygraph;
+
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerFactory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.script.ScriptException;
+
+import static org.apache.tinkerpop.gremlin.process.traversal.AnonymousTraversalSource.traversal;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class PropertyGraphHandlerTest
+{
+    private GraphTraversalSource g;
+    private PropertyGraphHandler handler;
+
+    @Before
+    public void setUp()
+    {
+        g = traversal().withEmbedded(TinkerFactory.createModern());
+        handler = new PropertyGraphHandler(null);
+    }
+
+    @After
+    public void tearDown() throws Exception
+    {
+        if (g != null) {
+            g.getGraph().close();
+        }
+    }
+
+    @Test
+    public void getResponseFromGremlinQuery_validValueMap_returnsTraversal() throws ScriptException
+    {
+        Object result = handler.getResponseFromGremlinQuery(g, "g.V().hasLabel('person').valueMap().limit(5)");
+        assertNotNull(result);
+        assertTrue(result instanceof GraphTraversal);
+    }
+
+    @Test
+    public void getResponseFromGremlinQuery_validElementMap_returnsTraversal() throws ScriptException
+    {
+        Object result = handler.getResponseFromGremlinQuery(g, "g.V().hasLabel('person').elementMap().limit(5)");
+        assertNotNull(result);
+        assertTrue(result instanceof GraphTraversal);
+    }
+
+    @Test
+    public void getResponseFromGremlinQuery_validProjectByValues_returnsTraversal() throws ScriptException
+    {
+        Object result = handler.getResponseFromGremlinQuery(g,
+                "g.V().hasLabel('person').project('name').by(values('name')).limit(5)");
+        assertNotNull(result);
+        assertTrue(result instanceof GraphTraversal);
+    }
+
+    @Test(expected = ScriptException.class)
+    public void getResponseFromGremlinQuery_nonGremlinThrow_throwsScriptException() throws ScriptException
+    {
+        handler.getResponseFromGremlinQuery(g,
+                "throw new RuntimeException('INVALID_GREMLIN'); g.V().valueMap()");
+    }
+
+    @Test(expected = ScriptException.class)
+    public void getResponseFromGremlinQuery_nonGremlinSystemCall_throwsScriptException() throws ScriptException
+    {
+        handler.getResponseFromGremlinQuery(g, "System.err.println('x'); g.V().valueMap()");
+    }
+}

--- a/athena-neptune/src/test/java/com/amazonaws/athena/connectors/neptune/qpt/NeptuneGremlinQueryPassthroughTest.java
+++ b/athena-neptune/src/test/java/com/amazonaws/athena/connectors/neptune/qpt/NeptuneGremlinQueryPassthroughTest.java
@@ -143,16 +143,35 @@ public class NeptuneGremlinQueryPassthroughTest {
     }
 
     @Test
-    public void testVerifyWithInvalidTraverseSyntax_ShouldThrowException() {
+    public void verify_withProjectByValues_shouldNotThrowException() {
+        baseArguments.put(TRAVERSE, "g.V().hasLabel('airport').project('name').by(values('name'))");
+
+        try {
+            queryPassthrough.verify(baseArguments);
+        } catch (Exception e) {
+            fail("Should not throw any exception");
+        }
+    }
+
+    @Test
+    public void verify_withElementMap_shouldNotThrowException() {
+        baseArguments.put(TRAVERSE, "g.V().hasLabel('airport').elementMap()");
+
+        try {
+            queryPassthrough.verify(baseArguments);
+        } catch (Exception e) {
+            fail("Should not throw any exception");
+        }
+    }
+
+    @Test
+    public void verify_withTraverseWithoutValueMapSubstring_shouldNotThrowException() {
         baseArguments.put(TRAVERSE, "g.V().hasLabel('airport')");
 
         try {
             queryPassthrough.verify(baseArguments);
-            fail("Expected AthenaConnectorException");
-        } catch (AthenaConnectorException e) {
-            assertEquals("Unsupported gremlin query format: We are currently supporting only valueMap gremlin queries. " +
-                    "Please make sure you are using valueMap gremlin query. " +
-                    "Example for valueMap query is g.V().hasLabel(\\\"airport\\\").valueMap().limit(5)", e.getMessage());
+        } catch (Exception e) {
+            fail("Should not throw any exception");
         }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Follow-up to [#3300](https://github.com/awslabs/aws-athena-query-federation/pull/3300) to fix Neptune Gremlin inline QPT validation.
Removed the strict traverse.contains("valueMap") gate so valid Map-shaped traversals like elementMap() and project(...).by(values(...)) are accepted.

Please find attached test results. [Neptune Gremlin Query Test Results.docx](https://github.com/user-attachments/files/29003444/Neptune.Gremlin.Query.Test.Results.docx)

***Why***
PR #3300 fixed row writing for mixed Map value shapes, but schema inference still failed for valid non-valueMap traversals due to the valueMap string check. This aligns validation with actual supported behavior (Map-shaped Gremlin results).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
