### PR TITLE
make jdbc handler closeable to release resources

### DIFF
--- a/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/security/KmsEncryptionProviderTest.java
+++ b/athena-federation-sdk/src/test/java/com/amazonaws/athena/connector/lambda/security/KmsEncryptionProviderTest.java
@@ -21,7 +21,7 @@ package com.amazonaws.athena.connector.lambda.security;
 
 import com.amazonaws.encryptionsdk.AwsCrypto;
 import com.amazonaws.encryptionsdk.CryptoMaterialsManager;
-import com.amazonaws.encryptionsdk.CryptoResult;;
+import com.amazonaws.encryptionsdk.CryptoResult;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.cache.Cache;

--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/MultiplexingJdbcMetadataHandler.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/MultiplexingJdbcMetadataHandler.java
@@ -44,6 +44,8 @@ import com.amazonaws.athena.connectors.jdbc.resolver.DefaultJDBCCaseResolver;
 import com.amazonaws.athena.connectors.jdbc.resolver.JDBCCaseResolver;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.commons.lang3.Validate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.athena.AthenaClient;
 import software.amazon.awssdk.services.glue.model.ErrorDetails;
 import software.amazon.awssdk.services.glue.model.FederationSourceErrorCode;
@@ -59,6 +61,7 @@ import java.util.Map;
 public class MultiplexingJdbcMetadataHandler
         extends JdbcMetadataHandler
 {
+    private static final Logger MUX_LOGGER = LoggerFactory.getLogger(MultiplexingJdbcMetadataHandler.class);
     private static final int MAX_CATALOGS_TO_MULTIPLEX = 100;
     protected Map<String, JdbcMetadataHandler> metadataHandlerMap;
 
@@ -182,5 +185,41 @@ public class MultiplexingJdbcMetadataHandler
     {
         validateMultiplexer(request.getCatalogName());
         return this.metadataHandlerMap.get(request.getCatalogName()).doGetDataSourceCapabilities(allocator, request);
+    }
+
+    /**
+     * Closes this handler's own connection factory along with every delegate's, since each
+     * delegate owns an independent connection pool. Delegates are closed on a best-effort
+     * basis so that one failure cannot leak the remaining pools.
+     */
+    @Override
+    public void close() throws Exception
+    {
+        Exception firstFailure = null;
+
+        for (Map.Entry<String, JdbcMetadataHandler> delegate : this.metadataHandlerMap.entrySet()) {
+            try {
+                delegate.getValue().close();
+            }
+            catch (Exception e) {
+                MUX_LOGGER.warn("Failed to close metadata handler for catalog {}", delegate.getKey(), e);
+                if (firstFailure == null) {
+                    firstFailure = e;
+                }
+            }
+        }
+
+        try {
+            super.close();
+        }
+        catch (Exception e) {
+            if (firstFailure == null) {
+                firstFailure = e;
+            }
+        }
+
+        if (firstFailure != null) {
+            throw firstFailure;
+        }
     }
 }

--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/MultiplexingJdbcRecordHandler.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/MultiplexingJdbcRecordHandler.java
@@ -34,6 +34,8 @@ import com.amazonaws.athena.connectors.jdbc.manager.JdbcRecordHandlerFactory;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.commons.lang3.Validate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.athena.AthenaClient;
 import software.amazon.awssdk.services.glue.model.ErrorDetails;
 import software.amazon.awssdk.services.glue.model.FederationSourceErrorCode;
@@ -53,6 +55,7 @@ import java.util.Map;
 public class MultiplexingJdbcRecordHandler
         extends JdbcRecordHandler
 {
+    private static final Logger MUX_LOGGER = LoggerFactory.getLogger(MultiplexingJdbcRecordHandler.class);
     private static final int MAX_CATALOGS_TO_MULTIPLEX = 100;
     private final Map<String, JdbcRecordHandler> recordHandlerMap;
 
@@ -104,5 +107,41 @@ public class MultiplexingJdbcRecordHandler
             throws SQLException
     {
         return this.recordHandlerMap.get(catalogName).buildSplitSql(jdbcConnection, catalogName, tableName, schema, constraints, split);
+    }
+
+    /**
+     * Closes this handler's own connection factory along with every delegate's, since each
+     * delegate owns an independent connection pool. Delegates are closed on a best-effort
+     * basis so that one failure cannot leak the remaining pools.
+     */
+    @Override
+    public void close() throws Exception
+    {
+        Exception firstFailure = null;
+
+        for (Map.Entry<String, JdbcRecordHandler> delegate : this.recordHandlerMap.entrySet()) {
+            try {
+                delegate.getValue().close();
+            }
+            catch (Exception e) {
+                MUX_LOGGER.warn("Failed to close record handler for catalog {}", delegate.getKey(), e);
+                if (firstFailure == null) {
+                    firstFailure = e;
+                }
+            }
+        }
+
+        try {
+            super.close();
+        }
+        catch (Exception e) {
+            if (firstFailure == null) {
+                firstFailure = e;
+            }
+        }
+
+        if (firstFailure != null) {
+            throw firstFailure;
+        }
     }
 }

--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/connection/GenericJdbcConnectionFactory.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/connection/GenericJdbcConnectionFactory.java
@@ -31,9 +31,6 @@ import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.glue.model.ErrorDetails;
 import software.amazon.awssdk.services.glue.model.FederationSourceErrorCode;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
@@ -51,18 +48,18 @@ public class GenericJdbcConnectionFactory
         implements JdbcConnectionFactory
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(GenericJdbcConnectionFactory.class);
-
     private static final String SECRET_NAME_PATTERN_STRING = "(\\$\\{[a-zA-Z0-9:/_+=.@!-]+})";
-    public static final Pattern SECRET_NAME_PATTERN = Pattern.compile(SECRET_NAME_PATTERN_STRING);
+    protected static final Pattern SECRET_NAME_PATTERN = Pattern.compile(SECRET_NAME_PATTERN_STRING);
 
