### PR TITLE
athena-synapse: managed FAS credentials, Substrait rendering

### DIFF
--- a/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseDialect.java
+++ b/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseDialect.java
@@ -1,0 +1,53 @@
+/*-
+ * #%L
+ * athena-synapse
+ * %%
+ * Copyright (C) 2019 - 2026 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.synapse;
+
+import org.apache.calcite.sql.SqlDialect;
+import org.apache.calcite.sql.dialect.MssqlSqlDialect;
+
+import java.util.Locale;
+
+/**
+ * Azure Synapse-specific SQL dialect with catalog casing filter support. Synapse uses the Microsoft SQL Server
+ * (T-SQL) engine and JDBC driver, so it renders Substrait-derived query plans with the Calcite MSSQL dialect and
+ * uses square brackets ({@code []}) for identifier quoting.
+ */
+public class SynapseDialect extends MssqlSqlDialect
+{
+    public static final SqlDialect DEFAULT = MssqlSqlDialect.DEFAULT;
+
+    private final boolean catalogCasingFilter;
+
+    public SynapseDialect(boolean catalogCasingFilter)
+    {
+        super(DEFAULT_CONTEXT);
+        this.catalogCasingFilter = catalogCasingFilter;
+    }
+
+    @Override
+    public StringBuilder quoteIdentifier(StringBuilder buf, String identifier)
+    {
+        if (catalogCasingFilter) {
+            String upper = identifier.toUpperCase(Locale.ROOT);
+            return buf.append("[").append(upper.replace("]", "]]")).append("]");
+        }
+        return super.quoteIdentifier(buf, identifier);
+    }
+}

--- a/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseMetadataHandler.java
+++ b/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseMetadataHandler.java
@@ -387,7 +387,7 @@ public class SynapseMetadataHandler extends JdbcMetadataHandler
         SchemaBuilder schemaBuilder;
         HashMap<String, List<String>> columnNameAndDataTypeMap = new HashMap<>();
 
-        try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider());
+        try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider(requestOverrideConfiguration));
              PreparedStatement stmt = connection.prepareStatement(dataTypeQuery)) {
             // fetch data types of columns and prepare map with column name and datatype information.
             stmt.setString(1, tableName.getSchemaName() + "." + tableName.getTableName());

--- a/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseMetadataHandler.java
+++ b/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseMetadataHandler.java
@@ -22,6 +22,7 @@ package com.amazonaws.athena.connectors.synapse;
 import com.amazonaws.athena.connector.credentials.CredentialsProvider;
 import com.amazonaws.athena.connector.credentials.CredentialsProviderFactory;
 import com.amazonaws.athena.connector.lambda.QueryStatusChecker;
+import com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants;
 import com.amazonaws.athena.connector.lambda.data.Block;
 import com.amazonaws.athena.connector.lambda.data.BlockAllocator;
 import com.amazonaws.athena.connector.lambda.data.BlockWriter;
@@ -321,6 +322,12 @@ public class SynapseMetadataHandler extends JdbcMetadataHandler
                 splitBuilder = Split.newBuilder(spillLocation, makeEncryptionKey(getRequestOverrideConfig(getSplitsRequest)))
                         .add(PARTITION_NUMBER, partInfo);
             }
