### PR TITLE
upgrade docdb driver to 4.9.1 to support AWS IAM Auth.

### DIFF
--- a/athena-docdb/pom.xml
+++ b/athena-docdb/pom.xml
@@ -44,8 +44,8 @@
         </dependency>
         <dependency>
             <groupId>org.mongodb</groupId>
-            <artifactId>mongo-java-driver</artifactId>
-            <version>3.12.14</version>
+            <artifactId>mongodb-driver-sync</artifactId>
+            <version>4.9.1</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/athena-docdb/src/test/java/com/amazonaws/athena/connectors/docdb/DocDBMetadataHandlerTest.java
+++ b/athena-docdb/src/test/java/com/amazonaws/athena/connectors/docdb/DocDBMetadataHandlerTest.java
@@ -304,7 +304,6 @@ public class DocDBMetadataHandlerTest
         when(mockDatabase.getCollection(eq(TEST_TABLE))).thenReturn(mockCollection);
         when(mockCollection.find()).thenReturn(mockIterable);
         when(mockIterable.limit(anyInt())).thenReturn(mockIterable);
-        Mockito.lenient().when(mockIterable.maxScan(anyInt())).thenReturn(mockIterable);
         when(mockIterable.batchSize(anyInt())).thenReturn(mockIterable);
         when(mockIterable.iterator()).thenReturn(new StubbingCursor(documents.iterator()));
 
@@ -399,7 +398,6 @@ public class DocDBMetadataHandlerTest
         when(mockDatabase.getCollection(eq(TEST_TABLE))).thenReturn(mockCollection);
         when(mockCollection.find()).thenReturn(mockIterable);
         when(mockIterable.limit(anyInt())).thenReturn(mockIterable);
-        Mockito.lenient().when(mockIterable.maxScan(anyInt())).thenReturn(mockIterable);
         when(mockIterable.batchSize(anyInt())).thenReturn(mockIterable);
         when(mockIterable.iterator()).thenReturn(new StubbingCursor(documents.iterator()));
 

--- a/athena-docdb/src/test/java/com/amazonaws/athena/connectors/docdb/DocDBRecordHandlerTest.java
+++ b/athena-docdb/src/test/java/com/amazonaws/athena/connectors/docdb/DocDBRecordHandlerTest.java
@@ -423,7 +423,6 @@ public class DocDBRecordHandlerTest
 
         when(mockCollection.find()).thenReturn(mockIterable);
         when(mockIterable.limit(anyInt())).thenReturn(mockIterable);
-        Mockito.lenient().when(mockIterable.maxScan(anyInt())).thenReturn(mockIterable);
         when(mockIterable.batchSize(anyInt())).thenReturn(mockIterable);
         when(mockIterable.iterator()).thenReturn(new StubbingCursor(documents.iterator()));
 
@@ -495,7 +494,6 @@ public class DocDBRecordHandlerTest
 
         when(mockCollection.find()).thenReturn(mockIterable);
         when(mockIterable.limit(anyInt())).thenReturn(mockIterable);
-        Mockito.lenient().when(mockIterable.maxScan(anyInt())).thenReturn(mockIterable);
         when(mockIterable.batchSize(anyInt())).thenReturn(mockIterable);
         when(mockIterable.iterator()).thenReturn(new StubbingCursor(documents.iterator()));
 

--- a/athena-docdb/src/test/java/com/amazonaws/athena/connectors/docdb/SchemaUtilsTest.java
+++ b/athena-docdb/src/test/java/com/amazonaws/athena/connectors/docdb/SchemaUtilsTest.java
@@ -60,7 +60,6 @@ public class SchemaUtilsTest
         when(mockDatabase.getCollection(any())).thenReturn(mockCollection);
         when(mockCollection.find()).thenReturn(mockIterable);
         when(mockIterable.limit(anyInt())).thenReturn(mockIterable);
-        when(mockIterable.maxScan(anyInt())).thenReturn(mockIterable);
         when(mockIterable.batchSize(anyInt())).thenReturn(mockIterable);
         when(mockIterable.iterator()).thenReturn(new StubbingCursor(docs.iterator()));
 
@@ -121,7 +120,6 @@ public class SchemaUtilsTest
         when(mockDatabase.getCollection(any())).thenReturn(mockCollection);
         when(mockCollection.find()).thenReturn(mockIterable);
         when(mockIterable.limit(anyInt())).thenReturn(mockIterable);
-        when(mockIterable.maxScan(anyInt())).thenReturn(mockIterable);
         when(mockIterable.batchSize(anyInt())).thenReturn(mockIterable);
         when(mockIterable.iterator()).thenReturn(new StubbingCursor(docs.iterator()));
 
@@ -171,7 +169,6 @@ public class SchemaUtilsTest
         when(mockDatabase.getCollection(any())).thenReturn(mockCollection);
         when(mockCollection.find()).thenReturn(mockIterable);
         when(mockIterable.limit(anyInt())).thenReturn(mockIterable);
-        when(mockIterable.maxScan(anyInt())).thenReturn(mockIterable);
         when(mockIterable.batchSize(anyInt())).thenReturn(mockIterable);
         when(mockIterable.iterator()).thenReturn(new StubbingCursor(docs.iterator()));
 
@@ -210,7 +207,6 @@ public class SchemaUtilsTest
         when(mockDatabase.getCollection(any())).thenReturn(mockCollection);
         when(mockCollection.find()).thenReturn(mockIterable);
         when(mockIterable.limit(anyInt())).thenReturn(mockIterable);
-        when(mockIterable.maxScan(anyInt())).thenReturn(mockIterable);
         when(mockIterable.batchSize(anyInt())).thenReturn(mockIterable);
         when(mockIterable.iterator()).thenReturn(new StubbingCursor(docs.iterator()));
 

--- a/athena-docdb/src/test/java/com/amazonaws/athena/connectors/docdb/StubbingCursor.java
+++ b/athena-docdb/src/test/java/com/amazonaws/athena/connectors/docdb/StubbingCursor.java
@@ -19,7 +19,6 @@
  */
 package com.amazonaws.athena.connectors.docdb;
 
-import com.mongodb.Block;
 import com.mongodb.Function;
 import com.mongodb.ServerAddress;
 import com.mongodb.ServerCursor;
@@ -71,6 +70,12 @@ public class StubbingCursor<T>
     }
 
     @Override
+    public int available()
+    {
+        return 0;
+    }
+
+    @Override
     public T tryNext()
     {
         throw new UnsupportedOperationException();
@@ -112,12 +117,6 @@ public class StubbingCursor<T>
 
             @Override
             public <U> MongoIterable<U> map(Function<X, U> function)
-            {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public void forEach(Block<? super X> block)
             {
                 throw new UnsupportedOperationException();
             }


### PR DESCRIPTION
*Issue #, if available:*
current docdb driver version does not support native AWS IAM Auth.

*Description of changes:*
upgrade docdb driver to 4.9.1 to support AWS IAM Auth.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
