### PR TITLE
bump pyOpenSSL to 26.4.0 for cryptography compatibility.

### DIFF
--- a/athena_federation_testing/requirements.txt
+++ b/athena_federation_testing/requirements.txt
@@ -40,7 +40,7 @@ PyJWT==2.13.0
 pymssql==2.3.7
 PyMySQL==1.1.1
 pyodbc==5.2.0
-pyOpenSSL==26.2.0
+pyOpenSSL==26.4.0
 python-dateutil==2.9.0.post0
 pytz==2025.2
 PyYAML==6.0.2


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
#3581 bumps `cryptography` to 50.0.0, but `pyOpenSSL==26.2.0` only allows `cryptography<49` (max 48.x), so `pip install -r requirements.txt` fails. This PR bumps `pyOpenSSL` to 26.4.0 (`cryptography>=49,<51`) to make it compatible with cryptography 50.0.0.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