+
+            if (getSplitsRequest.getIdentity().getConfigOptions() != null && getSplitsRequest.getIdentity().getConfigOptions().containsKey(EnvironmentConstants.CATALOG_CASING_FILTER)) {
+                LOGGER.info("Catalog Casing Filter found: {}", getSplitsRequest.getIdentity().getConfigOptions().get(EnvironmentConstants.CATALOG_CASING_FILTER));
+                splitBuilder.add(EnvironmentConstants.CATALOG_CASING_FILTER, getSplitsRequest.getIdentity().getConfigOptions().get(EnvironmentConstants.CATALOG_CASING_FILTER));
+            }
+
             splits.add(splitBuilder.build());
             if (splits.size() >= MAX_SPLITS_PER_REQUEST) {
                 //We exceeded the number of split we want to return in a single request, return and provide a continuation token.

--- a/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseMetadataHandler.java
+++ b/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseMetadataHandler.java
@@ -210,7 +210,7 @@ public class SynapseMetadataHandler extends JdbcMetadataHandler
         String tableName = getTableLayoutRequest.getTableName().getTableName();
         String schemaName = getTableLayoutRequest.getTableName().getSchemaName();
 
-        try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider());
+        try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider(getRequestOverrideConfig(getTableLayoutRequest)));
              PreparedStatement psPartitions = connection.prepareStatement(GET_PARTITIONS_SQL);
              PreparedStatement psRowCount = connection.prepareStatement(ROW_COUNT_SQL)) {
             psPartitions.setString(1, tableName);
@@ -311,14 +311,14 @@ public class SynapseMetadataHandler extends JdbcMetadataHandler
             // Included partition information to split if the table is partitioned
             if (partInfo.contains(":::")) {
                 String[] partInfoAr = partInfo.split(":::");
-                splitBuilder = Split.newBuilder(spillLocation, makeEncryptionKey())
+                splitBuilder = Split.newBuilder(spillLocation, makeEncryptionKey(getRequestOverrideConfig(getSplitsRequest)))
                         .add(PARTITION_NUMBER, partInfoAr[0])
                         .add(PARTITION_BOUNDARY_FROM, partInfoAr[1])
                         .add(PARTITION_BOUNDARY_TO, partInfoAr[2])
                         .add(PARTITION_COLUMN, partInfoAr[3]);
             }
             else {
-                splitBuilder = Split.newBuilder(spillLocation, makeEncryptionKey())
+                splitBuilder = Split.newBuilder(spillLocation, makeEncryptionKey(getRequestOverrideConfig(getSplitsRequest)))
                         .add(PARTITION_NUMBER, partInfo);
             }
             splits.add(splitBuilder.build());

--- a/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseMetadataHandler.java
+++ b/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseMetadataHandler.java
@@ -323,9 +323,11 @@ public class SynapseMetadataHandler extends JdbcMetadataHandler
                         .add(PARTITION_NUMBER, partInfo);
             }
 
-            if (getSplitsRequest.getIdentity().getConfigOptions() != null && getSplitsRequest.getIdentity().getConfigOptions().containsKey(EnvironmentConstants.CATALOG_CASING_FILTER)) {
-                LOGGER.info("Catalog Casing Filter found: {}", getSplitsRequest.getIdentity().getConfigOptions().get(EnvironmentConstants.CATALOG_CASING_FILTER));
-                splitBuilder.add(EnvironmentConstants.CATALOG_CASING_FILTER, getSplitsRequest.getIdentity().getConfigOptions().get(EnvironmentConstants.CATALOG_CASING_FILTER));
+            Map<String, String> identityConfigOptions = getSplitsRequest.getIdentity().getConfigOptions();
+            if (identityConfigOptions != null && identityConfigOptions.containsKey(EnvironmentConstants.CATALOG_CASING_FILTER)) {
+                String catalogCasingFilter = identityConfigOptions.get(EnvironmentConstants.CATALOG_CASING_FILTER);
+                LOGGER.info("Catalog Casing Filter found: {}", catalogCasingFilter);
+                splitBuilder.add(EnvironmentConstants.CATALOG_CASING_FILTER, catalogCasingFilter);
             }
 
             splits.add(splitBuilder.build());

--- a/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseQueryStringBuilder.java
+++ b/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseQueryStringBuilder.java
@@ -26,6 +26,7 @@ import com.amazonaws.athena.connectors.jdbc.manager.JdbcSplitQueryBuilder;
 import com.amazonaws.athena.connectors.jdbc.manager.TypeAndValue;
 import com.google.common.base.Strings;
 import org.apache.arrow.vector.types.Types;
+import org.apache.calcite.sql.SqlDialect;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -107,5 +108,17 @@ public class SynapseQueryStringBuilder extends JdbcSplitQueryBuilder
     protected String appendLimitOffset(Split split, Constraints constraints)
     {
         return emptyString;
+    }
+
+    @Override
+    protected SqlDialect getSqlDialect()
+    {
+        return SynapseDialect.DEFAULT;
+    }
+
+    @Override
+    protected SqlDialect getSqlDialect(boolean catalogCasingFilterUpperCase)
+    {
+        return new SynapseDialect(catalogCasingFilterUpperCase);
     }
 }

