### PR TITLE
Bump postgresql JDBC driver to 42.7.12

### DIFF
--- a/athena-postgresql/pom.xml
+++ b/athena-postgresql/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.7.11</version>
+            <version>42.7.12</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>


### PR DESCRIPTION
This fixes CVE-2026-54291

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
