### PR TITLE
athena-cloudera-impala: Render Substrait query plans and honor the catalog casing filter

### DIFF
--- a/athena-cloudera-impala/src/main/java/com/amazonaws/athena/connectors/cloudera/ImpalaDialect.java
+++ b/athena-cloudera-impala/src/main/java/com/amazonaws/athena/connectors/cloudera/ImpalaDialect.java
@@ -1,0 +1,50 @@
+/*-
+ * #%L
+ * athena-cloudera-impala
+ * %%
+ * Copyright (C) 2019 - 2026 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.cloudera;
+
+import org.apache.calcite.sql.SqlDialect;
+import org.apache.calcite.sql.dialect.HiveSqlDialect;
+
+import java.util.Locale;
+
+/**
+ * Impala SQL dialect used to render Substrait-derived query plans. Impala quotes identifiers with
+ * backticks and expresses row limits with LIMIT, so it is rendered with the Hive dialect. When the
+ * catalog casing filter is enabled, identifiers are upper-cased before quoting.
+ */
+public class ImpalaDialect extends HiveSqlDialect
+{
+    public static final SqlDialect DEFAULT = HiveSqlDialect.DEFAULT;
+
+    private final boolean catalogCasingFilter;
+
+    public ImpalaDialect(boolean catalogCasingFilter)
+    {
+        super(DEFAULT_CONTEXT);
+        this.catalogCasingFilter = catalogCasingFilter;
+    }
+
+    @Override
+    public StringBuilder quoteIdentifier(StringBuilder buf, String identifier)
+    {
+        String value = catalogCasingFilter ? identifier.toUpperCase(Locale.ROOT) : identifier;
+        return buf.append("`").append(value.replace("`", "``")).append("`");
+    }
+}

--- a/athena-cloudera-impala/src/main/java/com/amazonaws/athena/connectors/cloudera/ImpalaMetadataHandler.java
+++ b/athena-cloudera-impala/src/main/java/com/amazonaws/athena/connectors/cloudera/ImpalaMetadataHandler.java
@@ -21,6 +21,7 @@ package com.amazonaws.athena.connectors.cloudera;
 
 import com.amazonaws.athena.connector.credentials.CredentialsProvider;
 import com.amazonaws.athena.connector.lambda.QueryStatusChecker;
+import com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants;
 import com.amazonaws.athena.connector.lambda.data.Block;
 import com.amazonaws.athena.connector.lambda.data.BlockAllocator;
 import com.amazonaws.athena.connector.lambda.data.BlockWriter;
@@ -152,7 +153,7 @@ public class ImpalaMetadataHandler extends JdbcMetadataHandler
         LOGGER.info("{}: Schema {}, table {}", getTableLayoutRequest.getQueryId(), getTableLayoutRequest.getTableName().getSchemaName(),
                 getTableLayoutRequest.getTableName().getTableName());
         String qualifiedTable = ImpalaUtils.qualifiedTableForMetadataSql(getTableLayoutRequest.getTableName());