-    private final DatabaseConnectionInfo databaseConnectionInfo;
-    private final DatabaseConnectionConfig databaseConnectionConfig;
-    private final Properties jdbcProperties;
+    protected final DatabaseConnectionConfig databaseConnectionConfig;
+    protected final Properties jdbcProperties;
+    protected final DatabaseConnectionInfo databaseConnectionInfo;
+    
     private final boolean useDirectConnection;
     private volatile HikariDataSource ds;
 
     /**
-     * Existing constructor — uses HikariCP.
+     * Existing constructor — defaults to no configOptions (no Glue managed connection).
      */
     public GenericJdbcConnectionFactory(final DatabaseConnectionConfig databaseConnectionConfig, final Map<String, String> properties, final DatabaseConnectionInfo databaseConnectionInfo)
     {
@@ -72,7 +69,8 @@ public class GenericJdbcConnectionFactory
     /**
      * @param databaseConnectionConfig database connection configuration {@link DatabaseConnectionConfig}
      * @param properties JDBC connection properties.
-     * @param configOptions environment/config options; when {@code fas_token} is present, disables connection pooling.
+     * @param databaseConnectionInfo Contains JDBC driver and default port details.
+     * @param configOptions environment/config options; when {@code fas_token} is present, uses direct DriverManager connections.
      */
     public GenericJdbcConnectionFactory(final DatabaseConnectionConfig databaseConnectionConfig, final Map<String, String> properties, final DatabaseConnectionInfo databaseConnectionInfo, final Map<String, String> configOptions)
     {
@@ -101,53 +99,32 @@ public class GenericJdbcConnectionFactory
     public Connection getConnection(final CredentialsProvider credentialsProvider)
             throws Exception
     {
-        final String derivedJdbcString;
-        if (credentialsProvider != null) {
-            Matcher secretMatcher = SECRET_NAME_PATTERN.matcher(databaseConnectionConfig.getJdbcConnectionString());
-            derivedJdbcString = secretMatcher.replaceAll(Matcher.quoteReplacement(""));
-
-            jdbcProperties.putAll(credentialsProvider.getCredentialMap());
-        }
-        else {
-            derivedJdbcString = databaseConnectionConfig.getJdbcConnectionString();
-        }
-
         if (useDirectConnection) {
-            return getDirectConnection(derivedJdbcString);
+            return createDirectConnection(credentialsProvider);
         }
 
-        return getPooledConnection(derivedJdbcString);
-    }
-
-    /**
-     * Creates a direct JDBC connection using {@link DriverManager}, bypassing connection pooling.
-     * Used for Glue managed connections.
-     */
-    private Connection getDirectConnection(String jdbcUrl) throws SQLException
-    {
-        Properties connectionProps = new Properties();
-        connectionProps.putAll(jdbcProperties);
-        try {
-            return DriverManager.getConnection(jdbcUrl, connectionProps);
-        }
-        catch (SQLException e) {
-            handleSQLException(e);
-            throw e;
-        }
+        return getConnectionFromManagedPool(credentialsProvider);
     }
 
     /**
      * Returns a connection from the HikariCP connection pool, initializing the pool on first call.
+     * Subclasses can call this directly to bypass the {@code useDirectConnection} check.
+     *
+     * @param credentialsProvider jdbc user and password provider, or null if no credentials.
+     * @return JDBC connection from the pool.
+     * @throws SQLException if a connection cannot be obtained.
      */
-    private Connection getPooledConnection(String jdbcUrl) throws SQLException
+    protected Connection getConnectionFromManagedPool(final CredentialsProvider credentialsProvider) throws SQLException
     {
+        final String derivedJdbcString = getDerivedJdbcString(credentialsProvider);
+
         if (ds == null) {
-            synchronized (GenericJdbcConnectionFactory.class) {
-                if (ds == null) {
+            synchronized (GenericJdbcConnectionFactory.class) { // Synchronize on the class level
+                if (ds == null) { // Double-check to avoid creating more than one instance
                     HikariConfig config2 = new HikariConfig();
                     config2.setDriverClassName(databaseConnectionInfo.getDriverClassName());
                     config2.setDataSourceProperties(jdbcProperties);
-                    config2.setJdbcUrl(jdbcUrl);
+                    config2.setJdbcUrl(derivedJdbcString);
                     config2.setMinimumIdle(1);
                     ds = new HikariDataSource(config2);
                     LOGGER.debug("Create data source");
@@ -159,12 +136,56 @@ public class GenericJdbcConnectionFactory
             return ds.getConnection();
         }
         catch (SQLException e) {
-            handleSQLException(e);
+            handleSQLExceptionWhenGetConnection(e);
             throw e;
         }
     }
 
-    private void handleSQLException(SQLException e)
+    /**
+     * Creates a direct JDBC connection using {@link DriverManager}, bypassing connection pooling.
+     * Used for Glue managed connections.
+     */
+    private Connection createDirectConnection(final CredentialsProvider credentialsProvider) throws SQLException
+    {
+        final String derivedJdbcString = getDerivedJdbcString(credentialsProvider);
+
+        Properties connectionProps = new Properties();
+        connectionProps.putAll(jdbcProperties);
+        try {
+            return DriverManager.getConnection(derivedJdbcString, connectionProps);
+        }
+        catch (SQLException e) {
+            handleSQLExceptionWhenGetConnection(e);
+            throw e;
+        }
+    }
+
+    /**
+     * Derives the JDBC connection string by stripping secret placeholders and merging
+     * credentials into {@link #jdbcProperties}.
+     * <p>
+     * Note: URL encoding in the connection string is passed through as-is. The underlying
+     * JDBC driver is responsible for decoding (e.g. Snowflake's driver decodes %22 to ").
+     *
+     * @param credentialsProvider credential provider, or null if no credentials.
+     * @return the derived JDBC connection string.
+     */
+    private String getDerivedJdbcString(final CredentialsProvider credentialsProvider)
+    {
+        final String derivedJdbcString;
+        if (credentialsProvider != null) {
+            Matcher secretMatcher = SECRET_NAME_PATTERN.matcher(databaseConnectionConfig.getJdbcConnectionString());
+            derivedJdbcString = secretMatcher.replaceAll(Matcher.quoteReplacement(""));
+
+            jdbcProperties.putAll(credentialsProvider.getCredentialMap());
+        }
+        else {
+            derivedJdbcString = databaseConnectionConfig.getJdbcConnectionString();
+        }
+        return derivedJdbcString;
+    }
+
+    private void handleSQLExceptionWhenGetConnection(final SQLException e) throws SQLException
     {
         if (StringUtils.isNotBlank(e.getMessage()) && e.getMessage().contains("Name or service not known")) {
             throw new AthenaConnectorException(e.getMessage(), ErrorDetails.builder().errorCode(FederationSourceErrorCode.INVALID_INPUT_EXCEPTION.toString()).build());
@@ -172,16 +193,14 @@ public class GenericJdbcConnectionFactory
         else if (StringUtils.isNotBlank(e.getMessage()) && e.getMessage().contains("Incorrect username or password was specified.")) {
             throw new AthenaConnectorException(e.getMessage(), ErrorDetails.builder().errorCode(FederationSourceErrorCode.INVALID_CREDENTIALS_EXCEPTION.toString()).build());
         }
+        throw e;
     }
 
-    private String encodeValue(String value)
+    @Override
+    public void close() 
     {
-        try {
-            return URLEncoder.encode(value, StandardCharsets.UTF_8.toString());
-        }
-        catch (UnsupportedEncodingException ex) {
-            throw new AthenaConnectorException("Unsupported Encoding Exception: ",
-                    ErrorDetails.builder().errorCode(FederationSourceErrorCode.OPERATION_NOT_SUPPORTED_EXCEPTION.toString()).errorMessage(ex.getMessage()).build());
+        if (ds != null) {
+            ds.close();
         }
     }
 }

--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/connection/GenericJdbcConnectionFactory.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/connection/GenericJdbcConnectionFactory.java
@@ -31,11 +31,15 @@ import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.glue.model.ErrorDetails;
 import software.amazon.awssdk.services.glue.model.FederationSourceErrorCode;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Map;
 import java.util.Properties;
+import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -57,6 +61,8 @@ public class GenericJdbcConnectionFactory
     
     private final boolean useDirectConnection;
     private volatile HikariDataSource ds;
+    /** Hash of the JDBC URL and credentials the current pool was built for. */
+    private volatile String poolIdentityKey;
 
     /**
      * Existing constructor — defaults to no configOptions (no Glue managed connection).
@@ -117,27 +123,73 @@ public class GenericJdbcConnectionFactory
     protected Connection getConnectionFromManagedPool(final CredentialsProvider credentialsProvider) throws SQLException
     {
         final String derivedJdbcString = getDerivedJdbcString(credentialsProvider);
+        // HikariCP snapshots the credentials at pool-construction time (setDataSourceProperties
+        // copies them) and rejects per-call credentials with SQLFeatureNotSupportedException. A
+        // pool built for one identity would therefore keep serving that identity's connections
+        // even after a later request merged different credentials into jdbcProperties. Rebuild
+        // the pool when the effective identity changes so a request never borrows another's
+        // credentials. This matters for multi-tenant callers, where connectors such as Snowflake
+        // stay pooled even when fas_token is present.
+        final String poolIdentity = buildPoolIdentity(derivedJdbcString);
 
-        if (ds == null) {
-            synchronized (GenericJdbcConnectionFactory.class) { // Synchronize on the class level
-                if (ds == null) { // Double-check to avoid creating more than one instance
+        HikariDataSource dataSource = ds;
+        if (dataSource == null || dataSource.isClosed() || !poolIdentity.equals(poolIdentityKey)) {
+            // Lock on this instance, not on the class: each factory owns its own pool, so a
+            // class-level lock made unrelated factories (e.g. different multiplexed catalogs)
+            // serialize behind each other while a pool was being built.
+            synchronized (this) {
+                if (ds == null || ds.isClosed() || !poolIdentity.equals(poolIdentityKey)) { // Double-check to avoid creating more than one instance
+                    if (ds != null && !ds.isClosed()) {
+                        LOGGER.debug("Connection identity changed; replacing existing data source");
+                        ds.close();
+                    }
                     HikariConfig config2 = new HikariConfig();
                     config2.setDriverClassName(databaseConnectionInfo.getDriverClassName());
                     config2.setDataSourceProperties(jdbcProperties);
                     config2.setJdbcUrl(derivedJdbcString);
                     config2.setMinimumIdle(1);
                     ds = new HikariDataSource(config2);
+                    poolIdentityKey = poolIdentity;
                     LOGGER.debug("Create data source");
                 }
+                dataSource = ds;
             }
         }
 
         try {
-            return ds.getConnection();
+            return dataSource.getConnection();
         }
         catch (SQLException e) {
             handleSQLExceptionWhenGetConnection(e);
             throw e;
+        }
+    }
+
+    /**
+     * Builds an opaque key identifying the connection identity a pool was created for: the JDBC
+     * URL plus the credential-bearing properties. Values are hashed so credentials are never
+     * retained in memory in plaintext or exposed through logs.
+     */
+    private String buildPoolIdentity(final String derivedJdbcString)
+    {
+        StringBuilder identity = new StringBuilder(derivedJdbcString);
+        for (String key : new TreeSet<>(jdbcProperties.stringPropertyNames())) {
+            identity.append('\n').append(key).append('=').append(jdbcProperties.getProperty(key));
+        }
+
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256")
+                    .digest(identity.toString().getBytes(StandardCharsets.UTF_8));
+            StringBuilder hex = new StringBuilder(digest.length * 2);
+            for (byte b : digest) {
+                hex.append(String.format("%02x", b));
+            }
+            return hex.toString();
+        }
+        catch (NoSuchAlgorithmException e) {
+            // SHA-256 is required of every JVM, so this is unreachable in practice.
+            throw new AthenaConnectorException("SHA-256 is unavailable",
+                    ErrorDetails.builder().errorCode(FederationSourceErrorCode.INTERNAL_SERVICE_EXCEPTION.toString()).build());
         }
     }
 
@@ -196,11 +248,20 @@ public class GenericJdbcConnectionFactory
         throw e;
     }
 
+    /**
+     * Closes the connection pool, releasing pooled connections and their background threads.
+     * The factory stays usable: a later {@code getConnection} rebuilds the pool, so closing a
+     * handler that is subsequently reused does not permanently break it.
+     */
     @Override
-    public void close() 
+    public void close()
     {
-        if (ds != null) {
-            ds.close();
+        synchronized (this) {
+            if (ds != null) {
+                ds.close();
+                ds = null;
+                poolIdentityKey = null;
+            }
         }
     }
 }

--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/connection/JdbcConnectionFactory.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/connection/JdbcConnectionFactory.java
@@ -26,7 +26,7 @@ import java.sql.Connection;
 /**
  * Factory abstracts creation of JDBC connection to database.
  */
-public interface JdbcConnectionFactory
+public interface JdbcConnectionFactory extends AutoCloseable
 {
     /**
      * Retrieves database connection for a database type.
@@ -35,4 +35,10 @@ public interface JdbcConnectionFactory
      * @return JDBC connection. See {@link Connection}.
      */
     Connection getConnection(CredentialsProvider credentialsProvider) throws Exception;
+
+    @Override
+    default void close() throws Exception 
+    {
+        // no-op by default for backward compat
+    }
 }

--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JDBCUtil.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JDBCUtil.java
@@ -159,7 +159,18 @@ public final class JDBCUtil
        return getTableMetadata(preparedStatement, tablesAndViews);
     }
 
-    public static List<TableName> getTableMetadata(PreparedStatement preparedStatement, String tableType)
+    /**
+     * Lists tables/views for the given prepared statement.
+     * <p>
+     * A {@link SQLException} here means the data source could not be queried, which is not
+     * the same thing as a schema that legitimately holds no tables. Both used to be reported
+     * as an empty list, so a broken session (for example a Snowflake session with no active
+     * warehouse) surfaced to the customer as an empty schema and a successful request. The
+     * exception is propagated so the caller can fail the request instead.
+     *
+     * @throws SQLException if the table listing could not be retrieved.
+     */
+    public static List<TableName> getTableMetadata(PreparedStatement preparedStatement, String tableType) throws SQLException
     {
         ImmutableList.Builder<TableName> list = ImmutableList.builder();
         try (ResultSet resultSet = preparedStatement.executeQuery()) {
@@ -168,7 +179,8 @@ public final class JDBCUtil
             }
         }
         catch (SQLException ex) {
-            LOGGER.warn("Unable to return list of {} from data source!. Returning Empty list of table", tableType, ex);
+            LOGGER.warn("Unable to return list of {} from data source!", tableType, ex);
+            throw ex;
         }
         return list.build();
     }

--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandler.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandler.java
@@ -82,6 +82,7 @@ import static com.amazonaws.athena.connector.lambda.metadata.ListTablesRequest.U
  */
 public abstract class JdbcMetadataHandler
         extends MetadataHandler
+        implements AutoCloseable
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(JdbcMetadataHandler.class);
     public static final String TABLES_AND_VIEWS = "Tables and Views";
@@ -503,5 +504,19 @@ public abstract class JdbcMetadataHandler
     protected String wrapNameWithEscapedCharacter(String input)
     {
         return input;
+    }
+
+    /**
+     * Closes the underlying {@link JdbcConnectionFactory}, releasing any pooled connections
+     * and their associated background threads. Callers that create handler instances per-request
+     * (e.g., multi-tenant wrappers) should call this method when the handler is no longer needed
+     * to prevent thread and memory leaks from unreleased connection pools.
+     */
+    @Override
+    public void close() throws Exception
+    {
+        if (jdbcConnectionFactory != null) {
+            jdbcConnectionFactory.close();
+        }
     }
 }

--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcRecordHandler.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcRecordHandler.java
@@ -97,6 +97,7 @@ import java.util.Objects;
  */
 public abstract class JdbcRecordHandler
         extends RecordHandler
+        implements AutoCloseable
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(JdbcRecordHandler.class);
     private final JdbcConnectionFactory jdbcConnectionFactory;
@@ -434,6 +435,20 @@ public abstract class JdbcRecordHandler
             default:
                 throw new AthenaConnectorException("Unhandled type " + fieldType,
                         ErrorDetails.builder().errorCode(FederationSourceErrorCode.OPERATION_NOT_SUPPORTED_EXCEPTION.toString()).build());
+        }
+    }
+
+    /**
+     * Closes the underlying {@link JdbcConnectionFactory}, releasing any pooled connections
+     * and their associated background threads. Callers that create handler instances per-request
+     * (e.g., multi-tenant wrappers) should call this method when the handler is no longer needed
+     * to prevent thread and memory leaks from unreleased connection pools.
+     */
+    @Override
+    public void close() throws Exception
+    {
+        if (jdbcConnectionFactory != null) {
+            jdbcConnectionFactory.close();
         }
     }
 }

