### PR TITLE
Add support for QPT complex data types and extended scalars in athena-timestream.

### DIFF
--- a/athena-timestream/src/main/java/com/amazonaws/athena/connectors/timestream/TimestreamMetadataHandler.java
+++ b/athena-timestream/src/main/java/com/amazonaws/athena/connectors/timestream/TimestreamMetadataHandler.java
@@ -25,7 +25,6 @@ import com.amazonaws.athena.connector.lambda.data.BlockWriter;
 import com.amazonaws.athena.connector.lambda.data.SchemaBuilder;
 import com.amazonaws.athena.connector.lambda.domain.Split;
 import com.amazonaws.athena.connector.lambda.domain.TableName;
-import com.amazonaws.athena.connector.lambda.exceptions.AthenaConnectorException;
 import com.amazonaws.athena.connector.lambda.handlers.GlueMetadataHandler;
 import com.amazonaws.athena.connector.lambda.metadata.GetDataSourceCapabilitiesRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetDataSourceCapabilitiesResponse;
@@ -51,8 +50,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.athena.AthenaClient;
 import software.amazon.awssdk.services.glue.GlueClient;
-import software.amazon.awssdk.services.glue.model.ErrorDetails;
-import software.amazon.awssdk.services.glue.model.FederationSourceErrorCode;
 import software.amazon.awssdk.services.glue.model.Table;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.awssdk.services.timestreamquery.TimestreamQueryClient;
@@ -328,15 +325,7 @@ public class TimestreamMetadataHandler
         List<ColumnInfo> columnInfo = queryResult.columnInfo();
         SchemaBuilder schemaBuilder = SchemaBuilder.newBuilder();
         for (ColumnInfo column : columnInfo) {
-            String scalarType = column.type().scalarTypeAsString();
-            if (scalarType == null) {
-                throw new AthenaConnectorException(
-                    "The Timestream connector supports only a subset of the data types available in Timestream, specifically: "
-                    + "the scalar values varchar, double, and timestamp. Column '" + column.name() + "' has an unsupported type. "
-                    + "For more details, see https://docs.aws.amazon.com/athena/latest/ug/connectors-timestream.html",
-                    ErrorDetails.builder().errorCode(FederationSourceErrorCode.OPERATION_NOT_SUPPORTED_EXCEPTION.toString()).build());
-            }
-            Field nextField = TimestreamSchemaUtils.makeField(column.name(), scalarType.toLowerCase());
+            Field nextField = TimestreamSchemaUtils.makeFieldFromColumnInfo(column);
             schemaBuilder.addField(nextField);
         }
 

--- a/athena-timestream/src/main/java/com/amazonaws/athena/connectors/timestream/TimestreamRecordHandler.java
+++ b/athena-timestream/src/main/java/com/amazonaws/athena/connectors/timestream/TimestreamRecordHandler.java
@@ -27,9 +27,11 @@ import com.amazonaws.athena.connector.lambda.data.FieldResolver;
 import com.amazonaws.athena.connector.lambda.data.writers.GeneratedRowWriter;
 import com.amazonaws.athena.connector.lambda.data.writers.extractors.BigIntExtractor;
 import com.amazonaws.athena.connector.lambda.data.writers.extractors.BitExtractor;
+import com.amazonaws.athena.connector.lambda.data.writers.extractors.DateDayExtractor;
 import com.amazonaws.athena.connector.lambda.data.writers.extractors.DateMilliExtractor;
 import com.amazonaws.athena.connector.lambda.data.writers.extractors.Extractor;
 import com.amazonaws.athena.connector.lambda.data.writers.extractors.Float8Extractor;
+import com.amazonaws.athena.connector.lambda.data.writers.extractors.IntExtractor;
 import com.amazonaws.athena.connector.lambda.data.writers.extractors.VarCharExtractor;
 import com.amazonaws.athena.connector.lambda.data.writers.holders.NullableVarCharHolder;
 import com.amazonaws.athena.connector.lambda.domain.TableName;
@@ -44,8 +46,10 @@ import org.apache.arrow.util.VisibleForTesting;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.holders.NullableBigIntHolder;
 import org.apache.arrow.vector.holders.NullableBitHolder;
+import org.apache.arrow.vector.holders.NullableDateDayHolder;
 import org.apache.arrow.vector.holders.NullableDateMilliHolder;
 import org.apache.arrow.vector.holders.NullableFloat8Holder;
+import org.apache.arrow.vector.holders.NullableIntHolder;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.slf4j.Logger;
@@ -61,12 +65,14 @@ import software.amazon.awssdk.services.timestreamquery.model.Row;
 import software.amazon.awssdk.services.timestreamquery.model.TimeSeriesDataPoint;
 
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.ChronoField;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -80,6 +86,8 @@ public class TimestreamRecordHandler
             .appendFraction(ChronoField.MILLI_OF_SECOND, 0, 9, false)
             .toFormatter()
             .withZone(ZoneId.of("UTC"));
+
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE;
 
     //Used to denote the 'type' of this connector for diagnostic purposes.
     private static final String SOURCE_TYPE = "timestream";
@@ -182,8 +190,14 @@ public class TimestreamRecordHandler
                     break;
                 case BIT:
                     builder.withExtractor(nextField.getName(), (BitExtractor) (Object context, NullableBitHolder value) -> {
-                        value.isSet = 1;
-                        value.value = Boolean.valueOf(((Row) context).data().get(curFieldNum).scalarValue()) == false ? 0 : 1;
+                        String boolValue = ((Row) context).data().get(curFieldNum).scalarValue();
+                        if (boolValue != null) {
+                            value.isSet = 1;
+                            value.value = Boolean.parseBoolean(boolValue) ? 1 : 0;
+                        }
+                        else {
+                            value.isSet = 0;
+                        }
                     });
                     break;
                 case BIGINT:
@@ -192,6 +206,18 @@ public class TimestreamRecordHandler
                         if (longValue != null) {
                             value.isSet = 1;
                             value.value = Long.valueOf(longValue);
+                        }
+                        else {
+                            value.isSet = 0;
+                        }
+                    });
+                    break;
+                case INT:
+                    builder.withExtractor(nextField.getName(), (IntExtractor) (Object context, NullableIntHolder value) -> {
+                        String intValue = ((Row) context).data().get(curFieldNum).scalarValue();
+                        if (intValue != null) {
+                            value.isSet = 1;
+                            value.value = Integer.valueOf(intValue);
                         }
                         else {
                             value.isSet = 0;
@@ -210,12 +236,28 @@ public class TimestreamRecordHandler
                         }
                     });
                     break;
+                case DATEDAY:
+                    builder.withExtractor(nextField.getName(), (DateDayExtractor) (Object context, NullableDateDayHolder value) -> {
+                        String dateValue = ((Row) context).data().get(curFieldNum).scalarValue();
+                        if (dateValue != null) {
+                            value.isSet = 1;
+                            value.value = (int) LocalDate.parse(dateValue, DATE_FORMATTER).toEpochDay();
+                        }
+                        else {
+                            value.isSet = 0;
+                        }
+                    });
+                    break;
                 case LIST:
-                    //TODO: This presently only supports TimeSeries results but it is possible that customers may
-                    //generate LIST type results for other reasons when using VIEWs. For now this seems like an OK
-                    //compromise since it enables an important capability of TimeStream even if it doesn't enable arbitrary
-                    //complex types.
-                    buildTimeSeriesExtractor(builder, nextField, curFieldNum);
+                    if (isTimeSeriesListField(nextField)) {
+                        buildTimeSeriesExtractor(builder, nextField, curFieldNum);
+                    }
+                    else {
+                        buildListExtractor(builder, nextField, curFieldNum);
+                    }
+                    break;
+                case STRUCT:
+                    buildStructExtractor(builder, nextField, curFieldNum);
                     break;
                 default:
                     throw new RuntimeException("Unsupported field type[" + nextField.getType() + "] for field[" + nextField.getName() + "]");
@@ -231,40 +273,165 @@ public class TimestreamRecordHandler
                         (Object context, int rowNum) -> {
                             Row row = (Row) context;
                             Datum datum = row.data().get(curFieldNum);
-                            Field timeField = field.getChildren().get(0).getChildren().get(0);
-                            Field valueField = field.getChildren().get(0).getChildren().get(1);
-
-                            if (datum.timeSeriesValue() != null) {
-                                List<Map<String, Object>> values = new ArrayList<>();
-                                for (TimeSeriesDataPoint nextDatum : datum.timeSeriesValue()) {
-                                    Map<String, Object> eventMap = new HashMap<>();
-
-                                    eventMap.put(timeField.getName(), Instant.from(TIMESTAMP_FORMATTER.parse(nextDatum.time())).toEpochMilli());
-
-                                    switch (Types.getMinorTypeForArrowType(valueField.getType())) {
-                                        case FLOAT8:
-                                            eventMap.put(valueField.getName(), Double.valueOf(nextDatum.value().scalarValue()));
-                                            break;
-                                        case BIGINT:
-                                            eventMap.put(valueField.getName(), Long.valueOf(nextDatum.value().scalarValue()));
-                                            break;
-                                        case INT:
-                                            eventMap.put(valueField.getName(), Integer.valueOf(nextDatum.value().scalarValue()));
-                                            break;
-                                        case BIT:
-                                            eventMap.put(valueField.getName(),
-                                                    Boolean.valueOf(((Row) context).data().get(curFieldNum).scalarValue()) == false ? 0 : 1);
-                                            break;
-                                    }
-                                    values.add(eventMap);
-                                }
-                                BlockUtils.setComplexValue(vector, rowNum, FieldResolver.DEFAULT, values);
+                            if (Boolean.TRUE.equals(datum.nullValue())) {
+                                return true;
                             }
-                            else {
-                                throw new RuntimeException("Only LISTs of type TimeSeries are presently supported.");
+                            if (!datum.hasTimeSeriesValue()) {
+                                throw new RuntimeException("Expected TimeSeries payload for column[" + field.getName() + "]");
                             }
-
-                            return true;    //we don't yet support predicate pushdown on complex types
+                            List<Map<String, Object>> values = buildTimeSeriesRowMaps(datum, field);
+                            BlockUtils.setComplexValue(vector, rowNum, FieldResolver.DEFAULT, values);
+                            return true;
                         });
+    }
+
+    private void buildListExtractor(GeneratedRowWriter.RowWriterBuilder builder, Field field, int curFieldNum)
+    {
+        builder.withFieldWriterFactory(field.getName(),
+                (FieldVector vector, Extractor extractor, ConstraintProjector constraint) ->
+                        (Object context, int rowNum) -> {
+                            Datum datum = ((Row) context).data().get(curFieldNum);
+                            if (Boolean.TRUE.equals(datum.nullValue())) {
+                                return true;
+                            }
+                            Object value = convertDatumToObject(datum, field);
+                            BlockUtils.setComplexValue(vector, rowNum, FieldResolver.DEFAULT, value);
+                            return true;
+                        });
+    }
+
+    private void buildStructExtractor(GeneratedRowWriter.RowWriterBuilder builder, Field field, int curFieldNum)
+    {
+        builder.withFieldWriterFactory(field.getName(),
+                (FieldVector vector, Extractor extractor, ConstraintProjector constraint) ->
+                        (Object context, int rowNum) -> {
+                            Datum datum = ((Row) context).data().get(curFieldNum);
+                            if (Boolean.TRUE.equals(datum.nullValue())) {
+                                return true;
+                            }
+                            Object value = convertDatumToObject(datum, field);
+                            BlockUtils.setComplexValue(vector, rowNum, FieldResolver.DEFAULT, value);
+                            return true;
+                        });
+    }
+
+    /**
+     * Timestream time series columns are modeled as {@code LIST<STRUCT<time, measure_value>>} with {@code time} first.
+     */
+    private static boolean isTimeSeriesListField(Field listField)
+    {
+        if (listField.getChildren().size() != 1) {
+            return false;
+        }
+        Field inner = listField.getChildren().get(0);
+        if (Types.getMinorTypeForArrowType(inner.getType()) != Types.MinorType.STRUCT) {
+            return false;
+        }
+        if (inner.getChildren().size() != 2) {
+            return false;
+        }
+        Field timeChild = inner.getChildren().get(0);
+        return "time".equals(timeChild.getName())
+                && Types.getMinorTypeForArrowType(timeChild.getType()) == Types.MinorType.DATEMILLI;
+    }
+
+    private List<Map<String, Object>> buildTimeSeriesRowMaps(Datum datum, Field listField)
+    {
+        Field structField = listField.getChildren().get(0);
+        Field timeField = structField.getChildren().get(0);
+        Field valueField = structField.getChildren().get(1);
+        List<Map<String, Object>> values = new ArrayList<>();
+        for (TimeSeriesDataPoint nextDatum : datum.timeSeriesValue()) {
+            Map<String, Object> eventMap = new HashMap<>();
+            eventMap.put(timeField.getName(), Instant.from(TIMESTAMP_FORMATTER.parse(nextDatum.time())).toEpochMilli());
+            eventMap.put(valueField.getName(), parseMeasureScalar(nextDatum.value(), valueField));
+            values.add(eventMap);
+        }
+        return values;
+    }
+
+    private static Object parseMeasureScalar(Datum measureDatum, Field valueField)
+    {
+        String sv = measureDatum.scalarValue();
+        if (sv == null) {
+            return null;
+        }
+        switch (Types.getMinorTypeForArrowType(valueField.getType())) {
+            case FLOAT8:
+                return Double.valueOf(sv);
+            case BIGINT:
+                return Long.valueOf(sv);
+            case INT:
+                return Integer.valueOf(sv);
+            case BIT:
+                return Boolean.parseBoolean(sv) ? 1 : 0;
+            case VARCHAR:
+                return sv;
+            default:
+                throw new RuntimeException("Unsupported time series measure type[" + valueField.getType() + "]");
+        }
+    }
+
+    private Object convertDatumToObject(Datum datum, Field field)
+    {
+        if (datum == null || Boolean.TRUE.equals(datum.nullValue())) {
+            return null;
+        }
+        Types.MinorType minor = Types.getMinorTypeForArrowType(field.getType());
+        switch (minor) {
+            case LIST:
+                Field elementField = field.getChildren().get(0);
+                if (isTimeSeriesListField(field) && datum.hasTimeSeriesValue()) {
+                    return buildTimeSeriesRowMaps(datum, field);
+                }
+                if (datum.hasArrayValue()) {
+                    List<Object> elements = new ArrayList<>();
+                    for (Datum next : datum.arrayValue()) {
+                        elements.add(convertDatumToObject(next, elementField));
+                    }
+                    return elements;
+                }
+                throw new RuntimeException("Unexpected LIST payload for field[" + field.getName() + "]");
+            case STRUCT:
+                if (datum.rowValue() == null) {
+                    return null;
+                }
+                software.amazon.awssdk.services.timestreamquery.model.Row structRow = datum.rowValue();
+                Map<String, Object> map = new LinkedHashMap<>();
+                List<Field> children = field.getChildren();
+                for (int i = 0; i < children.size(); i++) {
+                    Field childField = children.get(i);
+                    Datum childDatum = structRow.data().get(i);
+                    map.put(childField.getName(), convertDatumToObject(childDatum, childField));
+                }
+                return map;
+            default:
+                return parseScalarString(datum.scalarValue(), field);
+        }
+    }
+
+    private static Object parseScalarString(String scalarValue, Field field)
+    {
+        if (scalarValue == null) {
+            return null;
+        }
+        switch (Types.getMinorTypeForArrowType(field.getType())) {
+            case VARCHAR:
+                return scalarValue;
+            case FLOAT8:
+                return Double.valueOf(scalarValue);
+            case BIT:
+                return Boolean.parseBoolean(scalarValue) ? 1 : 0;
+            case BIGINT:
+                return Long.valueOf(scalarValue);
+            case INT:
+                return Integer.valueOf(scalarValue);
+            case DATEMILLI:
+                return Instant.from(TIMESTAMP_FORMATTER.parse(scalarValue)).toEpochMilli();
+            case DATEDAY:
+                return (int) LocalDate.parse(scalarValue, DATE_FORMATTER).toEpochDay();
+            default:
+                return scalarValue;
+        }
     }
 }

