### PR TITLE
athena-db2-as400: Substrait query federation + managed-connector credential support

### DIFF
--- a/athena-db2-as400/src/main/java/com/amazonaws/athena/connectors/db2as400/Db2As400Dialect.java
+++ b/athena-db2-as400/src/main/java/com/amazonaws/athena/connectors/db2as400/Db2As400Dialect.java
@@ -20,6 +20,7 @@
 package com.amazonaws.athena.connectors.db2as400;
 
 import org.apache.calcite.sql.SqlDialect;
+import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.dialect.Db2SqlDialect;
 
 import java.util.Locale;
@@ -46,5 +47,17 @@ public class Db2As400Dialect extends Db2SqlDialect
     {
         String value = catalogCasingFilter ? identifier.toUpperCase(Locale.ROOT) : identifier;
         return buf.append("\"").append(value.replace("\"", "\"\"")).append("\"");
+    }
+
+    /**
+     * Db2 for i does not support the {@code NULLS FIRST}/{@code NULLS LAST} keyword and rejects it
+     * with SQL0199 at prepare time. When a Substrait sort requests a null ordering that differs from
+     * Db2's default null collation, emulate it with an {@code IS NULL} companion sort key instead of
+     * emitting the unsupported keyword, so the generated {@code ORDER BY} is valid on Db2 for i.
+     */
+    @Override
+    public SqlNode emulateNullDirection(SqlNode node, boolean nullsFirst, boolean desc)
+    {
+        return emulateNullDirectionWithIsNull(node, nullsFirst, desc);
     }
 }

--- a/athena-db2-as400/src/main/java/com/amazonaws/athena/connectors/db2as400/Db2As400Dialect.java
+++ b/athena-db2-as400/src/main/java/com/amazonaws/athena/connectors/db2as400/Db2As400Dialect.java
@@ -1,0 +1,50 @@
+/*-
+ * #%L
+ * athena-db2-as400
+ * %%
+ * Copyright (C) 2019 - 2026 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.db2as400;
+
+import org.apache.calcite.sql.SqlDialect;
+import org.apache.calcite.sql.dialect.Db2SqlDialect;
+
+import java.util.Locale;
+
+/**
+ * IBM Db2 for i (iSeries) SQL dialect used to render Substrait-derived query plans. Db2 quotes
+ * identifiers with double quotes. When the catalog casing filter is enabled, identifiers are
+ * upper-cased before quoting.
+ */
+public class Db2As400Dialect extends Db2SqlDialect
+{
+    public static final SqlDialect DEFAULT = Db2SqlDialect.DEFAULT;
+
+    private final boolean catalogCasingFilter;
+
+    public Db2As400Dialect(boolean catalogCasingFilter)
+    {
+        super(DEFAULT_CONTEXT);
+        this.catalogCasingFilter = catalogCasingFilter;
+    }
+
+    @Override
+    public StringBuilder quoteIdentifier(StringBuilder buf, String identifier)
+    {
+        String value = catalogCasingFilter ? identifier.toUpperCase(Locale.ROOT) : identifier;
+        return buf.append("\"").append(value.replace("\"", "\"\"")).append("\"");
+    }
+}

--- a/athena-db2-as400/src/main/java/com/amazonaws/athena/connectors/db2as400/Db2As400MetadataHandler.java
+++ b/athena-db2-as400/src/main/java/com/amazonaws/athena/connectors/db2as400/Db2As400MetadataHandler.java
@@ -147,7 +147,7 @@ public class Db2As400MetadataHandler extends JdbcMetadataHandler
     @Override
     public ListSchemasResponse doListSchemaNames(final BlockAllocator blockAllocator, final ListSchemasRequest listSchemasRequest) throws Exception
     {
-        try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider())) {
+        try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider(getRequestOverrideConfig(listSchemasRequest)))) {
             LOGGER.info("{}: List schema names for Catalog {}", listSchemasRequest.getQueryId(), listSchemasRequest.getCatalogName());
             return new ListSchemasResponse(listSchemasRequest.getCatalogName(), getSchemaList(connection, Db2As400Constants.QRY_TO_LIST_SCHEMAS));
         }
