### PR TITLE
Disable DirectPath for BigQuery Storage Read API on Lambda

### DIFF
--- a/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryRecordHandler.java
+++ b/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryRecordHandler.java
@@ -31,6 +31,7 @@ import com.amazonaws.athena.connector.lambda.handlers.RecordHandler;
 import com.amazonaws.athena.connector.lambda.records.ReadRecordsRequest;
 import com.amazonaws.athena.connector.substrait.model.SubstraitRelModel;
 import com.amazonaws.athena.connectors.google.bigquery.qpt.BigQueryQueryPassthrough;
+import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
 import com.google.api.gax.rpc.ServerStream;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryException;
@@ -246,9 +247,19 @@ public class BigQueryRecordHandler
         String secret = getSecret(getEnvBigQueryCredsSmId(configOptions), getRequestOverrideConfig(configOptions));
         boolean catalogCasingFilterUpperCase = isCasingFilterUpperCase();
 
-        // Create BigQueryReadClient with credentials from Secrets Manager
+        // Create BigQueryReadClient with credentials from Secrets Manager.
+        // The BigQuery Storage Read API enables DirectPath by default, which routes the channel
+        // through the google-c2p name resolver and a unix:/// bootstrap address. On Lambda the
+        // shaded gRPC transport has no unix-socket support, so the channel build fails with
+        // "Address types of NameResolver 'unix' ... not supported by transport". Disabling
+        // DirectPath keeps the client on the standard DNS + TCP path regardless of which gRPC
+        // resolver artifacts (grpc-googleapis / grpc-xds) land on the classpath transitively.
+        InstantiatingGrpcChannelProvider channelProvider = BigQueryReadSettings.defaultGrpcTransportProviderBuilder()
+                .setAttemptDirectPath(false)
+                .build();
         BigQueryReadSettings settings = BigQueryReadSettings.newBuilder()
                 .setCredentialsProvider(() -> BigQueryUtils.getCredentialsFromSecret(secret))
+                .setTransportChannelProvider(channelProvider)
                 .build();
 
         try (BigQueryReadClient client = BigQueryReadClient.create(settings)) {


### PR DESCRIPTION
*Issue #, if available:* #3312

*Description of changes:*

The BigQuery Storage Read API enables gRPC DirectPath by default. DirectPath routes the channel through the `google-c2p` name resolver and a `unix:///` bootstrap address. On AWS Lambda the shaded gRPC transport has no unix-socket support, so building the read channel fails with:

```
java.lang.IllegalArgumentException: Address types of NameResolver 'unix' for 'unix:///bigquerystorage.googleapis.com:443' not supported by transport
```

This makes standard `SELECT` queries fail while query passthrough (`system.query(...)`) still works, because passthrough uses the BigQuery job/REST path rather than the Storage Read gRPC channel.

This change explicitly disables DirectPath on the `BigQueryReadClient` transport channel provider (`setAttemptDirectPath(false)`), keeping the client on the standard DNS + TCP path. It is independent of which gRPC resolver artifacts (`grpc-googleapis` / `grpc-xds`) are pulled in transitively, so it does not regress if the dependency graph changes later.

Tested by building the connector image and running `SELECT` queries against a BigQuery data source in Athena; queries that previously failed with the error above now return rows.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
