### PR TITLE
CloudWatch managed connector: FAS credential override + Substrait tim…

### DIFF
--- a/athena-cloudwatch/src/main/java/com/amazonaws/athena/connectors/cloudwatch/CloudwatchMetadataHandler.java
+++ b/athena-cloudwatch/src/main/java/com/amazonaws/athena/connectors/cloudwatch/CloudwatchMetadataHandler.java
@@ -51,6 +51,7 @@ import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.services.athena.AthenaClient;
 import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
 import software.amazon.awssdk.services.cloudwatchlogs.model.DescribeLogGroupsRequest;
@@ -163,6 +164,8 @@ public class CloudwatchMetadataHandler
         DescribeLogGroupsRequest.Builder requestBuilder = DescribeLogGroupsRequest.builder();
         DescribeLogGroupsResponse response;
         List<String> schemas = new ArrayList<>();
+        AwsRequestOverrideConfiguration overrideConfig = getRequestOverrideConfig(listSchemasRequest.getIdentity().getConfigOptions());
+        requestBuilder.overrideConfiguration(overrideConfig);
         do {
             if (schemas.size() > MAX_RESULTS) {
                 throw new RuntimeException("Too many log groups, exceeded max metadata results for schema count.");
@@ -187,8 +190,10 @@ public class CloudwatchMetadataHandler
             throws TimeoutException
     {
         String nextToken = null;
-        String logGroupName = tableResolver.validateSchema(listTablesRequest.getSchemaName());
-        DescribeLogStreamsRequest.Builder requestBuilder = DescribeLogStreamsRequest.builder().logGroupName(logGroupName);
+        AwsRequestOverrideConfiguration overrideConfig = getRequestOverrideConfig(listTablesRequest.getIdentity().getConfigOptions());
+        String logGroupName = tableResolver.validateSchema(listTablesRequest.getSchemaName(), overrideConfig);
+        DescribeLogStreamsRequest.Builder requestBuilder = DescribeLogStreamsRequest.builder().logGroupName(logGroupName)
+                .overrideConfiguration(overrideConfig);
         DescribeLogStreamsResponse response;
         List<TableName> tables = new ArrayList<>();
         if (listTablesRequest.getPageSize() == UNLIMITED_PAGE_SIZE_VALUE) {
@@ -233,7 +238,8 @@ public class CloudwatchMetadataHandler
     public GetTableResponse doGetTable(BlockAllocator blockAllocator, GetTableRequest getTableRequest)
     {
         TableName tableName = getTableRequest.getTableName();
-        CloudwatchTableName cwTableName = tableResolver.validateTable(tableName);
+        AwsRequestOverrideConfiguration overrideConfig = getRequestOverrideConfig(getTableRequest.getIdentity().getConfigOptions());
+        CloudwatchTableName cwTableName = tableResolver.validateTable(tableName, overrideConfig);
         return new GetTableResponse(getTableRequest.getCatalogName(),
                 cwTableName.toTableName(),
                 CLOUDWATCH_SCHEMA,
@@ -273,9 +279,11 @@ public class CloudwatchMetadataHandler
             return;
         }
 
-        CloudwatchTableName cwTableName = tableResolver.validateTable(request.getTableName());
+        AwsRequestOverrideConfiguration overrideConfig = getRequestOverrideConfig(request.getIdentity().getConfigOptions());
+        CloudwatchTableName cwTableName = tableResolver.validateTable(request.getTableName(), overrideConfig);
 
-        DescribeLogStreamsRequest.Builder cwRequestBuilder = DescribeLogStreamsRequest.builder().logGroupName(cwTableName.getLogGroupName());
+        DescribeLogStreamsRequest.Builder cwRequestBuilder = DescribeLogStreamsRequest.builder().logGroupName(cwTableName.getLogGroupName())
+                .overrideConfiguration(overrideConfig);
         if (!ALL_LOG_STREAMS_TABLE.equals(cwTableName.getLogStreamName())) {
             cwRequestBuilder.logStreamNamePrefix(cwTableName.getLogStreamName());
         }
@@ -366,7 +374,8 @@ public class CloudwatchMetadataHandler
             throw new IllegalArgumentException("No Query passed through [{}]" + request);
         }
         // to get column names with limit 1
-        GetQueryResultsResponse getQueryResultsResponse = getResult(invoker, awsLogs, request.getQueryPassthroughArguments(), 1);
+        AwsRequestOverrideConfiguration overrideConfig = getRequestOverrideConfig(request.getIdentity().getConfigOptions());
+        GetQueryResultsResponse getQueryResultsResponse = getResult(invoker, awsLogs, request.getQueryPassthroughArguments(), 1, overrideConfig);
         SchemaBuilder schemaBuilder = SchemaBuilder.newBuilder();
         if (!getQueryResultsResponse.results().isEmpty()) {
             for (ResultField field : getQueryResultsResponse.results().get(0)) {

--- a/athena-cloudwatch/src/main/java/com/amazonaws/athena/connectors/cloudwatch/CloudwatchRecordHandler.java
+++ b/athena-cloudwatch/src/main/java/com/amazonaws/athena/connectors/cloudwatch/CloudwatchRecordHandler.java
@@ -26,15 +26,23 @@ import com.amazonaws.athena.connector.lambda.data.BlockSpiller;
 import com.amazonaws.athena.connector.lambda.domain.Split;
 import com.amazonaws.athena.connector.lambda.domain.TableName;
 import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
+import com.amazonaws.athena.connector.lambda.domain.predicate.QueryPlan;
 import com.amazonaws.athena.connector.lambda.domain.predicate.Range;
 import com.amazonaws.athena.connector.lambda.domain.predicate.SortedRangeSet;
 import com.amazonaws.athena.connector.lambda.domain.predicate.ValueSet;
 import com.amazonaws.athena.connector.lambda.handlers.RecordHandler;
 import com.amazonaws.athena.connector.lambda.records.ReadRecordsRequest;
+import com.amazonaws.athena.connector.substrait.SubstraitFunctionParser;
+import com.amazonaws.athena.connector.substrait.SubstraitMetadataParser;
+import com.amazonaws.athena.connector.substrait.SubstraitRelUtils;
+import com.amazonaws.athena.connector.substrait.model.ColumnPredicate;
+import com.amazonaws.athena.connector.substrait.model.SubstraitRelModel;
 import com.amazonaws.athena.connectors.cloudwatch.qpt.CloudwatchQueryPassthrough;
+import io.substrait.proto.Plan;
 import org.apache.arrow.util.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.services.athena.AthenaClient;
 import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
 import software.amazon.awssdk.services.cloudwatchlogs.model.GetLogEventsRequest;
@@ -104,8 +112,12 @@ public class CloudwatchRecordHandler
     protected void readWithConstraint(BlockSpiller spiller, ReadRecordsRequest recordsRequest, QueryStatusChecker queryStatusChecker)
             throws TimeoutException, InterruptedException
     {
+        // Managed-connector (Athena federation) path: apply the customer FAS credentials carried in
+        // configOptions to every Cloudwatch data-plane call. Null (no-op) on the AppFlow/DNA path,
+        // where the injected client already holds the customer credentials.
+        AwsRequestOverrideConfiguration overrideConfig = getRequestOverrideConfig(recordsRequest.getIdentity().getConfigOptions());
         if (recordsRequest.getConstraints().isQueryPassThrough()) {
-            getQueryPassthreoughResults(spiller, recordsRequest);
+            getQueryPassthreoughResults(spiller, recordsRequest, overrideConfig);
         }
         else {
             String continuationToken = null;
@@ -123,6 +135,7 @@ public class CloudwatchRecordHandler
                                         .nextToken(actualContinuationToken)
                                         // must be set to use nextToken correctly
                                         .startFromHead(true)
+                                        .overrideConfiguration(overrideConfig)
                                         .build()
                         )));
 
@@ -151,11 +164,12 @@ public class CloudwatchRecordHandler
         }
     }
 
-    private void getQueryPassthreoughResults(BlockSpiller spiller, ReadRecordsRequest recordsRequest) throws TimeoutException, InterruptedException
+    private void getQueryPassthreoughResults(BlockSpiller spiller, ReadRecordsRequest recordsRequest,
+            AwsRequestOverrideConfiguration awsRequestOverrideConfiguration) throws TimeoutException, InterruptedException
     {
         Map<String, String> qptArguments = recordsRequest.getConstraints().getQueryPassthroughArguments();
         queryPassthrough.verify(qptArguments);
-        GetQueryResultsResponse getQueryResultsResponse = getResult(invoker, awsLogs, qptArguments, Integer.parseInt(qptArguments.get(CloudwatchQueryPassthrough.LIMIT)));
+        GetQueryResultsResponse getQueryResultsResponse = getResult(invoker, awsLogs, qptArguments, Integer.parseInt(qptArguments.get(CloudwatchQueryPassthrough.LIMIT)), awsRequestOverrideConfiguration);
 
         for (List<ResultField> resultList : getQueryResultsResponse.results()) {
             spiller.writeRows((Block block, int rowNum) -> {
@@ -182,6 +196,17 @@ public class CloudwatchRecordHandler
     private GetLogEventsRequest pushDownConstraints(Constraints constraints, GetLogEventsRequest request)
     {
         GetLogEventsRequest.Builder requestBuilder = request.toBuilder();
+
+        // Managed-connector (Athena federation) path: predicates arrive as a Substrait query plan rather
+        // than in the Constraints summary. We push ONLY the log time range (>=, <=, =, between) down to
+        // Cloudwatch as startTime/endTime. Any other predicate (message/log_stream filters, etc.) has no
+        // GetLogEvents equivalent and is safely left for the engine to apply. If the plan cannot be
+        // parsed or contains operators we do not understand, we push nothing and let the engine filter.
+        if (constraints.getQueryPlan() != null) {
+            applySubstraitTimeRange(constraints, requestBuilder);
+            return requestBuilder.build();
+        }
+
         ValueSet timeConstraint = constraints.getSummary().get(LOG_TIME_FIELD);
         if (timeConstraint instanceof SortedRangeSet && !timeConstraint.isNullAllowed()) {
             //SortedRangeSet is how >, <, between is represented which are easiest and most common when
@@ -203,5 +228,62 @@ public class CloudwatchRecordHandler
         }
 
         return requestBuilder.build();
+    }
+
+    /**
+     * Extracts predicates on the log {@code time} column from the Substrait query plan and pushes them to
+     * Cloudwatch as {@code startTime}/{@code endTime}. This is a best-effort optimization: it never throws.
+     * Unsupported operators or plan shapes result in no pushdown, leaving all predicates for the engine to
+     * apply (federation permits returning a superset).
+     *
+     * @param constraints the read constraints, expected to carry a non-null Substrait query plan.
+     * @param requestBuilder the Cloudwatch GetLogEvents request builder to decorate with time bounds.
+     */
+    private void applySubstraitTimeRange(Constraints constraints, GetLogEventsRequest.Builder requestBuilder)
+    {
+        QueryPlan queryPlan = constraints.getQueryPlan();
+        if (queryPlan == null || queryPlan.getSubstraitPlan() == null) {
+            return;
+        }
+        try {
+            Plan plan = SubstraitRelUtils.deserializeSubstraitPlan(queryPlan.getSubstraitPlan());
+            SubstraitRelModel relModel = SubstraitRelModel.buildSubstraitRelModel(plan.getRelations(0).getRoot().getInput());
+            if (relModel.getFilterRel() == null) {
+                return;
+            }
+            List<String> tableColumns = SubstraitMetadataParser.getTableColumns(relModel);
+            Map<String, List<ColumnPredicate>> predicatesByColumn = SubstraitFunctionParser.getColumnPredicatesMap(
+                    plan.getExtensionsList(), relModel.getFilterRel().getCondition(), tableColumns);
+
+            for (ColumnPredicate predicate : predicatesByColumn.getOrDefault(LOG_TIME_FIELD, List.of())) {
+                Object value = predicate.getValue();
+                if (!(value instanceof Number)) {
+                    continue;
+                }
+                long epochMillis = ((Number) value).longValue();
+                switch (predicate.getOperator()) {
+                    case GREATER_THAN:
+                    case GREATER_THAN_OR_EQUAL_TO:
+                        requestBuilder.startTime(epochMillis);
+                        break;
+                    case LESS_THAN:
+                    case LESS_THAN_OR_EQUAL_TO:
+                        requestBuilder.endTime(epochMillis);
+                        break;
+                    case EQUAL:
+                        requestBuilder.startTime(epochMillis);
+                        requestBuilder.endTime(epochMillis);
+                        break;
+                    default:
+                        // No GetLogEvents equivalent (e.g. NOT_EQUAL / IS_NULL); leave to the engine.
+                        break;
+                }
+            }
+        }
+        catch (Exception e) {
+            // Best-effort pushdown only: never fail the query. If the plan contains operators or shapes
+            // we do not understand, skip pushdown and let the engine apply all predicates.
+            logger.warn("Unable to push Substrait time-range predicate to Cloudwatch; leaving predicates to the engine.", e);
+        }
     }
 }

--- a/athena-cloudwatch/src/main/java/com/amazonaws/athena/connectors/cloudwatch/CloudwatchTableResolver.java
+++ b/athena-cloudwatch/src/main/java/com/amazonaws/athena/connectors/cloudwatch/CloudwatchTableResolver.java
@@ -26,6 +26,7 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
 import software.amazon.awssdk.services.cloudwatchlogs.model.DescribeLogGroupsRequest;
 import software.amazon.awssdk.services.cloudwatchlogs.model.DescribeLogGroupsResponse;
@@ -62,6 +63,10 @@ public class CloudwatchTableResolver
     private final LoadingCache<String, String> schemaCache;
     //The table cache that is presto casing to cloudwatch casing
     private final LoadingCache<TableName, CloudwatchTableName> tableCache;
+    //The customer FAS credential override applied to Cloudwatch calls on the managed-connector path.
+    //Null on the AppFlow/DNA path, where the injected client already carries the customer credentials.
+    //Set per request by validateTable/validateSchema immediately before a (potential) cache-miss load.
+    private volatile AwsRequestOverrideConfiguration awsRequestOverrideConfiguration;
 
     /**
      * Constructs an instance of the table resolver.
@@ -119,7 +124,8 @@ public class CloudwatchTableResolver
 
         logger.info("loadLogStreams: Did not find a match for the table, falling back to LogGroup scan for  {}:{}",
                 logGroup, logStream);
-        DescribeLogStreamsRequest.Builder validateTableRequestBuilder = DescribeLogStreamsRequest.builder().logGroupName(logGroup);
+        DescribeLogStreamsRequest.Builder validateTableRequestBuilder = DescribeLogStreamsRequest.builder().logGroupName(logGroup)
+                .overrideConfiguration(awsRequestOverrideConfiguration);
         DescribeLogStreamsResponse validateTableResponse;
         do {
             validateTableResponse = invoker.invoke(() -> logsClient.describeLogStreams(validateTableRequestBuilder.build()));
@@ -164,7 +170,7 @@ public class CloudwatchTableResolver
             effectiveTableName = effectiveTableName.replace(LAMBDA_PATTERN, LAMBDA_ACTUAL_PATTERN);
         }
         DescribeLogStreamsRequest request = DescribeLogStreamsRequest.builder().logGroupName(logGroup)
-                .logStreamNamePrefix(effectiveTableName).build();
+                .logStreamNamePrefix(effectiveTableName).overrideConfiguration(awsRequestOverrideConfiguration).build();
         DescribeLogStreamsResponse response = invoker.invoke(() -> logsClient.describeLogStreams(request));
         for (LogStream nextStream : response.logStreams()) {
             String logStreamName = nextStream.logStreamName();
@@ -195,7 +201,8 @@ public class CloudwatchTableResolver
         }
 
         logger.info("loadLogGroups: Did not find a match for the schema, falling back to LogGroup scan for  {}", schemaName);
-        DescribeLogGroupsRequest.Builder validateSchemaRequestBuilder = DescribeLogGroupsRequest.builder();
+        DescribeLogGroupsRequest.Builder validateSchemaRequestBuilder = DescribeLogGroupsRequest.builder()
+                .overrideConfiguration(awsRequestOverrideConfiguration);
         DescribeLogGroupsResponse validateSchemaResponse;
         do {
             validateSchemaResponse = invoker.invoke(() -> logsClient.describeLogGroups(validateSchemaRequestBuilder.build()));
@@ -224,7 +231,8 @@ public class CloudwatchTableResolver
     private String loadLogGroup(String schemaName)
             throws TimeoutException
     {
-        DescribeLogGroupsRequest request = DescribeLogGroupsRequest.builder().logGroupNamePrefix(schemaName).build();
+        DescribeLogGroupsRequest request = DescribeLogGroupsRequest.builder().logGroupNamePrefix(schemaName)
+                .overrideConfiguration(awsRequestOverrideConfiguration).build();
         DescribeLogGroupsResponse response = invoker.invoke(() -> logsClient.describeLogGroups(request));
         for (LogGroup next : response.logGroups()) {
             String nextLogGroupName = next.logGroupName();
@@ -247,7 +255,17 @@ public class CloudwatchTableResolver
      */
     public CloudwatchTableName validateTable(TableName tableName)
     {
-        String actualSchema = validateSchema(tableName.getSchemaName());
+        return validateTable(tableName, null);
+    }
+
+    /**
+     * Managed-connector overload. Applies the supplied customer FAS credential override to any
+     * Cloudwatch describe calls made while resolving (on cache miss).
+     */
+    public CloudwatchTableName validateTable(TableName tableName, AwsRequestOverrideConfiguration awsRequestOverrideConfiguration)
+    {
+        this.awsRequestOverrideConfiguration = awsRequestOverrideConfiguration;
+        String actualSchema = validateSchema(tableName.getSchemaName(), awsRequestOverrideConfiguration);
         CloudwatchTableName actual = null;
         try {
             actual = tableCache.get(new TableName(actualSchema, tableName.getTableName()));
@@ -271,6 +289,16 @@ public class CloudwatchTableResolver
      */
     public String validateSchema(String schema)
     {
+        return validateSchema(schema, null);
+    }
+
+    /**
+     * Managed-connector overload. Applies the supplied customer FAS credential override to any
+     * Cloudwatch describe calls made while resolving (on cache miss).
+     */
+    public String validateSchema(String schema, AwsRequestOverrideConfiguration awsRequestOverrideConfiguration)
+    {
+        this.awsRequestOverrideConfiguration = awsRequestOverrideConfiguration;
         String actual = null;
         try {
             actual = schemaCache.get(schema);

--- a/athena-cloudwatch/src/main/java/com/amazonaws/athena/connectors/cloudwatch/CloudwatchUtils.java
+++ b/athena-cloudwatch/src/main/java/com/amazonaws/athena/connectors/cloudwatch/CloudwatchUtils.java
@@ -23,6 +23,7 @@ import com.amazonaws.athena.connector.lambda.ThrottlingInvoker;
 import com.amazonaws.athena.connectors.cloudwatch.qpt.CloudwatchQueryPassthrough;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
 import software.amazon.awssdk.services.cloudwatchlogs.model.GetQueryResultsRequest;
 import software.amazon.awssdk.services.cloudwatchlogs.model.GetQueryResultsResponse;
@@ -63,17 +64,36 @@ public final class CloudwatchUtils
 
     public static GetQueryResultsResponse getQueryResults(CloudWatchLogsClient awsLogs, StartQueryResponse startQueryResponse)
     {
-        return awsLogs.getQueryResults(GetQueryResultsRequest.builder().queryId(startQueryResponse.queryId()).build());
+        return getQueryResults(awsLogs, startQueryResponse, null);
+    }
+
+    public static GetQueryResultsResponse getQueryResults(CloudWatchLogsClient awsLogs, StartQueryResponse startQueryResponse,
+            AwsRequestOverrideConfiguration awsRequestOverrideConfiguration)
+    {
+        return awsLogs.getQueryResults(GetQueryResultsRequest.builder().queryId(startQueryResponse.queryId())
+                .overrideConfiguration(awsRequestOverrideConfiguration).build());
     }
 
     public static GetQueryResultsResponse getResult(ThrottlingInvoker invoker, CloudWatchLogsClient awsLogs, Map<String, String> qptArguments, int limit) throws TimeoutException, InterruptedException
     {
-        StartQueryResponse startQueryResponse = invoker.invoke(() -> getQueryResult(awsLogs, startQueryRequest(qptArguments).toBuilder().limit(limit).build()));
+        return getResult(invoker, awsLogs, qptArguments, limit, null);
+    }
+
+    /**
+     * Runs a Cloudwatch Logs Insights query (StartQuery + poll GetQueryResults). When a non-null
+     * {@link AwsRequestOverrideConfiguration} is supplied (managed-connector / Athena federation path),
+     * the customer FAS credentials it carries are applied to every Cloudwatch Logs call.
+     */
+    public static GetQueryResultsResponse getResult(ThrottlingInvoker invoker, CloudWatchLogsClient awsLogs, Map<String, String> qptArguments, int limit,
+            AwsRequestOverrideConfiguration awsRequestOverrideConfiguration) throws TimeoutException, InterruptedException
+    {
+        StartQueryResponse startQueryResponse = invoker.invoke(() -> getQueryResult(awsLogs, startQueryRequest(qptArguments).toBuilder().limit(limit)
+                .overrideConfiguration(awsRequestOverrideConfiguration).build()));
         QueryStatus status = null;
         GetQueryResultsResponse getQueryResultsResponse;
         Instant startTime = Instant.now(); // Record the start time
         do {
-            getQueryResultsResponse = invoker.invoke(() -> getQueryResults(awsLogs, startQueryResponse));
+            getQueryResultsResponse = invoker.invoke(() -> getQueryResults(awsLogs, startQueryResponse, awsRequestOverrideConfiguration));
             status = getQueryResultsResponse.status();
             Thread.sleep(1000);
 

--- a/athena-cloudwatch/src/test/java/com/amazonaws/athena/connectors/cloudwatch/CloudwatchMetadataHandlerTest.java
+++ b/athena-cloudwatch/src/test/java/com/amazonaws/athena/connectors/cloudwatch/CloudwatchMetadataHandlerTest.java
@@ -50,12 +50,14 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.services.athena.AthenaClient;
 import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
 import software.amazon.awssdk.services.cloudwatchlogs.model.DescribeLogGroupsRequest;
@@ -76,7 +78,11 @@ import java.util.concurrent.TimeoutException;
 import static com.amazonaws.athena.connector.lambda.domain.predicate.Constraints.DEFAULT_NO_LIMIT;
 import static com.amazonaws.athena.connector.lambda.metadata.ListTablesRequest.UNLIMITED_PAGE_SIZE_VALUE;
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -413,5 +419,46 @@ public class CloudwatchMetadataHandlerTest
         assertTrue(numContinuations > 0);
 
         logger.info("doGetSplits: exit");
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Managed-connector (Athena federation) behaviour: the customer FAS credentials returned by
+    // getRequestOverrideConfig(configOptions) must be threaded onto the Cloudwatch Logs metadata calls
+    // (both the direct describe* calls and those the table resolver makes).
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    public void listSchemaNamesAppliesFasOverrideToDescribeLogGroups()
+            throws Exception
+    {
+        CloudwatchMetadataHandler spyHandler = spy(handler);
+        AwsRequestOverrideConfiguration fasOverride = AwsRequestOverrideConfiguration.builder().build();
+        doReturn(fasOverride).when(spyHandler).getRequestOverrideConfig(anyMap());
+
+        spyHandler.doListSchemaNames(allocator, new ListSchemasRequest(identity, "queryId", "default"));
+
+        ArgumentCaptor<DescribeLogGroupsRequest> captor = ArgumentCaptor.forClass(DescribeLogGroupsRequest.class);
+        verify(mockAwsLogs, atLeastOnce()).describeLogGroups(captor.capture());
+        assertTrue("expected customer FAS override on the DescribeLogGroups request",
+                captor.getValue().overrideConfiguration().isPresent());
+        assertSame(fasOverride, captor.getValue().overrideConfiguration().get());
+    }
+
+    @Test
+    public void listTablesAppliesFasOverrideToDescribeLogStreams()
+            throws Exception
+    {
+        CloudwatchMetadataHandler spyHandler = spy(handler);
+        AwsRequestOverrideConfiguration fasOverride = AwsRequestOverrideConfiguration.builder().build();
+        doReturn(fasOverride).when(spyHandler).getRequestOverrideConfig(anyMap());
+
+        spyHandler.doListTables(allocator, new ListTablesRequest(identity, "queryId", "default",
+                "schema-1", null, UNLIMITED_PAGE_SIZE_VALUE));
+
+        ArgumentCaptor<DescribeLogStreamsRequest> captor = ArgumentCaptor.forClass(DescribeLogStreamsRequest.class);
+        verify(mockAwsLogs, atLeastOnce()).describeLogStreams(captor.capture());
+        assertTrue("expected customer FAS override on the DescribeLogStreams request",
+                captor.getValue().overrideConfiguration().isPresent());
+        assertSame(fasOverride, captor.getValue().overrideConfiguration().get());
     }
 }

--- a/athena-cloudwatch/src/test/java/com/amazonaws/athena/connectors/cloudwatch/CloudwatchRecordHandlerTest.java
+++ b/athena-cloudwatch/src/test/java/com/amazonaws/athena/connectors/cloudwatch/CloudwatchRecordHandlerTest.java
@@ -27,6 +27,7 @@ import com.amazonaws.athena.connector.lambda.data.S3BlockSpillReader;
 import com.amazonaws.athena.connector.lambda.domain.Split;
 import com.amazonaws.athena.connector.lambda.domain.TableName;
 import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
+import com.amazonaws.athena.connector.lambda.domain.predicate.QueryPlan;
 import com.amazonaws.athena.connector.lambda.domain.predicate.Range;
 import com.amazonaws.athena.connector.lambda.domain.predicate.SortedRangeSet;
 import com.amazonaws.athena.connector.lambda.domain.predicate.ValueSet;
@@ -47,11 +48,13 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.athena.AthenaClient;
@@ -78,13 +81,41 @@ import java.util.UUID;
 import static com.amazonaws.athena.connector.lambda.domain.predicate.Constraints.DEFAULT_NO_LIMIT;
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CloudwatchRecordHandlerTest
 {
     private static final Logger logger = LoggerFactory.getLogger(CloudwatchRecordHandlerTest.class);
+
+    // Managed-connector (Athena federation) Substrait plans, used by the tests below. These are real
+    // plans produced by the same Isthmus SqlToSubstrait + SchemaSerDe path the DNA test runner uses,
+    // over the Cloudwatch table schema [log_stream VARCHAR, time BIGINT, message VARCHAR]. They are
+    // embedded as constants because the connector does not depend on Isthmus/Calcite. Regenerate from
+    // the SQL noted on each constant if the schema or Substrait version changes.
+    // SELECT * FROM "cloudwatch-test-stream" WHERE "time" > 1700000000000
+    private static final String PLAN_TIME_GT =
+            "Ch4IARIaL2Z1bmN0aW9uc19jb21wYXJpc29uLnlhbWwSEhoQCAEQARoKZ3Q6YW55X2FueRrZARLWAQq4ATq1AQoHEgUKAwMEBRKHARKEAQoCCgASVwpVCgIKABIxCgpsb2dfc3RyZWFtCgR0aW1lCgdtZXNzYWdlEhQKBGICEAEKBDoCEAEKBGICEAEYAjocCgJkYgoWY2xvdWR3YXRjaC10ZXN0LXN0cmVhbRolGiMIARoECgIQASIMGgoSCAoEEgIIASIAIgsaCQoHOIDQlf+8MRoIEgYKAhIAIgAaChIICgQSAggBIgAaChIICgQSAggCIgASCmxvZ19zdHJlYW0SBHRpbWUSB21lc3NhZ2UyCxBKKgdpc3RobXVz";
+    // SELECT * FROM "cloudwatch-test-stream" WHERE "time" >= 1700000000000 AND "time" <= 1700000100000
+    private static final String PLAN_TIME_BETWEEN =
+            "ChsIARIXL2Z1bmN0aW9uc19ib29sZWFuLnlhbWwKHggCEhovZnVuY3Rpb25zX2NvbXBhcmlzb24ueWFtbBIQGg4IARABGghhbmQ6Ym9vbBITGhEIAhACGgtndGU6YW55X2FueRITGhEIAhADGgtsdGU6YW55X2FueRqQAhKNAgrvATrsAQoHEgUKAwMEBRK+ARK7AQoCCgASVwpVCgIKABIxCgpsb2dfc3RyZWFtCgR0aW1lCgdtZXNzYWdlEhQKBGICEAEKBDoCEAEKBGICEAEYAjocCgJkYgoWY2xvdWR3YXRjaC10ZXN0LXN0cmVhbRpcGloIARoECgIQASInGiUaIwgCGgQKAhABIgwaChIICgQSAggBIgAiCxoJCgc4gNCV/7wxIicaJRojCAMaBAoCEAEiDBoKEggKBBICCAEiACILGgkKBzig3Zv/vDEaCBIGCgISACIAGgoSCAoEEgIIASIAGgoSCAoEEgIIAiIAEgpsb2dfc3RyZWFtEgR0aW1lEgdtZXNzYWdlMgsQSioHaXN0aG11cw==";
+    // SELECT * FROM "cloudwatch-test-stream" WHERE "time" = 1700000000000
+    private static final String PLAN_TIME_EQUAL =
+            "Ch4IARIaL2Z1bmN0aW9uc19jb21wYXJpc29uLnlhbWwSFRoTCAEQARoNZXF1YWw6YW55X2FueRrZARLWAQq4ATq1AQoHEgUKAwMEBRKHARKEAQoCCgASVwpVCgIKABIxCgpsb2dfc3RyZWFtCgR0aW1lCgdtZXNzYWdlEhQKBGICEAEKBDoCEAEKBGICEAEYAjocCgJkYgoWY2xvdWR3YXRjaC10ZXN0LXN0cmVhbRolGiMIARoECgIQASIMGgoSCAoEEgIIASIAIgsaCQoHOIDQlf+8MRoIEgYKAhIAIgAaChIICgQSAggBIgAaChIICgQSAggCIgASCmxvZ19zdHJlYW0SBHRpbWUSB21lc3NhZ2UyCxBKKgdpc3RobXVz";
+    // SELECT * FROM "cloudwatch-test-stream" WHERE "message" = 'err'  (non-time predicate; not pushable)
+    private static final String PLAN_MESSAGE_EQUAL =
+            "Ch4IARIaL2Z1bmN0aW9uc19jb21wYXJpc29uLnlhbWwSFRoTCAEQARoNZXF1YWw6YW55X2FueRrXARLUAQq2ATqzAQoHEgUKAwMEBRKFARKCAQoCCgASVwpVCgIKABIxCgpsb2dfc3RyZWFtCgR0aW1lCgdtZXNzYWdlEhQKBGICEAEKBDoCEAEKBGICEAEYAjocCgJkYgoWY2xvdWR3YXRjaC10ZXN0LXN0cmVhbRojGiEIARoECgIQASIMGgoSCAoEEgIIAiIAIgkaBwoFYgNlcnIaCBIGCgISACIAGgoSCAoEEgIIASIAGgoSCAoEEgIIAiIAEgpsb2dfc3RyZWFtEgR0aW1lEgdtZXNzYWdlMgsQSioHaXN0aG11cw==";
+    // Valid base64 that does not decode to a Substrait Plan protobuf.
+    private static final String PLAN_MALFORMED = "Zm9vYmFy";
+    private static final long TIME_LOWER = 1_700_000_000_000L;
+    private static final long TIME_UPPER = 1_700_000_100_000L;
 
     private FederatedIdentity identity = new FederatedIdentity("arn", "account", Collections.emptyMap(), Collections.emptyList(), Collections.emptyMap());
     private List<ByteHolder> mockS3Storage;
@@ -279,6 +310,137 @@ public class CloudwatchRecordHandlerTest
         }
 
         logger.info("doReadRecordsSpill: exit");
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Managed-connector (Athena federation) behaviour: customer FAS credential override + Substrait
+    // time-range pushdown. These tests re-stub getLogEvents with a single-page capturing answer
+    // (the @Before stub asserts non-null time bounds and returns a large multi-page response, which
+    // is incompatible with the no-pushdown assertions below).
+    // ---------------------------------------------------------------------------------------------
+
+    private void stubCapturingGetLogEvents()
+    {
+        // Use doAnswer(...).when(...) rather than when(...).thenAnswer(...): the latter would re-invoke the
+        // asserting answer installed in @Before (with a null request) while evaluating the matcher.
+        doAnswer((InvocationOnMock inv) ->
+                GetLogEventsResponse.builder()
+                        .events(OutputLogEvent.builder().timestamp(100L).message("message-0").build())
+                        .build())
+                .when(mockAwsLogs).getLogEvents(nullable(GetLogEventsRequest.class));
+    }
+
+    private ReadRecordsRequest managedConnectorRequest(Constraints constraints)
+    {
+        Split split = Split.newBuilder(S3SpillLocation.newBuilder()
+                        .withBucket(UUID.randomUUID().toString())
+                        .withSplitId(UUID.randomUUID().toString())
+                        .withQueryId(UUID.randomUUID().toString())
+                        .withIsDirectory(true)
+                        .build(), keyFactory.create())
+                .add(CloudwatchMetadataHandler.LOG_GROUP_FIELD, "/glue-connectors/cloudwatch-test")
+                .add(CloudwatchMetadataHandler.LOG_STREAM_FIELD, "cloudwatch-test-stream")
+                .build();
+
+        return new ReadRecordsRequest(identity,
+                "catalog",
+                "queryId-" + System.currentTimeMillis(),
+                new TableName("/glue-connectors/cloudwatch-test", "cloudwatch-test-stream"),
+                schemaForRead,
+                split,
+                constraints,
+                100_000_000_000L,  // large so the single row never spills
+                100_000_000_000L);
+    }
+
+    private Constraints substraitConstraints(String planBase64)
+    {
+        return new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(),
+                DEFAULT_NO_LIMIT, Collections.emptyMap(), new QueryPlan("", planBase64));
+    }
+
+    private GetLogEventsRequest runAndCaptureLogEventsRequest(CloudwatchRecordHandler target, Constraints constraints)
+            throws Exception
+    {
+        RecordResponse response = target.doReadRecords(allocator, managedConnectorRequest(constraints));
+        assertTrue(response instanceof ReadRecordsResponse);
+        ArgumentCaptor<GetLogEventsRequest> captor = ArgumentCaptor.forClass(GetLogEventsRequest.class);
+        verify(mockAwsLogs, atLeastOnce()).getLogEvents(captor.capture());
+        return captor.getValue();
+    }
+
+    @Test
+    public void substraitTimeGreaterThanIsPushedToStartTime()
+            throws Exception
+    {
+        stubCapturingGetLogEvents();
+        GetLogEventsRequest request = runAndCaptureLogEventsRequest(handler, substraitConstraints(PLAN_TIME_GT));
+        assertEquals(Long.valueOf(TIME_LOWER), request.startTime());
+        assertNull(request.endTime());
+    }
+
+    @Test
+    public void substraitTimeRangeIsPushedToStartAndEndTime()
+            throws Exception
+    {
+        stubCapturingGetLogEvents();
+        GetLogEventsRequest request = runAndCaptureLogEventsRequest(handler, substraitConstraints(PLAN_TIME_BETWEEN));
+        assertEquals(Long.valueOf(TIME_LOWER), request.startTime());
+        assertEquals(Long.valueOf(TIME_UPPER), request.endTime());
+    }
+
+    @Test
+    public void substraitTimeEqualIsPushedToBothBounds()
+            throws Exception
+    {
+        stubCapturingGetLogEvents();
+        GetLogEventsRequest request = runAndCaptureLogEventsRequest(handler, substraitConstraints(PLAN_TIME_EQUAL));
+        assertEquals(Long.valueOf(TIME_LOWER), request.startTime());
+        assertEquals(Long.valueOf(TIME_LOWER), request.endTime());
+    }
+
+    @Test
+    public void substraitNonTimePredicateIsNotPushedDown()
+            throws Exception
+    {
+        // A predicate on message has no GetLogEvents equivalent; nothing is pushed and no exception occurs.
+        stubCapturingGetLogEvents();
+        GetLogEventsRequest request = runAndCaptureLogEventsRequest(handler, substraitConstraints(PLAN_MESSAGE_EQUAL));
+        assertNull(request.startTime());
+        assertNull(request.endTime());
+    }
+
+    @Test
+    public void malformedSubstraitPlanDoesNotThrowAndSkipsPushdown()
+            throws Exception
+    {
+        // Best-effort guard: an unparseable plan must never fail the query; it just skips time pushdown.
+        stubCapturingGetLogEvents();
+        GetLogEventsRequest request = runAndCaptureLogEventsRequest(handler, substraitConstraints(PLAN_MALFORMED));
+        assertNull(request.startTime());
+        assertNull(request.endTime());
+    }
+
+    @Test
+    public void appliesCustomerFasOverrideToCloudwatchCalls()
+            throws Exception
+    {
+        // On the managed-connector path getRequestOverrideConfig(configOptions) yields the customer FAS
+        // credentials. Verify that override is threaded onto the Cloudwatch GetLogEvents call.
+        stubCapturingGetLogEvents();
+        CloudwatchRecordHandler spyHandler = spy(handler);
+        AwsRequestOverrideConfiguration fasOverride = AwsRequestOverrideConfiguration.builder().build();
+        doReturn(fasOverride).when(spyHandler).getRequestOverrideConfig(anyMap());
+
+        // Legacy (non-Substrait) constraints: null queryPlan and empty summary => no time pushdown, but
+        // the override must still be applied.
+        Constraints constraints = new Constraints(Collections.emptyMap(), Collections.emptyList(),
+                Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null);
+
+        GetLogEventsRequest request = runAndCaptureLogEventsRequest(spyHandler, constraints);
+        assertTrue("expected customer FAS override on the Cloudwatch request",
+                request.overrideConfiguration().isPresent());
+        assertSame(fasOverride, request.overrideConfiguration().get());
     }
 
     private class ByteHolder


### PR DESCRIPTION
…e-range pushdown

- Thread per-request FAS credentials (getRequestOverrideConfig) onto all CloudWatch Logs calls in CloudwatchMetadataHandler, CloudwatchRecordHandler, CloudwatchTableResolver, and the query-passthrough path in CloudwatchUtils (managed-connector / Athena federation path). Old method signatures are preserved as delegating overloads for backward compatibility.
- Push Substrait time-range predicates on the 'time' column down to GetLogEvents startTime/endTime (GT/GTE->startTime, LT/LTE->endTime, EQUAL->both). The extractor is best-effort and never throws on unsupported operators or unparseable plans, leaving those predicates to the engine.
- Add unit tests for the FAS override (metadata + record handlers) and for Substrait time-range pushdown plus the never-throw guard.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