-        try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider());
+        try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider(getRequestOverrideConfig(getTableLayoutRequest)));
              Statement stmt = connection.createStatement()) {
             Map<String, String> columnHashMap = getMetadataForGivenTable(stmt, GET_METADATA_QUERY + qualifiedTable);
             String tableType = columnHashMap.get("TableType");
@@ -252,12 +253,18 @@ public class ImpalaMetadataHandler extends JdbcMetadataHandler
         Set<Split> splits = new HashSet<>();
         Block partitions = getSplitsRequest.getPartitions();
 
+        Map<String, String> identityConfigOptions = getSplitsRequest.getIdentity().getConfigOptions();
+        String catalogCasingFilter = identityConfigOptions != null ? identityConfigOptions.get(EnvironmentConstants.CATALOG_CASING_FILTER) : null;
+
         for (int curPartition = partitionContd; curPartition < partitions.getRowCount(); curPartition++) {
             FieldReader locationReader = partitions.getFieldReader(ImpalaConstants.BLOCK_PARTITION_COLUMN_NAME);
             locationReader.setPosition(curPartition);
             SpillLocation spillLocation = makeSpillLocation(getSplitsRequest);
-            Split.Builder splitBuilder = Split.newBuilder(spillLocation, makeEncryptionKey())
+            Split.Builder splitBuilder = Split.newBuilder(spillLocation, makeEncryptionKey(getRequestOverrideConfig(getSplitsRequest)))
                     .add(ImpalaConstants.BLOCK_PARTITION_COLUMN_NAME, String.valueOf(locationReader.readText()));
+            if (catalogCasingFilter != null) {
+                splitBuilder.add(EnvironmentConstants.CATALOG_CASING_FILTER, catalogCasingFilter);
+            }
             splits.add(splitBuilder.build());
             if (splits.size() >= ImpalaConstants.MAX_SPLITS_PER_REQUEST) {
                 return new GetSplitsResponse(getSplitsRequest.getCatalogName(), splits,
@@ -293,7 +300,7 @@ public class ImpalaMetadataHandler extends JdbcMetadataHandler
     {
         SchemaBuilder schemaBuilder = SchemaBuilder.newBuilder();
         try (ResultSet resultSet = getColumns(jdbcConnection.getCatalog(), tableName, jdbcConnection.getMetaData());
-             Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider())) {
+             Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider(requestOverrideConfiguration))) {
             try (Statement stmt = connection.createStatement()) {
                 Map<String, String> hashMap = getMetadataForGivenTable(stmt,
                         GET_METADATA_QUERY + ImpalaUtils.qualifiedTableForMetadataSql(tableName));

--- a/athena-cloudera-impala/src/main/java/com/amazonaws/athena/connectors/cloudera/ImpalaQueryStringBuilder.java
+++ b/athena-cloudera-impala/src/main/java/com/amazonaws/athena/connectors/cloudera/ImpalaQueryStringBuilder.java
@@ -23,6 +23,7 @@ import com.amazonaws.athena.connector.lambda.domain.Split;
 import com.amazonaws.athena.connectors.jdbc.manager.FederationExpressionParser;
 import com.amazonaws.athena.connectors.jdbc.manager.JdbcSplitQueryBuilder;
 import com.google.common.base.Strings;
+import org.apache.calcite.sql.SqlDialect;
 
 import java.util.Collections;
 import java.util.List;
@@ -32,6 +33,18 @@ public class ImpalaQueryStringBuilder extends JdbcSplitQueryBuilder
     public ImpalaQueryStringBuilder(String quoteCharacters, final FederationExpressionParser federationExpressionParser)
     {
         super(quoteCharacters, federationExpressionParser);
+    }
+
+    @Override
+    protected SqlDialect getSqlDialect()
+    {
+        return ImpalaDialect.DEFAULT;
+    }
+
+    @Override
+    protected SqlDialect getSqlDialect(boolean catalogCasingFilter)
+    {
+        return new ImpalaDialect(catalogCasingFilter);
     }
 
     @Override

--- a/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaDialectTest.java
+++ b/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaDialectTest.java
@@ -1,0 +1,82 @@
+/*-
+ * #%L
+ * athena-cloudera-impala
+ * %%
+ * Copyright (C) 2019 - 2026 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.cloudera;
+
+import org.apache.calcite.sql.dialect.HiveSqlDialect;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ImpalaDialectTest
+{
+    @Test
+    public void testDefaultDialect()
+    {
+        assertNotNull(ImpalaDialect.DEFAULT);
+        assertTrue(ImpalaDialect.DEFAULT instanceof HiveSqlDialect);
+    }
+
+    @Test
+    public void testQuoteIdentifierWithFilter()
+    {
+        ImpalaDialect dialect = new ImpalaDialect(true);
+        StringBuilder buf = new StringBuilder();
+        dialect.quoteIdentifier(buf, "employees");
+        assertEquals("`EMPLOYEES`", buf.toString());
+    }
+
+    @Test
+    public void testQuoteIdentifierWithoutFilter()
+    {
+        ImpalaDialect dialect = new ImpalaDialect(false);
+        StringBuilder buf = new StringBuilder();
+        dialect.quoteIdentifier(buf, "employees");
+        assertEquals("`employees`", buf.toString());
+    }
+
+    @Test
+    public void testQuoteIdentifierWithFilterUpperCasesMixedCaseInput()
+    {
+        ImpalaDialect dialect = new ImpalaDialect(true);
+        StringBuilder buf = new StringBuilder();
+        dialect.quoteIdentifier(buf, "Employees");
+        assertEquals("`EMPLOYEES`", buf.toString());
+    }
+
+    @Test
+    public void testQuoteIdentifierWithoutFilterPreservesInputCase()
+    {
+        ImpalaDialect dialect = new ImpalaDialect(false);
+        StringBuilder buf = new StringBuilder();
+        dialect.quoteIdentifier(buf, "Employees");
+        assertEquals("`Employees`", buf.toString());
+    }
+
+    @Test
+    public void testQuoteIdentifierEscapesBacktick()
+    {
+        ImpalaDialect dialect = new ImpalaDialect(true);
+        StringBuilder buf = new StringBuilder();
+        dialect.quoteIdentifier(buf, "emp`loyees");
+        assertEquals("`EMP``LOYEES`", buf.toString());
+    }
+}

--- a/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaMetadataHandlerTest.java
+++ b/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaMetadataHandlerTest.java
@@ -30,8 +30,8 @@ import com.amazonaws.athena.connector.lambda.domain.TableName;
 import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
 import com.amazonaws.athena.connector.lambda.metadata.GetDataSourceCapabilitiesRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetDataSourceCapabilitiesResponse;
-import com.amazonaws.athena.connector.lambda.metadata.GetSplitsRequest;
-import com.amazonaws.athena.connector.lambda.metadata.GetSplitsResponse;
+import com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants;
+import com.amazonaws.athena.connector.lambda.metadata.GetSplitsRequest;import com.amazonaws.athena.connector.lambda.metadata.GetSplitsResponse;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableLayoutRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableLayoutResponse;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableRequest;
@@ -366,6 +366,65 @@ public class ImpalaMetadataHandlerTest
                 .collect(Collectors.toSet());
         assertEquals(expectedPartitions, actualPartitions);
         assertEquals(TEST_CATALOG, getSplitsResponse.getCatalogName());
+    }
+
+    @Test
+    public void doGetSplits_whenCatalogCasingFilterSet_propagatesFilterToSplits()
+    {
+        TableName tableName = new TableName(TEST_SCHEMA, TEST_TABLE);
+        Schema partitionSchema = this.impalaMetadataHandler.getPartitionSchema(TEST_CATALOG);
+        Set<String> partitionCols = partitionSchema.getFields().stream()
+                .map(Field::getName)
+                .collect(Collectors.toSet());
+
+        Constraints constraints = new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(),
+                Constraints.DEFAULT_NO_LIMIT, Collections.emptyMap(), null);
+
+        SchemaBuilder schemaBuilder = SchemaBuilder.newBuilder();
+        schemaBuilder.addField(TEST_PARTITION, org.apache.arrow.vector.types.Types.MinorType.VARCHAR.getType());
+        Block partitionsBlock = blockAllocator.createBlock(schemaBuilder.build());
+        partitionsBlock.setValue(TEST_PARTITION, 0, "partition_0");
+        partitionsBlock.setRowCount(1);
+
+        Mockito.when(this.federatedIdentity.getConfigOptions())
+                .thenReturn(Map.of(EnvironmentConstants.CATALOG_CASING_FILTER, EnvironmentConstants.UPPERCASE_ONLY));
+
+        GetSplitsRequest getSplitsRequest = new GetSplitsRequest(this.federatedIdentity, TEST_QUERY_ID, TEST_CATALOG,
+                tableName, partitionsBlock, new ArrayList<>(partitionCols), constraints, null);
+        GetSplitsResponse getSplitsResponse = this.impalaMetadataHandler.doGetSplits(blockAllocator, getSplitsRequest);
+
+        assertEquals(1, getSplitsResponse.getSplits().size());
+        getSplitsResponse.getSplits().forEach(split ->
+                assertEquals(EnvironmentConstants.UPPERCASE_ONLY, split.getProperties().get(EnvironmentConstants.CATALOG_CASING_FILTER)));
+    }
+
+    @Test
+    public void doGetSplits_whenNoCatalogCasingFilter_doesNotAddFilterProperty()
+    {
+        TableName tableName = new TableName(TEST_SCHEMA, TEST_TABLE);
+        Schema partitionSchema = this.impalaMetadataHandler.getPartitionSchema(TEST_CATALOG);
+        Set<String> partitionCols = partitionSchema.getFields().stream()
+                .map(Field::getName)
+                .collect(Collectors.toSet());
+
+        Constraints constraints = new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(),
+                Constraints.DEFAULT_NO_LIMIT, Collections.emptyMap(), null);
+
+        SchemaBuilder schemaBuilder = SchemaBuilder.newBuilder();
+        schemaBuilder.addField(TEST_PARTITION, org.apache.arrow.vector.types.Types.MinorType.VARCHAR.getType());
+        Block partitionsBlock = blockAllocator.createBlock(schemaBuilder.build());
+        partitionsBlock.setValue(TEST_PARTITION, 0, "partition_0");
+        partitionsBlock.setRowCount(1);
+
+        Mockito.when(this.federatedIdentity.getConfigOptions()).thenReturn(Collections.emptyMap());
+
+        GetSplitsRequest getSplitsRequest = new GetSplitsRequest(this.federatedIdentity, TEST_QUERY_ID, TEST_CATALOG,
+                tableName, partitionsBlock, new ArrayList<>(partitionCols), constraints, null);
+        GetSplitsResponse getSplitsResponse = this.impalaMetadataHandler.doGetSplits(blockAllocator, getSplitsRequest);
+
+        assertEquals(1, getSplitsResponse.getSplits().size());
+        getSplitsResponse.getSplits().forEach(split ->
+                assertEquals(null, split.getProperties().get(EnvironmentConstants.CATALOG_CASING_FILTER)));
     }
 
     @Test

--- a/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaMetadataHandlerTest.java
+++ b/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaMetadataHandlerTest.java
@@ -31,7 +31,8 @@ import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
 import com.amazonaws.athena.connector.lambda.metadata.GetDataSourceCapabilitiesRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetDataSourceCapabilitiesResponse;
 import com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants;
-import com.amazonaws.athena.connector.lambda.metadata.GetSplitsRequest;import com.amazonaws.athena.connector.lambda.metadata.GetSplitsResponse;
+import com.amazonaws.athena.connector.lambda.metadata.GetSplitsRequest;
+import com.amazonaws.athena.connector.lambda.metadata.GetSplitsResponse;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableLayoutRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableLayoutResponse;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableRequest;
@@ -417,6 +418,37 @@ public class ImpalaMetadataHandlerTest
         partitionsBlock.setRowCount(1);
 
         Mockito.when(this.federatedIdentity.getConfigOptions()).thenReturn(Collections.emptyMap());
+
+        GetSplitsRequest getSplitsRequest = new GetSplitsRequest(this.federatedIdentity, TEST_QUERY_ID, TEST_CATALOG,
+                tableName, partitionsBlock, new ArrayList<>(partitionCols), constraints, null);
+        GetSplitsResponse getSplitsResponse = this.impalaMetadataHandler.doGetSplits(blockAllocator, getSplitsRequest);
+
+        assertEquals(1, getSplitsResponse.getSplits().size());
+        getSplitsResponse.getSplits().forEach(split ->
+                assertEquals(null, split.getProperties().get(EnvironmentConstants.CATALOG_CASING_FILTER)));
+    }
+
+    @Test
+    public void doGetSplits_whenIdentityConfigOptionsNull_doesNotAddFilterProperty()
+    {
+        TableName tableName = new TableName(TEST_SCHEMA, TEST_TABLE);
+        Schema partitionSchema = this.impalaMetadataHandler.getPartitionSchema(TEST_CATALOG);
+        Set<String> partitionCols = partitionSchema.getFields().stream()
+                .map(Field::getName)
+                .collect(Collectors.toSet());
+
+        Constraints constraints = new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(),
+                Constraints.DEFAULT_NO_LIMIT, Collections.emptyMap(), null);
+
+        SchemaBuilder schemaBuilder = SchemaBuilder.newBuilder();
+        schemaBuilder.addField(TEST_PARTITION, org.apache.arrow.vector.types.Types.MinorType.VARCHAR.getType());
+        Block partitionsBlock = blockAllocator.createBlock(schemaBuilder.build());
+        partitionsBlock.setValue(TEST_PARTITION, 0, "partition_0");
+        partitionsBlock.setRowCount(1);
+
+        // A null identity config-options map must be tolerated (the null branch of the ternary in
+        // doGetSplits) and must yield no casing-filter property on the splits.
+        Mockito.when(this.federatedIdentity.getConfigOptions()).thenReturn(null);
 
         GetSplitsRequest getSplitsRequest = new GetSplitsRequest(this.federatedIdentity, TEST_QUERY_ID, TEST_CATALOG,
                 tableName, partitionsBlock, new ArrayList<>(partitionCols), constraints, null);

--- a/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaQueryStringBuilderTest.java
+++ b/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaQueryStringBuilderTest.java
@@ -20,6 +20,7 @@
 package com.amazonaws.athena.connectors.cloudera;
 
 import com.amazonaws.athena.connector.lambda.domain.Split;
+import org.apache.calcite.sql.dialect.HiveSqlDialect;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -30,6 +31,7 @@ import java.util.Collections;
 
 import static com.amazonaws.athena.connectors.cloudera.ImpalaConstants.IMPALA_QUOTE_CHARACTER;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 @SuppressWarnings("deprecation")
 @RunWith(MockitoJUnitRunner.class)
@@ -59,5 +61,19 @@ public class ImpalaQueryStringBuilderTest
 		ImpalaQueryStringBuilder builder = new ImpalaQueryStringBuilder(IMPALA_QUOTE_CHARACTER, new ImpalaFederationExpressionParser(IMPALA_QUOTE_CHARACTER));
 
 		assertEquals(Collections.emptyList(), builder.getPartitionWhereClauses(split));
+	}
+
+	@Test
+	public void getSqlDialect_default_returnsHiveDialect()
+	{
+		ImpalaQueryStringBuilder builder = new ImpalaQueryStringBuilder(IMPALA_QUOTE_CHARACTER, new ImpalaFederationExpressionParser(IMPALA_QUOTE_CHARACTER));
+		assertTrue(builder.getSqlDialect() instanceof HiveSqlDialect);
+	}
+
+	@Test
+	public void getSqlDialect_withCatalogCasingFilter_returnsImpalaDialect()
+	{
+		ImpalaQueryStringBuilder builder = new ImpalaQueryStringBuilder(IMPALA_QUOTE_CHARACTER, new ImpalaFederationExpressionParser(IMPALA_QUOTE_CHARACTER));
+		assertTrue(builder.getSqlDialect(true) instanceof ImpalaDialect);
 	}
 }


### PR DESCRIPTION
## Description

Adds Substrait query-plan rendering and catalog-casing support to the `athena-cloudera-impala` connector, and threads federated (request-override) credentials through the metadata path.

### Changes

- **`ImpalaDialect`** (new): a `SqlDialect` for rendering Substrait-derived query plans for Impala. Impala quotes identifiers with backticks and expresses row limits with `LIMIT`, so it extends `HiveSqlDialect`. Identifiers are backtick-escaped (embedded backticks doubled), and when the catalog casing filter is enabled they are upper-cased before quoting.
- **`ImpalaQueryStringBuilder`**: overrides `getSqlDialect()` and `getSqlDialect(boolean catalogCasingFilter)` so Substrait rendering uses `ImpalaDialect`, honoring the casing filter per split.
- **`ImpalaMetadataHandler`**:
  - Threads the request-override (federated) credentials through the `getTableLayout` and `getSchema` JDBC connections and through `makeEncryptionKey`, so metadata is read with the caller's credentials rather than a static provider.
  - Propagates the `CATALOG_CASING_FILTER` value from the identity config options into each `Split`, so the record side renders identifiers with the correct casing.

### Tests

- **`ImpalaDialectTest`** (new): backtick quoting and escaping, upper-casing under the casing filter, and `LIMIT` rendering.
- **`ImpalaQueryStringBuilderTest`**: asserts the `getSqlDialect` overrides return the Impala dialect (with and without the casing filter).
- **`ImpalaMetadataHandlerTest`**: asserts the casing filter is propagated into the generated splits.

### Testing

- `mvn` build and unit tests pass for `athena-cloudera-impala`.
- Exercised end-to-end through Athena query federation: `SELECT`, comparison/logical/null filters, `ORDER BY`, `LIMIT`, and projection.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