--- a/athena-timestream/src/main/java/com/amazonaws/athena/connectors/timestream/TimestreamSchemaUtils.java
+++ b/athena-timestream/src/main/java/com/amazonaws/athena/connectors/timestream/TimestreamSchemaUtils.java
@@ -20,7 +20,18 @@
 package com.amazonaws.athena.connectors.timestream;
 
 import com.amazonaws.athena.connector.lambda.data.FieldBuilder;
+import com.amazonaws.athena.connector.lambda.exceptions.AthenaConnectorException;
+import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import software.amazon.awssdk.services.glue.model.ErrorDetails;
+import software.amazon.awssdk.services.glue.model.FederationSourceErrorCode;
+import software.amazon.awssdk.services.timestreamquery.model.ColumnInfo;
+import software.amazon.awssdk.services.timestreamquery.model.Type;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 public class TimestreamSchemaUtils
 {
@@ -30,5 +41,90 @@ public class TimestreamSchemaUtils
     {
         TimestreamType timeStreamType = TimestreamType.fromId(type);
         return FieldBuilder.newBuilder(name, timeStreamType.getMinorType().getType()).build();
+    }
+
+    /**
+     * Builds an Arrow field from Timestream {@link ColumnInfo}, including array, row, and timeseries types.
+     */
+    public static Field makeFieldFromColumnInfo(ColumnInfo columnInfo)
+    {
+        String columnName = columnInfo.name();
+        if (columnName == null) {
+            columnName = "";
+        }
+        return fieldFromTimestreamType(columnName, columnInfo.type());
+    }
+
+    private static Field fieldFromTimestreamType(String columnName, Type type)
+    {
+        if (type == null) {
+            throw new AthenaConnectorException(
+                    "Timestream column '" + columnName + "' has no type information.",
+                    ErrorDetails.builder().errorCode(FederationSourceErrorCode.INVALID_INPUT_EXCEPTION.toString()).build());
+        }
+        if (type.timeSeriesMeasureValueColumnInfo() != null) {
+            return buildTimeSeriesListField(columnName, type.timeSeriesMeasureValueColumnInfo());
+        }
+        if (type.arrayColumnInfo() != null) {
+            return buildArrayField(columnName, type.arrayColumnInfo());
+        }
+        if (type.hasRowColumnInfo()) {
+            return buildRowField(columnName, type.rowColumnInfo());
+        }
+        String scalar = type.scalarTypeAsString();
+        if (scalar != null && !scalar.trim().isEmpty()) {
+            return makeField(columnName.isEmpty() ? "item" : columnName, scalar.trim().toLowerCase());
+        }
+        throw new AthenaConnectorException(
+                "The Timestream connector could not map column '" + columnName
+                        + "' to an Arrow type (missing scalar, array, row, or timeseries metadata). "
+                        + "For more details, see https://docs.aws.amazon.com/athena/latest/ug/connectors-timestream.html",
+                ErrorDetails.builder().errorCode(FederationSourceErrorCode.OPERATION_NOT_SUPPORTED_EXCEPTION.toString()).build());
+    }
+
+    private static Field buildTimeSeriesListField(String columnName, ColumnInfo measureValueColumnInfo)
+    {
+        String valueName = measureValueColumnInfo.name();
+        if (valueName == null || valueName.isEmpty()) {
+            valueName = "measure_value";
+        }
+        Field valueField = fieldFromTimestreamType(valueName, measureValueColumnInfo.type());
+        Field timeField = new Field("time", FieldType.nullable(Types.MinorType.DATEMILLI.getType()), null);
+        Field structField = new Field(
+                "item",
+                FieldType.nullable(Types.MinorType.STRUCT.getType()),
+                List.of(timeField, valueField));
+        return new Field(
+                columnName,
+                FieldType.nullable(Types.MinorType.LIST.getType()),
+                Collections.singletonList(structField));
+    }
+
+    private static Field buildArrayField(String columnName, ColumnInfo arrayElementColumnInfo)
+    {
+        String elementName = arrayElementColumnInfo.name();
+        if (elementName == null || elementName.isEmpty()) {
+            elementName = "item";
+        }
+        Field elementField = fieldFromTimestreamType(elementName, arrayElementColumnInfo.type());
+        return new Field(
+                columnName,
+                FieldType.nullable(Types.MinorType.LIST.getType()),
+                Collections.singletonList(elementField));
+    }
+
+    private static Field buildRowField(String columnName, List<ColumnInfo> rowColumnInfo)
+    {
+        List<Field> children = new ArrayList<>();
+        int idx = 0;
+        for (ColumnInfo col : rowColumnInfo) {
+            String fieldName = col.name();
+            if (fieldName == null || fieldName.isEmpty()) {
+                fieldName = "field_" + idx;
+            }
+            idx++;
+            children.add(makeFieldFromColumnInfo(ColumnInfo.builder().name(fieldName).type(col.type()).build()));
+        }
+        return new Field(columnName, FieldType.nullable(Types.MinorType.STRUCT.getType()), children);
     }
 }

--- a/athena-timestream/src/main/java/com/amazonaws/athena/connectors/timestream/TimestreamType.java
+++ b/athena-timestream/src/main/java/com/amazonaws/athena/connectors/timestream/TimestreamType.java
@@ -30,7 +30,13 @@ public enum TimestreamType
     DOUBLE("double", Types.MinorType.FLOAT8),
     BOOLEAN("boolean", Types.MinorType.BIT),
     TIMESTAMP("timestamp", Types.MinorType.DATEMILLI),