--- a/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/MultiplexingJdbcMetadataHandlerTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/MultiplexingJdbcMetadataHandlerTest.java
@@ -194,4 +194,40 @@ public class MultiplexingJdbcMetadataHandlerTest
         this.jdbcMetadataHandler.doGetDataSourceCapabilities(this.allocator, getDataSourceCapabilitiesRequest);
         Mockito.verify(this.fakeDatabaseHandler, Mockito.times(1)).doGetDataSourceCapabilities(Mockito.eq(this.allocator), Mockito.eq(getDataSourceCapabilitiesRequest));
     }
+
+    @Test
+    public void testCloseClosesDelegatesAndOwnFactory() throws Exception
+    {
+        // Each delegate owns an independent HikariCP pool. Closing only the multiplexer's own
+        // factory leaked one pool (and its housekeeper thread) per delegate for the life of the
+        // container, which showed up in production as 34 pools started and zero shut down.
+        this.jdbcMetadataHandler.close();
+
+        Mockito.verify(this.fakeDatabaseHandler, Mockito.times(1)).close();
+        Mockito.verify(this.jdbcConnectionFactory, Mockito.times(1)).close();
+    }
+
+    @Test
+    public void testCloseClosesRemainingDelegatesWhenOneFails() throws Exception
+    {
+        JdbcMetadataHandler failingHandler = Mockito.mock(JdbcMetadataHandler.class);
+        JdbcMetadataHandler healthyHandler = Mockito.mock(JdbcMetadataHandler.class);
+        Mockito.doThrow(new RuntimeException("boom")).when(failingHandler).close();
+
+        Map<String, JdbcMetadataHandler> handlerMap = new HashMap<>();
+        handlerMap.put("failing", failingHandler);
+        handlerMap.put("healthy", healthyHandler);
+
+        JdbcConnectionFactory ownFactory = Mockito.mock(JdbcConnectionFactory.class);
+        JdbcMetadataHandler handler = new MultiplexingJdbcMetadataHandler(
+                this.secretsManager, this.athena, ownFactory, handlerMap,
+                this.databaseConnectionConfig, com.google.common.collect.ImmutableMap.of());
+
+        // The first failure surfaces, but no pool is left behind because of it.
+        assertThrows(RuntimeException.class, handler::close);
+
+        Mockito.verify(failingHandler, Mockito.times(1)).close();
+        Mockito.verify(healthyHandler, Mockito.times(1)).close();
+        Mockito.verify(ownFactory, Mockito.times(1)).close();
+    }
 }

