### PR TITLE
Support advanced logging controls for Lambda functions

### DIFF
--- a/athena-aws-cmdb/pom.xml
+++ b/athena-aws-cmdb/pom.xml
@@ -78,6 +78,12 @@
             <version>${log4j2Version}</version>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-layout-template-json</artifactId>
+            <version>${log4j2Version}</version>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/athena-aws-cmdb/src/main/resources/log4j2.xml
+++ b/athena-aws-cmdb/src/main/resources/log4j2.xml
@@ -21,16 +21,21 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
-        <Lambda name="Lambda">
-            <PatternLayout>
-                <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
-            </PatternLayout>
+        <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
         </Lambda>
     </Appenders>
     <Loggers>
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.aws.cmdb" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
-        <Root level="info">
+        <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-aws-cmdb/src/main/resources/log4j2.xml
+++ b/athena-aws-cmdb/src/main/resources/log4j2.xml
@@ -21,7 +21,23 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
+        <Lambda name="LambdaDebug" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <LevelRangeFilter minLevel="DEBUG" maxLevel="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
+        </Lambda>
         <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
             <LambdaTextFormat>
                 <PatternLayout>
                     <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
@@ -36,6 +52,7 @@
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.aws.cmdb" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
+            <AppenderRef ref="LambdaDebug" />
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-clickhouse/src/main/resources/log4j2.xml
+++ b/athena-clickhouse/src/main/resources/log4j2.xml
@@ -21,16 +21,21 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
-        <Lambda name="Lambda">
-            <PatternLayout>
-                <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
-            </PatternLayout>
+        <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
         </Lambda>
     </Appenders>
     <Loggers>
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.mysql" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
-        <Root level="info">
+        <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-clickhouse/src/main/resources/log4j2.xml
+++ b/athena-clickhouse/src/main/resources/log4j2.xml
@@ -21,7 +21,23 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
+        <Lambda name="LambdaDebug" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <LevelRangeFilter minLevel="DEBUG" maxLevel="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
+        </Lambda>
         <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
             <LambdaTextFormat>
                 <PatternLayout>
                     <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
@@ -36,6 +52,7 @@
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.mysql" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
+            <AppenderRef ref="LambdaDebug" />
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-cloudera-hive/src/main/resources/log4j2.xml
+++ b/athena-cloudera-hive/src/main/resources/log4j2.xml
@@ -21,16 +21,21 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
-        <Lambda name="Lambda">
-            <PatternLayout>
-                <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
-            </PatternLayout>
+        <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
         </Lambda>
     </Appenders>
     <Loggers>
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.cloudera" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
-        <Root level="info">
+        <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-cloudera-hive/src/main/resources/log4j2.xml
+++ b/athena-cloudera-hive/src/main/resources/log4j2.xml
@@ -21,7 +21,23 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
+        <Lambda name="LambdaDebug" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <LevelRangeFilter minLevel="DEBUG" maxLevel="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
+        </Lambda>
         <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
             <LambdaTextFormat>
                 <PatternLayout>
                     <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
@@ -36,6 +52,7 @@
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.cloudera" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
+            <AppenderRef ref="LambdaDebug" />
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-cloudera-impala/src/main/resources/log4j2.xml
+++ b/athena-cloudera-impala/src/main/resources/log4j2.xml
@@ -21,16 +21,21 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
-        <Lambda name="Lambda">
-            <PatternLayout>
-                <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
-            </PatternLayout>
+        <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
         </Lambda>
     </Appenders>
     <Loggers>
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.cloudera" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
-        <Root level="info">
+        <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-cloudera-impala/src/main/resources/log4j2.xml
+++ b/athena-cloudera-impala/src/main/resources/log4j2.xml
@@ -21,7 +21,23 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
+        <Lambda name="LambdaDebug" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <LevelRangeFilter minLevel="DEBUG" maxLevel="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
+        </Lambda>
         <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
             <LambdaTextFormat>
                 <PatternLayout>
                     <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