-    BIGINT("bigint", Types.MinorType.BIGINT);
+    BIGINT("bigint", Types.MinorType.BIGINT),
+    INT("int", Types.MinorType.INT),
+    DATE("date", Types.MinorType.DATEDAY),
+    TIME("time", Types.MinorType.VARCHAR),
+    INTERVAL_DAY_TO_SECOND("interval_day_to_second", Types.MinorType.VARCHAR),
+    INTERVAL_YEAR_TO_MONTH("interval_year_to_month", Types.MinorType.VARCHAR),
+    UNKNOWN("unknown", Types.MinorType.VARCHAR);
 
     private static final Map<String, TimestreamType> TIMESTREAM_TYPEMAP = new HashMap<>();
 
@@ -38,6 +44,7 @@ public enum TimestreamType
         for (TimestreamType next : values()) {
             TIMESTREAM_TYPEMAP.put(next.id, next);
         }
+        TIMESTREAM_TYPEMAP.put("integer", INT);
     }
 
     private String id;
@@ -51,7 +58,11 @@ public enum TimestreamType
 
     public static TimestreamType fromId(String id)
     {
-        TimestreamType result = TIMESTREAM_TYPEMAP.get(id);
+        if (id == null) {
+            throw new IllegalArgumentException("Unknown type for null");
+        }
+        String normalized = id.trim().toLowerCase();
+        TimestreamType result = TIMESTREAM_TYPEMAP.get(normalized);
         if (result == null) {
             throw new IllegalArgumentException("Unknown type for " + id);
         }

--- a/athena-timestream/src/test/java/com/amazonaws/athena/connectors/timestream/TestUtils.java
+++ b/athena-timestream/src/test/java/com/amazonaws/athena/connectors/timestream/TestUtils.java
@@ -112,6 +112,9 @@ public class TestUtils
             case DATEMILLI:
                 datum.scalarValue(startDate.plusDays(num).toString().replace('T', ' '));
                 break;
+            case DATEDAY:
+                datum.scalarValue(startDate.plusDays(num).toLocalDate().toString());
+                break;
             case LIST:
                 buildTimeSeries(field, datum, num);
                 break;
@@ -151,6 +154,11 @@ public class TestUtils
                 case BIGINT:
                     dataPointValue.scalarValue(String.valueOf(RAND.nextLong()));
                     break;
+                case VARCHAR:
+                    dataPointValue.scalarValue("ts-" + RAND.nextInt(10_000));
+                    break;
+                default:
+                    throw new RuntimeException("Unsupported time series measure type[" + baseSeriesType.getType() + "]");
             }
 
             dataPoint.value(dataPointValue.build());

--- a/athena-timestream/src/test/java/com/amazonaws/athena/connectors/timestream/TimestreamMetadataHandlerTest.java
+++ b/athena-timestream/src/test/java/com/amazonaws/athena/connectors/timestream/TimestreamMetadataHandlerTest.java
@@ -262,6 +262,12 @@ public class TimestreamMetadataHandlerTest
             rows.add(Row.builder().data(Datum.builder().scalarValue("time").build(),
                     Datum.builder().scalarValue("timestamp").build(),
                     Datum.builder().scalarValue("timestamp").build()).build());
+            rows.add(Row.builder().data(Datum.builder().scalarValue("sample_int").build(),
+                    Datum.builder().scalarValue("int").build(),
+                    Datum.builder().scalarValue("measure").build()).build());
+            rows.add(Row.builder().data(Datum.builder().scalarValue("sample_date").build(),
+                    Datum.builder().scalarValue("date").build(),
+                    Datum.builder().scalarValue("dimension").build()).build());
 
             return QueryResponse.builder().rows(rows).build();
         });
@@ -274,7 +280,7 @@ public class TimestreamMetadataHandlerTest
         GetTableResponse res = handler.doGetTable(allocator, req);
         logger.info("doGetTable - {}", res);
 
-        assertEquals(4, res.getSchema().getFields().size());
+        assertEquals(6, res.getSchema().getFields().size());
 
         Field measureName = res.getSchema().findField("measure_name");
         assertEquals(Types.MinorType.VARCHAR, Types.getMinorTypeForArrowType(measureName.getType()));
@@ -287,6 +293,12 @@ public class TimestreamMetadataHandlerTest
 
         Field time = res.getSchema().findField("time");
         assertEquals(Types.MinorType.DATEMILLI, Types.getMinorTypeForArrowType(time.getType()));
+
+        Field sampleInt = res.getSchema().findField("sample_int");
+        assertEquals(Types.MinorType.INT, Types.getMinorTypeForArrowType(sampleInt.getType()));
+
+        Field sampleDate = res.getSchema().findField("sample_date");
+        assertEquals(Types.MinorType.DATEDAY, Types.getMinorTypeForArrowType(sampleDate.getType()));
 
         logger.info("doGetTable - exit");
     }
@@ -488,6 +500,18 @@ public class TimestreamMetadataHandlerTest
                 .type(Type.builder().scalarType(ScalarType.DOUBLE).build()).build());
         columnInfos.add(ColumnInfo.builder().name("time")
                 .type(Type.builder().scalarType(ScalarType.TIMESTAMP).build()).build());
+        columnInfos.add(ColumnInfo.builder().name("day")
+                .type(Type.builder().scalarType(ScalarType.DATE).build()).build());
+        columnInfos.add(ColumnInfo.builder().name("cnt")
+                .type(Type.builder().scalarType(ScalarType.INTEGER).build()).build());
+        columnInfos.add(ColumnInfo.builder().name("clock")
+                .type(Type.builder().scalarType(ScalarType.TIME).build()).build());
+        columnInfos.add(ColumnInfo.builder().name("iv_day")
+                .type(Type.builder().scalarType(ScalarType.INTERVAL_DAY_TO_SECOND).build()).build());
+        columnInfos.add(ColumnInfo.builder().name("iv_month")
+                .type(Type.builder().scalarType(ScalarType.INTERVAL_YEAR_TO_MONTH).build()).build());
+        columnInfos.add(ColumnInfo.builder().name("unknown_col")
+                .type(Type.builder().scalarType(ScalarType.UNKNOWN).build()).build());
 
         QueryResponse queryResponse = QueryResponse.builder()
                 .columnInfo(columnInfos)
@@ -497,17 +521,29 @@ public class TimestreamMetadataHandlerTest
 
         GetTableResponse res = handler.doGetQueryPassthroughSchema(allocator, request);
 
-        assertEquals(3, res.getSchema().getFields().size());
+        assertEquals(9, res.getSchema().getFields().size());
         assertEquals(Types.MinorType.VARCHAR,
                 Types.getMinorTypeForArrowType(res.getSchema().findField("id").getType()));
         assertEquals(Types.MinorType.FLOAT8,
                 Types.getMinorTypeForArrowType(res.getSchema().findField("measure_value").getType()));
         assertEquals(Types.MinorType.DATEMILLI,
                 Types.getMinorTypeForArrowType(res.getSchema().findField("time").getType()));