--- a/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseRecordHandler.java
+++ b/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseRecordHandler.java
@@ -105,7 +105,7 @@ public class SynapseRecordHandler extends JdbcRecordHandler
         LOGGER.info("{}: Catalog: {}, table {}, splits {}", readRecordsRequest.getQueryId(), readRecordsRequest.getCatalogName(), readRecordsRequest.getTableName(),
                 readRecordsRequest.getSplit().getProperties());
 
-        try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider())) {
+        try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider(getRequestOverrideConfig(readRecordsRequest)))) {
             connection.setAutoCommit(false); // For consistency. This is needed to be false to enable streaming for some database types.
             try (PreparedStatement preparedStatement = buildSplitSql(connection, readRecordsRequest.getCatalogName(), readRecordsRequest.getTableName(),
                     readRecordsRequest.getSchema(), readRecordsRequest.getConstraints(), readRecordsRequest.getSplit());

--- a/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseRecordHandler.java
+++ b/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseRecordHandler.java
@@ -106,7 +106,17 @@ public class SynapseRecordHandler extends JdbcRecordHandler
                 readRecordsRequest.getSplit().getProperties());
 
         try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider(getRequestOverrideConfig(readRecordsRequest)))) {
-            connection.setAutoCommit(false); // For consistency. This is needed to be false to enable streaming for some database types.
+            /*
+            Azure Synapse serverless (on-demand) SQL pool does not support transactions. The SqlServer JDBC driver
+            references @@TRANCOUNT during both commit() and the implicit rollback performed when a pooled connection is
+            closed with autoCommit=false, which fails with "'@@TRANCOUNT' is not supported." on serverless. So for the
+            serverless environment we leave autoCommit at its default (true) and skip commit(); adaptive buffering still
+            streams results with the configured fetch size. Dedicated SQL pools support transactions and are unaffected.
+             */
+            boolean isAzureServerless = SynapseConstants.SQL_POOL.equalsIgnoreCase(SynapseUtil.checkEnvironment(connection.getMetaData().getURL()));
+            if (!isAzureServerless) {
+                connection.setAutoCommit(false); // For consistency. This is needed to be false to enable streaming for some database types.
+            }
             try (PreparedStatement preparedStatement = buildSplitSql(connection, readRecordsRequest.getCatalogName(), readRecordsRequest.getTableName(),
                     readRecordsRequest.getSchema(), readRecordsRequest.getConstraints(), readRecordsRequest.getSplit());
                  ResultSet resultSet = preparedStatement.executeQuery()) {
@@ -133,12 +143,7 @@ public class SynapseRecordHandler extends JdbcRecordHandler
                 }
                 LOGGER.info("{} rows returned by database.", rowsReturnedFromDatabase);
 
-                /*
-                SqlServer jdbc driver is using @@TRANCOUNT while performing commit(), it results below RuntimeException.
-                com.microsoft.sqlserver.jdbc.SQLServerException:  '@@TRANCOUNT' is not supported.
-                So we are evading this connection.commit(), in case of Azure serverless environment.
-                 */
-                if (!SynapseConstants.SQL_POOL.equalsIgnoreCase(SynapseUtil.checkEnvironment(connection.getMetaData().getURL()))) {
+                if (!isAzureServerless) {
                     connection.commit();
                 }
             }

--- a/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/SynapseDialectTest.java
+++ b/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/SynapseDialectTest.java
@@ -1,0 +1,51 @@
+/*-
+ * #%L
+ * athena-synapse
+ * %%
+ * Copyright (C) 2019 - 2026 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.synapse;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class SynapseDialectTest
+{
+    @Test
+    void testDefaultDialect()
+    {
+        assertNotNull(SynapseDialect.DEFAULT);
+    }
+
+    @Test
+    void testQuoteIdentifierWithFilter()
+    {
+        SynapseDialect dialect = new SynapseDialect(true);
+        StringBuilder buf = new StringBuilder();
+        dialect.quoteIdentifier(buf, "employees");
+        assertEquals("[EMPLOYEES]", buf.toString());
+    }
+
+    @Test
+    void testQuoteIdentifierWithoutFilter()
+    {
+        SynapseDialect dialect = new SynapseDialect(false);
+        StringBuilder buf = new StringBuilder();
+        dialect.quoteIdentifier(buf, "employees");
+        assertEquals("[employees]", buf.toString());
+    }
+}

--- a/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/SynapseDialectTest.java
+++ b/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/SynapseDialectTest.java
@@ -48,4 +48,31 @@ public class SynapseDialectTest
         dialect.quoteIdentifier(buf, "employees");
         assertEquals("[employees]", buf.toString());
     }
+
+    @Test
+    void testQuoteIdentifierWithFilterUpperCasesMixedCaseInput()
+    {
+        SynapseDialect dialect = new SynapseDialect(true);
+        StringBuilder buf = new StringBuilder();
+        dialect.quoteIdentifier(buf, "Employees");
+        assertEquals("[EMPLOYEES]", buf.toString());
+    }
+
+    @Test
+    void testQuoteIdentifierWithoutFilterPreservesUpperCaseInput()
+    {
+        SynapseDialect dialect = new SynapseDialect(false);
+        StringBuilder buf = new StringBuilder();
+        dialect.quoteIdentifier(buf, "EMPLOYEES");
+        assertEquals("[EMPLOYEES]", buf.toString());
+    }
+
+    @Test
+    void testQuoteIdentifierWithFilterEscapesClosingBracket()
+    {
+        SynapseDialect dialect = new SynapseDialect(true);
+        StringBuilder buf = new StringBuilder();
+        dialect.quoteIdentifier(buf, "emp]loyees");
+        assertEquals("[EMP]]LOYEES]", buf.toString());
+    }
 }

--- a/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/SynapseMetadataHandlerTest.java
+++ b/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/SynapseMetadataHandlerTest.java
@@ -53,6 +53,7 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.athena.AthenaClient;
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
 import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
@@ -89,8 +90,13 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class SynapseMetadataHandlerTest
@@ -404,6 +410,47 @@ public class SynapseMetadataHandlerTest
         assertEquals(expected, getTableResponse.getSchema());
         assertEquals(inputTableName, getTableResponse.getTableName());
         assertEquals(TEST_CATALOG, getTableResponse.getCatalogName());
+    }
+
+    @Test
+    public void doGetTable_getSchema_usesRequestOverrideCredentials()
+            throws Exception
+    {
+        // Regression guard for the managed-connector FAS fix: getSchema must obtain its JDBC connection with the
+        // request-override credentials, i.e. getCredentialProvider(requestOverrideConfiguration). Previously getSchema
+        // called the no-arg getCredentialProvider(), which falls back to the connector's execution role and fails a
+        // cross-account secretsmanager:GetSecretValue in managed-connector mode. Mirrors athena-sqlserver (PR #3531).
+        BlockAllocator blockAllocator = new BlockAllocatorImpl();
+        String[] schema = {"DATA_TYPE", "COLUMN_NAME", "PRECISION", "SCALE"};
+        int[] types = {Types.INTEGER, Types.VARCHAR, Types.VARCHAR, Types.VARCHAR};
+        Object[][] values = {{Types.INTEGER, "testCol1", 0, 0}, {Types.VARCHAR, "testCol2", 0, 0}};
+        ResultSet resultSet = mockResultSet(schema, types, values, new AtomicInteger(-1));
+
+        String[] columns = {"DATA_TYPE", "COLUMN_SIZE", "DECIMAL_DIGITS", "COLUMN_NAME"};
+        int[] types2 = {Types.INTEGER, Types.INTEGER, Types.INTEGER, Types.VARCHAR};
+        Object[][] values2 = {{Types.INTEGER, 12, 0, "testCol1"}, {Types.VARCHAR, 25, 0, "testCol2"}};
+        ResultSet resultSet2 = mockResultSet(columns, types2, values2, new AtomicInteger(-1));
+
+        PreparedStatement stmt = mock(PreparedStatement.class);
+        when(connection.prepareStatement(nullable(String.class))).thenReturn(stmt);
+        when(stmt.executeQuery()).thenReturn(resultSet);
+        when(connection.getMetaData().getURL()).thenReturn("jdbc:sqlserver://hostname;databaseName=fakedatabase");
+        TableName inputTableName = new TableName(TEST_SCHEMA, TEST_TABLE);
+        when(connection.getCatalog()).thenReturn(TEST_CATALOG);
+        when(connection.getMetaData().getColumns(TEST_CATALOG, inputTableName.getSchemaName(), inputTableName.getTableName(), null)).thenReturn(resultSet2);
+
+        // Spy the handler and force a distinct (sentinel) override so we can assert getSchema forwards it through.
+        SynapseMetadataHandler spyHandler = spy(this.synapseMetadataHandler);
+        AwsRequestOverrideConfiguration sentinelOverride = AwsRequestOverrideConfiguration.builder().build();
+        doReturn(sentinelOverride).when(spyHandler).getRequestOverrideConfig(any(GetTableRequest.class));
+
+        spyHandler.doGetTable(blockAllocator,
+                new GetTableRequest(this.federatedIdentity, TEST_QUERY_ID, TEST_CATALOG, inputTableName, Collections.emptyMap()));
+
+        // getSchema (and doGetTable) must request credentials WITH the override...
+        verify(spyHandler, atLeastOnce()).getCredentialProvider(sentinelOverride);
+        // ...and must NEVER use the no-arg (execution-role) credential provider anywhere on the doGetTable path.
+        verify(spyHandler, never()).getCredentialProvider();
     }
 
     @Test

--- a/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/SynapseMetadataHandlerTest.java
+++ b/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/SynapseMetadataHandlerTest.java
@@ -54,6 +54,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.athena.AthenaClient;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
+import com.amazonaws.athena.connector.credentials.CredentialsProviderFactory;
+import org.mockito.MockedStatic;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
 import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
@@ -419,7 +421,7 @@ public class SynapseMetadataHandlerTest
         // Regression guard for the managed-connector FAS fix: getSchema must obtain its JDBC connection with the
         // request-override credentials, i.e. getCredentialProvider(requestOverrideConfiguration). Previously getSchema
         // called the no-arg getCredentialProvider(), which falls back to the connector's execution role and fails a
-        // cross-account secretsmanager:GetSecretValue in managed-connector mode. Mirrors athena-sqlserver (PR #3531).
+        // cross-account secretsmanager:GetSecretValue in managed-connector mode.
         BlockAllocator blockAllocator = new BlockAllocatorImpl();
         String[] schema = {"DATA_TYPE", "COLUMN_NAME", "PRECISION", "SCALE"};
         int[] types = {Types.INTEGER, Types.VARCHAR, Types.VARCHAR, Types.VARCHAR};
@@ -451,6 +453,25 @@ public class SynapseMetadataHandlerTest
         verify(spyHandler, atLeastOnce()).getCredentialProvider(sentinelOverride);
         // ...and must NEVER use the no-arg (execution-role) credential provider anywhere on the doGetTable path.
         verify(spyHandler, never()).getCredentialProvider();
+    }
+
+    @Test
+    public void createCredentialsProvider_forwardsRequestOverrideConfiguration()
+    {
+        // Regression guard: createCredentialsProvider must forward requestOverrideConfiguration to the 4-arg
+        // CredentialsProviderFactory overload. The 3-arg overload passes null, discarding the FAS/vended
+        // credentials, so the SecretsManager read falls back to the connector execution role and fails a
+        // cross-account secretsmanager:GetSecretValue in managed-connector mode.
+        AwsRequestOverrideConfiguration sentinelOverride = AwsRequestOverrideConfiguration.builder().build();
+        try (MockedStatic<CredentialsProviderFactory> factory = mockStatic(CredentialsProviderFactory.class)) {
+            this.synapseMetadataHandler.createCredentialsProvider("test-secret", sentinelOverride);
+
+            // must call the 4-arg overload WITH the override...
+            factory.verify(() -> CredentialsProviderFactory.createCredentialProvider(
+                    any(), any(), any(), eq(sentinelOverride)));
+            // ...and must NEVER call the 3-arg overload that drops the override (passes null).
+            factory.verify(() -> CredentialsProviderFactory.createCredentialProvider(any(), any(), any()), never());
+        }
     }
 
     @Test

--- a/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/SynapseRecordHandlerTest.java
+++ b/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/SynapseRecordHandlerTest.java
@@ -253,6 +253,66 @@ public class SynapseRecordHandlerTest
     }
 
     @Test
+    public void readWithConstraint_AzureServerless_SkipsAutoCommitAndCommit() throws Exception {
+        // Serverless (on-demand) host: autoCommit must stay at default and commit() must be skipped,
+        // otherwise the connection close triggers a rollback that emits @@TRANCOUNT (unsupported on serverless).
+        runReadWithConstraintForUrl("jdbc:sqlserver://test-ondemand.sql.azuresynapse.net:1433;databaseName=testdb;");
+
+        verify(connection, Mockito.never()).setAutoCommit(Mockito.anyBoolean());
+        verify(connection, Mockito.never()).commit();
+    }
+
+    @Test
+    public void readWithConstraint_DedicatedPool_SetsAutoCommitAndCommits() throws Exception {
+        // Dedicated pool host (no "ondemand"): transactions are supported, so autoCommit(false) + commit() are used.
+        runReadWithConstraintForUrl("jdbc:sqlserver://test.sql.azuresynapse.net:1433;databaseName=testdb;");
+
+        verify(connection, Mockito.times(1)).setAutoCommit(false);
+        verify(connection, Mockito.times(1)).commit();
+    }
+
+    private void runReadWithConstraintForUrl(String jdbcUrl) throws Exception {
+        Schema schema = SchemaBuilder.newBuilder()
+                .addField(FieldBuilder.newBuilder(TEST_ID_COL, Types.MinorType.INT.getType()).build())
+                .addField(FieldBuilder.newBuilder(TEST_NAME_COL, Types.MinorType.VARCHAR.getType()).build())
+                .build();
+
+        Split split = Mockito.mock(Split.class);
+        when(split.getProperties()).thenReturn(Collections.emptyMap());
+
+        ResultSet resultSet = Mockito.mock(ResultSet.class);
+        when(resultSet.next()).thenReturn(true, false);
+        when(resultSet.getInt(TEST_ID_COL)).thenReturn(TEST_ID_1);
+        when(resultSet.getString(TEST_NAME_COL)).thenReturn(TEST_NAME_1);
+
+        PreparedStatement preparedStatement = Mockito.mock(PreparedStatement.class);
+        when(connection.prepareStatement(Mockito.anyString())).thenReturn(preparedStatement);
+        when(preparedStatement.executeQuery()).thenReturn(resultSet);
+
+        DatabaseMetaData metaData = Mockito.mock(DatabaseMetaData.class);
+        when(connection.getMetaData()).thenReturn(metaData);
+        when(metaData.getURL()).thenReturn(jdbcUrl);
+
+        ReadRecordsRequest request = new ReadRecordsRequest(
+                federatedIdentity,
+                TEST_CATALOG,
+                TEST_QUERY_ID,
+                TEST_TABLE_NAME,
+                schema,
+                split,
+                new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), 1000, Collections.emptyMap(), null),
+                0,
+                0
+        );
+
+        BlockSpiller spiller = Mockito.mock(BlockSpiller.class);
+        QueryStatusChecker queryStatusChecker = mock(QueryStatusChecker.class);
+        when(queryStatusChecker.isQueryRunning()).thenReturn(true);
+
+        synapseRecordHandler.readWithConstraint(spiller, request, queryStatusChecker);
+    }
+
+    @Test
     public void buildSplitSql_WithOrderBy_ReturnsCorrectSql() throws SQLException {
         TableName tableName = new TableName(TEST_SCHEMA, TEST_TABLE);
         SchemaBuilder schemaBuilder = createSchemaWithCommonFields();

--- a/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/SynapseRecordHandlerTest.java
+++ b/athena-synapse/src/test/java/com/amazonaws/athena/connectors/synapse/SynapseRecordHandlerTest.java
@@ -27,6 +27,7 @@ import com.amazonaws.athena.connector.lambda.data.SchemaBuilder;
 import com.amazonaws.athena.connector.lambda.domain.Split;
 import com.amazonaws.athena.connector.lambda.domain.TableName;
 import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
+import com.amazonaws.athena.connector.lambda.domain.predicate.QueryPlan;
 import com.amazonaws.athena.connector.lambda.domain.predicate.Marker;
 import com.amazonaws.athena.connector.lambda.domain.predicate.OrderByField;
 import com.amazonaws.athena.connector.lambda.domain.predicate.Range;
@@ -45,6 +46,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.mockito.ArgumentCaptor;
 import software.amazon.awssdk.services.athena.AthenaClient;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
@@ -64,6 +66,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static com.amazonaws.athena.connector.lambda.metadata.optimizations.querypassthrough.QueryPassthroughSignature.SCHEMA_FUNCTION_NAME;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.CATALOG_CASING_FILTER;
+import static com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants.UPPERCASE_ONLY;
 import static com.amazonaws.athena.connectors.jdbc.qpt.JdbcQueryPassthrough.QUERY;
 import static com.amazonaws.athena.connectors.synapse.SynapseConstants.QUOTE_CHARACTER;
 import static org.mockito.ArgumentMatchers.eq;
@@ -721,5 +725,55 @@ public class SynapseRecordHandlerTest
     private SchemaBuilder createSchemaWithValueField() {
         return createSchemaWithCommonFields()
                 .addField(FieldBuilder.newBuilder(COL_VALUE, Types.MinorType.FLOAT8.getType()).build());
+    }
+
+    // Substrait plan (base64) for: SELECT col1, col2, col3 FROM test_schema.test_table LIMIT 10
+    private static final String SUBSTRAIT_PLAN_FETCH =
+            "GlsSWQpXGlUKAgoAEksKSQoCCgASKAoEY29sMQoEY29sMgoEY29sMxIUCgRiAhABCgQqAhABCgRiAhABGAI6GQoLdGVzdF9zY2hlbWEKCnRlc3RfdGFibGUYACAK";
+
+    @Test
+    public void buildSplitSql_SubstraitPlanWithUppercaseCasingFilter_UppercasesIdentifiers() throws SQLException
+    {
+        assertSubstraitPlanGeneratesExpectedSql(UPPERCASE_ONLY, "SELECT TOP (10) *\nFROM [TEST_SCHEMA].[TEST_TABLE]");
+    }
+
+    @Test
+    public void buildSplitSql_SubstraitPlanWithLowercaseCasingFilter_PreservesCase() throws SQLException
+    {
+        assertSubstraitPlanGeneratesExpectedSql("LOWERCASE_ONLY", "SELECT TOP (10) *\nFROM [test_schema].[test_table]");
+    }
+
+    @Test
+    public void buildSplitSql_SubstraitPlanWithoutCasingFilter_PreservesCase() throws SQLException
+    {
+        assertSubstraitPlanGeneratesExpectedSql(null, "SELECT TOP (10) *\nFROM [test_schema].[test_table]");
+    }
+
+    private void assertSubstraitPlanGeneratesExpectedSql(String casingFilter, String expectedSql) throws SQLException
+    {
+        TableName tableName = new TableName("test_schema", "test_table");
+        Schema schema = SchemaBuilder.newBuilder()
+                .addField(FieldBuilder.newBuilder("col1", Types.MinorType.VARCHAR.getType()).build())
+                .addField(FieldBuilder.newBuilder("col2", Types.MinorType.INT.getType()).build())
+                .addField(FieldBuilder.newBuilder("col3", Types.MinorType.VARCHAR.getType()).build())
+                .build();
+
+        // No PARTITION_COLUMN stubbed -> getPartitionWhereClauses returns empty, so the asserted SQL is purely the rendered plan.
+        Split split = Mockito.mock(Split.class);
+        when(split.getProperty(CATALOG_CASING_FILTER)).thenReturn(casingFilter);
+
+        QueryPlan queryPlan = new QueryPlan("", SUBSTRAIT_PLAN_FETCH);
+        Constraints constraints = Mockito.mock(Constraints.class);
+        when(constraints.getQueryPlan()).thenReturn(queryPlan);
+
+        PreparedStatement mockStmt = Mockito.mock(PreparedStatement.class);
+        when(this.connection.prepareStatement(Mockito.anyString())).thenReturn(mockStmt);
+        when(mockStmt.getParameterMetaData()).thenReturn(null);
+
+        this.synapseRecordHandler.buildSplitSql(this.connection, TEST_CATALOG_NAME, tableName, schema, constraints, split);
+
+        ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+        verify(this.connection).prepareStatement(sqlCaptor.capture());
+        Assert.assertEquals(expectedSql, sqlCaptor.getValue());
     }
 }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Adds Athena query-federation (Substrait) support and Glue-managed-connector credential handling to the Azure Synapse connector (`athena-synapse`), and fixes a read failure on serverless SQL pools.

### Summary

1. **Substrait query-plan rendering.** When a request carries a Substrait query plan (`Constraints.getQueryPlan() != null`), `JdbcSplitQueryBuilder` renders SQL through the Calcite `SqlDialect` returned by `getSqlDialect()`. `athena-synapse` did not override it and fell back to `AnsiSqlDialect`, producing ANSI SQL for a T-SQL engine. This adds `SynapseDialect` (Calcite `MssqlSqlDialect` with `[ ]` identifier quoting, catalog-casing aware) and overrides `getSqlDialect()` / `getSqlDialect(boolean)`. Azure Synapse is accessed over the Microsoft SQL Server JDBC driver (port 1433) and speaks T-SQL, so `MssqlSqlDialect` with `[ ]` quoting is the correct dialect.

2. **Catalog casing filter for Substrait.** `SynapseMetadataHandler.doGetSplits` propagates the `CATALOG_CASING_FILTER` config property into each split so the casing-aware dialect is selected during Substrait rendering.

3. **Managed-connector credentials (FAS).** `SynapseRecordHandler` / `SynapseMetadataHandler` forward the request's `AwsRequestOverrideConfiguration` via `getCredentialProvider(getRequestOverrideConfig(request))` (and `makeEncryptionKey(...)`), enabling Federated Identity (FAS) request-override credentials and customer-KMS spill in managed-connector mode. This includes the metadata `getSchema` path.

4. **Serverless `@@TRANCOUNT` fix.** `readWithConstraint` set `connection.setAutoCommit(false)` unconditionally. On an Azure Synapse **serverless (on-demand)** SQL pool — which does not support transactions — running reads with `autoCommit=false` manifests as `"'@@TRANCOUNT' is not supported."`, failing serverless reads. The fix detects the serverless environment once (`SynapseUtil.checkEnvironment(url) == SynapseConstants.SQL_POOL`) and guards **both** `setAutoCommit(false)` and `commit()`: on serverless the connection stays at `autoCommit=true` and `commit()` is skipped, while result streaming (driven by the configured statement fetch size) is unaffected. Dedicated SQL pools (which support transactions) are unchanged.

### Notably NOT changed: LIMIT pushdown

`SynapseQueryStringBuilder.appendLimitOffset` still returns an empty string (no LIMIT pushdown). This is deliberate: Azure Synapse **dedicated** SQL pool does not support the `OFFSET/FETCH` clause, so pushing `FETCH` down would fail against a dedicated pool; the engine applies the limit.

### Changes

- **New** `athena-synapse/.../synapse/SynapseDialect.java` — Calcite `MssqlSqlDialect`, catalog-casing-aware identifier quoting.
- `athena-synapse/.../synapse/SynapseQueryStringBuilder.java` — override `getSqlDialect()` / `getSqlDialect(boolean)`.
- `athena-synapse/.../synapse/SynapseMetadataHandler.java` — propagate `CATALOG_CASING_FILTER` in `doGetSplits`; FAS request-override credentials + customer-KMS spill.
- `athena-synapse/.../synapse/SynapseRecordHandler.java` — serverless-guarded `setAutoCommit(false)` / `commit()` (`@@TRANCOUNT` fix); FAS request-override credentials.
- **New** `athena-synapse/.../synapse/SynapseDialectTest.java`.
- `athena-synapse/.../synapse/SynapseRecordHandlerTest.java`, `SynapseMetadataHandlerTest.java` — serverless/dedicated and request-override credential cases.

### Testing

- `mvn -pl athena-synapse -am -DskipTests package` — build succeeds.
- `mvn -pl athena-synapse test` on Corretto 17 — unit tests pass, including the new `SynapseDialectTest` and the serverless/dedicated `SynapseRecordHandlerTest` cases.
- End-to-end: verified in a gamma environment that a serverless Synapse read (previously failing with `'@@TRANCOUNT' is not supported.`) succeeds after the fix, including filter/order-by pushdown.

### Notes

- No `pom.xml` / SDK-version changes: the shared `athena-jdbc` and `athena-federation-sdk` already provide the Substrait machinery; this change wires the connector-specific dialect, split property, credential forwarding, and serverless autoCommit guard.
- Rebased onto the latest `master`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
