### PR TITLE
Fix SQL injection in DB2-AS400 partition column

### DIFF
--- a/athena-db2-as400/src/main/java/com/amazonaws/athena/connectors/db2as400/Db2As400QueryStringBuilder.java
+++ b/athena-db2-as400/src/main/java/com/amazonaws/athena/connectors/db2as400/Db2As400QueryStringBuilder.java
@@ -73,7 +73,7 @@ public class Db2As400QueryStringBuilder extends JdbcSplitQueryBuilder
         if (column != null) {
             LOGGER.debug("Fetching data using Partition");
             //example query: select * from EMP_TABLE WHERE DATAPARTITIONNUM(EMP_NO) = 0
-            return Collections.singletonList(" DATAPARTITIONNUM(" + column + ") = " + split.getProperty(Db2As400MetadataHandler.PARTITION_NUMBER));
+            return Collections.singletonList(" DATAPARTITIONNUM(" + quote(column) + ") = " + split.getProperty(Db2As400MetadataHandler.PARTITION_NUMBER));
         }
         else {
             LOGGER.debug("Fetching data without Partition");


### PR DESCRIPTION
*Issue #, if available:* Fix SQL injection in DB2-AS400 connector partition WHERE-clause builder


*Description of changes:*

Added `quote()` around the partition column identifier in `getPartitionWhereClauses()` to prevent unsanitized column names from being interpreted as executable SQL. Same fix pattern as GHSA-43cr-4635-mfjp. Service team / subject matter experts should review for any breaking changes or customer disruption before merging to mainline.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
