### PR TITLE
Adding proper handling of async exception during S3 bucket spill

### DIFF
--- a/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/S3BlockSpiller.java
+++ b/athena-federation-sdk/src/main/java/com/amazonaws/athena/connector/lambda/data/S3BlockSpiller.java
@@ -286,6 +286,9 @@ public class S3BlockSpiller
             }
 
             lock.lock();
+            if (asyncException.get() != null) {
+                throw asyncException.get();
+            }
             return spillLocations;
         }
         finally {

--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/data/S3BlockSpillerTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/data/S3BlockSpillerTest.java
@@ -330,6 +330,156 @@ public class S3BlockSpillerTest
         return capturedRequest;
     }
 
+    @Test(expected = RuntimeException.class)
+    public void getSpillLocationsThrowsOnAsyncS3Error()
+            throws IOException
+    {
+        // Create a spiller with async spill threads enabled
+        SpillConfig asyncSpillConfig = SpillConfig.newBuilder()
+                .withEncryptionKey(keyFactory.create())
+                .withRequestId(requestId)
+                .withSpillLocation(S3SpillLocation.newBuilder()
+                        .withBucket(bucket)
+                        .withPrefix(prefix)
+                        .withQueryId(requestId)
+                        .withSplitId(splitId)
+                        .withIsDirectory(true)
+                        .build())
+                .withRequestId(requestId)
+                .withMaxBlockBytes(100) // small so it spills immediately
+                .withMaxInlineBlockBytes(0) // force spill
+                .withNumSpillThreads(1)
+                .build();
+
+        Schema schema = SchemaBuilder.newBuilder()
+                .addField("col1", new ArrowType.Int(32, true))
+                .build();
+
+        S3BlockSpiller asyncSpiller = new S3BlockSpiller(mockS3, asyncSpillConfig, allocator, schema,
+                ConstraintEvaluator.emptyEvaluator(), com.google.common.collect.ImmutableMap.of());
+
+        // Mock S3 putObject to throw a permission error (simulating AccessDenied)
+        when(mockS3.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+                .thenThrow(new RuntimeException("Access Denied"));
+
+        try {
+            // Write enough data to trigger a spill
+            asyncSpiller.writeRows((Block block, int rowNum) -> {
+                BlockUtils.setValue(block.getFieldVector("col1"), rowNum, 100);
+                return 1;
+            });
+
+            // This should throw because the async S3 write failed with permission error
+            asyncSpiller.getSpillLocations();
+        }
+        finally {
+            asyncSpiller.close();
+        }
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void spilledThrowsOnAsyncS3Error()
+            throws IOException
+    {
+        // Create a spiller with async spill threads enabled
+        SpillConfig asyncSpillConfig = SpillConfig.newBuilder()
+                .withEncryptionKey(keyFactory.create())
+                .withRequestId(requestId)
+                .withSpillLocation(S3SpillLocation.newBuilder()
+                        .withBucket(bucket)
+                        .withPrefix(prefix)
+                        .withQueryId(requestId)
+                        .withSplitId(splitId)
+                        .withIsDirectory(true)
+                        .build())
+                .withRequestId(requestId)
+                .withMaxBlockBytes(100) // small so it spills immediately
+                .withMaxInlineBlockBytes(0) // force spill
+                .withNumSpillThreads(1)
+                .build();
+
+        Schema schema = SchemaBuilder.newBuilder()
+                .addField("col1", new ArrowType.Int(32, true))
+                .addField("col2", new ArrowType.Utf8())
+                .build();
+
+        S3BlockSpiller asyncSpiller = new S3BlockSpiller(mockS3, asyncSpillConfig, allocator, schema,
+                ConstraintEvaluator.emptyEvaluator(), com.google.common.collect.ImmutableMap.of());
+
+        // Mock S3 putObject to throw a permission error
+        when(mockS3.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+                .thenThrow(new RuntimeException("Access Denied"));
+
+        try {
+            // Write multiple rows to exceed maxBlockBytes and trigger a spill
+            for (int i = 0; i < 20; i++) {
+                asyncSpiller.writeRows((Block block, int rowNum) -> {
+                    BlockUtils.setValue(block.getFieldVector("col1"), rowNum, 100);
+                    BlockUtils.setValue(block.getFieldVector("col2"), rowNum, "SomeDataToIncreaseBlockSize");
+                    return 1;
+                });
+            }
+
+            // Close the spiller which awaits async thread termination
+            asyncSpiller.close();
+
+            // After close, the async thread has completed - spilled() should throw
+            asyncSpiller.spilled();
+        }
+        finally {
+            // already closed above, but safe to call again
+        }
+    }
+
+    @Test
+    public void getSpillLocationsSucceedsWhenS3WriteSucceeds()
+            throws IOException
+    {
+        // Create a spiller with async spill threads enabled
+        SpillConfig asyncSpillConfig = SpillConfig.newBuilder()
+                .withEncryptionKey(keyFactory.create())
+                .withRequestId(requestId)
+                .withSpillLocation(S3SpillLocation.newBuilder()
+                        .withBucket(bucket)
+                        .withPrefix(prefix)
+                        .withQueryId(requestId)
+                        .withSplitId(splitId)
+                        .withIsDirectory(true)
+                        .build())
+                .withRequestId(requestId)
+                .withMaxBlockBytes(100) // small so it spills immediately
+                .withMaxInlineBlockBytes(0) // force spill
+                .withNumSpillThreads(1)
+                .build();
+
+        Schema schema = SchemaBuilder.newBuilder()
+                .addField("col1", new ArrowType.Int(32, true))
+                .build();
+
+        S3BlockSpiller asyncSpiller = new S3BlockSpiller(mockS3, asyncSpillConfig, allocator, schema,
+                ConstraintEvaluator.emptyEvaluator(), com.google.common.collect.ImmutableMap.of());
+
+        // Mock S3 putObject to succeed
+        when(mockS3.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+                .thenReturn(PutObjectResponse.builder().build());
+
+        try {
+            // Write enough data to trigger a spill
+            asyncSpiller.writeRows((Block block, int rowNum) -> {
+                BlockUtils.setValue(block.getFieldVector("col1"), rowNum, 100);
+                return 1;
+            });
+
+            // Should succeed without exception
+            java.util.List<SpillLocation> locations = asyncSpiller.getSpillLocations();
+            assertNotNull(locations);
+            assertFalse(locations.isEmpty());
+        }
+        finally {
+            asyncSpiller.close();
+        }
+    }
+
     private class ByteHolder
     {
         private byte[] bytes;


### PR DESCRIPTION
Fix: Surface async S3 spill errors in getSpillLocations
  
**Problem**
  
  When the S3BlockSpiller uses async spilling (via thread pool), S3 permission errors (e.g., AccessDenied) during putObject were silently lost. The write() method sets asyncException via compareAndSet, but getSpillLocations() never checked it after acquiring the write lock. Since spilled() checks
  asyncException before the lock (so the async thread may still be in-flight), a single-spill scenario could return to the caller without surfacing the error.
  
  This caused confusing failures where the customer sees a generic "no data" response instead of a clear S3 permission error.
  
  **Fix**
  
  Added asyncException check in getSpillLocations() after acquiring the write lock. The write lock guarantees all async spill threads have completed (they hold read locks), so the exception is guaranteed to be visible at this point.
 
  
  **Testing**
  
  Added 3 unit tests to S3BlockSpillerTest:
  
  - getSpillLocationsThrowsOnAsyncS3Error — verifies the permission error propagates through getSpillLocations()
  - spilledThrowsOnAsyncS3Error — verifies spilled() throws when asyncException is set
  - getSpillLocationsSucceedsWhenS3WriteSucceeds — positive case, async spill works correctly