--- a/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/MultiplexingJdbcRecordHandlerTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/MultiplexingJdbcRecordHandlerTest.java
@@ -171,4 +171,37 @@ public class MultiplexingJdbcRecordHandlerTest
         );
         assertTrue(exception.getMessage().contains("recordHandlerMap must not be empty"));
     }
+
+    @Test
+    public void testCloseClosesDelegatesAndOwnFactory() throws Exception
+    {
+        // Each delegate owns an independent HikariCP pool; all of them must be released.
+        this.jdbcRecordHandler.close();
+
+        Mockito.verify(this.fakeJdbcRecordHandler, Mockito.times(1)).close();
+        Mockito.verify(this.jdbcConnectionFactory, Mockito.times(1)).close();
+    }
+
+    @Test
+    public void testCloseClosesRemainingDelegatesWhenOneFails() throws Exception
+    {
+        JdbcRecordHandler failingHandler = Mockito.mock(JdbcRecordHandler.class);
+        JdbcRecordHandler healthyHandler = Mockito.mock(JdbcRecordHandler.class);
+        Mockito.doThrow(new RuntimeException("boom")).when(failingHandler).close();
+
+        Map<String, JdbcRecordHandler> handlerMap = new HashMap<>();
+        handlerMap.put("failing", failingHandler);
+        handlerMap.put("healthy", healthyHandler);
+
+        JdbcConnectionFactory ownFactory = Mockito.mock(JdbcConnectionFactory.class);
+        JdbcRecordHandler handler = new MultiplexingJdbcRecordHandler(
+                this.amazonS3, this.secretsManager, this.athena, ownFactory,
+                this.databaseConnectionConfig, handlerMap, com.google.common.collect.ImmutableMap.of());
+
+        assertThrows(RuntimeException.class, handler::close);
+
+        Mockito.verify(failingHandler, Mockito.times(1)).close();
+        Mockito.verify(healthyHandler, Mockito.times(1)).close();
+        Mockito.verify(ownFactory, Mockito.times(1)).close();
+    }
 }

