### PR TITLE
Fix pip dependency conflicts from redshift-connector 2.1.14 upgrade

### DIFF
--- a/athena_federation_testing/requirements.txt
+++ b/athena_federation_testing/requirements.txt
@@ -1,8 +1,8 @@
 asn1crypto==1.5.1
 awswrangler==3.12.1
-beautifulsoup4==4.13.4
-boto3==1.38.1
-botocore==1.38.1
+beautifulsoup4==4.15.0
+boto3==1.43.47
+botocore==1.43.47
 cachetools==5.5.2
 certifi==2025.1.31
 cffi==1.17.1
@@ -17,11 +17,12 @@ google-cloud-core==2.4.3
 google-crc32c==1.7.1
 google-resumable-media==2.7.2
 googleapis-common-protos==1.70.0
+greenlet==3.5.3
 grpcio==1.74.0
 grpcio-status==1.74.0
 idna==3.15
 jmespath==1.0.1
-lxml==5.4.0
+lxml==6.1.1
 numpy==2.0.2
 opensearch-py==3.0.0
 oracledb==3.3.0
@@ -46,7 +47,7 @@ PyYAML==6.0.2
 redshift-connector==2.1.14
 requests==2.33.0
 rsa==4.9.1
-s3transfer==0.12.0
+s3transfer==0.19.1
 scramp==1.4.6
 setuptools==80.9.0
 six==1.17.0


### PR DESCRIPTION
Dependabot PR #3453 bumped redshift-connector from 2.1.8 to 2.1.14 without updating its transitive dependencies. This broke the Daily Run release tests workflow.

Bumped: beautifulsoup4 4.13.4->4.15.0, boto3/botocore 1.38.1->1.43.47, lxml 5.4.0->6.1.1, s3transfer 0.12.0->0.19.1.
Added: greenlet 3.5.3 (SQLAlchemy transitive dep).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
