### PR TITLE
dependabot mongodb-driver-sync-5.9.1 build issue fix

### DIFF
--- a/athena-docdb/src/test/java/com/amazonaws/athena/connectors/docdb/DocDBCaseInsensitiveResolverTest.java
+++ b/athena-docdb/src/test/java/com/amazonaws/athena/connectors/docdb/DocDBCaseInsensitiveResolverTest.java
@@ -19,6 +19,7 @@
  */
 package com.amazonaws.athena.connectors.docdb;
 
+import com.mongodb.client.ListCollectionNamesIterable;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.MongoIterable;
@@ -60,7 +61,7 @@ public class DocDBCaseInsensitiveResolverTest
     private MongoIterable<String> mockDatabaseNames;
 
     @Mock
-    private MongoIterable<String> mockCollectionNames;
+    private ListCollectionNamesIterable mockCollectionNames;
 
     private Map<String, String> configOptions;
 

--- a/athena-docdb/src/test/java/com/amazonaws/athena/connectors/docdb/DocDBMetadataHandlerTest.java
+++ b/athena-docdb/src/test/java/com/amazonaws/athena/connectors/docdb/DocDBMetadataHandlerTest.java
@@ -44,6 +44,7 @@ import com.amazonaws.athena.connector.lambda.metadata.MetadataResponse;
 import com.amazonaws.athena.connector.lambda.security.LocalKeyFactory;
 import com.google.common.collect.ImmutableList;
 import com.mongodb.client.FindIterable;
+import com.mongodb.client.ListCollectionNamesIterable;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
@@ -390,7 +391,7 @@ public class DocDBMetadataHandlerTest
 
         when(mockListDatabaseNamesIterable.spliterator()).thenReturn(ImmutableList.of(DEFAULT_SCHEMA).spliterator());
 
-        MongoIterable mockListCollectionsNamesIterable = mock(MongoIterable.class);
+        ListCollectionNamesIterable mockListCollectionsNamesIterable = mock(ListCollectionNamesIterable.class);
         when(mockDatabase.listCollectionNames()).thenReturn(mockListCollectionsNamesIterable);
         when(mockListCollectionsNamesIterable.spliterator()).thenReturn(ImmutableList.of(TEST_TABLE).spliterator());
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-athena-query-federation/pull/3564

*Description of changes:*
- Dependabot #3564 upgraded `mongodb-driver-sync` from 4.9.1 to 5.9.1
- In driver 5.x, `MongoDatabase.listCollectionNames()` returns `ListCollectionNamesIterable` instead of `MongoIterable<String>`
- Updated unit test mocks to match the new return type.
- PFA functional test results for reference.

[DOCDB_FUNCTIONAL_TEST_2026-07-28.xlsx](https://github.com/user-attachments/files/30463513/DOCDB_FUNCTIONAL_TEST_2026-07-28.xlsx)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
