### PR TITLE
athena-datalakegen2: Substrait query-plan rendering and credential federation for managed-connector mode

### DIFF
--- a/athena-datalakegen2/src/main/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2Dialect.java
+++ b/athena-datalakegen2/src/main/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2Dialect.java
@@ -1,0 +1,54 @@
+/*-
+ * #%L
+ * athena-datalakegen2
+ * %%
+ * Copyright (C) 2019 - 2026 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.datalakegen2;
+
+import org.apache.calcite.sql.SqlDialect;
+import org.apache.calcite.sql.dialect.MssqlSqlDialect;
+
+import java.util.Locale;
+
+/**
+ * Azure Data Lake Storage Gen2-specific SQL dialect with catalog casing filter support. DataLake Gen2 is
+ * accessed over a Microsoft SQL Server (T-SQL) compatible endpoint via the SQL Server JDBC driver, so it
+ * renders Substrait-derived query plans with the Calcite MSSQL dialect and uses square brackets ({@code []})
+ * for identifier quoting. When the catalog casing filter is enabled, identifiers are upper-cased before quoting.
+ */
+public class DataLakeGen2Dialect extends MssqlSqlDialect
+{
+    public static final SqlDialect DEFAULT = MssqlSqlDialect.DEFAULT;
+
+    private final boolean catalogCasingFilter;
+
+    public DataLakeGen2Dialect(boolean catalogCasingFilter)
+    {
+        super(DEFAULT_CONTEXT);
+        this.catalogCasingFilter = catalogCasingFilter;
+    }
+
+    @Override
+    public StringBuilder quoteIdentifier(StringBuilder buf, String identifier)
+    {
+        if (catalogCasingFilter) {
+            String upper = identifier.toUpperCase(Locale.ROOT);
+            return buf.append("[").append(upper.replace("]", "]]")).append("]");
+        }
+        return super.quoteIdentifier(buf, identifier);
+    }
+}

--- a/athena-datalakegen2/src/main/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2MetadataHandler.java
+++ b/athena-datalakegen2/src/main/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2MetadataHandler.java
@@ -22,6 +22,7 @@ package com.amazonaws.athena.connectors.datalakegen2;
 import com.amazonaws.athena.connector.credentials.CredentialsProvider;
 import com.amazonaws.athena.connector.credentials.CredentialsProviderFactory;
 import com.amazonaws.athena.connector.lambda.QueryStatusChecker;
+import com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants;
 import com.amazonaws.athena.connector.lambda.data.Block;
 import com.amazonaws.athena.connector.lambda.data.BlockAllocator;
 import com.amazonaws.athena.connector.lambda.data.BlockWriter;
@@ -191,8 +192,17 @@ public class DataLakeGen2MetadataHandler extends JdbcMetadataHandler
         }
         // Always create single split
         Set<Split> splits = new HashSet<>();
-        splits.add(Split.newBuilder(makeSpillLocation(getSplitsRequest), makeEncryptionKey())
-                .add(PARTITION_NUMBER, "0").build());
+        Split.Builder splitBuilder = Split.newBuilder(makeSpillLocation(getSplitsRequest), makeEncryptionKey(getRequestOverrideConfig(getSplitsRequest)))
+                .add(PARTITION_NUMBER, "0");
+
+        Map<String, String> identityConfigOptions = getSplitsRequest.getIdentity().getConfigOptions();
+        if (identityConfigOptions != null && identityConfigOptions.containsKey(EnvironmentConstants.CATALOG_CASING_FILTER)) {
+            String catalogCasingFilter = identityConfigOptions.get(EnvironmentConstants.CATALOG_CASING_FILTER);
+            LOGGER.info("Catalog Casing Filter found: {}", catalogCasingFilter);
+            splitBuilder.add(EnvironmentConstants.CATALOG_CASING_FILTER, catalogCasingFilter);
+        }
+
+        splits.add(splitBuilder.build());
         return new GetSplitsResponse(getSplitsRequest.getCatalogName(), splits, null);
     }
 

