### PR TITLE
Add connection retry for Aurora Serverless v2 cold-start failures

### DIFF
--- a/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/connection/GenericJdbcConnectionFactory.java
+++ b/athena-jdbc/src/main/java/com/amazonaws/athena/connectors/jdbc/connection/GenericJdbcConnectionFactory.java
@@ -101,15 +101,67 @@ public class GenericJdbcConnectionFactory
         }
     }
 
+    private static final int MAX_CONNECTION_RETRIES = 3;
+    private static final long CONNECTION_RETRY_BACKOFF_MS = 15_000; // 15 seconds
+
     @Override
     public Connection getConnection(final CredentialsProvider credentialsProvider)
             throws Exception
     {
-        if (useDirectConnection) {
-            return createDirectConnection(credentialsProvider);
-        }
+        Connection connection = null;
+        Exception lastException = null;
 
-        return getConnectionFromManagedPool(credentialsProvider);
+        for (int attempt = 1; attempt <= MAX_CONNECTION_RETRIES; attempt++) {
+            try {
+                if (useDirectConnection) {
+                    connection = createDirectConnection(credentialsProvider);
+                }
+                else {
+                    connection = getConnectionFromManagedPool(credentialsProvider);
+                }
+                if (attempt > 1) {
+                    LOGGER.info("Successfully connected on attempt {}", attempt);
+                }
+                return connection;
+            }
+            catch (Exception e) {
+                lastException = e;
+                if (attempt == MAX_CONNECTION_RETRIES || !isRetryableConnectionError(e)) {
+                    throw e;
+                }
+                LOGGER.warn("Connection attempt {} of {} failed: {}. Retrying in {}ms...",
+                        attempt, MAX_CONNECTION_RETRIES, e.getMessage(), CONNECTION_RETRY_BACKOFF_MS);
+                try {
+                    Thread.sleep(CONNECTION_RETRY_BACKOFF_MS);
+                }
+                catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    throw lastException;
+                }
+            }
+        }
+        if (lastException != null) {
+            throw lastException;
+        }
+        return connection;
+    }
+
+    /**
+     * Determines if an exception represents a transient connection failure,
+     * typically caused by Aurora Serverless v2 resuming from a paused state (0 ACU).
+     */
+    private boolean isRetryableConnectionError(Throwable e)
+    {
+        Throwable current = e;
+        while (current != null) {
+            String message = current.getMessage();
+            if (message != null && (message.toLowerCase().contains("failed to initialize pool")
+                    || message.toLowerCase().contains("connect timed out"))) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
     }
 
     /**

--- a/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/connection/GenericJdbcConnectionFactoryTest.java
+++ b/athena-jdbc/src/test/java/com/amazonaws/athena/connectors/jdbc/connection/GenericJdbcConnectionFactoryTest.java
@@ -401,4 +401,119 @@ public class GenericJdbcConnectionFactoryTest
             assertEquals(expected, actual);
         }
     }
+
+    // --- Retry logic tests ---
+
+    @Test
+    public void getConnection_directMode_retriesOnPoolInitFailureAndSucceeds() throws Exception
+    {
+        GenericJdbcConnectionFactory factory = newDirectModeFactory(uniqueH2Url());
+        Connection mockConnection = Mockito.mock(Connection.class);
+        SQLException poolInitError = new SQLException("Failed to initialize pool: The connection attempt failed.");
+
+        try (MockedStatic<DriverManager> mockedDriverManager = Mockito.mockStatic(DriverManager.class)) {
+            mockedDriverManager.when(() -> DriverManager.getConnection(any(String.class), any(Properties.class)))
+                    .thenThrow(poolInitError)
+                    .thenReturn(mockConnection);
+
+            Connection result = factory.getConnection(null);
+
+            assertEquals(mockConnection, result);
+            mockedDriverManager.verify(() -> DriverManager.getConnection(any(String.class), any(Properties.class)),
+                    Mockito.times(2));
+        }
+    }
+
+    @Test
+    public void getConnection_directMode_retriesOnConnectTimedOutAndSucceeds() throws Exception
+    {
+        GenericJdbcConnectionFactory factory = newDirectModeFactory(uniqueH2Url());
+        Connection mockConnection = Mockito.mock(Connection.class);
+        RuntimeException timeoutError = new RuntimeException("connect timed out");
+
+        try (MockedStatic<DriverManager> mockedDriverManager = Mockito.mockStatic(DriverManager.class)) {
+            mockedDriverManager.when(() -> DriverManager.getConnection(any(String.class), any(Properties.class)))
+                    .thenThrow(timeoutError)
+                    .thenReturn(mockConnection);
+
+            Connection result = factory.getConnection(null);
+
+            assertEquals(mockConnection, result);
+            mockedDriverManager.verify(() -> DriverManager.getConnection(any(String.class), any(Properties.class)),
+                    Mockito.times(2));
+        }
+    }
+
+    @Test
+    public void getConnection_directMode_exhaustsRetriesOnPersistentPoolInitFailure()
+    {
+        GenericJdbcConnectionFactory factory = newDirectModeFactory(uniqueH2Url());
+        SQLException poolInitError = new SQLException("Failed to initialize pool: The connection attempt failed.");
+
+        try (MockedStatic<DriverManager> mockedDriverManager = Mockito.mockStatic(DriverManager.class)) {
+            mockedDriverManager.when(() -> DriverManager.getConnection(any(String.class), any(Properties.class)))
+                    .thenThrow(poolInitError);
+
+            assertThrows(SQLException.class, () -> factory.getConnection(null));
+            mockedDriverManager.verify(() -> DriverManager.getConnection(any(String.class), any(Properties.class)),
+                    Mockito.times(3));
+        }
+    }
+
+    @Test
+    public void getConnection_directMode_doesNotRetryOnNonRetryableError()
+    {
+        GenericJdbcConnectionFactory factory = newDirectModeFactory(uniqueH2Url());
+        SQLException authError = new SQLException("Access denied: invalid credentials");
+
+        try (MockedStatic<DriverManager> mockedDriverManager = Mockito.mockStatic(DriverManager.class)) {
+            mockedDriverManager.when(() -> DriverManager.getConnection(any(String.class), any(Properties.class)))
+                    .thenThrow(authError);
+
+            assertThrows(SQLException.class, () -> factory.getConnection(null));
+            mockedDriverManager.verify(() -> DriverManager.getConnection(any(String.class), any(Properties.class)),
+                    Mockito.times(1));
+        }
+    }
+
+    @Test
+    public void getConnection_directMode_retriesOnNestedCauseChain() throws Exception
+    {
+        GenericJdbcConnectionFactory factory = newDirectModeFactory(uniqueH2Url());
+        Connection mockConnection = Mockito.mock(Connection.class);
+        Exception nested = new RuntimeException("wrapper",
+                new java.net.SocketTimeoutException("connect timed out"));
+
+        try (MockedStatic<DriverManager> mockedDriverManager = Mockito.mockStatic(DriverManager.class)) {
+            mockedDriverManager.when(() -> DriverManager.getConnection(any(String.class), any(Properties.class)))
+                    .thenThrow(nested)
+                    .thenReturn(mockConnection);
+
+            Connection result = factory.getConnection(null);
+
+            assertEquals(mockConnection, result);
+            mockedDriverManager.verify(() -> DriverManager.getConnection(any(String.class), any(Properties.class)),
+                    Mockito.times(2));
+        }
+    }
+
+    @Test
+    public void getConnection_directMode_retriesOnCaseInsensitivePoolInitFailure() throws Exception
+    {
+        GenericJdbcConnectionFactory factory = newDirectModeFactory(uniqueH2Url());
+        Connection mockConnection = Mockito.mock(Connection.class);
+        SQLException poolInitError = new SQLException("FAILED TO INITIALIZE POOL: Connection attempt failed.");
+
+        try (MockedStatic<DriverManager> mockedDriverManager = Mockito.mockStatic(DriverManager.class)) {
+            mockedDriverManager.when(() -> DriverManager.getConnection(any(String.class), any(Properties.class)))
+                    .thenThrow(poolInitError)
+                    .thenReturn(mockConnection);
+
+            Connection result = factory.getConnection(null);
+
+            assertEquals(mockConnection, result);
+            mockedDriverManager.verify(() -> DriverManager.getConnection(any(String.class), any(Properties.class)),
+                    Mockito.times(2));
+        }
+    }
 }


### PR DESCRIPTION
### Problem
When connecting to Aurora Serverless v2 with 0 ACU minimum capacity, the first connection attempt fails with 'Failed to initialize pool: The connection attempt failed' because the database is paused and needs ~25-45 seconds to resume.

*Refer to SIM Ticket - https://t.corp.amazon.com/V2153573163*

### Changes
Add retry logic (3 attempts, 15s backoff) in GenericJdbcConnectionFactory.getConnection() for transient connection failures. Only retries on:
- 'failed to initialize pool' (HikariCP pool init failure)
- 'connect timed out' (TCP timeout during database resume)

Non-retryable errors (auth failures, invalid host, etc.) fail without retry. 

### Testing
- Reproduced the error with gamma endpoint
- Deployed the fix to gamma VPC lambda and verified the issue is gone. 