### PR TITLE
Snowflake p2: authentication and credential retrieval

### DIFF
--- a/athena-snowflake/pom.xml
+++ b/athena-snowflake/pom.xml
@@ -17,6 +17,12 @@
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
+            <artifactId>aws-athena-federation-sdk</artifactId>
+            <version>2022.47.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
             <artifactId>athena-jdbc</artifactId>
             <version>2022.47.1</version>
         </dependency>

--- a/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeConstants.java
+++ b/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeConstants.java
@@ -89,6 +89,8 @@ public final class SnowflakeConstants
      */
     public static final String USERNAME = "username";
     public static final String PASSWORD = "password";
+    public static final String USERNAME_UPPERCASE = "USERNAME";
+    public static final String PASSWORD_UPPERCASE = "PASSWORD";
     public static final String USER = "user";
 
     /**

--- a/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeCredentialsProvider.java
+++ b/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeCredentialsProvider.java
@@ -28,8 +28,10 @@ import com.amazonaws.athena.connectors.snowflake.utils.SnowflakeAuthUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.annotations.VisibleForTesting;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.services.glue.model.ErrorDetails;
 import software.amazon.awssdk.services.glue.model.FederationSourceErrorCode;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
@@ -61,7 +63,7 @@ import static com.amazonaws.athena.connectors.snowflake.utils.SnowflakeAuthUtils
 public class SnowflakeCredentialsProvider implements CredentialsProvider
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(SnowflakeCredentialsProvider.class);
-    
+
     public static final String ACCESS_TOKEN = "access_token";
     public static final String FETCHED_AT = "fetched_at";
     public static final String REFRESH_TOKEN = "refresh_token";
@@ -69,18 +71,25 @@ public class SnowflakeCredentialsProvider implements CredentialsProvider
     private final String oauthSecretName;
     private final CachableSecretsManager secretsManager;
     private final ObjectMapper objectMapper;
+    private final AwsRequestOverrideConfiguration requestOverrideConfiguration;
 
     public SnowflakeCredentialsProvider(String oauthSecretName)
     {
-        this(oauthSecretName, SecretsManagerClient.create());
+        this(oauthSecretName, SecretsManagerClient.create(), null);
+    }
+
+    public SnowflakeCredentialsProvider(String oauthSecretName, AwsRequestOverrideConfiguration requestOverrideConfiguration)
+    {
+        this(oauthSecretName, SecretsManagerClient.create(), requestOverrideConfiguration);
     }
 
     @VisibleForTesting
-    public SnowflakeCredentialsProvider(String oauthSecretName, SecretsManagerClient secretsClient)
+    public SnowflakeCredentialsProvider(String oauthSecretName, SecretsManagerClient secretsClient, AwsRequestOverrideConfiguration requestOverrideConfiguration)
     {
         this.oauthSecretName = Validate.notNull(oauthSecretName, "oauthSecretName must not be null");
         this.secretsManager = new CachableSecretsManager(secretsClient);
         this.objectMapper = new ObjectMapper();
+        this.requestOverrideConfiguration = requestOverrideConfiguration;
     }
 
     @Override
@@ -97,9 +106,9 @@ public class SnowflakeCredentialsProvider implements CredentialsProvider
     public Map<String, String> getCredentialMap()
     {
         try {
-            String secretString = secretsManager.getSecret(oauthSecretName);
+            String secretString = secretsManager.getSecret(oauthSecretName, this.requestOverrideConfiguration);
             Map<String, String> secretMap = objectMapper.readValue(secretString, Map.class);
-            
+
             // Determine authentication type based on secret contents
             SnowflakeAuthType authType = SnowflakeAuthUtils.determineAuthType(secretMap);
             // Validate credentials once after determining auth type
@@ -116,6 +125,14 @@ public class SnowflakeCredentialsProvider implements CredentialsProvider
                     // Password authentication (backward compatible)
                     return handlePasswordAuthentication(secretMap);
             }
+        }
+        catch (IllegalArgumentException ex) {
+            // Client configuration errors — propagate without wrapping
+            throw ex;
+        }
+        catch (AthenaConnectorException ex) {
+            // Already properly typed (e.g., invalid private key format)
+            throw ex;
         }
         catch (Exception ex) {
             throw new RuntimeException("Error retrieving Snowflake credentials: " + ex.getMessage(), ex);
@@ -158,7 +175,11 @@ public class SnowflakeCredentialsProvider implements CredentialsProvider
     {
         Map<String, String> credentialMap = new HashMap<>();
         credentialMap.put(SnowflakeConstants.USER, getUsername(oauthConfig));
-        credentialMap.put(SnowflakeConstants.PASSWORD, oauthConfig.get(SnowflakeConstants.PASSWORD));
+        String password = oauthConfig.getOrDefault(SnowflakeConstants.PASSWORD, oauthConfig.get(SnowflakeConstants.PASSWORD_UPPERCASE));
+        if (password == null) {
+            throw new IllegalArgumentException("Missing required parameter: password/PASSWORD");
+        }
+        credentialMap.put(SnowflakeConstants.PASSWORD, password);
         LOGGER.debug("Using password authentication for user: {}", getUsername(oauthConfig));
         return credentialMap;
     }
@@ -186,6 +207,7 @@ public class SnowflakeCredentialsProvider implements CredentialsProvider
             secretsManager.getSecretsManager().putSecretValue(builder -> builder
                     .secretId(this.oauthSecretName)
                     .secretString(updatedSecretString)
+                    .overrideConfiguration(this.requestOverrideConfiguration)
                     .build());
         }
         catch (Exception e) {
@@ -197,11 +219,11 @@ public class SnowflakeCredentialsProvider implements CredentialsProvider
     private String fetchAccessTokenFromSecret(Map<String, String> oauthConfig) throws Exception
     {
         String accessToken;
-        String clientId = Validate.notNull(oauthConfig.get(SnowflakeConstants.CLIENT_ID), "Missing required property: client_id");
-        String tokenEndpoint = Validate.notNull(oauthConfig.get(SnowflakeConstants.TOKEN_URL), "Missing required property: token_url");
-        String redirectUri = Validate.notNull(oauthConfig.get(SnowflakeConstants.REDIRECT_URI), "Missing required property: redirect_uri");
-        String clientSecret = Validate.notNull(oauthConfig.get(SnowflakeConstants.CLIENT_SECRET), "Missing required property: client_secret");
-        String authCode = Validate.notNull(oauthConfig.get(SnowflakeConstants.AUTH_CODE), "Missing required property: auth_code");
+        String clientId = requireNonBlank(oauthConfig.get(SnowflakeConstants.CLIENT_ID), "Missing required property: client_id");
+        String tokenEndpoint = requireNonBlank(oauthConfig.get(SnowflakeConstants.TOKEN_URL), "Missing required property: token_url");
+        String redirectUri = requireNonBlank(oauthConfig.get(SnowflakeConstants.REDIRECT_URI), "Missing required property: redirect_uri");
+        String clientSecret = requireNonBlank(oauthConfig.get(SnowflakeConstants.CLIENT_SECRET), "Missing required property: client_secret");
+        String authCode = requireNonBlank(oauthConfig.get(SnowflakeConstants.AUTH_CODE), "Missing required property: auth_code");
 
         accessToken = loadTokenFromSecretsManager(oauthConfig);
 
@@ -271,6 +293,14 @@ public class SnowflakeCredentialsProvider implements CredentialsProvider
         ObjectNode tokenJson = objectMapper.readValue(response, ObjectNode.class);
         tokenJson.put(FETCHED_AT, System.currentTimeMillis() / 1000);
         return tokenJson;
+    }
+
+    private String requireNonBlank(String value, String message)
+    {
+        if (StringUtils.isBlank(value)) {
+            throw new IllegalArgumentException(message);
+        }
+        return value;
     }
 
     static HttpURLConnection getHttpURLConnection(String tokenEndpoint, String clientId, String clientSecret) throws IOException

--- a/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/connection/SnowflakeConnectionFactory.java
+++ b/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/connection/SnowflakeConnectionFactory.java
@@ -24,12 +24,12 @@ import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionConfig;
 import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionInfo;
 import com.amazonaws.athena.connectors.jdbc.connection.GenericJdbcConnectionFactory;
 import com.amazonaws.athena.connectors.snowflake.SnowflakeConstants;
-import com.amazonaws.athena.connectors.snowflake.utils.SnowflakeAuthType;
 import com.amazonaws.athena.connectors.snowflake.utils.SnowflakeAuthUtils;
-import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
@@ -43,101 +43,117 @@ import static com.amazonaws.athena.connectors.snowflake.SnowflakeConstants.USER;
 import static com.amazonaws.athena.connectors.snowflake.utils.SnowflakeAuthType.SNOWFLAKE_JWT;
 
 /**
- * Custom connection factory for Snowflake that supports key-pair authentication.
- * Extends GenericJdbcConnectionFactory to handle Snowflake-specific authentication methods.
+ * Custom connection factory for Snowflake that supports multiple authentication methods.
+ * <p>
+ * For JWT (key-pair) auth: uses {@link DriverManager} directly because HikariCP
+ * stringifies all property values via {@code toString()}, which breaks the
+ * {@link java.security.PrivateKey} object required by the Snowflake JDBC driver.
+ * <p>
+ * For password/OAuth auth: always uses HikariCP connection pooling via
+ * {@link GenericJdbcConnectionFactory#getConnectionFromManagedPool}, bypassing
+ * the parent's direct-connection path even when {@code fas_token} is present.
+ * <p>
+ * The Snowflake JDBC driver's {@code SnowflakeConnectString.parse()} URL-decodes
+ * query parameters internally, so both {@code %22} and literal {@code "} in the
+ * connection string work correctly for case-sensitive identifiers.
  */
 public class SnowflakeConnectionFactory extends GenericJdbcConnectionFactory
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(SnowflakeConnectionFactory.class);
-    private final DatabaseConnectionInfo databaseConnectionInfo;
-    private final DatabaseConnectionConfig databaseConnectionConfig;
-    private final Properties jdbcProperties;
 
