### PR TITLE
Fix issue where SQLServer connector is still using default credential…

### DIFF
--- a/athena-datalakegen2/src/main/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2MetadataHandler.java
+++ b/athena-datalakegen2/src/main/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2MetadataHandler.java
@@ -380,7 +380,8 @@ public class DataLakeGen2MetadataHandler extends JdbcMetadataHandler
         return CredentialsProviderFactory.createCredentialProvider(
                 getDatabaseConnectionConfig().getSecret(),
                 getCachableSecretsManager(),
-                new DataLakeGen2OAuthCredentialsProvider()
+                new DataLakeGen2OAuthCredentialsProvider(),
+                requestOverrideConfiguration
         );
     }
 }

--- a/athena-datalakegen2/src/main/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2RecordHandler.java
+++ b/athena-datalakegen2/src/main/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2RecordHandler.java
@@ -98,7 +98,8 @@ public class DataLakeGen2RecordHandler extends JdbcRecordHandler
         return CredentialsProviderFactory.createCredentialProvider(
             getDatabaseConnectionConfig().getSecret(),
             getCachableSecretsManager(),
-            new DataLakeGen2OAuthCredentialsProvider()
+            new DataLakeGen2OAuthCredentialsProvider(),
+            requestOverrideConfiguration
         );
     }
 

--- a/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerMetadataHandler.java
+++ b/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerMetadataHandler.java
@@ -526,7 +526,8 @@ public class SqlServerMetadataHandler extends JdbcMetadataHandler
         return CredentialsProviderFactory.createCredentialProvider(
                 getDatabaseConnectionConfig().getSecret(),
                 getCachableSecretsManager(),
-                new SqlServerOAuthCredentialsProvider()
+                new SqlServerOAuthCredentialsProvider(),
+                requestOverrideConfiguration
         );
     }
 }

--- a/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerRecordHandler.java
+++ b/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerRecordHandler.java
@@ -100,7 +100,8 @@ public class SqlServerRecordHandler extends JdbcRecordHandler
         return CredentialsProviderFactory.createCredentialProvider(
                 getDatabaseConnectionConfig().getSecret(),
                 getCachableSecretsManager(),
-                new SqlServerOAuthCredentialsProvider()
+                new SqlServerOAuthCredentialsProvider(),
+                requestOverrideConfiguration
         );
     }
 }

--- a/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseMetadataHandler.java
+++ b/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseMetadataHandler.java
@@ -521,7 +521,8 @@ public class SynapseMetadataHandler extends JdbcMetadataHandler
         return CredentialsProviderFactory.createCredentialProvider(
                 getDatabaseConnectionConfig().getSecret(),
                 getCachableSecretsManager(),
-                new SynapseOAuthCredentialsProvider()
+                new SynapseOAuthCredentialsProvider(),
+                requestOverrideConfiguration
         );
     }
 }

--- a/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseRecordHandler.java
+++ b/athena-synapse/src/main/java/com/amazonaws/athena/connectors/synapse/SynapseRecordHandler.java
@@ -151,7 +151,8 @@ public class SynapseRecordHandler extends JdbcRecordHandler
         return CredentialsProviderFactory.createCredentialProvider(
             getDatabaseConnectionConfig().getSecret(),
             getCachableSecretsManager(),
-            new SynapseOAuthCredentialsProvider()
+            new SynapseOAuthCredentialsProvider(),
+            requestOverrideConfiguration
         );
     }
 }


### PR DESCRIPTION
Fix issue where SQLServer connector is still using default credential to access secret when FAS credential is present.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