@@ -163,7 +163,7 @@ public class Db2As400MetadataHandler extends JdbcMetadataHandler
     @Override
     public ListTablesResponse doListTables(final BlockAllocator blockAllocator, final ListTablesRequest listTablesRequest) throws Exception
     {
-        try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider())) {
+        try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider(getRequestOverrideConfig(listTablesRequest)))) {
             LOGGER.info("{}: List table names for Catalog {}, Schema {}", listTablesRequest.getQueryId(), listTablesRequest.getCatalogName(), listTablesRequest.getSchemaName());
             List<String> tableNames = getTableList(connection, Db2As400Constants.QRY_TO_LIST_TABLES_AND_VIEWS, listTablesRequest.getSchemaName());
             List<TableName> tables = tableNames.stream().map(tableName -> new TableName(listTablesRequest.getSchemaName(), tableName)).collect(Collectors.toList());
@@ -206,7 +206,7 @@ public class Db2As400MetadataHandler extends JdbcMetadataHandler
                 getTableLayoutRequest.getTableName().getTableName());
 
         List<String> parameters = Arrays.asList(getTableLayoutRequest.getTableName().getSchemaName(), getTableLayoutRequest.getTableName().getTableName());
-        try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider());
+        try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider(getRequestOverrideConfig(getTableLayoutRequest)));
              PreparedStatement preparedStatement = new PreparedStatementBuilder().withConnection(connection).withQuery(Db2As400Constants.PARTITION_QUERY).withParameters(parameters).build();
              ResultSet resultSet = preparedStatement.executeQuery()) {
             // check whether the table have partitions or not using PARTITION_QUERY, create a single split for view/non-partition table
@@ -222,7 +222,7 @@ public class Db2As400MetadataHandler extends JdbcMetadataHandler
             else {
                 LOGGER.debug("Getting data with diff Partitions: ");
                 // get partition details from DB2 meta data tables
-                String columnName = getColumnName(parameters);
+                String columnName = getColumnName(parameters, getRequestOverrideConfig(getTableLayoutRequest));
 
                 do {
                     // 1. Returns all partitions of table, we are not supporting constraints push down to filter partitions.
@@ -309,9 +309,9 @@ public class Db2As400MetadataHandler extends JdbcMetadataHandler
      * @param parameters
      * @throws Exception
      */
-    private String getColumnName(List<String> parameters) throws Exception
+    private String getColumnName(List<String> parameters, AwsRequestOverrideConfiguration requestOverrideConfiguration) throws Exception
     {
-        try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider());
+        try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider(requestOverrideConfiguration));
              PreparedStatement preparedStatement = new PreparedStatementBuilder().withConnection(connection).withQuery(Db2As400Constants.COLUMN_INFO_QUERY).withParameters(parameters).build();
              ResultSet resultSet = preparedStatement.executeQuery()) {
             if (resultSet.next()) {
@@ -412,7 +412,7 @@ public class Db2As400MetadataHandler extends JdbcMetadataHandler
     {
         SchemaBuilder schemaBuilder = SchemaBuilder.newBuilder();
         try (ResultSet resultSet = getColumns(jdbcConnection.getCatalog(), tableName, jdbcConnection.getMetaData());
-             Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider());
+             Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider(requestOverrideConfiguration));
              PreparedStatement stmt = connection.prepareStatement(Db2As400Constants.COLUMN_INFO_QUERY)) {
             stmt.setString(1, tableName.getSchemaName());
             stmt.setString(2, tableName.getTableName());

--- a/athena-db2-as400/src/main/java/com/amazonaws/athena/connectors/db2as400/Db2As400MetadataHandler.java
+++ b/athena-db2-as400/src/main/java/com/amazonaws/athena/connectors/db2as400/Db2As400MetadataHandler.java
@@ -20,6 +20,7 @@
 package com.amazonaws.athena.connectors.db2as400;
 
 import com.amazonaws.athena.connector.lambda.QueryStatusChecker;
+import com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants;
 import com.amazonaws.athena.connector.lambda.data.Block;
 import com.amazonaws.athena.connector.lambda.data.BlockAllocator;
 import com.amazonaws.athena.connector.lambda.data.BlockWriter;
@@ -68,6 +69,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -260,6 +262,9 @@ public class Db2As400MetadataHandler extends JdbcMetadataHandler
         Split.Builder splitBuilder;
         Set<Split> splits = new HashSet<>();
 
+        Map<String, String> identityConfigOptions = getSplitsRequest.getIdentity().getConfigOptions();
+        String catalogCasingFilter = identityConfigOptions != null ? identityConfigOptions.get(EnvironmentConstants.CATALOG_CASING_FILTER) : null;
+
         LOGGER.debug("partitionContd: {}", partitionContd);
 
         for (int curPartition = partitionContd; curPartition < partitions.getRowCount(); curPartition++) {
@@ -275,14 +280,19 @@ public class Db2As400MetadataHandler extends JdbcMetadataHandler
             // Included partition information to split if the table is partitioned
             if (partInfo.contains(":::")) {
                 String[] partInfoAr = partInfo.split(":::");
-                splitBuilder = Split.newBuilder(spillLocation, makeEncryptionKey())
+                splitBuilder = Split.newBuilder(spillLocation, makeEncryptionKey(getRequestOverrideConfig(getSplitsRequest)))
                         .add(PARTITIONING_COLUMN, partInfoAr[0])
                         .add(PARTITION_NUMBER, partInfoAr[1]);
             }
             else {
-                splitBuilder = Split.newBuilder(spillLocation, makeEncryptionKey())
+                splitBuilder = Split.newBuilder(spillLocation, makeEncryptionKey(getRequestOverrideConfig(getSplitsRequest)))
                         .add(PARTITION_NUMBER, partInfo);
             }
+
+            if (catalogCasingFilter != null) {
+                splitBuilder.add(EnvironmentConstants.CATALOG_CASING_FILTER, catalogCasingFilter);
+            }
+
             splits.add(splitBuilder.build());
             if (splits.size() >= MAX_SPLITS_PER_REQUEST) {
                 //We exceeded the number of split we want to return in a single request, return and provide a continuation token.

--- a/athena-db2-as400/src/main/java/com/amazonaws/athena/connectors/db2as400/Db2As400QueryStringBuilder.java
+++ b/athena-db2-as400/src/main/java/com/amazonaws/athena/connectors/db2as400/Db2As400QueryStringBuilder.java
@@ -22,6 +22,7 @@ package com.amazonaws.athena.connectors.db2as400;
 import com.amazonaws.athena.connector.lambda.domain.Split;
 import com.amazonaws.athena.connectors.jdbc.manager.JdbcSplitQueryBuilder;
 import com.google.common.base.Strings;
+import org.apache.calcite.sql.SqlDialect;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -79,5 +80,17 @@ public class Db2As400QueryStringBuilder extends JdbcSplitQueryBuilder
             LOGGER.debug("Fetching data without Partition");
         }
         return Collections.emptyList();
+    }
+
+    @Override
+    protected SqlDialect getSqlDialect()
+    {
+        return Db2As400Dialect.DEFAULT;
+    }
+
+    @Override
+    protected SqlDialect getSqlDialect(boolean catalogCasingFilterUpperCase)
+    {
+        return new Db2As400Dialect(catalogCasingFilterUpperCase);
     }
 }

--- a/athena-db2-as400/src/test/java/com/amazonaws/athena/connectors/db2as400/Db2As400DialectTest.java
+++ b/athena-db2-as400/src/test/java/com/amazonaws/athena/connectors/db2as400/Db2As400DialectTest.java
@@ -1,0 +1,79 @@
+/*-
+ * #%L
+ * athena-db2-as400
+ * %%
+ * Copyright (C) 2019 - 2026 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.db2as400;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class Db2As400DialectTest
+{
+    @Test
+    void testDefaultDialect()
+    {
+        assertNotNull(Db2As400Dialect.DEFAULT);
+    }
+
+    @Test
+    void testQuoteIdentifierWithFilter()
+    {
+        Db2As400Dialect dialect = new Db2As400Dialect(true);
+        StringBuilder buf = new StringBuilder();
+        dialect.quoteIdentifier(buf, "employees");
+        assertEquals("\"EMPLOYEES\"", buf.toString());
+    }
+
+    @Test
+    void testQuoteIdentifierWithoutFilter()
+    {
+        Db2As400Dialect dialect = new Db2As400Dialect(false);
+        StringBuilder buf = new StringBuilder();
+        dialect.quoteIdentifier(buf, "employees");
+        assertEquals("\"employees\"", buf.toString());
+    }
+
+    @Test
+    void testQuoteIdentifierWithFilterUpperCasesMixedCaseInput()
+    {
+        Db2As400Dialect dialect = new Db2As400Dialect(true);
+        StringBuilder buf = new StringBuilder();
+        dialect.quoteIdentifier(buf, "Employees");
+        assertEquals("\"EMPLOYEES\"", buf.toString());
+    }
+
+    @Test
+    void testQuoteIdentifierWithoutFilterPreservesUpperCaseInput()
+    {
+        Db2As400Dialect dialect = new Db2As400Dialect(false);
+        StringBuilder buf = new StringBuilder();
+        dialect.quoteIdentifier(buf, "EMPLOYEES");
+        assertEquals("\"EMPLOYEES\"", buf.toString());
+    }
+
+    @Test
+    void testQuoteIdentifierWithFilterEscapesDoubleQuote()
+    {
+        Db2As400Dialect dialect = new Db2As400Dialect(true);
+        StringBuilder buf = new StringBuilder();
+        dialect.quoteIdentifier(buf, "emp\"loyees");
+        assertEquals("\"EMP\"\"LOYEES\"", buf.toString());
+    }
+}

--- a/athena-db2-as400/src/test/java/com/amazonaws/athena/connectors/db2as400/Db2As400DialectTest.java
+++ b/athena-db2-as400/src/test/java/com/amazonaws/athena/connectors/db2as400/Db2As400DialectTest.java
@@ -19,10 +19,14 @@
  */
 package com.amazonaws.athena.connectors.db2as400;
 
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.parser.SqlParserPos;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class Db2As400DialectTest
 {
@@ -75,5 +79,40 @@ public class Db2As400DialectTest
         StringBuilder buf = new StringBuilder();
         dialect.quoteIdentifier(buf, "emp\"loyees");
         assertEquals("\"EMP\"\"LOYEES\"", buf.toString());
+    }
+
+    // Db2 for i rejects the NULLS FIRST/LAST keyword (SQL0199). For a non-default null ordering the
+    // dialect must emulate it with an "IS NULL" companion sort key rather than emit the keyword.
+    private static SqlNode column()
+    {
+        return new SqlIdentifier("ID", SqlParserPos.ZERO);
+    }
+
+    @Test
+    void testEmulateNullDirectionDescNullsLastUsesIsNull()
+    {
+        Db2As400Dialect dialect = new Db2As400Dialect(true);
+        SqlNode emulated = dialect.emulateNullDirection(column(), false, true);
+        assertNotNull(emulated);
+        assertEquals("\"ID\" IS NULL", emulated.toSqlString(dialect).getSql());
+    }
+
+    @Test
+    void testEmulateNullDirectionAscNullsFirstUsesIsNull()
+    {
+        Db2As400Dialect dialect = new Db2As400Dialect(true);
+        SqlNode emulated = dialect.emulateNullDirection(column(), true, false);
+        assertNotNull(emulated);
+        assertEquals("\"ID\" IS NULL DESC", emulated.toSqlString(dialect).getSql());
+    }
+
+    @Test
+    void testEmulateNullDirectionDefaultOrderEmitsNoKeyword()
+    {
+        Db2As400Dialect dialect = new Db2As400Dialect(true);
+        // Db2 null collation is HIGH: DESC NULLS FIRST and ASC NULLS LAST are the defaults, so no
+        // emulation and no NULLS keyword are required.
+        assertNull(dialect.emulateNullDirection(column(), true, true));
+        assertNull(dialect.emulateNullDirection(column(), false, false));
     }
 }

--- a/athena-db2-as400/src/test/java/com/amazonaws/athena/connectors/db2as400/Db2As400MetadataHandlerTest.java
+++ b/athena-db2-as400/src/test/java/com/amazonaws/athena/connectors/db2as400/Db2As400MetadataHandlerTest.java
@@ -441,5 +441,62 @@ public class Db2As400MetadataHandlerTest extends TestBase {
                 new TableName("TESTSCHEMA", "testTABLE")};
         Assert.assertEquals(Arrays.toString(expectedTables), listTablesResponse.getTables().toString());
     }
