### PR TITLE
Use --releasever=latest to pull the newest AL2023 security patches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ARG JAVA_TOOL_OPTIONS=""
 ENV JAVA_TOOL_OPTIONS="-Djavax.net.ssl.trustStore=/var/lang/lib/security/cacerts ${JAVA_TOOL_OPTIONS}"
 
 # Install necessary tools
-RUN dnf update -y
+RUN dnf update --releasever=latest -y
 RUN dnf install -y perl openssl
 
 ENV truststore=/var/lang/lib/security/cacerts


### PR DESCRIPTION
The AL2023 base image (public.ecr.aws/lambda/java:11.al2023-x86_64) pins $releasever to a specific dated snapshot at image build time. Without overriding, 'dnf update -y' only pulls packages from that pinned snapshot it doesn't see security patches shipped to newer AL2023 snapshots.

Passing --releasever=latest resolves $releasever to the newest AL2023 snapshot, pulling all currently-available patches.

Inspector findings addressed by this change (18 CVEs):
- glib2 (7): CVE-2026-58010 through CVE-2026-58016
- python3 (5): CVE-2026-11940, CVE-2026-11972, CVE-2026-0864, CVE-2026-9669, CVE-2026-3276
- kernel6.18-headers (2): CVE-2026-53078, CVE-2026-53359
- libacl (2): CVE-2026-54369, CVE-2026-54370
- krb5-libs (1): CVE-2026-11850
- rust-toolset (1): CVE-2026-40034

Locally validated: rebuilt image with this change
Inspector scan confirmed all 18 findings above resolved.

Reference: https://docs.aws.amazon.com/linux/al2023/ug/deterministic-upgrades.html

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