--- a/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/connection/GenericJdbcConnectionFactoryTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/connection/GenericJdbcConnectionFactoryTest.java
@@ -156,7 +156,7 @@ public class GenericJdbcConnectionFactoryTest
     }
 
     @Test
-    public void close_afterPoolInitialized_closesPool() throws Exception
+    public void close_afterPoolInitialized_closesPoolAndAllowsReuse() throws Exception
     {
         DatabaseConnectionConfig config = new DatabaseConnectionConfig(TEST_CATALOG, TEST_ENGINE, uniqueH2Url());
         DatabaseConnectionInfo info = new DatabaseConnectionInfo(H2_DRIVER_CLASS, H2_DEFAULT_PORT);
@@ -166,11 +166,104 @@ public class GenericJdbcConnectionFactoryTest
             assertNotNull(connection);
         }
 
-        // Closes the underlying HikariDataSource — subsequent getConnection() should fail.
         factory.close();
 
-        SQLException failure = assertThrows(SQLException.class, () -> factory.getConnection(null));
-        assertNotNull(failure.getMessage());
+        // close() releases the pool but must not brick the factory: a handler that is closed and
+        // then reused would otherwise fail forever with "HikariDataSource has been closed".
+        try (Connection reopened = factory.getConnection(null)) {
+            assertNotNull(reopened);
+            Assert.assertTrue(reopened.isValid(2));
+        }
+
+        factory.close();
+    }
+
+    @Test
+    public void close_isIdempotent() throws Exception
+    {
+        DatabaseConnectionConfig config = new DatabaseConnectionConfig(TEST_CATALOG, TEST_ENGINE, uniqueH2Url());
+        DatabaseConnectionInfo info = new DatabaseConnectionInfo(H2_DRIVER_CLASS, H2_DEFAULT_PORT);
+        GenericJdbcConnectionFactory factory = new GenericJdbcConnectionFactory(config, EMPTY_JDBC_PROPERTIES, info);
+
+        try (Connection connection = factory.getConnection(null)) {
+            assertNotNull(connection);
+        }
+
+        factory.close();
+        factory.close();
+    }
+
+    @Test
+    public void getConnection_pooledMode_rebuildsPoolWhenCredentialsChange() throws Exception
+    {
+        // HikariCP snapshots credentials when the pool is built and rejects per-call credentials,
+        // so a pool created for one identity would keep serving it after a later request supplied
+        // different credentials -- one tenant borrowing another's connection.
+        String url = uniqueH2Url();
+        DatabaseConnectionConfig config = new DatabaseConnectionConfig(
+                TEST_CATALOG, TEST_ENGINE, url, TEST_SECRET_NAME);
+        DatabaseConnectionInfo info = new DatabaseConnectionInfo(H2_DRIVER_CLASS, H2_DEFAULT_PORT);
+        GenericJdbcConnectionFactory factory = new GenericJdbcConnectionFactory(config, EMPTY_JDBC_PROPERTIES, info);
+
+        CredentialsProvider tenantA = new StaticCredentialsProvider(new DefaultCredentials("tenantA", "secretA"));
+        CredentialsProvider tenantB = new StaticCredentialsProvider(new DefaultCredentials("tenantB", "secretB"));
+
+        try (Connection first = factory.getConnection(tenantA)) {
+            assertEquals("TENANTA", first.getMetaData().getUserName());
+        }
+
+        // H2 in-memory treats the first connection's credentials as the database owner, so a
+        // different user proves the pool was rebuilt rather than reused with stale credentials.
+        // Reuse would have silently returned a working tenantA connection instead.
+        Exception failure = assertThrows(Exception.class, () -> factory.getConnection(tenantB));
+        Assert.assertTrue("expected an authentication failure for the new identity, got: " + failure,
+                (failure.getMessage() + String.valueOf(failure.getCause())).contains("Wrong user name or password"));
+
+        factory.close();
+    }
+
+    @Test
+    public void getConnection_pooledMode_reusesPoolForSameCredentials() throws Exception
+    {
+        // The identity guard must not defeat pooling: repeated calls with the same credentials
+        // have to keep serving from one pool.
+        DatabaseConnectionConfig config = new DatabaseConnectionConfig(TEST_CATALOG, TEST_ENGINE, uniqueH2Url());
+        DatabaseConnectionInfo info = new DatabaseConnectionInfo(H2_DRIVER_CLASS, H2_DEFAULT_PORT);
+        GenericJdbcConnectionFactory factory = new GenericJdbcConnectionFactory(config, EMPTY_JDBC_PROPERTIES, info);
+
+        String firstPool;
+        try (Connection first = factory.getConnection(null)) {
+            firstPool = first.unwrap(Connection.class).toString();
+            assertNotNull(firstPool);
+        }
+        try (Connection second = factory.getConnection(null)) {
+            // Same underlying physical connection handed back by the same pool.
+            assertEquals(firstPool, second.unwrap(Connection.class).toString());
+        }
+
+        factory.close();
+    }
+
+    @Test
+    public void getConnection_pooledMode_distinctFactoriesDoNotBlockEachOther() throws Exception
+    {
+        // The pool-init lock is per instance, not per class: two unrelated factories (e.g. two
+        // multiplexed catalogs) must be able to build their pools concurrently.
+        DatabaseConnectionInfo info = new DatabaseConnectionInfo(H2_DRIVER_CLASS, H2_DEFAULT_PORT);
+        GenericJdbcConnectionFactory one = new GenericJdbcConnectionFactory(
+                new DatabaseConnectionConfig(TEST_CATALOG, TEST_ENGINE, uniqueH2Url()), EMPTY_JDBC_PROPERTIES, info);
+        GenericJdbcConnectionFactory two = new GenericJdbcConnectionFactory(
+                new DatabaseConnectionConfig("otherCatalog", TEST_ENGINE, uniqueH2Url()), EMPTY_JDBC_PROPERTIES, info);
+
+        try (Connection a = one.getConnection(null); Connection b = two.getConnection(null)) {
+            assertNotNull(a);
+            assertNotNull(b);
+            // Independent pools, so independent physical connections.
+            Assert.assertNotEquals(a.toString(), b.toString());
+        }
+
+        one.close();
+        two.close();
     }
 
     @Test