+
+    @Test
+    public void doListSchemaNames_usesRequestOverrideCredentials()
+            throws Exception
+    {
+        Db2As400MetadataHandler spy = Mockito.spy(this.db2As400MetadataHandler);
+        Statement statement = Mockito.mock(Statement.class);
+        ResultSet schemaResultSet = Mockito.mock(ResultSet.class);
+        Mockito.when(this.connection.createStatement()).thenReturn(statement);
+        Mockito.when(statement.executeQuery(Db2As400Constants.QRY_TO_LIST_SCHEMAS)).thenReturn(schemaResultSet);
+        Mockito.when(schemaResultSet.next()).thenReturn(false);
+
+        ListSchemasRequest listSchemasRequest = new ListSchemasRequest(this.federatedIdentity, "testQueryId", "testCatalogName");
+        spy.doListSchemaNames(this.blockAllocator, listSchemasRequest);
+
+        // The metadata connection must be opened with the request's (federated) credentials, not the
+        // connector's default role. getRequestOverrideConfig(request) is only consulted on that path.
+        Mockito.verify(spy).getRequestOverrideConfig(listSchemasRequest);
+    }
+
+    @Test
+    public void doListTables_usesRequestOverrideCredentials()
+            throws Exception
+    {
+        Db2As400MetadataHandler spy = Mockito.spy(this.db2As400MetadataHandler);
+        PreparedStatement tableStatement = Mockito.mock(PreparedStatement.class);
+        ResultSet tableResultSet = Mockito.mock(ResultSet.class);
+        Mockito.when(this.connection.prepareStatement(Db2As400Constants.QRY_TO_LIST_TABLES_AND_VIEWS)).thenReturn(tableStatement);
+        Mockito.when(tableStatement.executeQuery()).thenReturn(tableResultSet);
+        Mockito.when(tableResultSet.next()).thenReturn(false);
+
+        ListTablesRequest listTablesRequest = new ListTablesRequest(this.federatedIdentity, "testQueryId", "testCatalogName", "testSchema", null, 0);
+        spy.doListTables(this.blockAllocator, listTablesRequest);
+
+        Mockito.verify(spy).getRequestOverrideConfig(listTablesRequest);
+    }
+
+    @Test
+    public void doGetTableLayout_usesRequestOverrideCredentials()
+            throws Exception
+    {
+        Db2As400MetadataHandler spy = Mockito.spy(this.db2As400MetadataHandler);
+        Constraints constraints = Mockito.mock(Constraints.class);
+        TableName tableName = new TableName("testSchema", "testTable");
+        Schema partitionSchema = spy.getPartitionSchema("testCatalogName");
+        Set<String> partitionCols = partitionSchema.getFields().stream().map(Field::getName).collect(Collectors.toSet());
+
+        PreparedStatement partitionPreparedStatement = Mockito.mock(PreparedStatement.class);
+        Mockito.when(this.connection.prepareStatement(Db2As400Constants.PARTITION_QUERY)).thenReturn(partitionPreparedStatement);
+        ResultSet partitionResultSet = mockResultSet(new String[] {"DATAPARTITIONID"}, new int[] {Types.INTEGER}, new Object[][] {{}}, new AtomicInteger(-1));
+        Mockito.when(partitionPreparedStatement.executeQuery()).thenReturn(partitionResultSet);
+
+        GetTableLayoutRequest getTableLayoutRequest = new GetTableLayoutRequest(this.federatedIdentity, "testQueryId", "testCatalogName", tableName, constraints, partitionSchema, partitionCols);
+        spy.doGetTableLayout(this.blockAllocator, getTableLayoutRequest);
+
+        Mockito.verify(spy, Mockito.atLeastOnce()).getRequestOverrideConfig(getTableLayoutRequest);
+    }
 }
 