-    /**
-     * @param databaseConnectionConfig database connection configuration {@link DatabaseConnectionConfig}
-     * @param properties JDBC connection properties.
-     * @param databaseConnectionInfo Contains JDBC driver and default port details.
-     */
     public SnowflakeConnectionFactory(DatabaseConnectionConfig databaseConnectionConfig, Map<String, String> properties, DatabaseConnectionInfo databaseConnectionInfo)
     {
-        super(databaseConnectionConfig, properties, databaseConnectionInfo);
-        this.databaseConnectionInfo = Validate.notNull(databaseConnectionInfo, "databaseConnectionInfo must not be null");
-        this.databaseConnectionConfig = Validate.notNull(databaseConnectionConfig, "databaseConnectionConfig must not be null");
-        this.jdbcProperties = new Properties();
-        if (properties != null) {
-            this.jdbcProperties.putAll(properties);
-        }
+        this(databaseConnectionConfig, properties, databaseConnectionInfo, null);
+    }
+
+    public SnowflakeConnectionFactory(DatabaseConnectionConfig databaseConnectionConfig, Map<String, String> properties, DatabaseConnectionInfo databaseConnectionInfo, final Map<String, String> configOptions)
+    {
+        super(databaseConnectionConfig, properties, databaseConnectionInfo, configOptions);
     }
 
     @Override
     public Connection getConnection(CredentialsProvider credentialsProvider) throws Exception
     {
         if (credentialsProvider == null) {
-            // Fall back to parent implementation for no credentials
-            return super.getConnection(null);
+            return super.getConnectionFromManagedPool(null);
         }
-
-        Map<String, String> credentialMap = credentialsProvider.getCredentialMap();
-        SnowflakeAuthType authType = SnowflakeAuthUtils.determineAuthType(credentialMap);
-
-        if (SNOWFLAKE_JWT.equals(authType)) {
-            // Handle key-pair authentication
-            return getKeyPairConnection(credentialMap);
+        else if (SNOWFLAKE_JWT.equals(SnowflakeAuthUtils.determineAuthType(credentialsProvider.getCredentialMap()))) {
+            // Key-pair auth requires a PrivateKey object in Properties,
+            // which HikariCP cannot handle (it stringifies all property values).
+            // Use DriverManager directly with URL-decoded connection string.
+            return getKeyPairConnection(credentialsProvider.getCredentialMap());
         }
         else {
-            // Use parent implementation for password and OAuth authentication
-            return super.getConnection(credentialsProvider);
+            // Password and OAuth: always use HikariCP for connection pooling,
+            // bypassing the parent's direct-connection path even when fas_token is present.
+            return super.getConnectionFromManagedPool(credentialsProvider);
         }
     }
 
     /**
-     * Creates a connection using key-pair authentication.
-     * 
-     * @param credentialMap The credential map containing username and private key
-     * @return JDBC connection
-     * @throws SQLException if connection fails
+     * Creates a connection using key-pair authentication via {@link DriverManager}.
+     * <p>
+     * Secret placeholders are stripped and the connection string is URL-decoded as a
+     * safety measure, though the Snowflake JDBC driver also decodes query parameters
+     * internally via {@code SnowflakeConnectString.parse()}.
      */
     private Connection getKeyPairConnection(Map<String, String> credentialMap) throws SQLException
     {
-        try {
-            String username = credentialMap.get(USER);
-            String privateKeyPem = credentialMap.get(SnowflakeConstants.PEM_PRIVATE_KEY);
-            String passphrase =  credentialMap.get(SnowflakeConstants.PEM_PRIVATE_KEY_PASSPHRASE);
-            
-            // Create private key object
-            java.security.PrivateKey privateKey = SnowflakeAuthUtils.createPrivateKey(privateKeyPem, passphrase);
-            
-            // Build connection string
-            String connectionString = buildConnectionString();
-            
-            // Create properties for key-pair authentication
-            Properties props = new Properties();
-            props.putAll(jdbcProperties);
-            props.setProperty(USER, username);
-            props.setProperty(AUTHENTICATOR, SNOWFLAKE_JWT.getValue());
-            props.put(PRIVATE_KEY, privateKey);
-            
-            LOGGER.debug("Creating Snowflake connection with key-pair authentication for user: {}", username);
-            
-            return DriverManager.getConnection(connectionString, props);
-        }
-        catch (Exception e) {
-            LOGGER.error("Failed to create Snowflake connection with key-pair authentication", e);
-            throw new SQLException("Failed to create Snowflake connection with key-pair authentication: " + e.getMessage(), e);
-        }
-    }
-
-    /**
-     * Builds the JDBC connection string for Snowflake.
-     * 
-     * @return The connection string
-     */
-    private String buildConnectionString()
-    {
-        String jdbcString = databaseConnectionConfig.getJdbcConnectionString();
-        
-        // Remove any secret placeholders from the connection string
-        Matcher secretMatcher = SECRET_NAME_PATTERN.matcher(jdbcString);
-        return secretMatcher.replaceAll(Matcher.quoteReplacement(""));
-    }
+      try {
+          String username = credentialMap.get(USER);
+          String privateKeyPem = credentialMap.get(SnowflakeConstants.PEM_PRIVATE_KEY);
+          String passphrase = credentialMap.get(SnowflakeConstants.PEM_PRIVATE_KEY_PASSPHRASE);
+  
+          java.security.PrivateKey privateKey = SnowflakeAuthUtils.createPrivateKey(privateKeyPem, passphrase);
+  
+          String jdbcString = databaseConnectionConfig.getJdbcConnectionString();
+          Matcher secretMatcher = SECRET_NAME_PATTERN.matcher(jdbcString);
+          String cleanedString = secretMatcher.replaceAll(Matcher.quoteReplacement(""));
+  
+          // Parse the JDBC URL and extract query parameters into Properties
+          // instead of passing them in the URL. The Snowflake JDBC driver's
+          // SnowflakeConnectString.parse() rejects URLs containing special
+          // characters (e.g., decoded double quotes from URLDecoder.decode()).
+          // HikariCP (used by the AppFlow path) avoids this by passing
+          // parameters as DataSource properties rather than in the URL.
+          String baseUrl;
+          Properties props = new Properties();
+          props.putAll(jdbcProperties);
+  
+          int queryIndex = cleanedString.indexOf('?');
+          if (queryIndex >= 0) {
+              baseUrl = cleanedString.substring(0, queryIndex);
+              String query = cleanedString.substring(queryIndex + 1);
+              for (String param : query.split("&")) {
+                  String[] kv = param.split("=", 2);
+                  if (kv.length == 2) {
+                      props.setProperty(
+                          URLDecoder.decode(kv[0], StandardCharsets.UTF_8),
+                          URLDecoder.decode(kv[1], StandardCharsets.UTF_8));
+                  }
+              }
+          }
+          else {
+              baseUrl = cleanedString;
+          }
+  
+          props.setProperty(USER, username);
+          props.setProperty(AUTHENTICATOR, SNOWFLAKE_JWT.getValue());
+          props.put(PRIVATE_KEY, privateKey);
+  
+          LOGGER.debug("Creating Snowflake connection with key-pair authentication for user: {}", username);
+  
+          // Explicitly register the Snowflake JDBC driver with DriverManager.
+          // The Athena Federation code path (FederationRequest) does not use HikariCP here,
+          // so the driver may not be auto-registered. HikariCP handles this via its own
+          // fallback mechanism, but DriverManager.getConnection() does not.
+          Class.forName(databaseConnectionInfo.getDriverClassName());
+  
+          return DriverManager.getConnection(baseUrl, props);
+      }
+      catch (Exception e) {
+          LOGGER.error("Failed to create Snowflake connection with key-pair authentication", e);
+          throw new SQLException("Failed to create Snowflake connection with key-pair authentication: " + e.getMessage(), e);
+      }
+  }
 }

