### PR TITLE
athena-db2: Substrait query federation + managed-connector credential support

### DIFF
--- a/athena-db2/src/main/java/com/amazonaws/athena/connectors/db2/Db2Dialect.java
+++ b/athena-db2/src/main/java/com/amazonaws/athena/connectors/db2/Db2Dialect.java
@@ -1,0 +1,49 @@
+/*-
+ * #%L
+ * athena-db2
+ * %%
+ * Copyright (C) 2019 - 2026 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.db2;
+
+import org.apache.calcite.sql.SqlDialect;
+import org.apache.calcite.sql.dialect.Db2SqlDialect;
+
+import java.util.Locale;
+
+/**
+ * IBM DB2 SQL dialect used to render Substrait-derived query plans. DB2 quotes identifiers with
+ * double quotes. When the catalog casing filter is enabled, identifiers are upper-cased before quoting.
+ */
+public class Db2Dialect extends Db2SqlDialect
+{
+    public static final SqlDialect DEFAULT = Db2SqlDialect.DEFAULT;
+
+    private final boolean catalogCasingFilter;
+
+    public Db2Dialect(boolean catalogCasingFilter)
+    {
+        super(DEFAULT_CONTEXT);
+        this.catalogCasingFilter = catalogCasingFilter;
+    }
+
+    @Override
+    public StringBuilder quoteIdentifier(StringBuilder buf, String identifier)
+    {
+        String value = catalogCasingFilter ? identifier.toUpperCase(Locale.ROOT) : identifier;
+        return buf.append("\"").append(value.replace("\"", "\"\"")).append("\"");
+    }
+}

--- a/athena-db2/src/main/java/com/amazonaws/athena/connectors/db2/Db2MetadataHandler.java
+++ b/athena-db2/src/main/java/com/amazonaws/athena/connectors/db2/Db2MetadataHandler.java
@@ -154,7 +154,7 @@ public class Db2MetadataHandler extends JdbcMetadataHandler
     @Override
     public ListSchemasResponse doListSchemaNames(final BlockAllocator blockAllocator, final ListSchemasRequest listSchemasRequest) throws Exception
     {
-        try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider())) {
+        try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider(getRequestOverrideConfig(listSchemasRequest)))) {
             LOGGER.info("{}: List schema names for Catalog {}", listSchemasRequest.getQueryId(), listSchemasRequest.getCatalogName());
             return new ListSchemasResponse(listSchemasRequest.getCatalogName(), getSchemaList(connection, Db2Constants.QRY_TO_LIST_SCHEMAS));
         }
@@ -243,7 +243,7 @@ public class Db2MetadataHandler extends JdbcMetadataHandler
                 getTableLayoutRequest.getTableName().getTableName());
 
         List<String> parameters = Arrays.asList(getTableLayoutRequest.getTableName().getSchemaName(), getTableLayoutRequest.getTableName().getTableName());