@@ -36,6 +52,7 @@
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.cloudera" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
+            <AppenderRef ref="LambdaDebug" />
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-cloudwatch-metrics/pom.xml
+++ b/athena-cloudwatch-metrics/pom.xml
@@ -63,6 +63,12 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-layout-template-json</artifactId>
+            <version>${log4j2Version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
             <version>${mockito.version}</version>

--- a/athena-cloudwatch-metrics/src/main/resources/log4j2.xml
+++ b/athena-cloudwatch-metrics/src/main/resources/log4j2.xml
@@ -21,16 +21,21 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
-        <Lambda name="Lambda">
-            <PatternLayout>
-                <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
-            </PatternLayout>
+        <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
         </Lambda>
     </Appenders>
     <Loggers>
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.cloudwatch.metrics" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
-        <Root level="info">
+        <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-cloudwatch-metrics/src/main/resources/log4j2.xml
+++ b/athena-cloudwatch-metrics/src/main/resources/log4j2.xml
@@ -21,7 +21,23 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
+        <Lambda name="LambdaDebug" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <LevelRangeFilter minLevel="DEBUG" maxLevel="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
+        </Lambda>
         <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
             <LambdaTextFormat>
                 <PatternLayout>
                     <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
@@ -36,6 +52,7 @@
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.cloudwatch.metrics" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
+            <AppenderRef ref="LambdaDebug" />
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-cloudwatch/pom.xml
+++ b/athena-cloudwatch/pom.xml
@@ -95,6 +95,12 @@
             <version>${log4j2Version}</version>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-layout-template-json</artifactId>
+            <version>${log4j2Version}</version>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/athena-cloudwatch/src/main/resources/log4j2.xml
+++ b/athena-cloudwatch/src/main/resources/log4j2.xml
@@ -21,16 +21,21 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
-        <Lambda name="Lambda">
-            <PatternLayout>
-                <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
-            </PatternLayout>
+        <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
         </Lambda>
     </Appenders>
     <Loggers>
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.cloudwatch" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
-        <Root level="info">
+        <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-cloudwatch/src/main/resources/log4j2.xml
+++ b/athena-cloudwatch/src/main/resources/log4j2.xml
@@ -21,7 +21,23 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
+        <Lambda name="LambdaDebug" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <LevelRangeFilter minLevel="DEBUG" maxLevel="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
+        </Lambda>
         <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
             <LambdaTextFormat>
                 <PatternLayout>
                     <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
@@ -36,6 +52,7 @@
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.cloudwatch" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
+            <AppenderRef ref="LambdaDebug" />
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-datalakegen2/src/main/resources/log4j2.xml
+++ b/athena-datalakegen2/src/main/resources/log4j2.xml
@@ -1,16 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
-        <Lambda name="Lambda">
-            <PatternLayout>
-                <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
-            </PatternLayout>
+        <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
         </Lambda>
     </Appenders>
     <Loggers>
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.datalakegen2" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
-        <Root level="info">
+        <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-datalakegen2/src/main/resources/log4j2.xml
+++ b/athena-datalakegen2/src/main/resources/log4j2.xml
@@ -1,7 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
+        <Lambda name="LambdaDebug" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <LevelRangeFilter minLevel="DEBUG" maxLevel="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
+        </Lambda>
         <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
             <LambdaTextFormat>
                 <PatternLayout>
                     <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
@@ -16,6 +32,7 @@
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.datalakegen2" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
+            <AppenderRef ref="LambdaDebug" />
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-db2-as400/src/main/resources/log4j2.xml
+++ b/athena-db2-as400/src/main/resources/log4j2.xml
@@ -1,16 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
-        <Lambda name="Lambda">
-            <PatternLayout>
-                <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
-            </PatternLayout>
+        <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
         </Lambda>
     </Appenders>
     <Loggers>
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.db2as400" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
-        <Root level="info">
+        <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-db2-as400/src/main/resources/log4j2.xml
+++ b/athena-db2-as400/src/main/resources/log4j2.xml
@@ -1,7 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
+        <Lambda name="LambdaDebug" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <LevelRangeFilter minLevel="DEBUG" maxLevel="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
+        </Lambda>
         <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
             <LambdaTextFormat>
                 <PatternLayout>
                     <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
@@ -16,6 +32,7 @@
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.db2as400" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
+            <AppenderRef ref="LambdaDebug" />
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-db2/src/main/resources/log4j2.xml
+++ b/athena-db2/src/main/resources/log4j2.xml
@@ -1,16 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
-        <Lambda name="Lambda">
-            <PatternLayout>
-                <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
-            </PatternLayout>
+        <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
         </Lambda>
     </Appenders>
     <Loggers>
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.db2" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
-        <Root level="info">
+        <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-db2/src/main/resources/log4j2.xml
+++ b/athena-db2/src/main/resources/log4j2.xml
@@ -1,7 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
+        <Lambda name="LambdaDebug" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <LevelRangeFilter minLevel="DEBUG" maxLevel="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
+        </Lambda>
         <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
             <LambdaTextFormat>
                 <PatternLayout>
                     <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
@@ -16,6 +32,7 @@
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.db2" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
+            <AppenderRef ref="LambdaDebug" />
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-docdb/pom.xml
+++ b/athena-docdb/pom.xml
@@ -87,6 +87,12 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-layout-template-json</artifactId>
+            <version>${log4j2Version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
             <version>${mockito.version}</version>

--- a/athena-docdb/src/main/resources/log4j2.xml
+++ b/athena-docdb/src/main/resources/log4j2.xml
@@ -21,16 +21,21 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
-        <Lambda name="Lambda">
-            <PatternLayout>
-                <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
-            </PatternLayout>
+        <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
         </Lambda>
     </Appenders>
     <Loggers>
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.docdb" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
-        <Root level="info">
+        <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-docdb/src/main/resources/log4j2.xml
+++ b/athena-docdb/src/main/resources/log4j2.xml
@@ -21,7 +21,23 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
+        <Lambda name="LambdaDebug" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <LevelRangeFilter minLevel="DEBUG" maxLevel="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
+        </Lambda>
         <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
             <LambdaTextFormat>
                 <PatternLayout>
                     <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
@@ -36,6 +52,7 @@
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.docdb" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
+            <AppenderRef ref="LambdaDebug" />
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-dynamodb/pom.xml
+++ b/athena-dynamodb/pom.xml
@@ -84,6 +84,12 @@
             <version>${log4j2Version}</version>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-layout-template-json</artifactId>
+            <version>${log4j2Version}</version>
+            <scope>runtime</scope>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awscdk/dynamodb -->
         <dependency>
             <groupId>software.amazon.awscdk</groupId>

--- a/athena-dynamodb/src/main/resources/log4j2.xml
+++ b/athena-dynamodb/src/main/resources/log4j2.xml
@@ -21,16 +21,21 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
-        <Lambda name="Lambda">
-            <PatternLayout>
-                <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
-            </PatternLayout>
+        <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
         </Lambda>
     </Appenders>
     <Loggers>
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.dynamodb" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
-        <Root level="info">
+        <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-dynamodb/src/main/resources/log4j2.xml
+++ b/athena-dynamodb/src/main/resources/log4j2.xml
@@ -21,7 +21,23 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
+        <Lambda name="LambdaDebug" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <LevelRangeFilter minLevel="DEBUG" maxLevel="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
+        </Lambda>
         <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
             <LambdaTextFormat>
                 <PatternLayout>
                     <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
@@ -36,6 +52,7 @@
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.dynamodb" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
+            <AppenderRef ref="LambdaDebug" />
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-elasticsearch/pom.xml
+++ b/athena-elasticsearch/pom.xml
@@ -62,6 +62,12 @@
             <version>${log4j2Version}</version>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-layout-template-json</artifactId>
+            <version>${log4j2Version}</version>
+            <scope>runtime</scope>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awscdk/elasticsearch -->
         <dependency>
             <groupId>software.amazon.awscdk</groupId>

--- a/athena-elasticsearch/src/main/resources/log4j2.xml
+++ b/athena-elasticsearch/src/main/resources/log4j2.xml
@@ -21,16 +21,21 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
-        <Lambda name="Lambda">
-            <PatternLayout>
-                <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
-            </PatternLayout>
+        <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
         </Lambda>
     </Appenders>
     <Loggers>
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.elasticsearch" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
-        <Root level="info">
+        <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-elasticsearch/src/main/resources/log4j2.xml
+++ b/athena-elasticsearch/src/main/resources/log4j2.xml
@@ -21,7 +21,23 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
+        <Lambda name="LambdaDebug" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <LevelRangeFilter minLevel="DEBUG" maxLevel="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
+        </Lambda>
         <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
             <LambdaTextFormat>
                 <PatternLayout>
                     <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
@@ -36,6 +52,7 @@
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.elasticsearch" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
+            <AppenderRef ref="LambdaDebug" />
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-example/pom.xml
+++ b/athena-example/pom.xml
@@ -56,6 +56,12 @@
             <version>${log4j2Version}</version>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-layout-template-json</artifactId>
+            <version>${log4j2Version}</version>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/athena-example/src/main/resources/log4j2.xml
+++ b/athena-example/src/main/resources/log4j2.xml
@@ -21,16 +21,21 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
-        <Lambda name="Lambda">
-            <PatternLayout>
-                <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
-            </PatternLayout>
+        <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
         </Lambda>
     </Appenders>
     <Loggers>
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.example" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
-        <Root level="info">
+        <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-example/src/main/resources/log4j2.xml
+++ b/athena-example/src/main/resources/log4j2.xml
@@ -21,7 +21,23 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
+        <Lambda name="LambdaDebug" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <LevelRangeFilter minLevel="DEBUG" maxLevel="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
+        </Lambda>
         <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
             <LambdaTextFormat>
                 <PatternLayout>
                     <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
@@ -36,6 +52,7 @@
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.example" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
+            <AppenderRef ref="LambdaDebug" />
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-federation-integ-test/pom.xml
+++ b/athena-federation-integ-test/pom.xml
@@ -51,6 +51,12 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-layout-template-json</artifactId>
+            <version>${log4j2Version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>${guava.version}</version>

--- a/athena-federation-sdk-tools/pom.xml
+++ b/athena-federation-sdk-tools/pom.xml
@@ -63,6 +63,12 @@
             <version>${log4j2Version}</version>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-layout-template-json</artifactId>
+            <version>${log4j2Version}</version>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/athena-federation-sdk/pom.xml
+++ b/athena-federation-sdk/pom.xml
@@ -225,6 +225,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-layout-template-json</artifactId>
+            <version>${log4j2Version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk18on</artifactId>
             <version>1.84</version>

--- a/athena-gcs/pom.xml
+++ b/athena-gcs/pom.xml
@@ -61,6 +61,12 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-layout-template-json</artifactId>
+            <version>${log4j2Version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.arrow</groupId>
             <artifactId>arrow-dataset</artifactId>
             <version>${apache.arrow.version}</version>

--- a/athena-gcs/src/main/resources/log4j2.xml
+++ b/athena-gcs/src/main/resources/log4j2.xml
@@ -21,16 +21,21 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
-        <Lambda name="Lambda">
-            <PatternLayout>
-                <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
-            </PatternLayout>
+        <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
         </Lambda>
     </Appenders>
     <Loggers>
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}"/>
         <Logger name="com.amazonaws.athena.connectors.gcs" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}"/>
-        <Root level="info">
+        <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
             <AppenderRef ref="Lambda"/>
         </Root>
     </Loggers>

--- a/athena-gcs/src/main/resources/log4j2.xml
+++ b/athena-gcs/src/main/resources/log4j2.xml
@@ -21,7 +21,23 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
+        <Lambda name="LambdaDebug" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <LevelRangeFilter minLevel="DEBUG" maxLevel="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
+        </Lambda>
         <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
             <LambdaTextFormat>
                 <PatternLayout>
                     <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
@@ -36,7 +52,8 @@
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}"/>
         <Logger name="com.amazonaws.athena.connectors.gcs" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}"/>
         <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
-            <AppenderRef ref="Lambda"/>
+            <AppenderRef ref="LambdaDebug" />
+            <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>
 </Configuration>

--- a/athena-google-bigquery/pom.xml
+++ b/athena-google-bigquery/pom.xml
@@ -92,6 +92,12 @@
             <artifactId>ST4</artifactId>
             <version>${antlr.st4.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-layout-template-json</artifactId>
+            <version>${log4j2Version}</version>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -124,6 +130,7 @@
                         <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
                         <version>${log4j2.cachefile.transformer.version}</version>
                     </dependency>
+
                 </dependencies>
                 <executions>
                     <execution>

--- a/athena-google-bigquery/src/main/resources/log4j2.xml
+++ b/athena-google-bigquery/src/main/resources/log4j2.xml
@@ -21,16 +21,21 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
-        <Lambda name="Lambda">
-            <PatternLayout>
-                <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
-            </PatternLayout>
+        <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
         </Lambda>
     </Appenders>
     <Loggers>
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.google.bigquery" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
-        <Root level="info">
+        <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-google-bigquery/src/main/resources/log4j2.xml
+++ b/athena-google-bigquery/src/main/resources/log4j2.xml
@@ -21,7 +21,23 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
+        <Lambda name="LambdaDebug" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <LevelRangeFilter minLevel="DEBUG" maxLevel="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
+        </Lambda>
         <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
             <LambdaTextFormat>
                 <PatternLayout>
                     <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
@@ -36,6 +52,7 @@
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.google.bigquery" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
+            <AppenderRef ref="LambdaDebug" />
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-hbase/pom.xml
+++ b/athena-hbase/pom.xml
@@ -101,6 +101,12 @@
             <version>${log4j2Version}</version>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-layout-template-json</artifactId>
+            <version>${log4j2Version}</version>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/athena-hbase/src/main/resources/log4j2.xml
+++ b/athena-hbase/src/main/resources/log4j2.xml
@@ -21,16 +21,21 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
-        <Lambda name="Lambda">
-            <PatternLayout>
-                <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
-            </PatternLayout>
+        <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
         </Lambda>
     </Appenders>
     <Loggers>
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.hbase" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
-        <Root level="info">
+        <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-hbase/src/main/resources/log4j2.xml
+++ b/athena-hbase/src/main/resources/log4j2.xml
@@ -21,7 +21,23 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
+        <Lambda name="LambdaDebug" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <LevelRangeFilter minLevel="DEBUG" maxLevel="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
+        </Lambda>
         <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
             <LambdaTextFormat>
                 <PatternLayout>
                     <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
@@ -36,6 +52,7 @@
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.hbase" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
+            <AppenderRef ref="LambdaDebug" />
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-hortonworks-hive/src/main/resources/log4j2.xml
+++ b/athena-hortonworks-hive/src/main/resources/log4j2.xml
@@ -21,16 +21,21 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
-        <Lambda name="Lambda">
-            <PatternLayout>
-                <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
-            </PatternLayout>
+        <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
         </Lambda>
     </Appenders>
     <Loggers>
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.hortonworks" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
-        <Root level="info">
+        <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-hortonworks-hive/src/main/resources/log4j2.xml
+++ b/athena-hortonworks-hive/src/main/resources/log4j2.xml
@@ -21,7 +21,23 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
+        <Lambda name="LambdaDebug" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <LevelRangeFilter minLevel="DEBUG" maxLevel="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
+        </Lambda>
         <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
             <LambdaTextFormat>
                 <PatternLayout>
                     <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
@@ -36,6 +52,7 @@
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.hortonworks" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
+            <AppenderRef ref="LambdaDebug" />
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-jdbc/pom.xml
+++ b/athena-jdbc/pom.xml
@@ -122,6 +122,12 @@
             <version>${log4j2Version}</version>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-layout-template-json</artifactId>
+            <version>${log4j2Version}</version>
+            <scope>runtime</scope>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-redshift -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/athena-jdbc/src/main/resources/log4j2.xml
+++ b/athena-jdbc/src/main/resources/log4j2.xml
@@ -21,16 +21,21 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
-        <Lambda name="Lambda">
-            <PatternLayout>
-                <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
-            </PatternLayout>
+        <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
         </Lambda>
     </Appenders>
     <Loggers>
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.jdbc" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
-        <Root level="info">
+        <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-jdbc/src/main/resources/log4j2.xml
+++ b/athena-jdbc/src/main/resources/log4j2.xml
@@ -21,7 +21,23 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
+        <Lambda name="LambdaDebug" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <LevelRangeFilter minLevel="DEBUG" maxLevel="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
+        </Lambda>
         <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
             <LambdaTextFormat>
                 <PatternLayout>
                     <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
@@ -36,6 +52,7 @@
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.jdbc" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
+            <AppenderRef ref="LambdaDebug" />
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-kafka/pom.xml
+++ b/athena-kafka/pom.xml
@@ -81,6 +81,12 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-layout-template-json</artifactId>
+            <version>${log4j2Version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
             <version>2022.47.1</version>

--- a/athena-kafka/src/main/resources/log4j2.xml
+++ b/athena-kafka/src/main/resources/log4j2.xml
@@ -21,16 +21,21 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
-        <Lambda name="Lambda">
-            <PatternLayout>
-                <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
-            </PatternLayout>
+        <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
         </Lambda>
     </Appenders>
     <Loggers>
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.kafka" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
-        <Root level="info">
+        <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-kafka/src/main/resources/log4j2.xml
+++ b/athena-kafka/src/main/resources/log4j2.xml
@@ -21,7 +21,23 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
+        <Lambda name="LambdaDebug" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <LevelRangeFilter minLevel="DEBUG" maxLevel="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
+        </Lambda>
         <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
             <LambdaTextFormat>
                 <PatternLayout>
                     <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
@@ -36,6 +52,7 @@
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.kafka" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
+            <AppenderRef ref="LambdaDebug" />
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-msk/pom.xml
+++ b/athena-msk/pom.xml
@@ -124,6 +124,12 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-layout-template-json</artifactId>
+            <version>${log4j2Version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena-federation-integ-test</artifactId>
             <version>2022.47.1</version>

--- a/athena-msk/src/main/resources/log4j2.xml
+++ b/athena-msk/src/main/resources/log4j2.xml
@@ -21,16 +21,21 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
-        <Lambda name="Lambda">
-            <PatternLayout>
-                <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
-            </PatternLayout>
+        <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
         </Lambda>
     </Appenders>
     <Loggers>
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.msk" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
-        <Root level="info">
+        <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-msk/src/main/resources/log4j2.xml
+++ b/athena-msk/src/main/resources/log4j2.xml
@@ -21,7 +21,23 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
+        <Lambda name="LambdaDebug" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <LevelRangeFilter minLevel="DEBUG" maxLevel="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
+        </Lambda>
         <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
             <LambdaTextFormat>
                 <PatternLayout>
                     <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
@@ -36,6 +52,7 @@
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.msk" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
+            <AppenderRef ref="LambdaDebug" />
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-mysql/src/main/resources/log4j2.xml
+++ b/athena-mysql/src/main/resources/log4j2.xml
@@ -21,16 +21,21 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
-        <Lambda name="Lambda">
-            <PatternLayout>
-                <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
-            </PatternLayout>
+        <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
         </Lambda>
     </Appenders>
     <Loggers>
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.mysql" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
-        <Root level="info">
+        <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-mysql/src/main/resources/log4j2.xml
+++ b/athena-mysql/src/main/resources/log4j2.xml
@@ -21,7 +21,23 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
+        <Lambda name="LambdaDebug" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <LevelRangeFilter minLevel="DEBUG" maxLevel="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
+        </Lambda>
         <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
             <LambdaTextFormat>
                 <PatternLayout>
                     <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
@@ -36,6 +52,7 @@
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.mysql" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
+            <AppenderRef ref="LambdaDebug" />
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-neptune/pom.xml
+++ b/athena-neptune/pom.xml
@@ -171,6 +171,12 @@
             <version>${log4j2Version}</version>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-layout-template-json</artifactId>
+            <version>${log4j2Version}</version>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/athena-neptune/src/main/resources/log4j2.xml
+++ b/athena-neptune/src/main/resources/log4j2.xml
@@ -21,17 +21,22 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
-        <Lambda name="Lambda">
-            <PatternLayout>
-                <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
-            </PatternLayout>
+        <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
         </Lambda>
     </Appenders>
     <Loggers>
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.neptune" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.neptune.rdf" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
-        <Root level="info">
+        <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-neptune/src/main/resources/log4j2.xml
+++ b/athena-neptune/src/main/resources/log4j2.xml
@@ -21,7 +21,23 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
+        <Lambda name="LambdaDebug" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <LevelRangeFilter minLevel="DEBUG" maxLevel="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
+        </Lambda>
         <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
             <LambdaTextFormat>
                 <PatternLayout>
                     <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
@@ -37,6 +53,7 @@
         <Logger name="com.amazonaws.athena.connectors.neptune" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.neptune.rdf" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
+            <AppenderRef ref="LambdaDebug" />
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-oracle/src/main/resources/log4j2.xml
+++ b/athena-oracle/src/main/resources/log4j2.xml
@@ -21,16 +21,21 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
-        <Lambda name="Lambda">
-            <PatternLayout>
-                <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
-            </PatternLayout>
+        <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
         </Lambda>
     </Appenders>
     <Loggers>
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.oracle" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
-        <Root level="info">
+        <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-oracle/src/main/resources/log4j2.xml
+++ b/athena-oracle/src/main/resources/log4j2.xml
@@ -21,7 +21,23 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
+        <Lambda name="LambdaDebug" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <LevelRangeFilter minLevel="DEBUG" maxLevel="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
+        </Lambda>
         <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
             <LambdaTextFormat>
                 <PatternLayout>
                     <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
@@ -36,6 +52,7 @@
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.oracle" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
+            <AppenderRef ref="LambdaDebug" />
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-postgresql/pom.xml
+++ b/athena-postgresql/pom.xml
@@ -60,6 +60,7 @@
             <version>${aws-cdk.version}</version>
             <scope>test</scope>
         </dependency>
+
     </dependencies>
     <build>
         <plugins>
@@ -91,6 +92,7 @@
                         <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
                         <version>${log4j2.cachefile.transformer.version}</version>
                     </dependency>
+
                 </dependencies>
                 <executions>
                     <execution>

--- a/athena-postgresql/src/main/resources/log4j2.xml
+++ b/athena-postgresql/src/main/resources/log4j2.xml
@@ -21,16 +21,21 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
-        <Lambda name="Lambda">
-            <PatternLayout>
-                <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
-            </PatternLayout>
+        <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
         </Lambda>
     </Appenders>
     <Loggers>
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.postgresql" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
-        <Root level="info">
+        <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-postgresql/src/main/resources/log4j2.xml
+++ b/athena-postgresql/src/main/resources/log4j2.xml
@@ -21,7 +21,23 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
+        <Lambda name="LambdaDebug" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <LevelRangeFilter minLevel="DEBUG" maxLevel="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
+        </Lambda>
         <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
             <LambdaTextFormat>
                 <PatternLayout>
                     <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
@@ -36,6 +52,7 @@
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.postgresql" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
+            <AppenderRef ref="LambdaDebug" />
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-redis/pom.xml
+++ b/athena-redis/pom.xml
@@ -87,6 +87,12 @@
             <version>${log4j2Version}</version>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-layout-template-json</artifactId>
+            <version>${log4j2Version}</version>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/athena-redis/src/main/resources/log4j2.xml
+++ b/athena-redis/src/main/resources/log4j2.xml
@@ -21,16 +21,21 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
-        <Lambda name="Lambda">
-            <PatternLayout>
-                <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
-            </PatternLayout>
+        <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
         </Lambda>
     </Appenders>
     <Loggers>
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.redis" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
-        <Root level="info">
+        <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-redis/src/main/resources/log4j2.xml
+++ b/athena-redis/src/main/resources/log4j2.xml
@@ -21,7 +21,23 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
+        <Lambda name="LambdaDebug" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <LevelRangeFilter minLevel="DEBUG" maxLevel="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
+        </Lambda>
         <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
             <LambdaTextFormat>
                 <PatternLayout>
                     <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
@@ -36,6 +52,7 @@
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.redis" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
+            <AppenderRef ref="LambdaDebug" />
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-redshift/src/main/resources/log4j2.xml
+++ b/athena-redshift/src/main/resources/log4j2.xml
@@ -21,16 +21,21 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
-        <Lambda name="Lambda">
-            <PatternLayout>
-                <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
-            </PatternLayout>
+        <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
         </Lambda>
     </Appenders>
     <Loggers>
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.redshift" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
-        <Root level="info">
+        <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-redshift/src/main/resources/log4j2.xml
+++ b/athena-redshift/src/main/resources/log4j2.xml
@@ -21,7 +21,23 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
+        <Lambda name="LambdaDebug" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <LevelRangeFilter minLevel="DEBUG" maxLevel="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
+        </Lambda>
         <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
             <LambdaTextFormat>
                 <PatternLayout>
                     <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
@@ -36,6 +52,7 @@
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.redshift" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
+            <AppenderRef ref="LambdaDebug" />
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-saphana/src/main/resources/log4j2.xml
+++ b/athena-saphana/src/main/resources/log4j2.xml
@@ -21,16 +21,21 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
-        <Lambda name="Lambda">
-            <PatternLayout>
-                <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
-            </PatternLayout>
+        <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
         </Lambda>
     </Appenders>
     <Loggers>
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.saphana" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
-        <Root level="info">
+        <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-saphana/src/main/resources/log4j2.xml
+++ b/athena-saphana/src/main/resources/log4j2.xml
@@ -21,7 +21,23 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
+        <Lambda name="LambdaDebug" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <LevelRangeFilter minLevel="DEBUG" maxLevel="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
+        </Lambda>
         <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
             <LambdaTextFormat>
                 <PatternLayout>
                     <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
@@ -36,6 +52,7 @@
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.saphana" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
+            <AppenderRef ref="LambdaDebug" />
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-snowflake/src/main/resources/log4j2.xml
+++ b/athena-snowflake/src/main/resources/log4j2.xml
@@ -21,16 +21,21 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
-        <Lambda name="Lambda">
-            <PatternLayout>
-                <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
-            </PatternLayout>
+        <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
         </Lambda>
     </Appenders>
     <Loggers>
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.snowflake" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
-        <Root level="info">
+        <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-snowflake/src/main/resources/log4j2.xml
+++ b/athena-snowflake/src/main/resources/log4j2.xml
@@ -21,7 +21,23 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
+        <Lambda name="LambdaDebug" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <LevelRangeFilter minLevel="DEBUG" maxLevel="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
+        </Lambda>
         <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
             <LambdaTextFormat>
                 <PatternLayout>
                     <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
@@ -36,6 +52,7 @@
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.snowflake" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
+            <AppenderRef ref="LambdaDebug" />
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-sqlserver/src/main/resources/log4j2.xml
+++ b/athena-sqlserver/src/main/resources/log4j2.xml
@@ -1,16 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
-        <Lambda name="Lambda">
-            <PatternLayout>
-                <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
-            </PatternLayout>
+        <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
         </Lambda>
     </Appenders>
     <Loggers>
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.sqlserver" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
-        <Root level="info">
+        <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-sqlserver/src/main/resources/log4j2.xml
+++ b/athena-sqlserver/src/main/resources/log4j2.xml
@@ -1,7 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
+        <Lambda name="LambdaDebug" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <LevelRangeFilter minLevel="DEBUG" maxLevel="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
+        </Lambda>
         <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
             <LambdaTextFormat>
                 <PatternLayout>
                     <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
@@ -16,6 +32,7 @@
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.sqlserver" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
+            <AppenderRef ref="LambdaDebug" />
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-synapse/src/main/resources/log4j2.xml
+++ b/athena-synapse/src/main/resources/log4j2.xml
@@ -1,16 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
-        <Lambda name="Lambda">
-            <PatternLayout>
-                <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
-            </PatternLayout>
+        <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
         </Lambda>
     </Appenders>
     <Loggers>
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.synapse" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
-        <Root level="info">
+        <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-synapse/src/main/resources/log4j2.xml
+++ b/athena-synapse/src/main/resources/log4j2.xml
@@ -1,7 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
+        <Lambda name="LambdaDebug" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <LevelRangeFilter minLevel="DEBUG" maxLevel="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
+        </Lambda>
         <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
             <LambdaTextFormat>
                 <PatternLayout>
                     <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
@@ -16,6 +32,7 @@
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.synapse" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
+            <AppenderRef ref="LambdaDebug" />
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-teradata/src/main/resources/log4j2.xml
+++ b/athena-teradata/src/main/resources/log4j2.xml
@@ -21,16 +21,21 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
-        <Lambda name="Lambda">
-            <PatternLayout>
-                <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
-            </PatternLayout>
+        <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
         </Lambda>
     </Appenders>
     <Loggers>
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.teradata" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
-        <Root level="info">
+        <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-teradata/src/main/resources/log4j2.xml
+++ b/athena-teradata/src/main/resources/log4j2.xml
@@ -21,7 +21,23 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
+        <Lambda name="LambdaDebug" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <LevelRangeFilter minLevel="DEBUG" maxLevel="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
+        </Lambda>
         <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
             <LambdaTextFormat>
                 <PatternLayout>
                     <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
@@ -36,6 +52,7 @@
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.teradata" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
+            <AppenderRef ref="LambdaDebug" />
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-timestream/pom.xml
+++ b/athena-timestream/pom.xml
@@ -86,6 +86,12 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-layout-template-json</artifactId>
+            <version>${log4j2Version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
             <version>${mockito.version}</version>

--- a/athena-timestream/src/main/resources/log4j2.xml
+++ b/athena-timestream/src/main/resources/log4j2.xml
@@ -21,16 +21,21 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
-        <Lambda name="Lambda">
-            <PatternLayout>
-                <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
-            </PatternLayout>
+        <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
         </Lambda>
     </Appenders>
     <Loggers>
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.timestream" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
-        <Root level="info">
+        <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-timestream/src/main/resources/log4j2.xml
+++ b/athena-timestream/src/main/resources/log4j2.xml
@@ -21,7 +21,23 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
+        <Lambda name="LambdaDebug" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <LevelRangeFilter minLevel="DEBUG" maxLevel="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
+        </Lambda>
         <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
             <LambdaTextFormat>
                 <PatternLayout>
                     <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
@@ -36,6 +52,7 @@
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.timestream" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
+            <AppenderRef ref="LambdaDebug" />
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-tpcds/pom.xml
+++ b/athena-tpcds/pom.xml
@@ -61,6 +61,12 @@
             <version>${log4j2Version}</version>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-layout-template-json</artifactId>
+            <version>${log4j2Version}</version>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/athena-tpcds/src/main/resources/log4j2.xml
+++ b/athena-tpcds/src/main/resources/log4j2.xml
@@ -21,16 +21,21 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
-        <Lambda name="Lambda">
-            <PatternLayout>
-                <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
-            </PatternLayout>
+        <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
         </Lambda>
     </Appenders>
     <Loggers>
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.tpcds" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
-        <Root level="info">
+        <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-tpcds/src/main/resources/log4j2.xml
+++ b/athena-tpcds/src/main/resources/log4j2.xml
@@ -21,7 +21,23 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
+        <Lambda name="LambdaDebug" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <LevelRangeFilter minLevel="DEBUG" maxLevel="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
+        </Lambda>
         <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
             <LambdaTextFormat>
                 <PatternLayout>
                     <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
@@ -36,6 +52,7 @@
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.tpcds" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
+            <AppenderRef ref="LambdaDebug" />
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-udfs/pom.xml
+++ b/athena-udfs/pom.xml
@@ -56,6 +56,12 @@
             <version>${log4j2Version}</version>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-layout-template-json</artifactId>
+            <version>${log4j2Version}</version>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/athena-udfs/src/main/resources/log4j2.xml
+++ b/athena-udfs/src/main/resources/log4j2.xml
@@ -21,16 +21,21 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
-        <Lambda name="Lambda">
-            <PatternLayout>
-                <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
-            </PatternLayout>
+        <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
         </Lambda>
     </Appenders>
     <Loggers>
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.udfs" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
-        <Root level="info">
+        <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-udfs/src/main/resources/log4j2.xml
+++ b/athena-udfs/src/main/resources/log4j2.xml
@@ -21,7 +21,23 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
+        <Lambda name="LambdaDebug" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <LevelRangeFilter minLevel="DEBUG" maxLevel="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
+        </Lambda>
         <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
             <LambdaTextFormat>
                 <PatternLayout>
                     <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
@@ -36,6 +52,7 @@
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.udfs" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
+            <AppenderRef ref="LambdaDebug" />
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-vertica/src/main/resources/log4j2.xml
+++ b/athena-vertica/src/main/resources/log4j2.xml
@@ -21,16 +21,21 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
-        <Lambda name="Lambda">
-            <PatternLayout>
-                <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
-            </PatternLayout>
+        <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
         </Lambda>
     </Appenders>
     <Loggers>
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.vertica" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
-        <Root level="info">
+        <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/athena-vertica/src/main/resources/log4j2.xml
+++ b/athena-vertica/src/main/resources/log4j2.xml
@@ -21,7 +21,23 @@
 
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
+        <Lambda name="LambdaDebug" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <LevelRangeFilter minLevel="DEBUG" maxLevel="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
+            <LambdaTextFormat>
+                <PatternLayout>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
+                </PatternLayout>
+            </LambdaTextFormat>
+            <LambdaJSONFormat>
+                <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+            </LambdaJSONFormat>
+        </Lambda>
         <Lambda name="Lambda" format="${env:AWS_LAMBDA_LOG_FORMAT:-TEXT}">
+            <Filters>
+                <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+            </Filters>
             <LambdaTextFormat>
                 <PatternLayout>
                     <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
@@ -36,6 +52,7 @@
         <Logger name="com.amazonaws.athena.connector.lambda" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Logger name="com.amazonaws.athena.connectors.vertica" level="${env:ATHENA_FEDERATION_SDK_LOG_LEVEL:-warn}" />
         <Root level="${env:AWS_LAMBDA_LOG_LEVEL:-INFO}">
+            <AppenderRef ref="LambdaDebug" />
             <AppenderRef ref="Lambda" />
         </Root>
     </Loggers>

--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,11 @@
                 <artifactId>junit</artifactId>
                 <version>${junit.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-layout-template-json</artifactId>
+                <version>${log4j2Version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <organization>


### PR DESCRIPTION
*Issue #, if available:* 
[#2409](https://github.com/awslabs/aws-athena-query-federation/issues/2409)

*Description of changes:* 
Adds support for AWS Lambda Advanced Logging Controls so connector logs follow Lambda logging settings.

**Changes:**
Updated connector Log4j2 configurations to use the AWS Lambda Log4j2 appender.
Added support for Lambda log format selection through: AWS_LAMBDA_LOG_FORMAT
1. TEXT
2. JSON

Added support for Lambda log level configuration through: AWS_LAMBDA_LOG_LEVEL (controls the root logging level for the Lambda function)
ATHENA_FEDERATION_SDK_LOG_LEVEL controls the logging level for Athena Federation SDK and connector-specific loggers.

Preserved backward compatibility with existing text-based logging behavior.

Please find attached analysis document.
[Support_Advanced_Logging_Controls_For_Lambda_Functions.docx](https://github.com/user-attachments/files/30588298/Support_Advanced_Logging_Controls_For_Lambda_Functions.docx)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