--- a/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/utils/SnowflakeAuthUtils.java
+++ b/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/utils/SnowflakeAuthUtils.java
@@ -196,6 +196,9 @@ public class SnowflakeAuthUtils
             username = credentials.get(SnowflakeConstants.USERNAME);
         }
         if (StringUtils.isBlank(username)) {
+            username = credentials.get(SnowflakeConstants.USERNAME_UPPERCASE);
+        }
+        if (StringUtils.isBlank(username)) {
             throw new IllegalArgumentException("Missing required parameter: username/sfUser");
         }
         return username;
@@ -213,7 +216,7 @@ public class SnowflakeAuthUtils
         if (credentials == null || credentials.isEmpty()) {
             throw new IllegalArgumentException("Credentials cannot be null or empty");
         }
-        // Check for sfUser (or "username" field)
+        // Check for sfUser (or "username" / "USERNAME" field)
         getUsername(credentials);
 
         switch (authType) {
@@ -229,7 +232,11 @@ public class SnowflakeAuthUtils
                 }
                 break;
             case SNOWFLAKE:
-                if (StringUtils.isBlank(credentials.get(SnowflakeConstants.PASSWORD))) {
+                String password = credentials.get(SnowflakeConstants.PASSWORD);
+                if (password == null) {
+                    password = credentials.get(SnowflakeConstants.PASSWORD_UPPERCASE);
+                }
+                if (StringUtils.isBlank(password)) {
                     throw new IllegalArgumentException("password is required for password authentication");
                 }
                 break;

--- a/athena-snowflake/src/test/java/com/amazonaws/athena/connectors/snowflake/SnowflakeCredentialsProviderTest.java
+++ b/athena-snowflake/src/test/java/com/amazonaws/athena/connectors/snowflake/SnowflakeCredentialsProviderTest.java
@@ -76,11 +76,11 @@ public class SnowflakeCredentialsProviderTest
 
         try (MockedConstruction<CachableSecretsManager> mockedConstruction = mockConstruction(CachableSecretsManager.class,
                 (mock, context) -> {
-                    when(mock.getSecret(TEST_SECRET_NAME)).thenReturn(secretJson);
+                    when(mock.getSecret(TEST_SECRET_NAME, null)).thenReturn(secretJson);
                     when(mock.getSecretsManager()).thenReturn(mockSecretsClient);
                 })) {
 
-            SnowflakeCredentialsProvider provider = new SnowflakeCredentialsProvider(TEST_SECRET_NAME, mockSecretsClient);
+            SnowflakeCredentialsProvider provider = new SnowflakeCredentialsProvider(TEST_SECRET_NAME, mockSecretsClient, null);
 
             try (MockedStatic<SnowflakeCredentialsProvider> mockedStatic = Mockito.mockStatic(SnowflakeCredentialsProvider.class)) {
                 HttpURLConnection mockConnection = createMockHttpConnection(200, createTokenResponse());
@@ -103,11 +103,11 @@ public class SnowflakeCredentialsProviderTest
 
         try (MockedConstruction<CachableSecretsManager> mockedConstruction = mockConstruction(CachableSecretsManager.class,
                 (mock, context) -> {
-                    when(mock.getSecret(TEST_SECRET_NAME)).thenReturn(secretJson);
+                    when(mock.getSecret(TEST_SECRET_NAME, null)).thenReturn(secretJson);
                     when(mock.getSecretsManager()).thenReturn(mockSecretsClient);
                 })) {
 
-            SnowflakeCredentialsProvider provider = new SnowflakeCredentialsProvider(TEST_SECRET_NAME, mockSecretsClient);
+            SnowflakeCredentialsProvider provider = new SnowflakeCredentialsProvider(TEST_SECRET_NAME, mockSecretsClient, null);
 
             try (MockedStatic<SnowflakeCredentialsProvider> mockedStatic = Mockito.mockStatic(SnowflakeCredentialsProvider.class)) {
                 HttpURLConnection mockConnection = createMockHttpConnection(200, createTokenResponse());
@@ -131,11 +131,11 @@ public class SnowflakeCredentialsProviderTest
 
         try (MockedConstruction<CachableSecretsManager> mockedConstruction = mockConstruction(CachableSecretsManager.class,
                 (mock, context) -> {
-                    when(mock.getSecret(TEST_SECRET_NAME)).thenReturn(secretJson);
+                    when(mock.getSecret(TEST_SECRET_NAME, null)).thenReturn(secretJson);
                     when(mock.getSecretsManager()).thenReturn(mockSecretsClient);
                 })) {
 
-            SnowflakeCredentialsProvider provider = new SnowflakeCredentialsProvider(TEST_SECRET_NAME, mockSecretsClient);
+            SnowflakeCredentialsProvider provider = new SnowflakeCredentialsProvider(TEST_SECRET_NAME, mockSecretsClient, null);
 
             Map<String, String> credentialMap = provider.getCredentialMap();
 
@@ -153,11 +153,11 @@ public class SnowflakeCredentialsProviderTest
 
         try (MockedConstruction<CachableSecretsManager> mockedConstruction = mockConstruction(CachableSecretsManager.class,
                 (mock, context) -> {
-                    when(mock.getSecret(TEST_SECRET_NAME)).thenReturn(secretJson);
+                    when(mock.getSecret(TEST_SECRET_NAME, null)).thenReturn(secretJson);
                     when(mock.getSecretsManager()).thenReturn(mockSecretsClient);
                 })) {
 
-            SnowflakeCredentialsProvider provider = new SnowflakeCredentialsProvider(TEST_SECRET_NAME, mockSecretsClient);
+            SnowflakeCredentialsProvider provider = new SnowflakeCredentialsProvider(TEST_SECRET_NAME, mockSecretsClient, null);
 
             try (MockedStatic<SnowflakeCredentialsProvider> mockedStatic = Mockito.mockStatic(SnowflakeCredentialsProvider.class)) {
                 HttpURLConnection mockConnection = createMockHttpConnection(200, createTokenResponse());
@@ -181,11 +181,11 @@ public class SnowflakeCredentialsProviderTest
 
         try (MockedConstruction<CachableSecretsManager> mockedConstruction = mockConstruction(CachableSecretsManager.class,
                 (mock, context) -> {
-                    when(mock.getSecret(TEST_SECRET_NAME)).thenReturn(secretJson);
+                    when(mock.getSecret(TEST_SECRET_NAME, null)).thenReturn(secretJson);
                     when(mock.getSecretsManager()).thenReturn(mockSecretsClient);
                 })) {
 
-            SnowflakeCredentialsProvider provider = new SnowflakeCredentialsProvider(TEST_SECRET_NAME, mockSecretsClient);
+            SnowflakeCredentialsProvider provider = new SnowflakeCredentialsProvider(TEST_SECRET_NAME, mockSecretsClient, null);
 
             Map<String, String> credentialMap = provider.getCredentialMap();
 
@@ -203,11 +203,11 @@ public class SnowflakeCredentialsProviderTest
 
         try (MockedConstruction<CachableSecretsManager> mockedConstruction = mockConstruction(CachableSecretsManager.class,
                 (mock, context) -> {
-                    when(mock.getSecret(TEST_SECRET_NAME)).thenReturn(secretJson);
+                    when(mock.getSecret(TEST_SECRET_NAME, null)).thenReturn(secretJson);
                     when(mock.getSecretsManager()).thenReturn(mockSecretsClient);
                 })) {
 
-            SnowflakeCredentialsProvider provider = new SnowflakeCredentialsProvider(TEST_SECRET_NAME, mockSecretsClient);
+            SnowflakeCredentialsProvider provider = new SnowflakeCredentialsProvider(TEST_SECRET_NAME, mockSecretsClient, null);
 
             Map<String, String> credentialMap = provider.getCredentialMap();
 
@@ -225,11 +225,11 @@ public class SnowflakeCredentialsProviderTest
 
         try (MockedConstruction<CachableSecretsManager> mockedConstruction = mockConstruction(CachableSecretsManager.class,
                 (mock, context) -> {
-                    when(mock.getSecret(TEST_SECRET_NAME)).thenReturn(secretJson);
+                    when(mock.getSecret(TEST_SECRET_NAME, null)).thenReturn(secretJson);
                     when(mock.getSecretsManager()).thenReturn(mockSecretsClient);
                 })) {
 
-            SnowflakeCredentialsProvider provider = new SnowflakeCredentialsProvider(TEST_SECRET_NAME, mockSecretsClient);
+            SnowflakeCredentialsProvider provider = new SnowflakeCredentialsProvider(TEST_SECRET_NAME, mockSecretsClient, null);
 
             RuntimeException exception = assertThrows(RuntimeException.class, () -> {
                 provider.getCredentialMap();
@@ -246,11 +246,11 @@ public class SnowflakeCredentialsProviderTest
 
         try (MockedConstruction<CachableSecretsManager> mockedConstruction = mockConstruction(CachableSecretsManager.class,
                 (mock, context) -> {
-                    when(mock.getSecret(TEST_SECRET_NAME)).thenReturn(secretJson);
+                    when(mock.getSecret(TEST_SECRET_NAME, null)).thenReturn(secretJson);
                     when(mock.getSecretsManager()).thenReturn(mockSecretsClient);
                 })) {
 
-            SnowflakeCredentialsProvider provider = new SnowflakeCredentialsProvider(TEST_SECRET_NAME, mockSecretsClient);
+            SnowflakeCredentialsProvider provider = new SnowflakeCredentialsProvider(TEST_SECRET_NAME, mockSecretsClient, null);
 
             try (MockedStatic<SnowflakeCredentialsProvider> mockedStatic = Mockito.mockStatic(SnowflakeCredentialsProvider.class)) {
                 HttpURLConnection mockConnection = createMockHttpConnection(400, "{\"error\":\"invalid_request\"}");
@@ -273,11 +273,11 @@ public class SnowflakeCredentialsProviderTest
 
         try (MockedConstruction<CachableSecretsManager> mockedConstruction = mockConstruction(CachableSecretsManager.class,
                 (mock, context) -> {
-                    when(mock.getSecret(TEST_SECRET_NAME)).thenReturn(secretJson);
+                    when(mock.getSecret(TEST_SECRET_NAME, null)).thenReturn(secretJson);
                     when(mock.getSecretsManager()).thenReturn(mockSecretsClient);
                 })) {
 
-            SnowflakeCredentialsProvider provider = new SnowflakeCredentialsProvider(TEST_SECRET_NAME, mockSecretsClient);
+            SnowflakeCredentialsProvider provider = new SnowflakeCredentialsProvider(TEST_SECRET_NAME, mockSecretsClient, null);
 
             try (MockedStatic<SnowflakeCredentialsProvider> mockedStatic = Mockito.mockStatic(SnowflakeCredentialsProvider.class)) {
                 HttpURLConnection mockConnection = createMockHttpConnection(200, "invalid json response");
@@ -300,11 +300,11 @@ public class SnowflakeCredentialsProviderTest
 
         try (MockedConstruction<CachableSecretsManager> mockedConstruction = mockConstruction(CachableSecretsManager.class,
                 (mock, context) -> {
-                    when(mock.getSecret(TEST_SECRET_NAME)).thenReturn(secretJson);
+                    when(mock.getSecret(TEST_SECRET_NAME, null)).thenReturn(secretJson);
                     when(mock.getSecretsManager()).thenReturn(mockSecretsClient);
                 })) {
 
-            SnowflakeCredentialsProvider provider = new SnowflakeCredentialsProvider(TEST_SECRET_NAME, mockSecretsClient);
+            SnowflakeCredentialsProvider provider = new SnowflakeCredentialsProvider(TEST_SECRET_NAME, mockSecretsClient, null);
 
             try (MockedStatic<SnowflakeCredentialsProvider> mockedStatic = Mockito.mockStatic(SnowflakeCredentialsProvider.class)) {
                 HttpURLConnection mockConnection = mock(HttpURLConnection.class);
@@ -331,13 +331,11 @@ public class SnowflakeCredentialsProviderTest
                     when(mock.getSecretsManager()).thenReturn(mockSecretsClient);
                 })) {
 
-            SnowflakeCredentialsProvider provider = new SnowflakeCredentialsProvider(TEST_SECRET_NAME, mockSecretsClient);
+            SnowflakeCredentialsProvider provider = new SnowflakeCredentialsProvider(TEST_SECRET_NAME, mockSecretsClient, null);
 
-            RuntimeException exception = assertThrows(RuntimeException.class, () -> {
+            assertThrows(IllegalArgumentException.class, () -> {
                 provider.getCredentialMap();
             });
-
-            assertTrue(exception.getMessage().contains("Error retrieving Snowflake credentials"));
         }
     }
 
@@ -350,13 +348,11 @@ public class SnowflakeCredentialsProviderTest
                     when(mock.getSecretsManager()).thenReturn(mockSecretsClient);
                 })) {
 
-            SnowflakeCredentialsProvider provider = new SnowflakeCredentialsProvider(TEST_SECRET_NAME, mockSecretsClient);
+            SnowflakeCredentialsProvider provider = new SnowflakeCredentialsProvider(TEST_SECRET_NAME, mockSecretsClient, null);
 
-            RuntimeException exception = assertThrows(RuntimeException.class, () -> {
+            assertThrows(RuntimeException.class, () -> {
                 provider.getCredentialMap();
             });
-
-            assertTrue(exception.getMessage().contains("Error retrieving Snowflake credentials"));
         }
     }
 
@@ -367,11 +363,11 @@ public class SnowflakeCredentialsProviderTest
 
         try (MockedConstruction<CachableSecretsManager> mockedConstruction = mockConstruction(CachableSecretsManager.class,
                 (mock, context) -> {
-                    when(mock.getSecret(TEST_SECRET_NAME)).thenReturn(secretJson);
+                    when(mock.getSecret(TEST_SECRET_NAME, null)).thenReturn(secretJson);
                     when(mock.getSecretsManager()).thenReturn(mockSecretsClient);
                 })) {
 
-            SnowflakeCredentialsProvider provider = new SnowflakeCredentialsProvider(TEST_SECRET_NAME, mockSecretsClient);
+            SnowflakeCredentialsProvider provider = new SnowflakeCredentialsProvider(TEST_SECRET_NAME, mockSecretsClient, null);
 
             try (MockedStatic<SnowflakeCredentialsProvider> mockedStatic = Mockito.mockStatic(SnowflakeCredentialsProvider.class)) {
                 HttpURLConnection mockConnection = createMockHttpConnection(200, createTokenResponse());
@@ -387,6 +383,54 @@ public class SnowflakeCredentialsProviderTest
                 assertEquals(TEST_ACCESS_TOKEN, credentialMap.get("password"));
                 assertEquals("oauth", credentialMap.get("authenticator"));
             }
+        }
+    }
+
+    @Test
+    public void testGetCredentialMapWithUppercasePassword()
+    {
+        // Secret with USERNAME_UPPERCASE and PASSWORD_UPPERCASE keys
+        String secretJson = new ObjectMapper().createObjectNode()
+                .put("USERNAME", TEST_USERNAME)
+                .put("PASSWORD", TEST_PASSWORD)
+                .toString();
+
+        try (MockedConstruction<CachableSecretsManager> mockedConstruction = mockConstruction(CachableSecretsManager.class,
+                (mock, context) -> {
+                    when(mock.getSecret(TEST_SECRET_NAME, null)).thenReturn(secretJson);
+                    when(mock.getSecretsManager()).thenReturn(mockSecretsClient);
+                })) {
+
+            SnowflakeCredentialsProvider provider = new SnowflakeCredentialsProvider(TEST_SECRET_NAME, mockSecretsClient, null);
+
+            Map<String, String> credentialMap = provider.getCredentialMap();
+
+            assertNotNull(credentialMap);
+            assertEquals(TEST_USERNAME, credentialMap.get("user"));
+            assertEquals(TEST_PASSWORD, credentialMap.get("password"));
+        }
+    }
+
+    @Test
+    public void testGetCredentialMapWithMissingPassword()
+    {
+        // Secret with username but no password in any case
+        String secretJson = new ObjectMapper().createObjectNode()
+                .put("username", TEST_USERNAME)
+                .toString();
+
+        try (MockedConstruction<CachableSecretsManager> mockedConstruction = mockConstruction(CachableSecretsManager.class,
+                (mock, context) -> {
+                    when(mock.getSecret(TEST_SECRET_NAME, null)).thenReturn(secretJson);
+                    when(mock.getSecretsManager()).thenReturn(mockSecretsClient);
+                })) {
+
+            SnowflakeCredentialsProvider provider = new SnowflakeCredentialsProvider(TEST_SECRET_NAME, mockSecretsClient, null);
+
+            RuntimeException exception = assertThrows(RuntimeException.class, () -> {
+                provider.getCredentialMap();
+            });
+            assertTrue(exception.getMessage().contains("password is required for password authentication"));
         }
     }
 

--- a/athena-snowflake/src/test/java/com/amazonaws/athena/connectors/snowflake/utils/SnowflakeAuthUtilsTest.java
+++ b/athena-snowflake/src/test/java/com/amazonaws/athena/connectors/snowflake/utils/SnowflakeAuthUtilsTest.java
@@ -319,4 +319,64 @@ public class SnowflakeAuthUtilsTest
         // Should not throw exception
         SnowflakeAuthUtils.validateCredentials(credentials, SnowflakeAuthType.SNOWFLAKE_JWT);
     }
+
+    @Test
+    public void testGetUsernameWithUppercaseKey()
+    {
+        Map<String, String> credentials = new HashMap<>();
+        credentials.put(SnowflakeConstants.USERNAME_UPPERCASE, TESTUSER);
+        credentials.put(SnowflakeConstants.PASSWORD, TESTPASSWORD);
+
+        String username = SnowflakeAuthUtils.getUsername(credentials);
+        assertEquals(TESTUSER, username);
+    }
+
+    @Test
+    public void testGetUsernameFallbackOrder()
+    {
+        // Test that SF_USER takes priority over USERNAME and USERNAME_UPPERCASE
+        Map<String, String> credentials = new HashMap<>();
+        credentials.put(SnowflakeConstants.SF_USER, "sfuser");
+        credentials.put(SnowflakeConstants.USERNAME, "username");
+        credentials.put(SnowflakeConstants.USERNAME_UPPERCASE, "USERNAME");
+
+        String username = SnowflakeAuthUtils.getUsername(credentials);
+        assertEquals("sfuser", username);
+    }
+
+    @Test
+    public void testGetUsernameFallbackToUppercase()
+    {
+        // Test that USERNAME_UPPERCASE is used when SF_USER and USERNAME are blank
+        Map<String, String> credentials = new HashMap<>();
+        credentials.put(SnowflakeConstants.SF_USER, "");
+        credentials.put(SnowflakeConstants.USERNAME, "");
+        credentials.put(SnowflakeConstants.USERNAME_UPPERCASE, TESTUSER);
+
+        String username = SnowflakeAuthUtils.getUsername(credentials);
+        assertEquals(TESTUSER, username);
+    }
+
+    @Test
+    public void testValidateCredentialsWithPasswordUppercase()
+    {
+        Map<String, String> credentials = new HashMap<>();
+        credentials.put(SnowflakeConstants.USERNAME, TESTUSER);
+        credentials.put(SnowflakeConstants.PASSWORD_UPPERCASE, TESTPASSWORD);
+
+        // Should not throw exception - PASSWORD_UPPERCASE should be accepted
+        SnowflakeAuthUtils.validateCredentials(credentials, SnowflakeAuthType.SNOWFLAKE);
+    }
+
+    @Test
+    public void testValidateCredentialsWithPasswordMissingBothCases()
+    {
+        Map<String, String> credentials = new HashMap<>();
+        credentials.put(SnowflakeConstants.USERNAME, TESTUSER);
+        // Neither PASSWORD nor PASSWORD_UPPERCASE is set
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            SnowflakeAuthUtils.validateCredentials(credentials, SnowflakeAuthType.SNOWFLAKE);
+        });
+    }
 }


### PR DESCRIPTION
First slice of the athena-snowflake work, on top of the athena-jdbc changes merged as #3547. Scope is limited to authentication and credential handling so it can be reviewed on its own; catalog casing, the query builder and the large-table guards follow in p3. Complete changes are in #3230

- SnowflakeConnectionFactory: route key-pair (JWT) auth through DriverManager, because HikariCP stringifies property values and destroys the PrivateKey object the driver needs. Password and OAuth keep using the pool. Takes configOptions so it can opt into pooling even when fas_token is present.
- SnowflakeCredentialsProvider / SnowflakeAuthUtils: accept a request override configuration so credentials are resolved per request, and tolerate upper-case USERNAME/PASSWORD secret keys alongside the lower-case forms.
- SnowflakeConstants: add USERNAME_UPPERCASE / PASSWORD_UPPERCASE.
- pom: add the federation SDK test dependency the new tests need.

athena-snowflake: 169 tests, 0 failures.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
