### PR TITLE
[athena-cloudwatch] Use aws-sdk-v2.version property for cloudwatchlogs

### DIFF
--- a/athena-cloudwatch/pom.xml
+++ b/athena-cloudwatch/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>cloudwatchlogs</artifactId>
-            <version>2.49.3</version>
+            <version>${aws-sdk-v2.version}</version>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->
                 <exclusion>


### PR DESCRIPTION
## Summary
`athena-cloudwatch/pom.xml` hardcoded the `software.amazon.awssdk:cloudwatchlogs`
version as a literal instead of using the shared `${aws-sdk-v2.version}` property.
Dependabot bumped that literal independently (2.44.4 → 2.47.3 in #3482, → 2.49.3 in
#3538), letting it drift ahead of `sdk-core`, which stays at the property value
(2.46.17, mediated from every other property-pinned SDK client).

`cloudwatchlogs` >= 2.47.0 calls `ClientExecutionParams.withAuthSchemeOptionsResolver(...)`,
a method added to `sdk-core` in 2.47.0. Since the connector image resolves `sdk-core`
to 2.46.17, the newer client throws `NoSuchMethodError` at runtime on the first call
(`describeLogGroups` → `CloudwatchMetadataHandler.doListSchemaNames`).

Impact: any customer creating a new CloudWatch Logs data source on image 2026.28.1+
hits this on "list databases". Regression from 2026.24.1 (where both were 2.44.4).

## Fix
Point `cloudwatchlogs` at `${aws-sdk-v2.version}` so it tracks `sdk-core` and the
other AWS SDK v2 artifacts in lockstep (matching the `cloudwatch` dependency directly
below it). This also prevents Dependabot from drifting it independently going forward.

## Validation
- Built the connector locally with the fix; `mvn dependency:tree` confirms
  `cloudwatchlogs`, `cloudwatch`, and `sdk-core` all resolve to 2.46.17.
- Built the connector container image, deployed it as a Lambda + Athena data
  catalog in a test account, and ran `athena list-databases` (the failing path:
  `doListSchemaNames` → `describeLogGroups`). It now returns log groups
  successfully; the `NoSuchMethodError` is gone.

## Note
This lands `cloudwatchlogs` on the current property value (2.46.17). A separate
follow-up could bump `aws-sdk-v2.version` repo-wide to the latest to move all
connectors to the newest SDK.