-        try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider());
+        try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider(getRequestOverrideConfig(getTableLayoutRequest)));
              PreparedStatement preparedStatement = new PreparedStatementBuilder().withConnection(connection).withQuery(Db2Constants.PARTITION_QUERY).withParameters(parameters).build();
              ResultSet resultSet = preparedStatement.executeQuery()) {
             // check whether the table have partitions or not using PARTITION_QUERY, create a single split for view/non-partition table
@@ -259,7 +259,7 @@ public class Db2MetadataHandler extends JdbcMetadataHandler
             else {
                 LOGGER.debug("Getting data with diff Partitions: ");
                 // get partition details from DB2 meta data tables
-                String columnName = getColumnName(parameters);
+                String columnName = getColumnName(parameters, getRequestOverrideConfig(getTableLayoutRequest));
 
                 do {
                     // 1. Returns all partitions of table, we are not supporting constraints push down to filter partitions.
@@ -378,9 +378,9 @@ public class Db2MetadataHandler extends JdbcMetadataHandler
      * @param parameters
      * @throws Exception
      */
-    private String getColumnName(List<String> parameters) throws Exception
+    private String getColumnName(List<String> parameters, AwsRequestOverrideConfiguration requestOverrideConfiguration) throws Exception
     {
-        try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider());
+        try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider(requestOverrideConfiguration));
              PreparedStatement preparedStatement = new PreparedStatementBuilder().withConnection(connection).withQuery(Db2Constants.COLUMN_INFO_QUERY).withParameters(parameters).build();
              ResultSet resultSet = preparedStatement.executeQuery()) {
             if (resultSet.next()) {
@@ -482,7 +482,7 @@ public class Db2MetadataHandler extends JdbcMetadataHandler
 
         SchemaBuilder schemaBuilder = SchemaBuilder.newBuilder();
         try (ResultSet resultSet = getColumns(jdbcConnection.getCatalog(), tableName, jdbcConnection.getMetaData());
-             Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider());
+             Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider(requestOverrideConfiguration));
              PreparedStatement stmt = connection.prepareStatement(Db2Constants.COLUMN_INFO_QUERY)) {
             stmt.setString(1, tableName.getSchemaName());
             stmt.setString(2, tableName.getTableName());

--- a/athena-db2/src/main/java/com/amazonaws/athena/connectors/db2/Db2MetadataHandler.java
+++ b/athena-db2/src/main/java/com/amazonaws/athena/connectors/db2/Db2MetadataHandler.java
@@ -20,6 +20,7 @@
 package com.amazonaws.athena.connectors.db2;
 
 import com.amazonaws.athena.connector.lambda.QueryStatusChecker;
+import com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants;
 import com.amazonaws.athena.connector.lambda.data.Block;
 import com.amazonaws.athena.connector.lambda.data.BlockAllocator;
 import com.amazonaws.athena.connector.lambda.data.BlockWriter;
@@ -79,6 +80,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -297,6 +299,9 @@ public class Db2MetadataHandler extends JdbcMetadataHandler
         Split.Builder splitBuilder;
         Set<Split> splits = new HashSet<>();
 
+        Map<String, String> identityConfigOptions = getSplitsRequest.getIdentity().getConfigOptions();
+        String catalogCasingFilter = identityConfigOptions != null ? identityConfigOptions.get(EnvironmentConstants.CATALOG_CASING_FILTER) : null;
+
         LOGGER.debug("partitionContd: {}", partitionContd);
 
         for (int curPartition = partitionContd; curPartition < partitions.getRowCount(); curPartition++) {
@@ -312,14 +317,19 @@ public class Db2MetadataHandler extends JdbcMetadataHandler
             // Included partition information to split if the table is partitioned
             if (partInfo.contains(":::")) {
                 String[] partInfoAr = partInfo.split(":::");
-                splitBuilder = Split.newBuilder(spillLocation, makeEncryptionKey())
+                splitBuilder = Split.newBuilder(spillLocation, makeEncryptionKey(getRequestOverrideConfig(getSplitsRequest)))
                         .add(PARTITIONING_COLUMN, partInfoAr[0])
                         .add(PARTITION_NUMBER, partInfoAr[1]);
             }
             else {
-                splitBuilder = Split.newBuilder(spillLocation, makeEncryptionKey())
+                splitBuilder = Split.newBuilder(spillLocation, makeEncryptionKey(getRequestOverrideConfig(getSplitsRequest)))
                         .add(PARTITION_NUMBER, partInfo);
             }
+
+            if (catalogCasingFilter != null) {
+                splitBuilder.add(EnvironmentConstants.CATALOG_CASING_FILTER, catalogCasingFilter);
+            }
+
             splits.add(splitBuilder.build());
             if (splits.size() >= MAX_SPLITS_PER_REQUEST) {
                 //We exceeded the number of split we want to return in a single request, return and provide a continuation token.

--- a/athena-db2/src/main/java/com/amazonaws/athena/connectors/db2/Db2QueryStringBuilder.java
+++ b/athena-db2/src/main/java/com/amazonaws/athena/connectors/db2/Db2QueryStringBuilder.java
@@ -23,6 +23,7 @@ import com.amazonaws.athena.connector.lambda.domain.Split;
 import com.amazonaws.athena.connectors.jdbc.manager.FederationExpressionParser;
 import com.amazonaws.athena.connectors.jdbc.manager.JdbcSplitQueryBuilder;
 import com.google.common.base.Strings;
+import org.apache.calcite.sql.SqlDialect;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -82,5 +83,17 @@ public class Db2QueryStringBuilder extends JdbcSplitQueryBuilder
             LOGGER.debug("Fetching data without Partition");
         }
         return Collections.emptyList();
+    }
+
+    @Override
+    protected SqlDialect getSqlDialect()
+    {
+        return Db2Dialect.DEFAULT;
+    }
+
+    @Override
+    protected SqlDialect getSqlDialect(boolean catalogCasingFilterUpperCase)
+    {
+        return new Db2Dialect(catalogCasingFilterUpperCase);
     }
 }

--- a/athena-db2/src/test/java/com/amazonaws/athena/connectors/db2/Db2DialectTest.java
+++ b/athena-db2/src/test/java/com/amazonaws/athena/connectors/db2/Db2DialectTest.java
@@ -1,0 +1,79 @@
+/*-
+ * #%L
+ * athena-db2
+ * %%
+ * Copyright (C) 2019 - 2026 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.db2;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class Db2DialectTest
+{
+    @Test
+    void testDefaultDialect()
+    {
+        assertNotNull(Db2Dialect.DEFAULT);
+    }
+
+    @Test
+    void testQuoteIdentifierWithFilter()
+    {
+        Db2Dialect dialect = new Db2Dialect(true);
+        StringBuilder buf = new StringBuilder();
+        dialect.quoteIdentifier(buf, "employees");
+        assertEquals("\"EMPLOYEES\"", buf.toString());
+    }
+
+    @Test
+    void testQuoteIdentifierWithoutFilter()
+    {
+        Db2Dialect dialect = new Db2Dialect(false);
+        StringBuilder buf = new StringBuilder();
+        dialect.quoteIdentifier(buf, "employees");
+        assertEquals("\"employees\"", buf.toString());
+    }
+
+    @Test
+    void testQuoteIdentifierWithFilterUpperCasesMixedCaseInput()
+    {
+        Db2Dialect dialect = new Db2Dialect(true);
+        StringBuilder buf = new StringBuilder();
+        dialect.quoteIdentifier(buf, "Employees");
+        assertEquals("\"EMPLOYEES\"", buf.toString());
+    }
+
+    @Test
+    void testQuoteIdentifierWithoutFilterPreservesUpperCaseInput()
+    {
+        Db2Dialect dialect = new Db2Dialect(false);
+        StringBuilder buf = new StringBuilder();
+        dialect.quoteIdentifier(buf, "EMPLOYEES");
+        assertEquals("\"EMPLOYEES\"", buf.toString());
+    }
+
+    @Test
+    void testQuoteIdentifierWithFilterEscapesDoubleQuote()
+    {
+        Db2Dialect dialect = new Db2Dialect(true);
+        StringBuilder buf = new StringBuilder();
+        dialect.quoteIdentifier(buf, "emp\"loyees");
+        assertEquals("\"EMP\"\"LOYEES\"", buf.toString());
+    }
+}

--- a/athena-db2/src/test/java/com/amazonaws/athena/connectors/db2/Db2MetadataHandlerTest.java
+++ b/athena-db2/src/test/java/com/amazonaws/athena/connectors/db2/Db2MetadataHandlerTest.java
@@ -702,4 +702,45 @@ public class Db2MetadataHandlerTest extends TestBase {
         assertTrue("Should support integer constant limit pushdown",
                 limitSubTypes.contains(LimitPushdownSubType.INTEGER_CONSTANT.getSubType()));
     }
+
+    @Test
+    public void doListSchemaNames_usesRequestOverrideCredentials()
+            throws Exception
+    {
+        Db2MetadataHandler spy = Mockito.spy(this.db2MetadataHandler);
+        Statement statement = Mockito.mock(Statement.class);
+        ResultSet schemaResultSet = Mockito.mock(ResultSet.class);
+        Mockito.when(this.connection.createStatement()).thenReturn(statement);
+        Mockito.when(statement.executeQuery(Db2Constants.QRY_TO_LIST_SCHEMAS)).thenReturn(schemaResultSet);
+        Mockito.when(schemaResultSet.next()).thenReturn(false);
+
+        ListSchemasRequest listSchemasRequest = new ListSchemasRequest(this.federatedIdentity, "testQueryId", "testCatalogName");
+        spy.doListSchemaNames(this.blockAllocator, listSchemasRequest);
+
+        // The metadata connection must be opened with the request's (federated) credentials, not the
+        // connector's default role. getRequestOverrideConfig(request) is only consulted on that path.
+        Mockito.verify(spy).getRequestOverrideConfig(listSchemasRequest);
+    }
+
+    @Test
+    public void doGetTableLayout_usesRequestOverrideCredentials()
+            throws Exception
+    {
+        Db2MetadataHandler spy = Mockito.spy(this.db2MetadataHandler);
+        Constraints constraints = new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(),
+                Constraints.DEFAULT_NO_LIMIT, Collections.emptyMap(), null);
+        TableName tableName = new TableName("testSchema", "testTable");
+        Schema partitionSchema = spy.getPartitionSchema("testCatalogName");
+        Set<String> partitionCols = partitionSchema.getFields().stream().map(Field::getName).collect(Collectors.toSet());
+
+        PreparedStatement partitionPreparedStatement = Mockito.mock(PreparedStatement.class);
+        Mockito.when(this.connection.prepareStatement(Db2Constants.PARTITION_QUERY)).thenReturn(partitionPreparedStatement);
+        ResultSet partitionResultSet = mockResultSet(new String[] {"DATAPARTITIONID"}, new int[] {Types.INTEGER}, new Object[][] {{}}, new AtomicInteger(-1));
+        Mockito.when(partitionPreparedStatement.executeQuery()).thenReturn(partitionResultSet);
+
+        GetTableLayoutRequest getTableLayoutRequest = new GetTableLayoutRequest(this.federatedIdentity, "testQueryId", "testCatalogName", tableName, constraints, partitionSchema, partitionCols);
+        spy.doGetTableLayout(this.blockAllocator, getTableLayoutRequest);
+
+        Mockito.verify(spy, Mockito.atLeastOnce()).getRequestOverrideConfig(getTableLayoutRequest);
+    }
 }

--- a/athena-db2/src/test/java/com/amazonaws/athena/connectors/db2/Db2MetadataHandlerTest.java
+++ b/athena-db2/src/test/java/com/amazonaws/athena/connectors/db2/Db2MetadataHandlerTest.java
@@ -20,6 +20,7 @@
 package com.amazonaws.athena.connectors.db2;
 
 import com.amazonaws.athena.connector.credentials.CredentialsProvider;
+import com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants;
 import com.amazonaws.athena.connector.lambda.data.Block;
 import com.amazonaws.athena.connector.lambda.data.BlockAllocator;
 import com.amazonaws.athena.connector.lambda.data.BlockAllocatorImpl;
@@ -172,6 +173,100 @@ public class Db2MetadataHandlerTest extends TestBase {
         assertEquals(expectedSplits.size(), getSplitsResponse.getSplits().size());
         Set<Map<String, String>> actualSplits = getSplitsResponse.getSplits().stream().map(Split::getProperties).collect(Collectors.toSet());
         assertEquals(expectedSplits, actualSplits);
+    }
+
+    @Test
+    public void doGetSplits_withCatalogCasingFilter_propagatesToSplit()
+            throws Exception
+    {
+        Constraints constraints = new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(),
+                Constraints.DEFAULT_NO_LIMIT, Collections.emptyMap(), null);
+        TableName tableName = new TableName("testSchema", "testTable");
+
+        Schema schema = this.db2MetadataHandler.getPartitionSchema("testCatalogName");
+        Set<String> cols = schema.getFields().stream().map(Field::getName).collect(Collectors.toSet());
+        GetTableLayoutRequest getTableLayoutRequest = new GetTableLayoutRequest(this.federatedIdentity, "testQueryId", "testCatalogName", tableName, constraints, schema, cols);
+
+        PreparedStatement partitionPreparedStatement = Mockito.mock(PreparedStatement.class);
+        Mockito.when(this.connection.prepareStatement(Db2Constants.PARTITION_QUERY)).thenReturn(partitionPreparedStatement);
+        ResultSet partitionResultSet = mockResultSet(new String[] {"DATAPARTITIONID"}, new int[] {Types.INTEGER}, new Object[][] {{}}, new AtomicInteger(-1));
+        Mockito.when(partitionPreparedStatement.executeQuery()).thenReturn(partitionResultSet);
+
+        GetTableLayoutResponse getTableLayoutResponse = this.db2MetadataHandler.doGetTableLayout(this.blockAllocator, getTableLayoutRequest);
+
+        Mockito.when(this.federatedIdentity.getConfigOptions()).thenReturn(
+                Collections.singletonMap(EnvironmentConstants.CATALOG_CASING_FILTER, EnvironmentConstants.UPPERCASE_ONLY));
+
+        BlockAllocator splitBlockAllocator = new BlockAllocatorImpl();
+        GetSplitsRequest getSplitsRequest = new GetSplitsRequest(this.federatedIdentity, "testQueryId", "testCatalogName", tableName, getTableLayoutResponse.getPartitions(), new ArrayList<>(cols), constraints, null);
+        GetSplitsResponse getSplitsResponse = this.db2MetadataHandler.doGetSplits(splitBlockAllocator, getSplitsRequest);
+
+        assertEquals(1, getSplitsResponse.getSplits().size());
+        Split split = getSplitsResponse.getSplits().iterator().next();
+        assertEquals("0", split.getProperty(PARTITION_NUMBER));
+        assertEquals(EnvironmentConstants.UPPERCASE_ONLY, split.getProperty(EnvironmentConstants.CATALOG_CASING_FILTER));
+    }
+
+    @Test
+    public void doGetSplits_withConfigOptionsButNoCasingFilter_doesNotAddCasingProperty()
+            throws Exception
+    {
+        Constraints constraints = new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(),
+                Constraints.DEFAULT_NO_LIMIT, Collections.emptyMap(), null);
+        TableName tableName = new TableName("testSchema", "testTable");
+
+        Schema schema = this.db2MetadataHandler.getPartitionSchema("testCatalogName");
+        Set<String> cols = schema.getFields().stream().map(Field::getName).collect(Collectors.toSet());
+        GetTableLayoutRequest getTableLayoutRequest = new GetTableLayoutRequest(this.federatedIdentity, "testQueryId", "testCatalogName", tableName, constraints, schema, cols);
+
+        PreparedStatement partitionPreparedStatement = Mockito.mock(PreparedStatement.class);
+        Mockito.when(this.connection.prepareStatement(Db2Constants.PARTITION_QUERY)).thenReturn(partitionPreparedStatement);
+        ResultSet partitionResultSet = mockResultSet(new String[] {"DATAPARTITIONID"}, new int[] {Types.INTEGER}, new Object[][] {{}}, new AtomicInteger(-1));
+        Mockito.when(partitionPreparedStatement.executeQuery()).thenReturn(partitionResultSet);
+
+        GetTableLayoutResponse getTableLayoutResponse = this.db2MetadataHandler.doGetTableLayout(this.blockAllocator, getTableLayoutRequest);
+
+        Mockito.when(this.federatedIdentity.getConfigOptions()).thenReturn(Collections.singletonMap("someOtherKey", "someValue"));
+
+        BlockAllocator splitBlockAllocator = new BlockAllocatorImpl();
+        GetSplitsRequest getSplitsRequest = new GetSplitsRequest(this.federatedIdentity, "testQueryId", "testCatalogName", tableName, getTableLayoutResponse.getPartitions(), new ArrayList<>(cols), constraints, null);
+        GetSplitsResponse getSplitsResponse = this.db2MetadataHandler.doGetSplits(splitBlockAllocator, getSplitsRequest);
+
+        assertEquals(1, getSplitsResponse.getSplits().size());
+        Split split = getSplitsResponse.getSplits().iterator().next();
+        assertEquals("0", split.getProperty(PARTITION_NUMBER));
+        assertFalse(split.getProperties().containsKey(EnvironmentConstants.CATALOG_CASING_FILTER));
+    }
+
+    @Test
+    public void doGetSplits_withNullConfigOptions_doesNotAddCasingProperty()
+            throws Exception
+    {
+        Constraints constraints = new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(),
+                Constraints.DEFAULT_NO_LIMIT, Collections.emptyMap(), null);
+        TableName tableName = new TableName("testSchema", "testTable");
+
+        Schema schema = this.db2MetadataHandler.getPartitionSchema("testCatalogName");
+        Set<String> cols = schema.getFields().stream().map(Field::getName).collect(Collectors.toSet());
+        GetTableLayoutRequest getTableLayoutRequest = new GetTableLayoutRequest(this.federatedIdentity, "testQueryId", "testCatalogName", tableName, constraints, schema, cols);
+
+        PreparedStatement partitionPreparedStatement = Mockito.mock(PreparedStatement.class);
+        Mockito.when(this.connection.prepareStatement(Db2Constants.PARTITION_QUERY)).thenReturn(partitionPreparedStatement);
+        ResultSet partitionResultSet = mockResultSet(new String[] {"DATAPARTITIONID"}, new int[] {Types.INTEGER}, new Object[][] {{}}, new AtomicInteger(-1));
+        Mockito.when(partitionPreparedStatement.executeQuery()).thenReturn(partitionResultSet);
+
+        GetTableLayoutResponse getTableLayoutResponse = this.db2MetadataHandler.doGetTableLayout(this.blockAllocator, getTableLayoutRequest);
+
+        Mockito.when(this.federatedIdentity.getConfigOptions()).thenReturn(null);
+
+        BlockAllocator splitBlockAllocator = new BlockAllocatorImpl();
+        GetSplitsRequest getSplitsRequest = new GetSplitsRequest(this.federatedIdentity, "testQueryId", "testCatalogName", tableName, getTableLayoutResponse.getPartitions(), new ArrayList<>(cols), constraints, null);
+        GetSplitsResponse getSplitsResponse = this.db2MetadataHandler.doGetSplits(splitBlockAllocator, getSplitsRequest);
+
+        assertEquals(1, getSplitsResponse.getSplits().size());
+        Split split = getSplitsResponse.getSplits().iterator().next();
+        assertEquals("0", split.getProperty(PARTITION_NUMBER));
+        assertFalse(split.getProperties().containsKey(EnvironmentConstants.CATALOG_CASING_FILTER));
     }
 
     @Test

--- a/athena-db2/src/test/java/com/amazonaws/athena/connectors/db2/Db2QueryStringBuilderTest.java
+++ b/athena-db2/src/test/java/com/amazonaws/athena/connectors/db2/Db2QueryStringBuilderTest.java
@@ -20,6 +20,8 @@
 package com.amazonaws.athena.connectors.db2;
 
 import com.amazonaws.athena.connector.lambda.domain.Split;
+import org.apache.calcite.sql.SqlDialect;
+import org.apache.calcite.sql.dialect.Db2SqlDialect;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -50,5 +52,21 @@ public class Db2QueryStringBuilderTest {
         Mockito.when(split.getProperty(Mockito.eq("partition_number"))).thenReturn("0");
         Mockito.when(split.getProperty(Mockito.eq("PARTITIONING_COLUMN"))).thenReturn("PC");
         Assert.assertEquals(List.of(" DATAPARTITIONNUM(PC) = 0"), builder.getPartitionWhereClauses(split));
+    }
+
+    @Test
+    public void getSqlDialect_returnsDb2Dialect()
+    {
+        Db2QueryStringBuilder builder = new Db2QueryStringBuilder(QUOTE_CHARACTER, new Db2FederationExpressionParser(QUOTE_CHARACTER));
+        SqlDialect dialect = builder.getSqlDialect();
+        Assert.assertTrue(dialect instanceof Db2SqlDialect);
+    }
+
+    @Test
+    public void getSqlDialectWithCasingFilter_returnsDb2Dialect()
+    {
+        Db2QueryStringBuilder builder = new Db2QueryStringBuilder(QUOTE_CHARACTER, new Db2FederationExpressionParser(QUOTE_CHARACTER));
+        SqlDialect dialect = builder.getSqlDialect(true);
+        Assert.assertTrue(dialect instanceof Db2Dialect);
     }
 }


### PR DESCRIPTION
## Description
Enables the athena-db2 connector to run as a managed Glue DNA connector with Substrait query federation. Two focused commits:

1. **Substrait query-plan rendering + catalog casing filter**
   - New `Db2Dialect` (extends Calcite `Db2SqlDialect`): renders Substrait-derived plans with DB2 semantics, double-quotes identifiers, and upper-cases them when the catalog casing filter is enabled.
   - `Db2QueryStringBuilder`: overrides `getSqlDialect()` / `getSqlDialect(boolean)` to use `Db2Dialect`.
   - `Db2MetadataHandler.doGetSplits`: creates the spill encryption key with the request override configuration (`makeEncryptionKey(getRequestOverrideConfig(...))`) and propagates `CATALOG_CASING_FILTER` into each split.

2. **Use request-override (federated) credentials on all metadata operations**
   - `Db2MetadataHandler` overrides `doListSchemaNames`, `getPartitions`, `getSchema` (and the `getColumnName` helper) with DB2-specific SQL, and opened their JDBC connections with the no-arg `getCredentialProvider()`. For managed connectors this made the metadata path read the data-source secret with the connector's default role instead of the caller's federated credentials.
   - This threads `getRequestOverrideConfig(request)` through all metadata connections so the secret is read with the request's credentials.

## Tests
- New `Db2DialectTest` (identifier quoting/casing).
- `Db2QueryStringBuilderTest`: dialect selection with/without casing filter.
- `Db2MetadataHandlerTest`: `CATALOG_CASING_FILTER` propagation (present / absent / null config), and spy tests asserting `doListSchemaNames` and `doGetTableLayout` consult `getRequestOverrideConfig(request)`.
- `mvn -pl athena-db2 test`: 58 tests, 0 failures (Corretto 17).

Behavior is unchanged for non-federated requests: `getRequestOverrideConfig` returns null when no FAS token is present, and `getCredentialProvider(null)` is equivalent to the previous no-arg call.
