### PR TITLE
Fix BigQuery NameResolver Issue in Base Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,8 +89,9 @@ RUN for file in ${LAMBDA_TASK_ROOT}/*.jar ${LAMBDA_TASK_ROOT}/*.zip; do \
         for svc in /tmp/extract/META-INF/services/*; do \
           [ -f "$svc" ] || continue; \
           base=$(basename "$svc"); \
-          cat "$svc" >> "${LAMBDA_TASK_ROOT}/META-INF/services/${base}" && \
-          sort -u "${LAMBDA_TASK_ROOT}/META-INF/services/${base}" -o "${LAMBDA_TASK_ROOT}/META-INF/services/${base}"; \
+          dest="${LAMBDA_TASK_ROOT}/META-INF/services/${base}"; \
+          touch "$dest"; \
+          awk '!seen[$0]++' "$dest" "$svc" > "$dest.tmp" && mv "$dest.tmp" "$dest"; \
         done && \
         rm -rf /tmp/extract/META-INF/services; \
       fi && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,23 @@ COPY \
   athena-vertica/target/athena-vertica-${JAR_VERSION}.jar \
   ${LAMBDA_TASK_ROOT}/
 
-# Run a shell loop to iterate over all jar/zip files and extract each one.
+# Unpack all connector jars/zips into the same task root.
+# Merge META-INF/services so SPI providers from each artifact are preserved.
 RUN for file in ${LAMBDA_TASK_ROOT}/*.jar ${LAMBDA_TASK_ROOT}/*.zip; do \
-      jar xf "$file" && rm -f "$file"; \
+      [ -e "$file" ] || continue; \
+      mkdir -p /tmp/extract && \
+      (cd /tmp/extract && jar xf "$file") && \
+      if [ -d /tmp/extract/META-INF/services ]; then \
+        mkdir -p ${LAMBDA_TASK_ROOT}/META-INF/services && \
+        for svc in /tmp/extract/META-INF/services/*; do \
+          [ -f "$svc" ] || continue; \
+          base=$(basename "$svc"); \
+          cat "$svc" >> "${LAMBDA_TASK_ROOT}/META-INF/services/${base}" && \
+          sort -u "${LAMBDA_TASK_ROOT}/META-INF/services/${base}" -o "${LAMBDA_TASK_ROOT}/META-INF/services/${base}"; \
+        done && \
+        rm -rf /tmp/extract/META-INF/services; \
+      fi && \
+      cp -a /tmp/extract/. ${LAMBDA_TASK_ROOT}/ && \
+      rm -rf /tmp/extract && \
+      rm -f "$file"; \
 done


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
While testing the BigQuery connector with the base Docker image, we identified a runtime issue:
**Delegate resolver not found, scheme: dns**

This occurs because Java SPI files under `META-INF/services/` can be overwritten when multiple archives contain files at the same path, resulting in the loss of service provider definitions.

This change updates the Docker image build process to **merge SPI service definition files** instead of overwriting them. As a result, all required service provider registrations are preserved, including the gRPC `NameResolverProvider` entries required by the BigQuery connector.

**Validation**
We tested the following connectors in addition to BigQuery to ensure that the fix does not impact other connectors:

- GCS
- DynamoDB
- Vertica
- Oracle

The results confirmed that the fix resolves the BigQuery issue without impacting other connectors.

Please refer to the attached functional testing and analysis document for additional details.
[BigQuery_NameResolver_Fix_For_Base_Docker_Image.docx](https://github.com/user-attachments/files/31178530/BigQuery_NameResolver_Fix_For_Base_Docker_Image.docx)
[BIGQUERY_FUNCTIONAL_TEST_2026-08-18.xlsx](https://github.com/user-attachments/files/31179184/BIGQUERY_FUNCTIONAL_TEST_2026-08-18.xlsx)





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