--- a/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/connection/GenericJdbcConnectionFactoryTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/connection/GenericJdbcConnectionFactoryTest.java
@@ -19,15 +19,59 @@
  */
 package com.amazonaws.athena.connectors.jdbc.connection;
 
+import com.amazonaws.athena.connector.credentials.CredentialsProvider;
+import com.amazonaws.athena.connector.credentials.DefaultCredentials;
+import com.amazonaws.athena.connector.credentials.StaticCredentialsProvider;
+import com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants;
+import com.amazonaws.athena.connector.lambda.exceptions.AthenaConnectorException;
+import com.google.common.collect.ImmutableMap;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import software.amazon.awssdk.services.glue.model.FederationSourceErrorCode;
 
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Map;
+import java.util.Properties;
+import java.util.UUID;
 import java.util.regex.Matcher;
 
 import static com.amazonaws.athena.connectors.jdbc.connection.GenericJdbcConnectionFactory.SECRET_NAME_PATTERN;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 
 public class GenericJdbcConnectionFactoryTest
 {
+    private static final String H2_DRIVER_CLASS = "org.h2.Driver";
+    private static final int H2_DEFAULT_PORT = 9092;
+    private static final String TEST_CATALOG = "testCatalog";
+    private static final String TEST_ENGINE = "h2";
+    private static final String TEST_SECRET_NAME = "testSecret";
+    private static final Map<String, String> EMPTY_JDBC_PROPERTIES = ImmutableMap.of();
+
+    /**
+     * Returns a fresh in-memory H2 URL for each test to avoid state leaking between tests.
+     */
+    private static String uniqueH2Url()
+    {
+        return "jdbc:h2:mem:" + UUID.randomUUID().toString().replace('-', '_') + ";DB_CLOSE_DELAY=-1";
+    }
+
+    private static GenericJdbcConnectionFactory newDirectModeFactory(String jdbcUrl)
+    {
+        DatabaseConnectionConfig config = new DatabaseConnectionConfig(TEST_CATALOG, TEST_ENGINE, jdbcUrl);
+        DatabaseConnectionInfo info = new DatabaseConnectionInfo(H2_DRIVER_CLASS, H2_DEFAULT_PORT);
+        Map<String, String> configOptions = ImmutableMap.of(EnvironmentConstants.FAS_TOKEN, "someToken");
+        return new GenericJdbcConnectionFactory(config, EMPTY_JDBC_PROPERTIES, info, configOptions);
+    }
+
     @Test
     public void matchSecretNamePattern()
     {
@@ -44,5 +88,224 @@ public class GenericJdbcConnectionFactoryTest
         Matcher secretMatcher = SECRET_NAME_PATTERN.matcher(jdbcConnectionString);
 
         Assert.assertFalse(secretMatcher.find());
+    }
+
+    @Test
+    public void getConnection_pooledMode_withCredentials_stripsSecretAndReturnsConnection() throws Exception
+    {
+        String rawUrl = uniqueH2Url() + ";INIT=CREATE SCHEMA IF NOT EXISTS TEST\\;--${" + TEST_SECRET_NAME + "}";
+        // The above URL contains a ${secret} placeholder that must be stripped before the driver receives it.
+        DatabaseConnectionConfig config = new DatabaseConnectionConfig(
+                TEST_CATALOG, TEST_ENGINE, rawUrl, TEST_SECRET_NAME);
+        DatabaseConnectionInfo info = new DatabaseConnectionInfo(H2_DRIVER_CLASS, H2_DEFAULT_PORT);
+        GenericJdbcConnectionFactory factory = new GenericJdbcConnectionFactory(config, EMPTY_JDBC_PROPERTIES, info);
+        CredentialsProvider credentialsProvider = new StaticCredentialsProvider(new DefaultCredentials("sa", "sa"));
+
+        try (Connection connection = factory.getConnection(credentialsProvider)) {
+            assertNotNull(connection);
+            Assert.assertTrue(connection.isValid(1));
+        }
+        finally {
+            factory.close();
+        }
+    }
+
+    @Test
+    public void getConnection_pooledMode_nullCredentials_usesJdbcStringAsIs() throws Exception
+    {
+        String rawUrl = uniqueH2Url();
+        DatabaseConnectionConfig config = new DatabaseConnectionConfig(TEST_CATALOG, TEST_ENGINE, rawUrl);
+        DatabaseConnectionInfo info = new DatabaseConnectionInfo(H2_DRIVER_CLASS, H2_DEFAULT_PORT);
+        GenericJdbcConnectionFactory factory = new GenericJdbcConnectionFactory(config, EMPTY_JDBC_PROPERTIES, info);
+
+        try (Connection connection = factory.getConnection(null)) {
+            assertNotNull(connection);
+            Assert.assertTrue(connection.isValid(1));
+        }
+        finally {
+            factory.close();
+        }
+    }
+
+    @Test
+    public void constructor_withNullProperties_isAcceptedAndPoolInitializes() throws Exception
+    {
+        // Exercises the delegating constructor and the null-properties branch.
+        String rawUrl = uniqueH2Url();
+        DatabaseConnectionConfig config = new DatabaseConnectionConfig(TEST_CATALOG, TEST_ENGINE, rawUrl);
+        DatabaseConnectionInfo info = new DatabaseConnectionInfo(H2_DRIVER_CLASS, H2_DEFAULT_PORT);
+        GenericJdbcConnectionFactory factory = new GenericJdbcConnectionFactory(config, null, info);
+
+        try (Connection connection = factory.getConnection(null)) {
+            assertNotNull(connection);
+        }
+        finally {
+            factory.close();
+        }
+    }
+
+    @Test
+    public void close_beforeAnyConnection_isNoOp()
+    {
+        DatabaseConnectionConfig config = new DatabaseConnectionConfig(TEST_CATALOG, TEST_ENGINE, uniqueH2Url());
+        DatabaseConnectionInfo info = new DatabaseConnectionInfo(H2_DRIVER_CLASS, H2_DEFAULT_PORT);
+        GenericJdbcConnectionFactory factory = new GenericJdbcConnectionFactory(config, EMPTY_JDBC_PROPERTIES, info);
+
+        // Does not throw when no pool was ever created (ds == null branch of close()).
+        factory.close();
+    }
+
+    @Test
+    public void close_afterPoolInitialized_closesPool() throws Exception
+    {
+        DatabaseConnectionConfig config = new DatabaseConnectionConfig(TEST_CATALOG, TEST_ENGINE, uniqueH2Url());
+        DatabaseConnectionInfo info = new DatabaseConnectionInfo(H2_DRIVER_CLASS, H2_DEFAULT_PORT);
+        GenericJdbcConnectionFactory factory = new GenericJdbcConnectionFactory(config, EMPTY_JDBC_PROPERTIES, info);
+
+        try (Connection connection = factory.getConnection(null)) {
+            assertNotNull(connection);
+        }
+
+        // Closes the underlying HikariDataSource — subsequent getConnection() should fail.
+        factory.close();
+
+        SQLException failure = assertThrows(SQLException.class, () -> factory.getConnection(null));
+        assertNotNull(failure.getMessage());
+    }
+
+    @Test
+    public void constructor_directMode_missingDriver_throwsAthenaConnectorException()
+    {
+        DatabaseConnectionConfig config = new DatabaseConnectionConfig(TEST_CATALOG, TEST_ENGINE, uniqueH2Url());
+        DatabaseConnectionInfo info = new DatabaseConnectionInfo("not.a.real.jdbc.Driver", H2_DEFAULT_PORT);
+        Map<String, String> configOptions = ImmutableMap.of(EnvironmentConstants.FAS_TOKEN, "someToken");
+
+        AthenaConnectorException ex = assertThrows(AthenaConnectorException.class, () ->
+                new GenericJdbcConnectionFactory(config, EMPTY_JDBC_PROPERTIES, info, configOptions));
+
+        assertEquals(FederationSourceErrorCode.INVALID_INPUT_EXCEPTION.toString(), ex.getErrorDetails().errorCode());
+        Assert.assertTrue(ex.getMessage().contains("JDBC driver not found"));
+    }
+
+    @Test
+    public void constructor_pooledMode_noFasToken_doesNotAttemptDriverLoad()
+    {
+        // When FAS_TOKEN is absent, the driver class is only loaded lazily by Hikari, so an unknown
+        // driver class name in the info block does NOT throw at construction time.
+        DatabaseConnectionConfig config = new DatabaseConnectionConfig(TEST_CATALOG, TEST_ENGINE, uniqueH2Url());
+        DatabaseConnectionInfo info = new DatabaseConnectionInfo("not.a.real.jdbc.Driver", H2_DEFAULT_PORT);
+        Map<String, String> configOptions = ImmutableMap.of();
+
+        // No exception expected.
+        GenericJdbcConnectionFactory factory =
+                new GenericJdbcConnectionFactory(config, EMPTY_JDBC_PROPERTIES, info, configOptions);
+        Assert.assertNotNull(factory);
+    }
+
+    @Test
+    public void getConnection_directMode_withCredentials_stripsSecretAndMergesProperties() throws Exception
+    {
+        String rawUrl = "jdbc:h2:mem:direct?param=${" + TEST_SECRET_NAME + "}";
+        DatabaseConnectionConfig config = new DatabaseConnectionConfig(
+                TEST_CATALOG, TEST_ENGINE, rawUrl, TEST_SECRET_NAME);
+        DatabaseConnectionInfo info = new DatabaseConnectionInfo(H2_DRIVER_CLASS, H2_DEFAULT_PORT);
+        Map<String, String> configOptions = ImmutableMap.of(EnvironmentConstants.FAS_TOKEN, "someToken");
+        Map<String, String> jdbcProperties = ImmutableMap.of("existing", "value");
+
+        GenericJdbcConnectionFactory factory =
+                new GenericJdbcConnectionFactory(config, jdbcProperties, info, configOptions);
+        CredentialsProvider credentialsProvider = new StaticCredentialsProvider(new DefaultCredentials("sa", "sa"));
+        Connection mockConnection = Mockito.mock(Connection.class);
+        ArgumentCaptor<Properties> propsCaptor = ArgumentCaptor.forClass(Properties.class);
+
+        try (MockedStatic<DriverManager> mockedDriverManager = Mockito.mockStatic(DriverManager.class)) {
+            mockedDriverManager.when(() -> DriverManager.getConnection(any(String.class), any(Properties.class)))
+                    .thenReturn(mockConnection);
+
+            Connection result = factory.getConnection(credentialsProvider);
+
+            assertEquals(mockConnection, result);
+            String expectedStrippedUrl = "jdbc:h2:mem:direct?param=";
+            mockedDriverManager.verify(() -> DriverManager.getConnection(eq(expectedStrippedUrl), propsCaptor.capture()));
+        }
+
+        Properties actualProps = propsCaptor.getValue();
+        // The pre-existing property and the credentials were both merged into the properties passed to DriverManager.
+        assertEquals("value", actualProps.getProperty("existing"));
+        assertEquals("sa", actualProps.getProperty("user"));
+        assertEquals("sa", actualProps.getProperty("password"));
+    }
+
+    @Test
+    public void getConnection_directMode_nullCredentials_passesUrlThrough() throws Exception
+    {
+        String rawUrl = uniqueH2Url();
+        GenericJdbcConnectionFactory factory = newDirectModeFactory(rawUrl);
+        Connection mockConnection = Mockito.mock(Connection.class);
+
+        try (MockedStatic<DriverManager> mockedDriverManager = Mockito.mockStatic(DriverManager.class)) {
+            mockedDriverManager.when(() -> DriverManager.getConnection(any(String.class), any(Properties.class)))
+                    .thenReturn(mockConnection);
+
+            Connection result = factory.getConnection(null);
+
+            assertEquals(mockConnection, result);
+            mockedDriverManager.verify(() -> DriverManager.getConnection(eq(rawUrl), any(Properties.class)));
+        }
+    }
+
+    @Test
+    public void getConnection_directMode_nameOrServiceNotKnown_wrapsAsInvalidInputException()
+    {
+        GenericJdbcConnectionFactory factory = newDirectModeFactory(uniqueH2Url());
+        // Construct the SQLException BEFORE opening the MockedStatic<DriverManager> scope.
+        // SQLException's constructor calls DriverManager.getLogWriter(), which Mockito would
+        // otherwise treat as an interaction mid-stubbing and fail with UnfinishedStubbingException.
+        SQLException driverError = new SQLException("Communications link failure: Name or service not known");
+
+        try (MockedStatic<DriverManager> mockedDriverManager = Mockito.mockStatic(DriverManager.class)) {
+            mockedDriverManager.when(() -> DriverManager.getConnection(any(String.class), any(Properties.class)))
+                    .thenThrow(driverError);
+
+            AthenaConnectorException ex = assertThrows(AthenaConnectorException.class,
+                    () -> factory.getConnection(null));
+
+            assertEquals(FederationSourceErrorCode.INVALID_INPUT_EXCEPTION.toString(),
+                    ex.getErrorDetails().errorCode());
+        }
+    }
+
+    @Test
+    public void getConnection_directMode_incorrectCredentials_wrapsAsInvalidCredentialsException()
+    {
+        GenericJdbcConnectionFactory factory = newDirectModeFactory(uniqueH2Url());
+        // See note in the sibling test — SQLException must be constructed outside the MockedStatic scope.
+        SQLException driverError = new SQLException("Incorrect username or password was specified.");
+
+        try (MockedStatic<DriverManager> mockedDriverManager = Mockito.mockStatic(DriverManager.class)) {
+            mockedDriverManager.when(() -> DriverManager.getConnection(any(String.class), any(Properties.class)))
+                    .thenThrow(driverError);
+
+            AthenaConnectorException ex = assertThrows(AthenaConnectorException.class,
+                    () -> factory.getConnection(null));
+
+            assertEquals(FederationSourceErrorCode.INVALID_CREDENTIALS_EXCEPTION.toString(),
+                    ex.getErrorDetails().errorCode());
+        }
+    }
+
+    @Test
+    public void getConnection_directMode_genericSqlException_propagates()
+    {
+        GenericJdbcConnectionFactory factory = newDirectModeFactory(uniqueH2Url());
+        SQLException expected = new SQLException("Some other database error");
+
+        try (MockedStatic<DriverManager> mockedDriverManager = Mockito.mockStatic(DriverManager.class)) {
+            mockedDriverManager.when(() -> DriverManager.getConnection(any(String.class), any(Properties.class)))
+                    .thenThrow(expected);
+
+            SQLException actual = assertThrows(SQLException.class, () -> factory.getConnection(null));
+            assertEquals(expected, actual);
+        }
     }
 }