--- a/athena-datalakegen2/src/main/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2QueryStringBuilder.java
+++ b/athena-datalakegen2/src/main/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2QueryStringBuilder.java
@@ -24,6 +24,7 @@ import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
 import com.amazonaws.athena.connectors.jdbc.manager.FederationExpressionParser;
 import com.amazonaws.athena.connectors.jdbc.manager.JdbcSplitQueryBuilder;
 import com.google.common.base.Strings;
+import org.apache.calcite.sql.SqlDialect;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,5 +70,17 @@ public class DataLakeGen2QueryStringBuilder extends JdbcSplitQueryBuilder
     protected String appendLimitOffset(Split split, Constraints constraints)
     {
         return emptyString;
+    }
+
+    @Override
+    protected SqlDialect getSqlDialect()
+    {
+        return DataLakeGen2Dialect.DEFAULT;
+    }
+
+    @Override
+    protected SqlDialect getSqlDialect(boolean catalogCasingFilterUpperCase)
+    {
+        return new DataLakeGen2Dialect(catalogCasingFilterUpperCase);
     }
 }

--- a/athena-datalakegen2/src/main/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2RecordHandler.java
+++ b/athena-datalakegen2/src/main/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2RecordHandler.java
@@ -110,7 +110,7 @@ public class DataLakeGen2RecordHandler extends JdbcRecordHandler
         LOGGER.info("{}: Catalog: {}, table {}, splits {}", readRecordsRequest.getQueryId(), readRecordsRequest.getCatalogName(), readRecordsRequest.getTableName(),
                 readRecordsRequest.getSplit().getProperties());
 