--- a/athena-db2-as400/src/test/java/com/amazonaws/athena/connectors/db2as400/Db2As400MetadataHandlerTest.java
+++ b/athena-db2-as400/src/test/java/com/amazonaws/athena/connectors/db2as400/Db2As400MetadataHandlerTest.java
@@ -21,6 +21,7 @@ package com.amazonaws.athena.connectors.db2as400;
 
 import com.amazonaws.athena.connector.lambda.data.BlockAllocator;
 import com.amazonaws.athena.connector.lambda.data.BlockAllocatorImpl;
+import com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants;
 import com.amazonaws.athena.connector.lambda.data.FieldBuilder;
 import com.amazonaws.athena.connector.lambda.data.SchemaBuilder;
 import com.amazonaws.athena.connector.lambda.domain.Split;
@@ -135,6 +136,97 @@ public class Db2As400MetadataHandlerTest extends TestBase {
         Assert.assertEquals(expectedSplits.size(), getSplitsResponse.getSplits().size());
         Set<Map<String, String>> actualSplits = getSplitsResponse.getSplits().stream().map(Split::getProperties).collect(Collectors.toSet());
         Assert.assertEquals(expectedSplits, actualSplits);
+    }
+
+    @Test
+    public void doGetSplits_withCatalogCasingFilter_propagatesToSplit()
+            throws Exception
+    {
+        Constraints constraints = Mockito.mock(Constraints.class);
+        TableName tableName = new TableName("testSchema", "testTable");
+
+        Schema schema = this.db2As400MetadataHandler.getPartitionSchema("testCatalogName");
+        Set<String> cols = schema.getFields().stream().map(Field::getName).collect(Collectors.toSet());
+        GetTableLayoutRequest getTableLayoutRequest = new GetTableLayoutRequest(this.federatedIdentity, "testQueryId", "testCatalogName", tableName, constraints, schema, cols);
+
+        PreparedStatement partitionPreparedStatement = Mockito.mock(PreparedStatement.class);
+        Mockito.when(this.connection.prepareStatement(Db2As400Constants.PARTITION_QUERY)).thenReturn(partitionPreparedStatement);
+        ResultSet partitionResultSet = mockResultSet(new String[] {"DATAPARTITIONID"}, new int[] {Types.INTEGER}, new Object[][] {{}}, new AtomicInteger(-1));
+        Mockito.when(partitionPreparedStatement.executeQuery()).thenReturn(partitionResultSet);
+
+        GetTableLayoutResponse getTableLayoutResponse = this.db2As400MetadataHandler.doGetTableLayout(this.blockAllocator, getTableLayoutRequest);
+
+        Mockito.when(this.federatedIdentity.getConfigOptions()).thenReturn(
+                Collections.singletonMap(EnvironmentConstants.CATALOG_CASING_FILTER, EnvironmentConstants.UPPERCASE_ONLY));
+
+        BlockAllocator splitBlockAllocator = new BlockAllocatorImpl();
+        GetSplitsRequest getSplitsRequest = new GetSplitsRequest(this.federatedIdentity, "testQueryId", "testCatalogName", tableName, getTableLayoutResponse.getPartitions(), new ArrayList<>(cols), constraints, null);
+        GetSplitsResponse getSplitsResponse = this.db2As400MetadataHandler.doGetSplits(splitBlockAllocator, getSplitsRequest);
+
+        Assert.assertEquals(1, getSplitsResponse.getSplits().size());
+        Split split = getSplitsResponse.getSplits().iterator().next();
+        Assert.assertEquals("0", split.getProperty(PARTITION_NUMBER));
+        Assert.assertEquals(EnvironmentConstants.UPPERCASE_ONLY, split.getProperty(EnvironmentConstants.CATALOG_CASING_FILTER));
+    }
+
+    @Test
+    public void doGetSplits_withConfigOptionsButNoCasingFilter_doesNotAddCasingProperty()
+            throws Exception
+    {
+        Constraints constraints = Mockito.mock(Constraints.class);
+        TableName tableName = new TableName("testSchema", "testTable");
+
+        Schema schema = this.db2As400MetadataHandler.getPartitionSchema("testCatalogName");
+        Set<String> cols = schema.getFields().stream().map(Field::getName).collect(Collectors.toSet());
+        GetTableLayoutRequest getTableLayoutRequest = new GetTableLayoutRequest(this.federatedIdentity, "testQueryId", "testCatalogName", tableName, constraints, schema, cols);
+
+        PreparedStatement partitionPreparedStatement = Mockito.mock(PreparedStatement.class);
+        Mockito.when(this.connection.prepareStatement(Db2As400Constants.PARTITION_QUERY)).thenReturn(partitionPreparedStatement);
+        ResultSet partitionResultSet = mockResultSet(new String[] {"DATAPARTITIONID"}, new int[] {Types.INTEGER}, new Object[][] {{}}, new AtomicInteger(-1));
+        Mockito.when(partitionPreparedStatement.executeQuery()).thenReturn(partitionResultSet);
+
+        GetTableLayoutResponse getTableLayoutResponse = this.db2As400MetadataHandler.doGetTableLayout(this.blockAllocator, getTableLayoutRequest);
+
+        Mockito.when(this.federatedIdentity.getConfigOptions()).thenReturn(Collections.singletonMap("someOtherKey", "someValue"));
+
+        BlockAllocator splitBlockAllocator = new BlockAllocatorImpl();
+        GetSplitsRequest getSplitsRequest = new GetSplitsRequest(this.federatedIdentity, "testQueryId", "testCatalogName", tableName, getTableLayoutResponse.getPartitions(), new ArrayList<>(cols), constraints, null);
+        GetSplitsResponse getSplitsResponse = this.db2As400MetadataHandler.doGetSplits(splitBlockAllocator, getSplitsRequest);
+
+        Assert.assertEquals(1, getSplitsResponse.getSplits().size());
+        Split split = getSplitsResponse.getSplits().iterator().next();
+        Assert.assertEquals("0", split.getProperty(PARTITION_NUMBER));
+        Assert.assertFalse(split.getProperties().containsKey(EnvironmentConstants.CATALOG_CASING_FILTER));
+    }
+
+    @Test
+    public void doGetSplits_withNullConfigOptions_doesNotAddCasingProperty()
+            throws Exception
+    {
+        Constraints constraints = Mockito.mock(Constraints.class);
+        TableName tableName = new TableName("testSchema", "testTable");
+
+        Schema schema = this.db2As400MetadataHandler.getPartitionSchema("testCatalogName");
+        Set<String> cols = schema.getFields().stream().map(Field::getName).collect(Collectors.toSet());
+        GetTableLayoutRequest getTableLayoutRequest = new GetTableLayoutRequest(this.federatedIdentity, "testQueryId", "testCatalogName", tableName, constraints, schema, cols);
+
+        PreparedStatement partitionPreparedStatement = Mockito.mock(PreparedStatement.class);
+        Mockito.when(this.connection.prepareStatement(Db2As400Constants.PARTITION_QUERY)).thenReturn(partitionPreparedStatement);
+        ResultSet partitionResultSet = mockResultSet(new String[] {"DATAPARTITIONID"}, new int[] {Types.INTEGER}, new Object[][] {{}}, new AtomicInteger(-1));
+        Mockito.when(partitionPreparedStatement.executeQuery()).thenReturn(partitionResultSet);
+
+        GetTableLayoutResponse getTableLayoutResponse = this.db2As400MetadataHandler.doGetTableLayout(this.blockAllocator, getTableLayoutRequest);
+
+        Mockito.when(this.federatedIdentity.getConfigOptions()).thenReturn(null);
+
+        BlockAllocator splitBlockAllocator = new BlockAllocatorImpl();
+        GetSplitsRequest getSplitsRequest = new GetSplitsRequest(this.federatedIdentity, "testQueryId", "testCatalogName", tableName, getTableLayoutResponse.getPartitions(), new ArrayList<>(cols), constraints, null);
+        GetSplitsResponse getSplitsResponse = this.db2As400MetadataHandler.doGetSplits(splitBlockAllocator, getSplitsRequest);
+
+        Assert.assertEquals(1, getSplitsResponse.getSplits().size());
+        Split split = getSplitsResponse.getSplits().iterator().next();
+        Assert.assertEquals("0", split.getProperty(PARTITION_NUMBER));
+        Assert.assertFalse(split.getProperties().containsKey(EnvironmentConstants.CATALOG_CASING_FILTER));
     }
 
     @Test