--- a/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/manager/JDBCUtilTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/manager/JDBCUtilTest.java
@@ -252,14 +252,42 @@ public class JDBCUtilTest
     public void testGetTableMetadataWithSQLException() throws SQLException
     {
         PreparedStatement mockStatement = org.mockito.Mockito.mock(PreparedStatement.class);
-        
-        // Mock SQLException to test exception handling
+
+        // A failure to query the data source must not be reported as "no tables". Returning an
+        // empty list here made a broken session (e.g. a Snowflake session with no active
+        // warehouse) look to the customer like an empty schema on an otherwise successful request.
         org.mockito.Mockito.when(mockStatement.executeQuery()).thenThrow(new SQLException("Test exception"));
-        
-        java.util.List<TableName> tables = JDBCUtil.getTableMetadata(mockStatement, "Tables");
-        
-        // Should return empty list when SQLException occurs
-        Assert.assertTrue(tables.isEmpty());
+
+        SQLException thrown = Assert.assertThrows(SQLException.class,
+                () -> JDBCUtil.getTableMetadata(mockStatement, "Tables"));
+        Assert.assertEquals("Test exception", thrown.getMessage());
+    }
+
+    @Test
+    public void testGetTableMetadataWithNoWarehouseSelectedPropagates() throws SQLException
+    {
+        // The exact Snowflake failure seen in production: ErrorCode(606) / SQLSTATE 57P03.
+        PreparedStatement mockStatement = org.mockito.Mockito.mock(PreparedStatement.class);
+        org.mockito.Mockito.when(mockStatement.executeQuery()).thenThrow(new SQLException(
+                "No active warehouse selected in the current session.  Select an active warehouse with the 'use warehouse' command.",
+                "57P03", 606));
+
+        SQLException thrown = Assert.assertThrows(SQLException.class,
+                () -> JDBCUtil.getTableMetadata(mockStatement, "Tables and Views"));
+        Assert.assertEquals("57P03", thrown.getSQLState());
+        Assert.assertEquals(606, thrown.getErrorCode());
+    }
+
+    @Test
+    public void testGetTableMetadataReturnsEmptyListForEmptySchema() throws SQLException
+    {
+        // A schema that genuinely holds no tables is still an empty list, not an exception.
+        PreparedStatement mockStatement = org.mockito.Mockito.mock(PreparedStatement.class);
+        java.sql.ResultSet mockResultSet = org.mockito.Mockito.mock(java.sql.ResultSet.class);
+        org.mockito.Mockito.when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+        org.mockito.Mockito.when(mockResultSet.next()).thenReturn(false);
+
+        Assert.assertTrue(JDBCUtil.getTableMetadata(mockStatement, "Tables").isEmpty());
     }
 
     @Test

