### PR TITLE
Fix CVE-2026-45674 and CVE-2026-47691: bump netty to 4.2.15.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,11 +96,11 @@
                 <artifactId>commons-lang3</artifactId>
                 <version>3.20.0</version>
             </dependency>
-            <!-- Fix for CVE-2025-24970, CVE-2025-58056, CVE-2025-58057, CVE-2025-55163, CVE-2026-33871: Override Netty version from transitive dependencies -->
+            <!-- Fix for CVE-2025-24970, CVE-2025-58056, CVE-2025-58057, CVE-2025-55163, CVE-2026-33871, CVE-2026-45674, CVE-2026-47691: Override Netty version from transitive dependencies -->
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.2.13.Final</version>
+                <version>4.2.15.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix https://github.com/advisories/GHSA-676x-f7gg-47vc: bump netty-bom to 4.2.15.Final
Fix https://github.com/advisories/GHSA-5pvg-856g-cp85: bump netty-bom to 4.2.15.Final

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
