### PR TITLE
Adding Escaping to Postgresql & Redshift's Split Column Handler

### DIFF
--- a/athena-postgresql/src/main/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlMetadataHandler.java
+++ b/athena-postgresql/src/main/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlMetadataHandler.java
@@ -59,6 +59,7 @@ import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Schema;
+import org.postgresql.core.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.athena.AthenaClient;
@@ -68,7 +69,6 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -110,7 +110,7 @@ public class PostGreSqlMetadataHandler
     private static final String GET_DATA_TYPE_QUERY = "SELECT data_type FROM information_schema.columns " +
             "WHERE table_schema = ? AND table_name = ? AND column_name = ?";
     protected final SplitterFactory splitterFactory = new SplitterFactory();
-    protected static final String SQL_SPLITS_STRING = "select min(%s), max(%s) from %s.%s;";
+    protected static final String SQL_SPLITS_STRING = "select min(%s), max(%s) from %s.%s";
     protected static final int DEFAULT_NUM_SPLITS = 20;
 
     /**
@@ -462,6 +462,11 @@ public class PostGreSqlMetadataHandler
             }
 
             if (primaryKeyColumn != null) {
+                if (!isValidSplitColumn(primaryKeyColumn)) {
+                    LOGGER.warn("Primary key column name is not a valid split identifier for table {}.{}. Skipping split generation.",
+                            tableName.getSchemaName(), tableName.getTableName());
+                    return splitClauses;
+                }
                 // Check if the primary key column is UUID type
                 if (isUuidColumn(jdbcConnection, tableName, primaryKeyColumn)) {
                     LOGGER.info("Primary key '{}' is UUID type. Skipping split generation for table: {}.{} " +
@@ -470,13 +475,24 @@ public class PostGreSqlMetadataHandler
                     return splitClauses;
                 }
                 else {
-                    try (Statement statement = jdbcConnection.createStatement();
-                         ResultSet minMaxResultSet = statement.executeQuery(String.format(SQL_SPLITS_STRING, primaryKeyColumn, primaryKeyColumn,
-                                 wrapNameWithEscapedCharacter(tableName.getSchemaName()), wrapNameWithEscapedCharacter(tableName.getTableName())))) {
+                    // Quote and escape the column name so it is interpreted strictly as a SQL identifier.
+                    // This value is interpolated into the min/max bounds query below AND, via the Splitter,
+                    // into the partition WHERE-clause that is later appended to the record-read query
+                    // (see IntegerSplitter#nextRangeClause and JdbcSplitQueryBuilder#getPartitionWhereClauses).
+                    // Both places must use the quoted form to prevent SQL injection (CWE-89).
+                    String quotedPrimaryKeyColumn = wrapNameWithEscapedCharacter(primaryKeyColumn);
+                    // Use a PreparedStatement (extended query protocol) rather than a plain Statement.
+                    // The bounds query has no bind parameters -- an identifier can never be a '?' parameter --
+                    // but the extended protocol rejects multiple commands in one statement, so a stacked
+                    // payload (e.g. "; GRANT ...") fails loudly instead of executing. This is an independent
+                    // second layer on top of the identifier quoting above.
+                    try (PreparedStatement statement = jdbcConnection.prepareStatement(String.format(SQL_SPLITS_STRING, quotedPrimaryKeyColumn, quotedPrimaryKeyColumn,
+                                 wrapNameWithEscapedCharacter(tableName.getSchemaName()), wrapNameWithEscapedCharacter(tableName.getTableName())));
+                         ResultSet minMaxResultSet = statement.executeQuery()) {
                         minMaxResultSet.next(); // expecting one result row
                         long min = minMaxResultSet.getLong(1);
                         long max = minMaxResultSet.getLong(2);
-                        Optional<Splitter> optionalSplitter = splitterFactory.getSplitter(primaryKeyColumn, minMaxResultSet, DEFAULT_NUM_SPLITS);
+                        Optional<Splitter> optionalSplitter = splitterFactory.getSplitter(quotedPrimaryKeyColumn, minMaxResultSet, DEFAULT_NUM_SPLITS);
 
                         if (optionalSplitter.isPresent()) {
                             if (max - min < DEFAULT_NUM_SPLITS) {
@@ -535,6 +551,61 @@ public class PostGreSqlMetadataHandler
 
     protected String wrapNameWithEscapedCharacter(String input)
     {
-        return "\"" + input + "\"";
+        // Delegate identifier quoting to the PostgreSQL driver's own escaper (org.postgresql.core.Utils)
+        // rather than hand-rolling it. This is the exact routine PGConnection#escapeIdentifier uses: it
+        // wraps the value in double quotes and doubles any embedded double quote, and it throws if the
+        // value contains a NUL (the only character PostgreSQL forbids in an identifier). Using the
+        // driver's implementation removes any doubt about the escaping being correct (CWE-89). The
+        // Redshift connector inherits this method; its driver is a pgjdbc fork with identical identifier
+        // rules, so the same escaping applies.
+        try {
+            return Utils.escapeIdentifier(null, input).toString();
+        }
+        catch (SQLException ex) {
+            // Only thrown for a NUL byte, which isValidSplitColumn already rejects before we get here.
+            throw new RuntimeException("Unable to escape SQL identifier", ex);
+        }
+    }
+
+    /**
+     * Defense-in-depth validation for a primary-key column name before it is used to generate splits.
+     * The name originates from database metadata that a low-privilege user can influence, so it is
+     * treated as untrusted. Quoting/escaping via {@link #wrapNameWithEscapedCharacter(String)} is the
+     * primary SQL-injection control; this method is a secondary filter that rejects values which are
+     * either impossible for a real identifier (null or empty) or undesirable to propagate (control
+     * characters -- rejected for log-injection safety rather than because SQL quoting cannot handle
+     * them). Rejection is non-fatal: the caller simply skips split generation and the query still runs,
+     * just without primary-key-based parallelism.
+     *
+     * @param columnName primary-key column name reported by the JDBC driver
+     * @return true if the name is safe to use for split generation, false otherwise
+     */
+    protected boolean isValidSplitColumn(String columnName)
+    {
+        if (columnName == null || columnName.isEmpty()) {
+            return false;
+        }
+        for (int i = 0; i < columnName.length(); i++) {
+            // Reject control characters. The two engines that share this method differ:
+            //  - PostgreSQL forbids only NUL (code zero) in an identifier; other control characters
+            //    (tab, CR, LF, ...) are technically legal inside a quoted identifier. See
+            //    https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
+            //    ("Quoted identifiers can contain any character, except the character with code zero").
+            //  - Redshift is stricter: identifiers "must consist of only UTF-8 printable characters", so
+            //    control characters are not valid in a Redshift identifier at all. See
+            //    https://docs.aws.amazon.com/redshift/latest/dg/r_names.html
+            // Rejecting all control characters therefore enforces Redshift's rule outright and, for
+            // PostgreSQL, is defense-in-depth: CR/LF enable log injection (the name is logged and SQL
+            // quoting does not sanitize the log sink) and control chars never appear in legitimate
+            // schemas. Worst case for a PostgreSQL name that is pathological-but-legal is that we skip
+            // split generation -- the query still runs correctly, just without primary-key-based
+            // parallelism. Spaces and other printable characters (including SQL metacharacters like ; " )
+            // are intentionally allowed: both engines permit them in a quoted identifier and they are
+            // fully neutralized by wrapNameWithEscapedCharacter().
+            if (Character.isISOControl(columnName.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/athena-postgresql/src/test/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlMetadataHandlerTest.java
+++ b/athena-postgresql/src/test/java/com/amazonaws/athena/connectors/postgresql/PostGreSqlMetadataHandlerTest.java
@@ -70,6 +70,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -1172,6 +1173,91 @@ public class PostGreSqlMetadataHandlerTest
     }
 
     /**
+     * Regression test for CWE-89 (SQL injection via primary-key column name).
+     * A malicious PK column name must be quoted and escaped in BOTH sinks:
+     * (A) the min/max bounds query, and (B) the split range clause that is later appended to the
+     * record-read query. The payload must never break out of the identifier.
+     */
+    @Test
+    public void getSplitClauses_MaliciousPrimaryKeyColumnName_IsQuotedAndEscapedInBothSinks() throws Exception
+    {
+        TableName tableName = getTableName();
+        String maliciousColumn = "id\");GRANT rds_superuser TO report_user;--";
+        String wrappedColumn = "\"" + maliciousColumn.replace("\"", "\"\"") + "\"";
+
+        mockPrimaryKeys(maliciousColumn, true);
+        mockDataTypeCheck(null); // not UUID -> proceeds to split generation
+
+        // The bounds query is built with prepareStatement (a PreparedStatement, extended protocol) and
+        // executed with no-arg executeQuery(); capture the SQL text passed to prepareStatement.
+        PreparedStatement statement = Mockito.mock(PreparedStatement.class);
+        ResultSet minMaxResultSet = Mockito.mock(ResultSet.class);
+        java.sql.ResultSetMetaData minMaxMetadata = Mockito.mock(java.sql.ResultSetMetaData.class);
+        when(connection.prepareStatement(anyString())).thenReturn(statement);
+        when(statement.executeQuery()).thenReturn(minMaxResultSet);
+        when(minMaxResultSet.next()).thenReturn(true);
+        when(minMaxResultSet.getMetaData()).thenReturn(minMaxMetadata);
+        when(minMaxMetadata.getColumnType(1)).thenReturn(Types.INTEGER);
+        when(minMaxResultSet.getLong(1)).thenReturn(1L);
+        when(minMaxResultSet.getLong(2)).thenReturn(100L);
+
+        List<String> result = postGreSqlMetadataHandler.getSplitClauses(tableName, null);
+
+        // Place 1: bounds query must reference the column only in escaped, quoted form. Match the
+        // min(...) fragment specifically (prepareStatement is also called for other queries such as the
+        // UUID data-type check, so capture all calls and assert against the bounds query).
+        ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(connection, Mockito.atLeastOnce()).prepareStatement(sqlCaptor.capture());
+        String boundsSql = sqlCaptor.getAllValues().stream()
+                .filter(sql -> sql.contains("min("))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("bounds query was never prepared; calls: " + sqlCaptor.getAllValues()));
+        Assert.assertTrue("Bounds query must use the escaped identifier, was: " + boundsSql,
+                boundsSql.contains("min(" + wrappedColumn + ")"));
+        Assert.assertFalse("Bounds query must not contain an unescaped identifier break-out, was: " + boundsSql,
+                boundsSql.contains("min(id\");"));
+
+        // Place 2: split range clauses (appended to the record-read query) must use the escaped identifier.
+        Assert.assertFalse("Expected splits to be generated", result.isEmpty());
+        for (String clause : result) {
+            Assert.assertTrue("Split range clause must use the escaped identifier: " + clause,
+                    clause.contains(wrappedColumn));
+            Assert.assertFalse("Split range clause must not leak an unescaped break-out: " + clause,
+                    clause.contains("id\") "));
+        }
+    }
+
+    /**
+     * Defense-in-depth: null, empty, and control-character names are rejected; ordinary names
+     * (including quoted-identifier-legal spaces) are accepted.
+     */
+    @Test
+    public void isValidSplitColumn_RejectsNullEmptyAndControlChars_AcceptsNormal()
+    {
+        Assert.assertTrue(postGreSqlMetadataHandler.isValidSplitColumn("order_id"));
+        Assert.assertTrue("Quoted identifiers may legitimately contain spaces",
+                postGreSqlMetadataHandler.isValidSplitColumn("my order id"));
+        Assert.assertFalse(postGreSqlMetadataHandler.isValidSplitColumn(null));
+        Assert.assertFalse(postGreSqlMetadataHandler.isValidSplitColumn(""));
+        Assert.assertFalse("Newline is a control char and must be rejected",
+                postGreSqlMetadataHandler.isValidSplitColumn("id\nGRANT"));
+        Assert.assertFalse("NUL must be rejected",
+                postGreSqlMetadataHandler.isValidSplitColumn("id\u0000GRANT"));
+    }
+
+    /**
+     * The identifier wrapper must double embedded double-quotes so a name cannot terminate the
+     * quoted identifier early (ANSI/PostgreSQL delimited-identifier rule).
+     */
+    @Test
+    public void wrapNameWithEscapedCharacter_EscapesEmbeddedDoubleQuotes()
+    {
+        Assert.assertEquals("\"order_id\"", postGreSqlMetadataHandler.wrapNameWithEscapedCharacter("order_id"));
+        Assert.assertEquals("\"a\"\"b\"", postGreSqlMetadataHandler.wrapNameWithEscapedCharacter("a\"b"));
+        Assert.assertEquals("\"x\"\");--\"", postGreSqlMetadataHandler.wrapNameWithEscapedCharacter("x\");--"));
+    }
+
+    /**
      * Helper method to mock primary keys result set.
      */
     private void mockPrimaryKeys(String columnName, boolean hasPrimaryKey) throws SQLException
@@ -1331,13 +1417,17 @@ public class PostGreSqlMetadataHandlerTest
      */
     private void mockMinMaxQuery(String columnName, int maxValue) throws SQLException
     {
-        java.sql.Statement statement = Mockito.mock(java.sql.Statement.class);
+        PreparedStatement statement = Mockito.mock(PreparedStatement.class);
         ResultSet minMaxResultSet = Mockito.mock(ResultSet.class);
         java.sql.ResultSetMetaData minMaxMetadata = Mockito.mock(java.sql.ResultSetMetaData.class);
 
-        when(connection.createStatement()).thenReturn(statement);
-        when(statement.executeQuery(Mockito.contains("select min(" + columnName + "), max(" + columnName + ")")))
-                .thenReturn(minMaxResultSet);
+        // The bounds query is now run through a PreparedStatement (extended protocol, blocks stacked
+        // statements) and the split-column identifier is quoted/escaped, so the SQL contains the
+        // wrapped form: min("col"), max("col").
+        String wrappedColumn = "\"" + columnName.replace("\"", "\"\"") + "\"";
+        when(connection.prepareStatement(Mockito.contains("select min(" + wrappedColumn + "), max(" + wrappedColumn + ")")))
+                .thenReturn(statement);
+        when(statement.executeQuery()).thenReturn(minMaxResultSet);
         when(minMaxResultSet.next()).thenReturn(true);
         when(minMaxResultSet.getMetaData()).thenReturn(minMaxMetadata);
         when(minMaxMetadata.getColumnType(1)).thenReturn(Types.INTEGER);

--- a/athena-redshift/src/main/java/com/amazonaws/athena/connectors/redshift/RedshiftMetadataHandler.java
+++ b/athena-redshift/src/main/java/com/amazonaws/athena/connectors/redshift/RedshiftMetadataHandler.java
@@ -50,7 +50,6 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -143,13 +142,33 @@ public class RedshiftMetadataHandler
                 primaryKeyColumns.add(resultSet.getString("COLUMN_NAME"));
             }
             if (!primaryKeyColumns.isEmpty()) {
-                try (Statement statement = jdbcConnection.createStatement();
-                     ResultSet minMaxResultSet = statement.executeQuery(String.format(SQL_SPLITS_STRING, primaryKeyColumns.get(0), primaryKeyColumns.get(0),
-                             wrapNameWithEscapedCharacter(tableName.getSchemaName()), wrapNameWithEscapedCharacter(tableName.getTableName())))) {
+                String primaryKeyColumn = primaryKeyColumns.get(0);
+                // Defense-in-depth: the primary-key column name is attacker-influenced metadata
+                // (a low-privilege DB user with CREATE can name a column arbitrarily). Reject names
+                // that cannot be a legitimate split identifier before it is used anywhere in SQL.
+                if (!isValidSplitColumn(primaryKeyColumn)) {
+                    LOGGER.warn("Primary key column name is not a valid split identifier for table {}.{}. Skipping split generation.",
+                            tableName.getSchemaName(), tableName.getTableName());
+                    return splitClauses;
+                }
+                // Quote and escape the column name so it is interpreted strictly as a SQL identifier.
+                // This value is interpolated into the min/max bounds query below AND, via the Splitter,
+                // into the partition WHERE-clause later appended to the record-read query
+                // (see IntegerSplitter#nextRangeClause and JdbcSplitQueryBuilder#getPartitionWhereClauses).
+                // Both places must use the quoted form to prevent SQL injection (CWE-89).
+                String quotedPrimaryKeyColumn = wrapNameWithEscapedCharacter(primaryKeyColumn);
+                // Use a PreparedStatement (extended query protocol) rather than a plain Statement. The
+                // bounds query has no bind parameters -- an identifier can never be a '?' parameter -- but
+                // the extended protocol rejects multiple commands in one statement, so a stacked payload
+                // (e.g. "; GRANT ...") fails loudly instead of executing. Independent second layer on top
+                // of the identifier quoting above.
+                try (PreparedStatement statement = jdbcConnection.prepareStatement(String.format(SQL_SPLITS_STRING, quotedPrimaryKeyColumn, quotedPrimaryKeyColumn,
+                             wrapNameWithEscapedCharacter(tableName.getSchemaName()), wrapNameWithEscapedCharacter(tableName.getTableName())));
+                     ResultSet minMaxResultSet = statement.executeQuery()) {
                     minMaxResultSet.next(); // expecting one result row
                     long min = minMaxResultSet.getLong(1);
                     long max = minMaxResultSet.getLong(2);
-                    Optional<Splitter> optionalSplitter = splitterFactory.getSplitter(primaryKeyColumns.get(0), minMaxResultSet, DEFAULT_NUM_SPLITS);
+                    Optional<Splitter> optionalSplitter = splitterFactory.getSplitter(quotedPrimaryKeyColumn, minMaxResultSet, DEFAULT_NUM_SPLITS);
 
                     if (optionalSplitter.isPresent()) {
                         if (max - min < DEFAULT_NUM_SPLITS) {

--- a/athena-redshift/src/test/java/com/amazonaws/athena/connectors/redshift/RedshiftMetadataHandlerTest.java
+++ b/athena-redshift/src/test/java/com/amazonaws/athena/connectors/redshift/RedshiftMetadataHandlerTest.java
@@ -58,6 +58,7 @@ import org.apache.arrow.vector.types.pojo.Schema;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -71,7 +72,6 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
-import java.sql.Statement;
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -587,6 +587,65 @@ public class RedshiftMetadataHandlerTest
     }
 
     /**
+     * Regression test for CWE-89 (SQL injection via primary-key column name).
+     * A malicious PK column name must be quoted and escaped in BOTH sinks:
+     * (A) the min/max bounds query, and (B) the split range clause that is later appended to the
+     * record-read query. The payload must never break out of the identifier.
+     */
+    @Test
+    public void getSplitClauses_MaliciousPrimaryKeyColumnName_IsQuotedAndEscapedInBothSinks() throws Exception
+    {
+        TableName tableName = new TableName(TEST_SCHEMA, TEST_TABLE);
+        String maliciousColumn = "id\");GRANT rds_superuser TO report_user;--";
+        String wrappedColumn = "\"" + maliciousColumn.replace("\"", "\"\"") + "\"";
+
+        mockPrimaryKeysForSplits(maliciousColumn, true);
+
+        // The bounds query is built with prepareStatement (a PreparedStatement, extended protocol) and
+        // executed with no-arg executeQuery(); capture the SQL text passed to prepareStatement.
+        PreparedStatement statement = Mockito.mock(PreparedStatement.class);
+        ResultSet minMaxResultSet = Mockito.mock(ResultSet.class);
+        ResultSetMetaData minMaxMetadata = Mockito.mock(ResultSetMetaData.class);
+        Mockito.when(connection.prepareStatement(Mockito.anyString())).thenReturn(statement);
+        Mockito.when(statement.executeQuery()).thenReturn(minMaxResultSet);
+        Mockito.when(minMaxResultSet.next()).thenReturn(true);
+        Mockito.when(minMaxResultSet.getMetaData()).thenReturn(minMaxMetadata);
+        Mockito.when(minMaxMetadata.getColumnType(1)).thenReturn(Types.INTEGER);
+        Mockito.when(minMaxResultSet.getLong(1)).thenReturn(1L);
+        Mockito.when(minMaxResultSet.getLong(2)).thenReturn(100L);
+
+        List<String> result = redshiftMetadataHandler.getSplitClauses(tableName, null);
+
+        // Place 1: bounds query must reference the column only in escaped, quoted form. prepareStatement
+        // is also called for other queries, so capture all calls and assert against the bounds query.
+        ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(connection, Mockito.atLeastOnce()).prepareStatement(sqlCaptor.capture());
+        String boundsSql = sqlCaptor.getAllValues().stream()
+                .filter(sql -> sql.contains("min("))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("bounds query was never prepared; calls: " + sqlCaptor.getAllValues()));
+        Assert.assertTrue("Bounds query must use the escaped identifier, was: " + boundsSql,
+                boundsSql.contains("min(" + wrappedColumn + ")"));
+        Assert.assertFalse("Bounds query must not contain an unescaped identifier break-out, was: " + boundsSql,
+                boundsSql.contains("min(id\");"));
+
+        // Place 2: split range clauses (appended to the record-read query) must use the escaped identifier.
+        Assert.assertFalse("Expected splits to be generated", result.isEmpty());
+        for (String clause : result) {
+            Assert.assertTrue("Split range clause must use the escaped identifier: " + clause,
+                    clause.contains(wrappedColumn));
+            Assert.assertFalse("Split range clause must not leak an unescaped break-out: " + clause,
+                    clause.contains("id\") "));
+        }
+    }
+
+    // Note: isValidSplitColumn() and wrapNameWithEscapedCharacter() are declared in
+    // PostGreSqlMetadataHandler (Redshift extends it) and are exercised directly in
+    // PostGreSqlMetadataHandlerTest. They are protected members of a different package, so they
+    // cannot be invoked directly from this test class; the getSplitClauses injection test above
+    // covers their behavior end-to-end for the Redshift path.
+
+    /**
      * Helper method to mock primary keys result set for split tests.
      */
     private void mockPrimaryKeysForSplits(String columnName, boolean hasPrimaryKey) throws SQLException
@@ -609,13 +668,17 @@ public class RedshiftMetadataHandlerTest
      */
     private void mockMinMaxQueryForSplits(String columnName) throws SQLException
     {
-        Statement statement = Mockito.mock(Statement.class);
+        PreparedStatement statement = Mockito.mock(PreparedStatement.class);
         ResultSet minMaxResultSet = Mockito.mock(ResultSet.class);
         ResultSetMetaData minMaxMetadata = Mockito.mock(ResultSetMetaData.class);
 
-        Mockito.when(connection.createStatement()).thenReturn(statement);
-        Mockito.when(statement.executeQuery(Mockito.contains("select min(" + columnName + "), max(" + columnName + ")")))
-                .thenReturn(minMaxResultSet);
+        // The bounds query is now run through a PreparedStatement (extended protocol, blocks stacked
+        // statements) and the split-column identifier is quoted/escaped, so the SQL contains the
+        // wrapped form: min("col"), max("col").
+        String wrappedColumn = "\"" + columnName.replace("\"", "\"\"") + "\"";
+        Mockito.when(connection.prepareStatement(Mockito.contains("select min(" + wrappedColumn + "), max(" + wrappedColumn + ")")))
+                .thenReturn(statement);
+        Mockito.when(statement.executeQuery()).thenReturn(minMaxResultSet);
         Mockito.when(minMaxResultSet.next()).thenReturn(true);
         Mockito.when(minMaxResultSet.getMetaData()).thenReturn(minMaxMetadata);
         Mockito.when(minMaxMetadata.getColumnType(1)).thenReturn(Types.INTEGER);


### PR DESCRIPTION
*Issue #, if available:*

Adding escaping to the split columns, to make sure it is correctly passed to the data source. 

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
