### PR TITLE
Update per-connector Dockerfiles to use AL2023 base image

### DIFF
--- a/athena-aws-cmdb/Dockerfile
+++ b/athena-aws-cmdb/Dockerfile
@@ -1,5 +1,5 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 11.al2023-x86_64
+ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 

--- a/athena-clickhouse/Dockerfile
+++ b/athena-clickhouse/Dockerfile
@@ -1,5 +1,5 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 11.al2023-x86_64
+ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 

--- a/athena-cloudera-hive/Dockerfile
+++ b/athena-cloudera-hive/Dockerfile
@@ -1,5 +1,5 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 11.al2023-x86_64
+ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 

--- a/athena-cloudera-impala/Dockerfile
+++ b/athena-cloudera-impala/Dockerfile
@@ -1,5 +1,5 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 11.al2023-x86_64
+ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 

--- a/athena-cloudwatch-metrics/Dockerfile
+++ b/athena-cloudwatch-metrics/Dockerfile
@@ -1,5 +1,5 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 11.al2023-x86_64
+ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 

--- a/athena-cloudwatch/Dockerfile
+++ b/athena-cloudwatch/Dockerfile
@@ -1,5 +1,5 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 11.al2023-x86_64
+ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 

--- a/athena-datalakegen2/Dockerfile
+++ b/athena-datalakegen2/Dockerfile
@@ -1,5 +1,5 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 11.al2023-x86_64
+ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 

--- a/athena-db2-as400/Dockerfile
+++ b/athena-db2-as400/Dockerfile
@@ -1,5 +1,5 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 11.al2023-x86_64
+ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 

--- a/athena-db2/Dockerfile
+++ b/athena-db2/Dockerfile
@@ -1,5 +1,5 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 11.al2023-x86_64
+ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 

--- a/athena-docdb/Dockerfile
+++ b/athena-docdb/Dockerfile
@@ -1,5 +1,5 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 11.al2023-x86_64
+ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
@@ -9,8 +9,8 @@ ARG JAVA_TOOL_OPTIONS=""
 ENV JAVA_TOOL_OPTIONS="-Djavax.net.ssl.trustStore=/var/lang/lib/security/cacerts ${JAVA_TOOL_OPTIONS}"
 
 # Install necessary tools
-RUN yum update -y
-RUN yum install -y curl perl openssl11
+RUN dnf update -y
+RUN dnf install -y perl openssl
 
 # Copy function code and runtime dependencies from Maven layout
 COPY target/athena-docdb-2022.47.1.jar ${LAMBDA_TASK_ROOT}
@@ -31,7 +31,7 @@ RUN curl -sS "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem"
 
 # Import certificates into the truststore
 RUN for CERT in rds-ca-*; do \
-        alias=$(openssl11 x509 -noout -text -in $CERT | perl -ne 'next unless /Subject:/; s/.*(CN=|CN = )//; print') && \
+        alias=$(openssl x509 -noout -text -in $CERT | perl -ne 'next unless /Subject:/; s/.*(CN=|CN = )//; print') && \
         echo "Importing $alias" && \
         keytool -import -file ${CERT} -alias "${alias}" -storepass ${storepassword} -keystore ${truststore} -noprompt && \
         rm $CERT; \

--- a/athena-dynamodb/Dockerfile
+++ b/athena-dynamodb/Dockerfile
@@ -1,13 +1,13 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 11.al2023-x86_64
+ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
 # Fix CVE-2025-14087: glib2 buffer underflow
 # Fix CVE-2025-64720 and CVE-2025-64505: libpng vulnerabilities
-RUN yum update -y glib2 libpng && \
-    yum clean all && \
-    rm -rf /var/cache/yum
+RUN dnf update -y glib2 libpng && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf
 
 # Argument for Java tool options, defaulting to an empty string
 ARG JAVA_TOOL_OPTIONS=""

--- a/athena-elasticsearch/Dockerfile
+++ b/athena-elasticsearch/Dockerfile
@@ -1,5 +1,5 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 11.al2023-x86_64
+ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 

--- a/athena-gcs/Dockerfile
+++ b/athena-gcs/Dockerfile
@@ -1,5 +1,5 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 11.al2023-x86_64
+ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 

--- a/athena-google-bigquery/Dockerfile
+++ b/athena-google-bigquery/Dockerfile
@@ -1,5 +1,5 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 11.al2023-x86_64
+ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 

--- a/athena-hbase/Dockerfile
+++ b/athena-hbase/Dockerfile
@@ -1,5 +1,5 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 11.al2023-x86_64
+ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 

--- a/athena-hortonworks-hive/Dockerfile
+++ b/athena-hortonworks-hive/Dockerfile
@@ -1,5 +1,5 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 11.al2023-x86_64
+ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 

--- a/athena-kafka/Dockerfile
+++ b/athena-kafka/Dockerfile
@@ -1,5 +1,5 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 11.al2023-x86_64
+ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 

--- a/athena-msk/Dockerfile
+++ b/athena-msk/Dockerfile
@@ -1,5 +1,5 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 11.al2023-x86_64
+ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 

--- a/athena-mysql/Dockerfile
+++ b/athena-mysql/Dockerfile
@@ -1,5 +1,5 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 11.al2023-x86_64
+ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 

--- a/athena-neptune/Dockerfile
+++ b/athena-neptune/Dockerfile
@@ -1,5 +1,5 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 11.al2023-x86_64
+ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 