+        assertEquals(Types.MinorType.DATEDAY,
+                Types.getMinorTypeForArrowType(res.getSchema().findField("day").getType()));
+        assertEquals(Types.MinorType.INT,
+                Types.getMinorTypeForArrowType(res.getSchema().findField("cnt").getType()));
+        assertEquals(Types.MinorType.VARCHAR,
+                Types.getMinorTypeForArrowType(res.getSchema().findField("clock").getType()));
+        assertEquals(Types.MinorType.VARCHAR,
+                Types.getMinorTypeForArrowType(res.getSchema().findField("iv_day").getType()));
+        assertEquals(Types.MinorType.VARCHAR,
+                Types.getMinorTypeForArrowType(res.getSchema().findField("iv_month").getType()));
+        assertEquals(Types.MinorType.VARCHAR,
+                Types.getMinorTypeForArrowType(res.getSchema().findField("unknown_col").getType()));
     }
 
     @Test
-    public void doGetQueryPassthroughSchema_timeseriesColumn_throwsException()
+    public void doGetQueryPassthroughSchema_timeseriesColumn_returnsSchema()
             throws Exception
     {
         Map<String, String> queryPassthroughArgs = new HashMap<>();
@@ -519,8 +555,11 @@ public class TimestreamMetadataHandlerTest
         GetTableRequest request = new GetTableRequest(identity, "query-id", "default",
                 new TableName("system", "query"), queryPassthroughArgs);
 
-        // Simulate Timestream returning a timeseries/non-scalar column: Type with no scalar (scalarTypeAsString() null).
-        Type timeseriesType = Type.builder().build();
+        ColumnInfo measureValueInfo = ColumnInfo.builder()
+                .name("cpu_util")
+                .type(Type.builder().scalarType(ScalarType.DOUBLE).build())
+                .build();
+        Type timeseriesType = Type.builder().timeSeriesMeasureValueColumnInfo(measureValueInfo).build();
         ColumnInfo timeseriesColumn = ColumnInfo.builder().name("my_time_series").type(timeseriesType).build();
         QueryResponse queryResponse = QueryResponse.builder()
                 .columnInfo(Collections.singletonList(timeseriesColumn))
@@ -529,14 +568,155 @@ public class TimestreamMetadataHandlerTest
 
         when(mockTsQuery.query(nullable(QueryRequest.class))).thenReturn(queryResponse);
 
+        GetTableResponse res = handler.doGetQueryPassthroughSchema(allocator, request);
+
+        Field ts = res.getSchema().findField("my_time_series");
+        assertEquals(Types.MinorType.LIST, Types.getMinorTypeForArrowType(ts.getType()));
+        Field structField = ts.getChildren().get(0);
+        assertEquals(Types.MinorType.STRUCT, Types.getMinorTypeForArrowType(structField.getType()));
+        assertEquals(Types.MinorType.DATEMILLI,
+                Types.getMinorTypeForArrowType(structField.getChildren().get(0).getType()));
+        assertEquals("cpu_util", structField.getChildren().get(1).getName());
+        assertEquals(Types.MinorType.FLOAT8,
+                Types.getMinorTypeForArrowType(structField.getChildren().get(1).getType()));
+    }
+
+    @Test
+    public void doGetQueryPassthroughSchema_nullColumnName_defaultsToItem()
+            throws Exception
+    {
+        Map<String, String> queryPassthroughArgs = new HashMap<>();
+        queryPassthroughArgs.put(SCHEMA_FUNCTION_NAME, TimestreamQueryPassthrough.SCHEMA_NAME + "." + TimestreamQueryPassthrough.NAME);
+        queryPassthroughArgs.put(TimestreamQueryPassthrough.QUERY, "SELECT col FROM \"db\".\"table\"");
+
+        GetTableRequest request = new GetTableRequest(identity, "query-id", "default",
+                new TableName("system", "query"), queryPassthroughArgs);
+
+        ColumnInfo unnamedColumn = ColumnInfo.builder()
+                .type(Type.builder().scalarType(ScalarType.VARCHAR).build())
+                .build();
+        QueryResponse queryResponse = QueryResponse.builder()
+                .columnInfo(Collections.singletonList(unnamedColumn))
+                .rows(Collections.emptyList())
+                .build();
+        when(mockTsQuery.query(nullable(QueryRequest.class))).thenReturn(queryResponse);
+
+        GetTableResponse res = handler.doGetQueryPassthroughSchema(allocator, request);
+        assertEquals("item", res.getSchema().getFields().get(0).getName());
+    }
+
+    @Test
+    public void doGetQueryPassthroughSchema_arrayAndRowColumns_returnsSchema()
+            throws Exception
+    {
+        Map<String, String> queryPassthroughArgs = new HashMap<>();
+        queryPassthroughArgs.put(SCHEMA_FUNCTION_NAME, TimestreamQueryPassthrough.SCHEMA_NAME + "." + TimestreamQueryPassthrough.NAME);
+        queryPassthroughArgs.put(TimestreamQueryPassthrough.QUERY, "SELECT arr, r FROM \"db\".\"table\"");
+
+        GetTableRequest request = new GetTableRequest(identity, "query-id", "default",
+                new TableName("system", "query"), queryPassthroughArgs);
+
+        Type arrayType = Type.builder()
+                .arrayColumnInfo(ColumnInfo.builder()
+                        .type(Type.builder().scalarType(ScalarType.INTEGER).build())
+                        .build())
+                .build();
+        Type rowType = Type.builder()
+                .rowColumnInfo(
+                        ColumnInfo.builder().name("x").type(Type.builder().scalarType(ScalarType.VARCHAR).build()).build(),
+                        ColumnInfo.builder().name("y").type(Type.builder().scalarType(ScalarType.DOUBLE).build()).build(),
+                        ColumnInfo.builder().type(Type.builder().scalarType(ScalarType.INTEGER).build()).build())
+                .build();
+
+        List<ColumnInfo> columnInfos = new ArrayList<>();
+        columnInfos.add(ColumnInfo.builder().name("arr").type(arrayType).build());
+        columnInfos.add(ColumnInfo.builder().name("r").type(rowType).build());
+
+        QueryResponse queryResponse = QueryResponse.builder()
+                .columnInfo(columnInfos)
+                .rows(Collections.emptyList())
+                .build();
+        when(mockTsQuery.query(nullable(QueryRequest.class))).thenReturn(queryResponse);
+
+        GetTableResponse res = handler.doGetQueryPassthroughSchema(allocator, request);
+
+        Field arr = res.getSchema().findField("arr");
+        assertEquals(Types.MinorType.LIST, Types.getMinorTypeForArrowType(arr.getType()));
+        assertEquals("item", arr.getChildren().get(0).getName());
+        assertEquals(Types.MinorType.INT,
+                Types.getMinorTypeForArrowType(arr.getChildren().get(0).getType()));
+
+        Field rowField = res.getSchema().findField("r");
+        assertEquals(Types.MinorType.STRUCT, Types.getMinorTypeForArrowType(rowField.getType()));
+        assertEquals(3, rowField.getChildren().size());
+        assertEquals("x", rowField.getChildren().get(0).getName());
+        assertEquals(Types.MinorType.VARCHAR,
+                Types.getMinorTypeForArrowType(rowField.getChildren().get(0).getType()));
+        assertEquals("y", rowField.getChildren().get(1).getName());
+        assertEquals(Types.MinorType.FLOAT8,
+                Types.getMinorTypeForArrowType(rowField.getChildren().get(1).getType()));
+        assertEquals("field_2", rowField.getChildren().get(2).getName());
+        assertEquals(Types.MinorType.INT,
+                Types.getMinorTypeForArrowType(rowField.getChildren().get(2).getType()));
+    }
+
+    @Test
+    public void doGetQueryPassthroughSchema_missingType_throwsException()
+            throws Exception
+    {
+        Map<String, String> queryPassthroughArgs = new HashMap<>();
+        queryPassthroughArgs.put(SCHEMA_FUNCTION_NAME, TimestreamQueryPassthrough.SCHEMA_NAME + "." + TimestreamQueryPassthrough.NAME);
+        queryPassthroughArgs.put(TimestreamQueryPassthrough.QUERY, "SELECT missing_type FROM \"db\".\"table\"");
+
+        GetTableRequest request = new GetTableRequest(identity, "query-id", "default",
+                new TableName("system", "query"), queryPassthroughArgs);
+
+        QueryResponse queryResponse = QueryResponse.builder()
+                .columnInfo(Collections.singletonList(ColumnInfo.builder().name("missing_type").build()))
+                .rows(Collections.emptyList())
+                .build();
+        when(mockTsQuery.query(nullable(QueryRequest.class))).thenReturn(queryResponse);
+
         try {
             handler.doGetQueryPassthroughSchema(allocator, request);
-            fail("Expected AthenaConnectorException for timeseries column");
+            fail("Expected AthenaConnectorException for missing Timestream type");
         }
         catch (AthenaConnectorException e) {
             assertNotNull(e.getMessage());
-            assertTrue("Message should mention supported scalar types",
-                    e.getMessage().contains("varchar") && e.getMessage().contains("double") && e.getMessage().contains("timestamp"));
+            assertTrue("Message should mention missing type information", e.getMessage().contains("has no type information"));
+            assertTrue("Message should mention the column name", e.getMessage().contains("missing_type"));
+        }
+    }
+
+    @Test
+    public void doGetQueryPassthroughSchema_emptyType_throwsException()
+            throws Exception
+    {
+        Map<String, String> queryPassthroughArgs = new HashMap<>();
+        queryPassthroughArgs.put(SCHEMA_FUNCTION_NAME, TimestreamQueryPassthrough.SCHEMA_NAME + "." + TimestreamQueryPassthrough.NAME);
+
+        queryPassthroughArgs.put(TimestreamQueryPassthrough.QUERY,
+                "SELECT id, my_time_series FROM \"db\".\"table\"");
+
+        GetTableRequest request = new GetTableRequest(identity, "query-id", "default",
+                new TableName("system", "query"), queryPassthroughArgs);
+
+        Type emptyType = Type.builder().build();
+        ColumnInfo badColumn = ColumnInfo.builder().name("my_time_series").type(emptyType).build();
+        QueryResponse queryResponse = QueryResponse.builder()
+                .columnInfo(Collections.singletonList(badColumn))
+                .rows(Collections.emptyList())
+                .build();
+
+        when(mockTsQuery.query(nullable(QueryRequest.class))).thenReturn(queryResponse);
+
+        try {
+            handler.doGetQueryPassthroughSchema(allocator, request);
+            fail("Expected AthenaConnectorException for empty Timestream type");
+        }
+        catch (AthenaConnectorException e) {
+            assertNotNull(e.getMessage());
+            assertTrue("Message should mention mapping failure", e.getMessage().contains("could not map"));
             assertTrue("Message should mention the column name", e.getMessage().contains("my_time_series"));
             assertTrue("Message should mention docs link", e.getMessage().contains("connectors-timestream.html"));
         }

--- a/athena-timestream/src/test/java/com/amazonaws/athena/connectors/timestream/TimestreamRecordHandlerTest.java
+++ b/athena-timestream/src/test/java/com/amazonaws/athena/connectors/timestream/TimestreamRecordHandlerTest.java
@@ -66,12 +66,14 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.awssdk.services.timestreamquery.TimestreamQueryClient;
+import software.amazon.awssdk.services.timestreamquery.model.Datum;
 import software.amazon.awssdk.services.timestreamquery.model.QueryRequest;
 import software.amazon.awssdk.services.timestreamquery.model.QueryResponse;
+import software.amazon.awssdk.services.timestreamquery.model.Row;
 
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.io.InputStream;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -139,9 +141,7 @@ public class TimestreamRecordHandlerTest
     }
 
     @Before