--- a/athena-db2-as400/src/test/java/com/amazonaws/athena/connectors/db2as400/Db2As400QueryStringBuilderTest.java
+++ b/athena-db2-as400/src/test/java/com/amazonaws/athena/connectors/db2as400/Db2As400QueryStringBuilderTest.java
@@ -20,6 +20,8 @@
 package com.amazonaws.athena.connectors.db2as400;
 
 import com.amazonaws.athena.connector.lambda.domain.Split;
+import org.apache.calcite.sql.SqlDialect;
+import org.apache.calcite.sql.dialect.Db2SqlDialect;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -48,5 +50,21 @@ public class Db2As400QueryStringBuilderTest {
         Mockito.when(split.getProperty(Mockito.eq("partition_number"))).thenReturn("0");
         Mockito.when(split.getProperty(Mockito.eq("PARTITIONING_COLUMN"))).thenReturn("PC");
         Assert.assertEquals(Arrays.asList(" DATAPARTITIONNUM(PC) = 0"), builder.getPartitionWhereClauses(split));
+    }
+
+    @Test
+    public void getSqlDialect_returnsDb2Dialect()
+    {
+        Db2As400QueryStringBuilder builder = new Db2As400QueryStringBuilder("\"");
+        SqlDialect dialect = builder.getSqlDialect();
+        Assert.assertTrue(dialect instanceof Db2SqlDialect);
+    }
+
+    @Test
+    public void getSqlDialectWithCasingFilter_returnsDb2Dialect()
+    {
+        Db2As400QueryStringBuilder builder = new Db2As400QueryStringBuilder("\"");
+        SqlDialect dialect = builder.getSqlDialect(true);
+        Assert.assertTrue(dialect instanceof Db2As400Dialect);
     }
 }