-        try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider())) {
+        try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider(getRequestOverrideConfig(readRecordsRequest)))) {
             String environment = DataLakeGen2Util.checkEnvironment(connection.getMetaData().getURL());
             if (!DataLakeGen2Constants.SQL_POOL.equalsIgnoreCase(environment)) {
                 // For consistency. This is needed to be false to enable streaming for some database types.

--- a/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2DialectTest.java
+++ b/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2DialectTest.java
@@ -1,0 +1,78 @@
+/*-
+ * #%L
+ * athena-datalakegen2
+ * %%
+ * Copyright (C) 2019 - 2026 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.datalakegen2;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class DataLakeGen2DialectTest
+{
+    @Test
+    void testDefaultDialect()
+    {
+        assertNotNull(DataLakeGen2Dialect.DEFAULT);
+    }
+
+    @Test
+    void testQuoteIdentifierWithFilter()
+    {
+        DataLakeGen2Dialect dialect = new DataLakeGen2Dialect(true);
+        StringBuilder buf = new StringBuilder();
+        dialect.quoteIdentifier(buf, "employees");
+        assertEquals("[EMPLOYEES]", buf.toString());
+    }
+
+    @Test
+    void testQuoteIdentifierWithoutFilter()
+    {
+        DataLakeGen2Dialect dialect = new DataLakeGen2Dialect(false);
+        StringBuilder buf = new StringBuilder();
+        dialect.quoteIdentifier(buf, "employees");
+        assertEquals("[employees]", buf.toString());
+    }
+
+    @Test
+    void testQuoteIdentifierWithFilterUpperCasesMixedCaseInput()
+    {
+        DataLakeGen2Dialect dialect = new DataLakeGen2Dialect(true);
+        StringBuilder buf = new StringBuilder();
+        dialect.quoteIdentifier(buf, "Employees");
+        assertEquals("[EMPLOYEES]", buf.toString());
+    }
+
+    @Test
+    void testQuoteIdentifierWithoutFilterPreservesUpperCaseInput()
+    {
+        DataLakeGen2Dialect dialect = new DataLakeGen2Dialect(false);
+        StringBuilder buf = new StringBuilder();
+        dialect.quoteIdentifier(buf, "EMPLOYEES");
+        assertEquals("[EMPLOYEES]", buf.toString());
+    }
+
+    @Test
+    void testQuoteIdentifierWithFilterEscapesClosingBracket()
+    {
+        DataLakeGen2Dialect dialect = new DataLakeGen2Dialect(true);
+        StringBuilder buf = new StringBuilder();
+        dialect.quoteIdentifier(buf, "emp]loyees");
+        assertEquals("[EMP]]LOYEES]", buf.toString());
+    }
+}

--- a/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2MetadataHandlerTest.java
+++ b/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2MetadataHandlerTest.java
@@ -20,6 +20,7 @@
 package com.amazonaws.athena.connectors.datalakegen2;
 
 import com.amazonaws.athena.connector.credentials.CredentialsProvider;
+import com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants;
 import com.amazonaws.athena.connector.lambda.data.Block;
 import com.amazonaws.athena.connector.lambda.data.BlockAllocator;
 import com.amazonaws.athena.connector.lambda.data.BlockAllocatorImpl;
@@ -219,6 +220,39 @@ public class DataLakeGen2MetadataHandlerTest
         assertEquals(expectedSplits.size(), getSplitsResponse.getSplits().size());
         Set<Map<String, String>> actualSplits = getSplitsResponse.getSplits().stream().map(Split::getProperties).collect(Collectors.toSet());
         assertEquals(expectedSplits, actualSplits);
+    }
+
+    @Test
+    public void doGetSplits_WithCatalogCasingFilter_PropagatesToSplit()
+            throws Exception
+    {
+        BlockAllocator blockAllocator = new BlockAllocatorImpl();
+        Constraints constraints = new Constraints(
+                Collections.emptyMap(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Constraints.DEFAULT_NO_LIMIT,
+                Collections.emptyMap(),
+                null
+        );
+        TableName tableName = new TableName("testSchema", "testTable");
+
+        Schema partitionSchema = this.dataLakeGen2MetadataHandler.getPartitionSchema("testCatalogName");
+        Set<String> partitionCols = partitionSchema.getFields().stream().map(Field::getName).collect(Collectors.toSet());
+        GetTableLayoutRequest getTableLayoutRequest = new GetTableLayoutRequest(this.federatedIdentity, "testQueryId", "testCatalogName", tableName, constraints, partitionSchema, partitionCols);
+        GetTableLayoutResponse getTableLayoutResponse = this.dataLakeGen2MetadataHandler.doGetTableLayout(blockAllocator, getTableLayoutRequest);
+
+        when(this.federatedIdentity.getConfigOptions()).thenReturn(
+                Collections.singletonMap(EnvironmentConstants.CATALOG_CASING_FILTER, EnvironmentConstants.UPPERCASE_ONLY));
+
+        BlockAllocator splitBlockAllocator = new BlockAllocatorImpl();
+        GetSplitsRequest getSplitsRequest = new GetSplitsRequest(this.federatedIdentity, "testQueryId", "testCatalogName", tableName, getTableLayoutResponse.getPartitions(), new ArrayList<>(partitionCols), constraints, null);
+        GetSplitsResponse getSplitsResponse = this.dataLakeGen2MetadataHandler.doGetSplits(splitBlockAllocator, getSplitsRequest);
+
+        assertEquals(1, getSplitsResponse.getSplits().size());
+        Split split = getSplitsResponse.getSplits().iterator().next();
+        assertEquals("0", split.getProperty(PARTITION_NUMBER));
+        assertEquals(EnvironmentConstants.UPPERCASE_ONLY, split.getProperty(EnvironmentConstants.CATALOG_CASING_FILTER));
     }
 
     @Test

--- a/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2MetadataHandlerTest.java
+++ b/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeGen2MetadataHandlerTest.java
@@ -256,6 +256,70 @@ public class DataLakeGen2MetadataHandlerTest
     }
 
     @Test
+    public void doGetSplits_WithConfigOptionsButNoCasingFilter_DoesNotAddCasingProperty()
+            throws Exception
+    {
+        BlockAllocator blockAllocator = new BlockAllocatorImpl();
+        Constraints constraints = new Constraints(
+                Collections.emptyMap(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Constraints.DEFAULT_NO_LIMIT,
+                Collections.emptyMap(),
+                null
+        );
+        TableName tableName = new TableName("testSchema", "testTable");
+
+        Schema partitionSchema = this.dataLakeGen2MetadataHandler.getPartitionSchema("testCatalogName");
+        Set<String> partitionCols = partitionSchema.getFields().stream().map(Field::getName).collect(Collectors.toSet());
+        GetTableLayoutRequest getTableLayoutRequest = new GetTableLayoutRequest(this.federatedIdentity, "testQueryId", "testCatalogName", tableName, constraints, partitionSchema, partitionCols);
+        GetTableLayoutResponse getTableLayoutResponse = this.dataLakeGen2MetadataHandler.doGetTableLayout(blockAllocator, getTableLayoutRequest);
+
+        when(this.federatedIdentity.getConfigOptions()).thenReturn(Collections.singletonMap("someOtherKey", "someValue"));
+
+        BlockAllocator splitBlockAllocator = new BlockAllocatorImpl();
+        GetSplitsRequest getSplitsRequest = new GetSplitsRequest(this.federatedIdentity, "testQueryId", "testCatalogName", tableName, getTableLayoutResponse.getPartitions(), new ArrayList<>(partitionCols), constraints, null);
+        GetSplitsResponse getSplitsResponse = this.dataLakeGen2MetadataHandler.doGetSplits(splitBlockAllocator, getSplitsRequest);
+
+        assertEquals(1, getSplitsResponse.getSplits().size());
+        Split split = getSplitsResponse.getSplits().iterator().next();
+        assertEquals("0", split.getProperty(PARTITION_NUMBER));
+        assertFalse(split.getProperties().containsKey(EnvironmentConstants.CATALOG_CASING_FILTER));
+    }
+
+    @Test
+    public void doGetSplits_WithNullConfigOptions_DoesNotAddCasingProperty()
+            throws Exception
+    {
+        BlockAllocator blockAllocator = new BlockAllocatorImpl();
+        Constraints constraints = new Constraints(
+                Collections.emptyMap(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Constraints.DEFAULT_NO_LIMIT,
+                Collections.emptyMap(),
+                null
+        );
+        TableName tableName = new TableName("testSchema", "testTable");
+
+        Schema partitionSchema = this.dataLakeGen2MetadataHandler.getPartitionSchema("testCatalogName");
+        Set<String> partitionCols = partitionSchema.getFields().stream().map(Field::getName).collect(Collectors.toSet());
+        GetTableLayoutRequest getTableLayoutRequest = new GetTableLayoutRequest(this.federatedIdentity, "testQueryId", "testCatalogName", tableName, constraints, partitionSchema, partitionCols);
+        GetTableLayoutResponse getTableLayoutResponse = this.dataLakeGen2MetadataHandler.doGetTableLayout(blockAllocator, getTableLayoutRequest);
+
+        when(this.federatedIdentity.getConfigOptions()).thenReturn(null);
+
+        BlockAllocator splitBlockAllocator = new BlockAllocatorImpl();
+        GetSplitsRequest getSplitsRequest = new GetSplitsRequest(this.federatedIdentity, "testQueryId", "testCatalogName", tableName, getTableLayoutResponse.getPartitions(), new ArrayList<>(partitionCols), constraints, null);
+        GetSplitsResponse getSplitsResponse = this.dataLakeGen2MetadataHandler.doGetSplits(splitBlockAllocator, getSplitsRequest);
+
+        assertEquals(1, getSplitsResponse.getSplits().size());
+        Split split = getSplitsResponse.getSplits().iterator().next();
+        assertEquals("0", split.getProperty(PARTITION_NUMBER));
+        assertFalse(split.getProperties().containsKey(EnvironmentConstants.CATALOG_CASING_FILTER));
+    }
+
+    @Test
     public void doGetTable()
             throws Exception
     {

--- a/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeQueryStringBuilderTest.java
+++ b/athena-datalakegen2/src/test/java/com/amazonaws/athena/connectors/datalakegen2/DataLakeQueryStringBuilderTest.java
@@ -21,6 +21,8 @@ package com.amazonaws.athena.connectors.datalakegen2;
 
 import com.amazonaws.athena.connector.lambda.domain.Split;
 import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
+import org.apache.calcite.sql.SqlDialect;
+import org.apache.calcite.sql.dialect.MssqlSqlDialect;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.testng.Assert;
@@ -72,5 +74,21 @@ public class DataLakeQueryStringBuilderTest
                 null
         );
         org.testng.Assert.assertEquals("", builder.appendLimitOffset(split, constraints));
+    }
+
+    @Test
+    public void testGetSqlDialectReturnsMssqlDialect()
+    {
+        DataLakeGen2QueryStringBuilder builder = new DataLakeGen2QueryStringBuilder(QUOTE_CHARACTER, new DataLakeGen2FederationExpressionParser(QUOTE_CHARACTER));
+        SqlDialect dialect = builder.getSqlDialect();
+        Assert.assertTrue(dialect instanceof MssqlSqlDialect);
+    }
+
+    @Test
+    public void testGetSqlDialectWithCasingFilterReturnsDataLakeGen2Dialect()
+    {
+        DataLakeGen2QueryStringBuilder builder = new DataLakeGen2QueryStringBuilder(QUOTE_CHARACTER, new DataLakeGen2FederationExpressionParser(QUOTE_CHARACTER));
+        SqlDialect dialect = builder.getSqlDialect(true);
+        Assert.assertTrue(dialect instanceof DataLakeGen2Dialect);
     }
 }


### PR DESCRIPTION
### Description
Enables query federation (managed-connector) mode for the Athena DataLake Gen2 connector, bringing it in line with the JDBC base connector's Substrait rendering and credential federation support. DataLake Gen2 is accessed over a Microsoft SQL Server (T-SQL) compatible endpoint via the SQL Server JDBC driver, so Substrait-derived query plans must render with the Calcite MSSQL dialect (square-bracket `[]` identifier quoting), and record reads must use federated credentials and customer-KMS spill encryption.

### Changes
- **`DataLakeGen2Dialect`** (new): extends Calcite `MssqlSqlDialect`; renders identifiers with square brackets and upper-cases them when the catalog casing filter is enabled.
- **`DataLakeGen2QueryStringBuilder`**: overrides `getSqlDialect()` and `getSqlDialect(boolean)` to return the MSSQL dialect (the base default is ANSI), so Substrait plans render with correct T-SQL syntax.
- **`DataLakeGen2MetadataHandler.doGetSplits`**: uses `makeEncryptionKey(getRequestOverrideConfig(...))` for customer-KMS spill encryption and propagates `CATALOG_CASING_FILTER` into the split.
- **`DataLakeGen2RecordHandler.readWithConstraint`**: obtains the JDBC connection via `getCredentialProvider(getRequestOverrideConfig(request))` so federated credentials are used.

### Testing
- `mvn -pl athena-datalakegen2 test` -> BUILD SUCCESS, **78 tests, 0 failures** (JDK 17).
- New/expanded unit tests:
  - `DataLakeGen2DialectTest` - identifier quoting with/without the casing filter, upper-casing of mixed-case input, and `]` escaping.
  - `DataLakeQueryStringBuilderTest` - `getSqlDialect()` returns an MSSQL dialect; `getSqlDialect(true)` returns the DataLake Gen2 dialect.
  - `DataLakeGen2MetadataHandlerTest` - `doGetSplits` propagates `CATALOG_CASING_FILTER` into the split.
- No behavior change for existing (non-federated) code paths; all pre-existing tests continue to pass.

### Notes
`createCredentialsProvider` already forwards `requestOverrideConfiguration`, so no change was needed there.
