### PR TITLE
migrate base image from AL2 to AL2023

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
@@ -9,8 +9,8 @@ ARG JAVA_TOOL_OPTIONS=""
 ENV JAVA_TOOL_OPTIONS="-Djavax.net.ssl.trustStore=/var/lang/lib/security/cacerts ${JAVA_TOOL_OPTIONS}"
 
 # Install necessary tools
-RUN yum update -y
-RUN yum install -y curl perl openssl11
+RUN dnf update -y
+RUN dnf install -y perl openssl
 
 ENV truststore=/var/lang/lib/security/cacerts
 ENV storepassword=changeit
@@ -21,7 +21,7 @@ RUN curl -sS "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem"
 
 # Import certificates into the truststore
 RUN for CERT in rds-ca-*; do \
-        alias=$(openssl11 x509 -noout -text -in $CERT | perl -ne 'next unless /Subject:/; s/.*(CN=|CN = )//; print') && \
+        alias=$(openssl x509 -noout -text -in $CERT | perl -ne 'next unless /Subject:/; s/.*(CN=|CN = )//; print') && \
         echo "Importing $alias" && \
         keytool -import -file ${CERT} -alias "${alias}" -storepass ${storepassword} -keystore ${truststore} -noprompt && \
         rm $CERT; \


### PR DESCRIPTION
Switch Lambda Java base image from public.ecr.aws/lambda/java:11 (AL2) to public.ecr.aws/lambda/java:11.al2023-x86_64 (AL2023).

Changes:
- Base image tag: 11 -> 11.al2023-x86_64
- Package manager: yum -> dnf (AL2023 uses microdnf/dnf)
- OpenSSL: openssl11 -> openssl (AL2023 ships OpenSSL 3.x as default)
- Removed curl from install (curl-minimal pre-installed in AL2023)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
