### PR TITLE
athena-docdb] Percent-encode DocumentDB credentials in connection URI

### DIFF
--- a/athena-docdb/src/main/java/com/amazonaws/athena/connectors/docdb/DocDBMetadataHandler.java
+++ b/athena-docdb/src/main/java/com/amazonaws/athena/connectors/docdb/DocDBMetadataHandler.java
@@ -65,6 +65,8 @@ import software.amazon.awssdk.services.glue.model.Database;
 import software.amazon.awssdk.services.glue.model.Table;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -509,7 +511,14 @@ public class DocDBMetadataHandler
             }
         }
 
-        String connStr = String.format(CONNECTION_STRING_TEMPLATE, username, password, host, port, authDb);
+        // Percent-encode the Secrets Manager username and password before inserting them into the
+        // MongoDB connection URI. Without encoding, special characters (e.g. '/', '@', ':', '?') in
+        // the credential values can terminate or restructure the URI authority, enabling host and
+        // authMechanism injection. The MongoDB driver URL-decodes userinfo, so URLEncoder-encoded
+        // values round-trip to their original form.
+        String encodedUsername = URLEncoder.encode(username, StandardCharsets.UTF_8);
+        String encodedPassword = URLEncoder.encode(password, StandardCharsets.UTF_8);
+        String connStr = String.format(CONNECTION_STRING_TEMPLATE, encodedUsername, encodedPassword, host, port, authDb);
         if (jdbcParams != null) {
             connStr += "?" + jdbcParams;
         }

--- a/athena-docdb/src/test/java/com/amazonaws/athena/connectors/docdb/DocDBMetadataHandlerTest.java
+++ b/athena-docdb/src/test/java/com/amazonaws/athena/connectors/docdb/DocDBMetadataHandlerTest.java
@@ -751,6 +751,45 @@ public class DocDBMetadataHandlerTest
         }
     }
 
+    @Test
+    public void getConnectionStringForFederatedRequestsEncodesCredentials() throws Exception
+    {
+        // Regression test for the DocumentDB connection-URI injection (CWE-75). Credentials read from
+        // Secrets Manager must be percent-encoded before being inserted into the MongoDB URI so that
+        // special characters cannot terminate/restructure the URI authority or inject an authMechanism.
+        String maliciousUser = "attackerHost";
+        String maliciousPassword = "p/ss:w@rd?authMechanism=MONGODB-AWS";
+        String secretJson = "{\"username\":\"" + maliciousUser + "\",\"password\":\"" + maliciousPassword + "\"}";
+
+        when(secretsManager.getSecretValue(any(software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest.class)))
+                .thenReturn(software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse.builder()
+                        .secretString(secretJson).build());
+
+        Map<String, String> connConfigOptions = new HashMap<>();
+        connConfigOptions.put("secret_arn", "arn:aws:secretsmanager:us-east-1:123456789012:secret:docdb-abc");
+        connConfigOptions.put("HOST", "realhost.docdb.amazonaws.com");
+        connConfigOptions.put("PORT", "27017");
+
+        java.lang.reflect.Method method = DocDBMetadataHandler.class
+                .getDeclaredMethod("getConnectionStringForFederatedRequests", Map.class);
+        method.setAccessible(true);
+        String connStr = (String) method.invoke(handler, connConfigOptions);
+
+        logger.info("Constructed federated connStr (encoded): {}", connStr);
+
+        // The real host/port must remain the effective authority (authority not terminated early).
+        assertTrue("real host/port must be preserved as the URI authority",
+                connStr.contains("@realhost.docdb.amazonaws.com:27017"));
+        // Password special characters must be percent-encoded.
+        assertTrue("'/' must be encoded to %2F", connStr.contains("%2F"));
+        assertTrue("'@' must be encoded to %40", connStr.contains("%40"));
+        assertTrue("':' must be encoded to %3A", connStr.contains("%3A"));
+        assertTrue("'?' must be encoded to %3F", connStr.contains("%3F"));
+        // The injected auth mechanism must not appear as an unencoded URI option.
+        assertFalse("authMechanism must not be injectable via credential values",
+                connStr.contains("?authMechanism=MONGODB-AWS"));
+    }
+
     private void assertMinorType(Schema schema, String field, Types.MinorType expected)
     {
         Field f = schema.findField(field);


### PR DESCRIPTION

**Description:**

The DocumentDB connector inserts the `username` and `password` from Secrets Manager into the MongoDB connection URI without URL-encoding. Credential values containing reserved characters (`/`, `@`, `:`, `?`) can alter the structure of the URI instead of being treated as literal userinfo.

This change percent-encodes the username and password before building the connection string, per the MongoDB connection-string spec.

**Changes:**
- Percent-encode `username`/`password` with `URLEncoder.encode(...)` in `DocDBMetadataHandler.getConnectionStringForFederatedRequests`.
- Added a unit test verifying credentials with reserved characters are encoded and the configured host stays the URI authority.

**Testing:** `mvn -pl athena-docdb test` — all tests pass (13/13).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