--- a/athena-oracle/Dockerfile
+++ b/athena-oracle/Dockerfile
@@ -1,5 +1,5 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 11.al2023-x86_64
+ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
@@ -9,8 +9,8 @@ ARG JAVA_TOOL_OPTIONS=""
 ENV JAVA_TOOL_OPTIONS="-Djavax.net.ssl.trustStore=/var/lang/lib/security/cacerts ${JAVA_TOOL_OPTIONS}"
 
 # Install necessary tools
-RUN yum update -y
-RUN yum install -y curl perl openssl11
+RUN dnf update -y
+RUN dnf install -y perl openssl
 
 # Set up environment variables
 ENV truststore=/var/lang/lib/security/cacerts
@@ -22,7 +22,7 @@ RUN curl -sS "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem"
 
 # Import certificates into the truststore
 RUN for CERT in rds-ca-*; do \
-        alias=$(openssl11 x509 -noout -text -in $CERT | perl -ne 'next unless /Subject:/; s/.*(CN=|CN = )//; print') && \
+        alias=$(openssl x509 -noout -text -in $CERT | perl -ne 'next unless /Subject:/; s/.*(CN=|CN = )//; print') && \
         echo "Importing $alias" && \
         keytool -import -file ${CERT} -alias "${alias}" -storepass ${storepassword} -keystore ${truststore} -noprompt && \
         rm $CERT; \

--- a/athena-postgresql/Dockerfile
+++ b/athena-postgresql/Dockerfile
@@ -1,5 +1,5 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 11.al2023-x86_64
+ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 

--- a/athena-redis/Dockerfile
+++ b/athena-redis/Dockerfile
@@ -1,5 +1,5 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 11.al2023-x86_64
+ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 

--- a/athena-redshift/Dockerfile
+++ b/athena-redshift/Dockerfile
@@ -1,5 +1,5 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 11.al2023-x86_64
+ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 

--- a/athena-saphana/Dockerfile
+++ b/athena-saphana/Dockerfile
@@ -1,5 +1,5 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 11.al2023-x86_64
+ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 

--- a/athena-snowflake/Dockerfile
+++ b/athena-snowflake/Dockerfile
@@ -1,5 +1,5 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 11.al2023-x86_64
+ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 

--- a/athena-sqlserver/Dockerfile
+++ b/athena-sqlserver/Dockerfile
@@ -1,5 +1,5 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 11.al2023-x86_64
+ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 
@@ -8,8 +8,8 @@ ARG JAVA_TOOL_OPTIONS="-Djavax.net.ssl.trustStore=/var/lang/lib/security/cacerts
 # Set the JAVA_TOOL_OPTIONS environment variable for Java 17
 ENV JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
 # Install necessary tools
-RUN yum update -y
-RUN yum install -y curl perl openssl11
+RUN dnf update -y
+RUN dnf install -y perl openssl
 
 ENV truststore=/var/lang/lib/security/cacerts
 ENV storepassword=changeit
@@ -20,7 +20,7 @@ RUN curl -sS "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem"
 
 # Import certificates into the truststore
 RUN for CERT in rds-ca-*; do \
-        alias=$(openssl11 x509 -noout -text -in $CERT | perl -ne 'next unless /Subject:/; s/.*(CN=|CN = )//; print') && \
+        alias=$(openssl x509 -noout -text -in $CERT | perl -ne 'next unless /Subject:/; s/.*(CN=|CN = )//; print') && \
         echo "Importing $alias" && \
         keytool -import -file ${CERT} -alias "${alias}" -storepass ${storepassword} -keystore ${truststore} -noprompt && \
         rm $CERT; \

--- a/athena-synapse/Dockerfile
+++ b/athena-synapse/Dockerfile
@@ -1,5 +1,5 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 11.al2023-x86_64
+ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 

--- a/athena-teradata/Dockerfile
+++ b/athena-teradata/Dockerfile
@@ -1,5 +1,5 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 11.al2023-x86_64
+ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 

--- a/athena-timestream/Dockerfile
+++ b/athena-timestream/Dockerfile
@@ -1,5 +1,5 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 11.al2023-x86_64
+ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 

--- a/athena-tpcds/Dockerfile
+++ b/athena-tpcds/Dockerfile
@@ -1,5 +1,5 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 11.al2023-x86_64
+ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 

--- a/athena-udfs/Dockerfile
+++ b/athena-udfs/Dockerfile
@@ -1,5 +1,5 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 11.al2023-x86_64
+ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 

--- a/athena-vertica/Dockerfile
+++ b/athena-vertica/Dockerfile
@@ -1,5 +1,5 @@
-# Argument for Java version, defaulting to 11
-ARG JAVA_VERSION=11
+# Argument for Java version, defaulting to 11.al2023-x86_64
+ARG JAVA_VERSION=11.al2023-x86_64
 # Use the specified version of Java
 FROM public.ecr.aws/lambda/java:${JAVA_VERSION}
 


### PR DESCRIPTION
- Bump ARG JAVA_VERSION default to 11.al2023-x86_64 across all 33 connector Dockerfiles
- Update docdb/oracle/sqlserver: yum -> dnf, drop curl (curl-minimal pre-installed), openssl11 -> openssl
- Update dynamodb: yum -> dnf, /var/cache/yum -> /var/cache/dnf
- Locally validated docker builds pass for all 33 per-connector Dockerfiles

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