-    public void setUp()
-            throws IOException
-    {
+    public void setUp() {
         logger.info("{}: enter", testName.getMethodName());
 
         allocator = new BlockAllocatorImpl();
@@ -500,5 +500,393 @@ public class TimestreamRecordHandlerTest
         }
 
         logger.info("doReadRecordsNoSpill: {}", BlockUtils.rowToString(response.getRecords(), 0));
+    }
+
+    @Test
+    public void doReadRecords_withIntAndDateDayScalars_returnsParsedValues()
+            throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder()
+                .addIntField("cnt_int")
+                .addField("reading_date", Types.MinorType.DATEDAY.getType())
+                .build();
+
+        List<Datum> rowData = List.of(
+                Datum.builder().scalarValue("42").build(),
+                Datum.builder().scalarValue("2024-06-15").build());
+        QueryResponse mockResult = QueryResponse.builder()
+                .rows(List.of(Row.builder().data(rowData).build()))
+                .build();
+
+        when(mockClient.query(nullable(QueryRequest.class))).thenReturn(mockResult);
+
+        ReadRecordsRequest request = newReadRecordsRequest(schema);
+        ReadRecordsResponse response = (ReadRecordsResponse) handler.doReadRecords(allocator, request);
+
+        Block block = response.getRecords();
+        FieldReader cnt = block.getFieldReader("cnt_int");
+        cnt.setPosition(0);
+        assertEquals(42, cnt.readInteger().intValue());
+
+        FieldReader readingDate = block.getFieldReader("reading_date");
+        readingDate.setPosition(0);
+        assertTrue(readingDate.isSet());
+    }
+
+    @Test
+    public void doReadRecords_withBitTrueFalseAndBigIntScalars_returnsParsedValues()
+            throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder()
+                .addBitField("active")
+                .addBitField("inactive")
+                .addBigIntField("total")
+                .build();
+
+        QueryResponse mockResult = QueryResponse.builder()
+                .rows(List.of(Row.builder().data(List.of(
+                        Datum.builder().scalarValue("true").build(),
+                        Datum.builder().scalarValue("false").build(),
+                        Datum.builder().scalarValue("1000").build())).build()))
+                .build();
+        when(mockClient.query(nullable(QueryRequest.class))).thenReturn(mockResult);
+
+        Block block = ((ReadRecordsResponse) handler.doReadRecords(allocator, newReadRecordsRequest(schema))).getRecords();
+        block.getFieldReader("active").setPosition(0);
+        assertTrue(block.getFieldReader("active").readBoolean());
+        block.getFieldReader("inactive").setPosition(0);
+        assertTrue(!block.getFieldReader("inactive").readBoolean());
+        block.getFieldReader("total").setPosition(0);
+        assertEquals(1000L, block.getFieldReader("total").readLong().longValue());
+    }
+
+    @Test
+    public void doReadRecords_withListStructWrongTimeFieldName_returnsListValue()
+            throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder()
+                .addField(FieldBuilder.newBuilder("readings", Types.MinorType.LIST.getType())
+                        .addField(FieldBuilder.newBuilder("item", Types.MinorType.STRUCT.getType())
+                                .addStringField("timestamp")
+                                .addFloat8Field("value")
+                                .build())
+                        .build())
+                .build();
+
+        Datum listDatum = Datum.builder()
+                .arrayValue(List.of(Datum.builder().rowValue(Row.builder().data(List.of(
+                        Datum.builder().scalarValue("2024-06-15").build(),
+                        Datum.builder().scalarValue("1.5").build())).build()).build()))
+                .build();
+        when(mockClient.query(nullable(QueryRequest.class))).thenReturn(QueryResponse.builder()
+                .rows(List.of(Row.builder().data(List.of(listDatum)).build()))
+                .build());
+
+        ReadRecordsResponse response = (ReadRecordsResponse) handler.doReadRecords(allocator, newReadRecordsRequest(schema));
+        assertEquals(1, response.getRecordCount());
+
+        List<Map<String, Object>> readings = (List<Map<String, Object>>) response.getRecords()
+                .getFieldReader("readings")
+                .readObject();
+        assertEquals(1, readings.size());
+        Map<String, Object> element = readings.get(0);
+        assertEquals("2024-06-15", element.get("timestamp").toString());
+        assertEquals(1.5, ((Number) element.get("value")).doubleValue(), 0.001);
+    }
+
+    @Test
+    public void doReadRecords_withNullScalars_returnsNullValues()
+            throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder()
+                .addStringField("name")
+                .addFloat8Field("reading")
+                .addBitField("active")
+                .addBigIntField("total")
+                .addIntField("count")
+                .addField("event_time", Types.MinorType.DATEMILLI.getType())
+                .addField("event_date", Types.MinorType.DATEDAY.getType())
+                .build();
+
+        List<Datum> rowData = List.of(
+                Datum.builder().build(),
+                Datum.builder().build(),
+                Datum.builder().build(),
+                Datum.builder().build(),
+                Datum.builder().build(),
+                Datum.builder().build(),
+                Datum.builder().build());
+        QueryResponse mockResult = QueryResponse.builder()
+                .rows(List.of(Row.builder().data(rowData).build()))
+                .build();
+
+        when(mockClient.query(nullable(QueryRequest.class))).thenReturn(mockResult);
+
+        ReadRecordsRequest request = newReadRecordsRequest(schema);
+        ReadRecordsResponse response = (ReadRecordsResponse) handler.doReadRecords(allocator, request);
+
+        assertEquals(1, response.getRecordCount());
+        assertNullValue(response.getRecords(), "name");
+        assertNullValue(response.getRecords(), "reading");
+        assertNullValue(response.getRecords(), "active");
+        assertNullValue(response.getRecords(), "total");
+        assertNullValue(response.getRecords(), "count");
+        assertNullValue(response.getRecords(), "event_time");
+        assertNullValue(response.getRecords(), "event_date");
+    }
+    
+    @Test
+    public void doReadRecords_withArrayColumn_returnsListValue()
+            throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder()
+                .addField(FieldBuilder.newBuilder("arr", Types.MinorType.LIST.getType())
+                        .addIntField("item")
+                        .build())
+                .build();
+
+        Datum arrDatum = Datum.builder()
+                .arrayValue(List.of(
+                        Datum.builder().scalarValue("100").build(),
+                        Datum.builder().scalarValue("200").build()))
+                .build();
+        QueryResponse mockResult = QueryResponse.builder()
+                .rows(List.of(Row.builder().data(List.of(arrDatum)).build()))
+                .build();
+
+        when(mockClient.query(nullable(QueryRequest.class))).thenReturn(mockResult);
+
+        ReadRecordsRequest request = newReadRecordsRequest(schema);
+        ReadRecordsResponse response = (ReadRecordsResponse) handler.doReadRecords(allocator, request);
+
+        assertEquals(1, response.getRecordCount());
+        assertNotNull(response.getRecords().getFieldReader("arr").readObject());
+    }
+
+    @Test
+    public void doReadRecords_withStructColumn_returnsRowValue()
+            throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder()
+                .addField(FieldBuilder.newBuilder("readings", Types.MinorType.STRUCT.getType())
+                        .addFloat8Field("temp")
+                        .addBitField("flag")
+                        .build())
+                .build();
+
+        Datum readings = Datum.builder()
+                .rowValue(Row.builder().data(List.of(
+                        Datum.builder().scalarValue("21.5").build(),
+                        Datum.builder().scalarValue("true").build())).build())
+                .build();
+        QueryResponse mockResult = QueryResponse.builder()
+                .rows(List.of(Row.builder().data(List.of(readings)).build()))
+                .build();
+
+        when(mockClient.query(nullable(QueryRequest.class))).thenReturn(mockResult);
+
+        ReadRecordsRequest request = newReadRecordsRequest(schema);
+        ReadRecordsResponse response = (ReadRecordsResponse) handler.doReadRecords(allocator, request);
+
+        assertEquals(1, response.getRecordCount());
+        assertNotNull(response.getRecords().getFieldReader("readings").readObject());
+    }
+
+    @Test
+    public void doReadRecords_withNestedDateFields_returnsComplexValue()
+            throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder()
+                .addField(FieldBuilder.newBuilder("readings", Types.MinorType.STRUCT.getType())
+                        .addField("event_time", Types.MinorType.DATEMILLI.getType(), null)
+                        .addField("event_date", Types.MinorType.DATEDAY.getType(), null)
+                        .build())
+                .build();
+
+        Datum readings = Datum.builder()
+                .rowValue(Row.builder().data(List.of(
+                        Datum.builder().scalarValue("2024-06-15 10:11:12.123").build(),
+                        Datum.builder().scalarValue("2024-06-15").build())).build())
+                .build();
+        QueryResponse mockResult = QueryResponse.builder()
+                .rows(List.of(Row.builder().data(List.of(readings)).build()))
+                .build();
+
+        when(mockClient.query(nullable(QueryRequest.class))).thenReturn(mockResult);
+
+        ReadRecordsRequest request = newReadRecordsRequest(schema);
+        ReadRecordsResponse response = (ReadRecordsResponse) handler.doReadRecords(allocator, request);
+
+        assertEquals(1, response.getRecordCount());
+        Map<String, Object> rowValue = (Map<String, Object>) response.getRecords()
+                .getFieldReader("readings")
+                .readObject();
+        assertEquals(LocalDateTime.of(2024, 6, 15, 10, 11, 12, 123_000_000), rowValue.get("event_time"));
+        assertEquals((int) LocalDate.of(2024, 6, 15).toEpochDay(), ((Integer) rowValue.get("event_date")).intValue());
+    }
+
+    @Test
+    public void doReadRecords_withTimeSeriesVarcharMeasure_returnsComplexValue()
+            throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder()
+                .addField(FieldBuilder.newBuilder("note_series", Types.MinorType.LIST.getType())
+                        .addField(FieldBuilder.newBuilder("item", Types.MinorType.STRUCT.getType())
+                                .addDateMilliField("time")
+                                .addStringField("measure_value")
+                                .build())
+                        .build())
+                .build();
+
+        QueryResponse mockResult = makeMockQueryResult(schema, 1, 1, false);
+        when(mockClient.query(nullable(QueryRequest.class))).thenReturn(mockResult);
+
+        ReadRecordsRequest request = newReadRecordsRequest(schema);
+        ReadRecordsResponse response = (ReadRecordsResponse) handler.doReadRecords(allocator, request);
+
+        assertEquals(1, response.getRecordCount());
+        assertNotNull(response.getRecords().getFieldReader("note_series").readObject());
+    }
+
+    @Test
+    public void doReadRecords_withNullComplexDatums_skipsRowWrite()
+            throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder()
+                .addField(FieldBuilder.newBuilder("arr", Types.MinorType.LIST.getType())
+                        .addIntField("item").build())
+                .addField(FieldBuilder.newBuilder("st", Types.MinorType.STRUCT.getType())
+                        .addFloat8Field("value").build())
+                .addField(FieldBuilder.newBuilder("ts", Types.MinorType.LIST.getType())
+                        .addField(FieldBuilder.newBuilder("item", Types.MinorType.STRUCT.getType())
+                                .addDateMilliField("time")
+                                .addFloat8Field("measure_value").build()).build())
+                .build();
+
+        Datum nullDatum = Datum.builder().nullValue(true).build();
+        QueryResponse mockResult = QueryResponse.builder()
+                .rows(List.of(Row.builder().data(List.of(nullDatum, nullDatum, nullDatum)).build()))
+                .build();
+
+        when(mockClient.query(nullable(QueryRequest.class))).thenReturn(mockResult);
+
+        ReadRecordsRequest request = newReadRecordsRequest(schema);
+        ReadRecordsResponse response = (ReadRecordsResponse) handler.doReadRecords(allocator, request);
+
+        assertEquals(1, response.getRecordCount());
+    }
+
+    @Test
+    public void doReadRecords_withTimeSeriesIntBigintBitMeasures_writesAllThreeTimeSeriesColumns()
+            throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder()
+                .addField(FieldBuilder.newBuilder("ts_int", Types.MinorType.LIST.getType())
+                        .addField(FieldBuilder.newBuilder("item", Types.MinorType.STRUCT.getType())
+                                .addDateMilliField("time")
+                                .addIntField("measure_value").build()).build())
+                .addField(FieldBuilder.newBuilder("ts_bigint", Types.MinorType.LIST.getType())
+                        .addField(FieldBuilder.newBuilder("item", Types.MinorType.STRUCT.getType())
+                                .addDateMilliField("time")
+                                .addBigIntField("measure_value").build()).build())
+                .addField(FieldBuilder.newBuilder("ts_bit", Types.MinorType.LIST.getType())
+                        .addField(FieldBuilder.newBuilder("item", Types.MinorType.STRUCT.getType())
+                                .addDateMilliField("time")
+                                .addBitField("measure_value").build()).build())
+                .build();
+
+        QueryResponse mockResult = makeMockQueryResult(schema, 1, 1, false);
+        when(mockClient.query(nullable(QueryRequest.class))).thenReturn(mockResult);
+
+        ReadRecordsRequest request = newReadRecordsRequest(schema);
+        ReadRecordsResponse response = (ReadRecordsResponse) handler.doReadRecords(allocator, request);
+
+        assertEquals(1, response.getRecordCount());
+        assertNotNull(response.getRecords().getFieldReader("ts_int").readObject());
+        assertNotNull(response.getRecords().getFieldReader("ts_bigint").readObject());
+        assertNotNull(response.getRecords().getFieldReader("ts_bit").readObject());
+    }
+
+    @Test
+    public void doReadRecords_withPagination_returnsTwoRecordsFromPaginatedQuery()
+            throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder().addStringField("col").build();
+
+        QueryResponse page1 = QueryResponse.builder()
+                .rows(List.of(Row.builder().data(List.of(Datum.builder().scalarValue("row1").build())).build()))
+                .nextToken("page2")
+                .build();
+        QueryResponse page2 = QueryResponse.builder()
+                .rows(List.of(Row.builder().data(List.of(Datum.builder().scalarValue("row2").build())).build()))
+                .build();
+
+        when(mockClient.query(nullable(QueryRequest.class)))
+                .thenReturn(page1)
+                .thenReturn(page2);
+
+        ReadRecordsRequest request = newReadRecordsRequest(schema);
+        ReadRecordsResponse response = (ReadRecordsResponse) handler.doReadRecords(allocator, request);
+
+        assertEquals(2, response.getRecordCount());
+    }
+
+    @Test
+    public void doReadRecords_withStructContainingVarcharBigintInt_writesInfoStructField()
+            throws Exception
+    {
+        Schema schema = SchemaBuilder.newBuilder()
+                .addField(FieldBuilder.newBuilder("info", Types.MinorType.STRUCT.getType())
+                        .addStringField("name")
+                        .addBigIntField("count")
+                        .addIntField("cnt_int")
+                        .build())
+                .build();
+
+        Datum structDatum = Datum.builder()
+                .rowValue(Row.builder().data(List.of(
+                        Datum.builder().scalarValue("alice").build(),
+                        Datum.builder().scalarValue("9876543210").build(),
+                        Datum.builder().scalarValue("42").build())).build())
+                .build();
+        QueryResponse mockResult = QueryResponse.builder()
+                .rows(List.of(Row.builder().data(List.of(structDatum)).build()))
+                .build();
+
+        when(mockClient.query(nullable(QueryRequest.class))).thenReturn(mockResult);
+
+        ReadRecordsRequest request = newReadRecordsRequest(schema);
+        ReadRecordsResponse response = (ReadRecordsResponse) handler.doReadRecords(allocator, request);
+
+        assertEquals(1, response.getRecordCount());
+        assertNotNull(response.getRecords().getFieldReader("info").readObject());
+    }
+
+    private ReadRecordsRequest newReadRecordsRequest(Schema schema)
+    {
+        S3SpillLocation splitLoc = S3SpillLocation.newBuilder()
+                .withBucket(UUID.randomUUID().toString())
+                .withSplitId(UUID.randomUUID().toString())
+                .withQueryId(UUID.randomUUID().toString())
+                .withIsDirectory(true)
+                .build();
+
+        return new ReadRecordsRequest(IDENTITY,
+                DEFAULT_CATALOG,
+                "queryId-" + System.currentTimeMillis(),
+                new TableName(DEFAULT_SCHEMA, TEST_TABLE),
+                schema,
+                Split.newBuilder(splitLoc, keyFactory.create()).build(),
+                new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(),
+                        DEFAULT_NO_LIMIT, Collections.emptyMap(), null),
+                10000000000L,
+                10000000000L);
+    }
+
+    private void assertNullValue(Block block, String fieldName)
+    {
+        FieldReader reader = block.getFieldReader(fieldName);
+        reader.setPosition(0);
+        assertTrue("Expected " + fieldName + " to be null", !reader.isSet());
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
Fixes #2808. Adds QPT support for time series, array, row, and extended scalar types.

*Description of changes:*
Added support for complex query result types in QPT (time series, array, row) and extended scalars in the Timestream connector schema and read paths.
PFA analysis document and functional testing results.
[Timestream_Unsupported_Types.docx](https://github.com/user-attachments/files/29095468/Timestream_Unsupported_Types.docx)

[TIMESTREAM_FUNCTIONAL_TEST_UNSUPPORTED_TYPES.xlsx](https://github.com/user-attachments/files/29093030/TIMESTREAM_FUNCTIONAL_TEST_UNSUPPORTED_TYPES.xlsx)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