--- a/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandlerTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcMetadataHandlerTest.java
@@ -131,6 +131,27 @@ public class JdbcMetadataHandlerTest
     }
 
     @Test
+    public void close_delegatesToJdbcConnectionFactory()
+            throws Exception
+    {
+        this.jdbcMetadataHandler.close();
+        Mockito.verify(this.jdbcConnectionFactory, Mockito.times(1)).close();
+    }
+
+    @Test
+    public void close_withNullFactory_isNoOp()
+            throws Exception
+    {
+        // Simulate the multiplexing-constructor case where the base handler has no factory of its own.
+        // The null-factory branch of close() should be a no-op and MUST NOT throw.
+        java.lang.reflect.Field factoryField = JdbcMetadataHandler.class.getDeclaredField("jdbcConnectionFactory");
+        factoryField.setAccessible(true);
+        factoryField.set(this.jdbcMetadataHandler, null);
+
+        this.jdbcMetadataHandler.close();
+    }
+
+    @Test
     public void doListSchemaNames()
             throws Exception
     {

--- a/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcRecordHandlerTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/manager/JdbcRecordHandlerTest.java
@@ -158,6 +158,28 @@ public class JdbcRecordHandlerTest
         };
         this.federatedIdentity = Mockito.mock(FederatedIdentity.class);
     }
+
+    @Test
+    public void close_delegatesToJdbcConnectionFactory()
+            throws Exception
+    {
+        this.jdbcRecordHandler.close();
+        Mockito.verify(this.jdbcConnectionFactory, Mockito.times(1)).close();
+    }
+
+    @Test
+    public void close_withNullFactory_isNoOp()
+            throws Exception
+    {
+        // Simulate the multiplexing-constructor case where the base handler has no factory of its own.
+        // The null-factory branch of close() should be a no-op and MUST NOT throw.
+        java.lang.reflect.Field factoryField = JdbcRecordHandler.class.getDeclaredField("jdbcConnectionFactory");
+        factoryField.setAccessible(true);
+        factoryField.set(this.jdbcRecordHandler, null);
+
+        this.jdbcRecordHandler.close();
+    }
+
     @Test
     public void readWithConstraint()
             throws Exception


### PR DESCRIPTION
*Description of changes:*

athena-query-federation handlers was designed to be single-tenant lambda handlers. For JDBC use cases, as long as the handlers are singleton objects, the underlying resources like Hikari pools will remain singleton. However when the lambda handler is used in multi-tenant scenarios, the handlers will be created on per request basis. As a result, after a long running time period of single AWS Lambda instance, multiple Hikari pools will be created with requests from different tenants, which causing OOM exceptions due to long running background threads managing the pools.

This change resolves this issue by making JDBC metadata and records handlers Autocloseable. All upstream callers of the handlers should managed the life cycle of athena-query-federation handlers by using try-with-resource or try finally blocks to eventually close the resources. As a results, all jvm resources used by SDK should be GCed correctly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
