### PR TITLE
Bump calcite to 1.42.0, pgjdbc to 42.7.12, and strip stale DEPENDENCI…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,3 +82,6 @@ COPY \
 RUN for file in ${LAMBDA_TASK_ROOT}/*.jar ${LAMBDA_TASK_ROOT}/*.zip; do \
       jar xf "$file" && rm -f "$file"; \
 done
+
+# Remove stale dependency metadata that causes false-positive Inspector findings
+RUN rm -f ${LAMBDA_TASK_ROOT}/META-INF/DEPENDENCIES

--- a/athena-postgresql/pom.xml
+++ b/athena-postgresql/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.7.11</version>
+            <version>42.7.12</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <mvn.javadoc.plugin.version>3.12.0</mvn.javadoc.plugin.version>
         <mvn.jar.plugin.version>3.5.0</mvn.jar.plugin.version>
         <io.substrait.version>0.65.0</io.substrait.version>
-        <org.apache.calcite.version>1.40.0</org.apache.calcite.version>
+        <org.apache.calcite.version>1.42.0</org.apache.calcite.version>
         <com.google.protobuf.version>4.35.1</com.google.protobuf.version>
         <doclint>none</doclint>
     </properties>


### PR DESCRIPTION
Addresses two application-dependency CVEs in the federation image:
- CVE-2026-46718 - org.apache.calcite:calcite-core
- CVE-2026-54291 - org.postgresql:postgresql

**Dockerfile:** 
`'RUN rm -f ${LAMBDA_TASK_ROOT}/META-INF/DEPENDENCIES'` 
Calcite 1.42.0 ships a META-INF/DEPENDENCIES metadata file declaring jackson 2.18.3 as a transitive dependency. Inspector reads this file and flags jackson CVEs against the declared version - a false positive because the actual jackson bundled in the image is 2.22.1 (patched).

Removing this stale metadata file after jar extraction eliminates the false positives.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