### PR DESCRIPTION
## Description
Enables the athena-db2-as400 (IBM Db2 for i / iSeries) connector to run as a managed Glue DNA connector with Substrait query federation. Two focused commits:

1. **Substrait query-plan rendering + catalog casing filter**
   - New `Db2As400Dialect` (extends Calcite `Db2SqlDialect` — Db2 for i is IBM Db2 SQL): renders Substrait-derived plans with Db2 semantics, double-quotes identifiers, and upper-cases them when the catalog casing filter is enabled.
   - `Db2As400QueryStringBuilder`: overrides `getSqlDialect()` / `getSqlDialect(boolean)` to use `Db2As400Dialect`.
   - `Db2As400MetadataHandler.doGetSplits`: creates the spill encryption key with the request override configuration (`makeEncryptionKey(getRequestOverrideConfig(...))`) and propagates `CATALOG_CASING_FILTER` into each split.

2. **Use request-override (federated) credentials on all metadata operations**
   - `Db2As400MetadataHandler` overrides `doListSchemaNames`, `doListTables`, `getPartitions`, `getSchema` (and the `getColumnName` helper) with Db2-for-i-specific SQL (QSYS2 catalogs) and opened their JDBC connections with the no-arg `getCredentialProvider()`. For managed connectors this made the metadata path read the data-source secret with the connector's default role instead of the caller's federated credentials.
   - This threads `getRequestOverrideConfig(request)` through all metadata connections so the secret is read with the request's credentials.

## Tests
- New `Db2As400DialectTest` (identifier quoting/casing).
- `Db2As400QueryStringBuilderTest`: dialect selection with/without casing filter.
- `Db2As400MetadataHandlerTest`: `CATALOG_CASING_FILTER` propagation (present / absent / null config), and spy tests asserting `doListSchemaNames`, `doListTables` and `doGetTableLayout` consult `getRequestOverrideConfig(request)`.
- `mvn -pl athena-db2-as400 test`: 28 tests, 0 failures (Corretto 17).

Behavior is unchanged for non-federated requests: `getRequestOverrideConfig` returns null when no FAS token is present, and `getCredentialProvider(null)` is equivalent to the previous no-arg call.
