### PR TITLE
Enhance DB2/DB2 AS400 data-partition SQL with identifier quoting.

### DIFF
--- a/athena-db2-as400/src/main/java/com/amazonaws/athena/connectors/db2as400/Db2As400QueryStringBuilder.java
+++ b/athena-db2-as400/src/main/java/com/amazonaws/athena/connectors/db2as400/Db2As400QueryStringBuilder.java
@@ -54,9 +54,9 @@ public class Db2As400QueryStringBuilder extends JdbcSplitQueryBuilder
             tableName.append(quote(catalog)).append('.');
         }
         if (!Strings.isNullOrEmpty(schema)) {
-            tableName.append(schema).append('.');
+            tableName.append(quote(schema)).append('.');
         }
-        tableName.append(table);
+        tableName.append(quote(table));
         return String.format(" FROM %s ", tableName);
     }
 

--- a/athena-db2-as400/src/main/java/com/amazonaws/athena/connectors/db2as400/Db2As400QueryStringBuilder.java
+++ b/athena-db2-as400/src/main/java/com/amazonaws/athena/connectors/db2as400/Db2As400QueryStringBuilder.java
@@ -72,8 +72,8 @@ public class Db2As400QueryStringBuilder extends JdbcSplitQueryBuilder
         String column = split.getProperty(Db2As400MetadataHandler.PARTITIONING_COLUMN);
         if (column != null) {
             LOGGER.debug("Fetching data using Partition");
-            //example query: select * from EMP_TABLE WHERE DATAPARTITIONNUM(EMP_NO) = 0
-            return Collections.singletonList(" DATAPARTITIONNUM(" + column + ") = " + split.getProperty(Db2As400MetadataHandler.PARTITION_NUMBER));
+            //example query: select * from EMP_TABLE WHERE DATAPARTITIONNUM("EMP_NO") = 0
+            return Collections.singletonList(" DATAPARTITIONNUM(" + quote(column) + ") = " + split.getProperty(Db2As400MetadataHandler.PARTITION_NUMBER));
         }
         else {
             LOGGER.debug("Fetching data without Partition");

--- a/athena-db2-as400/src/main/java/com/amazonaws/athena/connectors/db2as400/Db2As400QueryStringBuilder.java
+++ b/athena-db2-as400/src/main/java/com/amazonaws/athena/connectors/db2as400/Db2As400QueryStringBuilder.java
@@ -54,9 +54,9 @@ public class Db2As400QueryStringBuilder extends JdbcSplitQueryBuilder
             tableName.append(quote(catalog)).append('.');
         }
         if (!Strings.isNullOrEmpty(schema)) {
-            tableName.append(quote(schema)).append('.');
+            tableName.append(schema).append('.');
         }
-        tableName.append(quote(table));
+        tableName.append(table);
         return String.format(" FROM %s ", tableName);
     }
 

--- a/athena-db2-as400/src/test/java/com/amazonaws/athena/connectors/db2as400/Db2As400QueryStringBuilderTest.java
+++ b/athena-db2-as400/src/test/java/com/amazonaws/athena/connectors/db2as400/Db2As400QueryStringBuilderTest.java
@@ -38,8 +38,8 @@ public class Db2As400QueryStringBuilderTest {
     {
         Split split = Mockito.mock(Split.class);
         Db2As400QueryStringBuilder builder = new Db2As400QueryStringBuilder(QUOTE_CHARACTER);
-        Assert.assertEquals(" FROM \"default\".table ", builder.getFromClauseWithSplit("default", "", "table", split));
-        Assert.assertEquals(" FROM \"default\".schema.table ", builder.getFromClauseWithSplit("default", "schema", "table", split));
+        Assert.assertEquals(" FROM \"default\".\"table\" ", builder.getFromClauseWithSplit("default", "", "table", split));
+        Assert.assertEquals(" FROM \"default\".\"schema\".\"table\" ", builder.getFromClauseWithSplit("default", "schema", "table", split));
     }
 
     @Test

--- a/athena-db2-as400/src/test/java/com/amazonaws/athena/connectors/db2as400/Db2As400QueryStringBuilderTest.java
+++ b/athena-db2-as400/src/test/java/com/amazonaws/athena/connectors/db2as400/Db2As400QueryStringBuilderTest.java
@@ -25,9 +25,11 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.testng.Assert;
 
-import java.util.Arrays;
+import java.util.List;
 
 public class Db2As400QueryStringBuilderTest {
+    private static final String QUOTE_CHARACTER = "\"";
+
     @Mock
     Split split;
 
@@ -35,18 +37,30 @@ public class Db2As400QueryStringBuilderTest {
     public void testQueryBuilder()
     {
         Split split = Mockito.mock(Split.class);
-        Db2As400QueryStringBuilder builder = new Db2As400QueryStringBuilder("'");
-        Assert.assertEquals(" FROM 'default'.table ", builder.getFromClauseWithSplit("default", "", "table", split));
-        Assert.assertEquals(" FROM 'default'.schema.table ", builder.getFromClauseWithSplit("default", "schema", "table", split));
+        Db2As400QueryStringBuilder builder = new Db2As400QueryStringBuilder(QUOTE_CHARACTER);
+        Assert.assertEquals(" FROM \"default\".table ", builder.getFromClauseWithSplit("default", "", "table", split));
+        Assert.assertEquals(" FROM \"default\".schema.table ", builder.getFromClauseWithSplit("default", "schema", "table", split));
     }
 
     @Test
     public void testGetPartitionWhereClauses()
     {
-        Db2As400QueryStringBuilder builder = new Db2As400QueryStringBuilder("'");
+        Db2As400QueryStringBuilder builder = new Db2As400QueryStringBuilder(QUOTE_CHARACTER);
         Split split = Mockito.mock(Split.class);
         Mockito.when(split.getProperty(Mockito.eq("partition_number"))).thenReturn("0");
         Mockito.when(split.getProperty(Mockito.eq("PARTITIONING_COLUMN"))).thenReturn("PC");
-        Assert.assertEquals(Arrays.asList(" DATAPARTITIONNUM(PC) = 0"), builder.getPartitionWhereClauses(split));
+        Assert.assertEquals(List.of(" DATAPARTITIONNUM(\"PC\") = 0"), builder.getPartitionWhereClauses(split));
+    }
+
+    @Test
+    public void getPartitionWhereClauses_partitioningColumnWithSpecialCharacters_returnsQuotedIdentifier()
+    {
+        Db2As400QueryStringBuilder builder = new Db2As400QueryStringBuilder(QUOTE_CHARACTER);
+        Split split = Mockito.mock(Split.class);
+        Mockito.when(split.getProperty(Mockito.eq("partition_number"))).thenReturn("0");
+        Mockito.when(split.getProperty(Mockito.eq("PARTITIONING_COLUMN"))).thenReturn("\"X\") = 0 OR 1=1 --");
+        Assert.assertEquals(
+                List.of(" DATAPARTITIONNUM(\"\"\"X\"\") = 0 OR 1=1 --\") = 0"),
+                builder.getPartitionWhereClauses(split));
     }
 }

--- a/athena-db2-as400/src/test/java/com/amazonaws/athena/connectors/db2as400/Db2As400QueryStringBuilderTest.java
+++ b/athena-db2-as400/src/test/java/com/amazonaws/athena/connectors/db2as400/Db2As400QueryStringBuilderTest.java
@@ -38,8 +38,8 @@ public class Db2As400QueryStringBuilderTest {
     {
         Split split = Mockito.mock(Split.class);
         Db2As400QueryStringBuilder builder = new Db2As400QueryStringBuilder(QUOTE_CHARACTER);
-        Assert.assertEquals(" FROM \"default\".\"table\" ", builder.getFromClauseWithSplit("default", "", "table", split));
-        Assert.assertEquals(" FROM \"default\".\"schema\".\"table\" ", builder.getFromClauseWithSplit("default", "schema", "table", split));
+        Assert.assertEquals(" FROM \"default\".table ", builder.getFromClauseWithSplit("default", "", "table", split));
+        Assert.assertEquals(" FROM \"default\".schema.table ", builder.getFromClauseWithSplit("default", "schema", "table", split));
     }
 
     @Test

--- a/athena-db2-as400/src/test/java/com/amazonaws/athena/connectors/db2as400/Db2As400RecordHandlerTest.java
+++ b/athena-db2-as400/src/test/java/com/amazonaws/athena/connectors/db2as400/Db2As400RecordHandlerTest.java
@@ -104,7 +104,7 @@ public class Db2As400RecordHandlerTest {
                 .put("testCol4", valueSet)
                 .build());
 
-        String expectedSql = "SELECT \"testCol1\", \"testCol2\", \"testCol3\", \"testCol4\" FROM \"testSchema\".\"testTable\"  WHERE (\"testCol4\" = ?)";
+        String expectedSql = "SELECT \"testCol1\", \"testCol2\", \"testCol3\", \"testCol4\" FROM testSchema.testTable  WHERE (\"testCol4\" = ?)";
         PreparedStatement expectedPreparedStatement = Mockito.mock(PreparedStatement.class);
         Mockito.when(this.connection.prepareStatement(Mockito.eq(expectedSql))).thenReturn(expectedPreparedStatement);
         PreparedStatement preparedStatement = this.db2As400RecordHandler.buildSplitSql(this.connection, "testCatalogName", tableName, schema, constraints, split);

--- a/athena-db2-as400/src/test/java/com/amazonaws/athena/connectors/db2as400/Db2As400RecordHandlerTest.java
+++ b/athena-db2-as400/src/test/java/com/amazonaws/athena/connectors/db2as400/Db2As400RecordHandlerTest.java
@@ -67,7 +67,7 @@ public class Db2As400RecordHandlerTest {
         this.connection = Mockito.mock(Connection.class);
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         Mockito.when(this.jdbcConnectionFactory.getConnection(nullable(CredentialsProvider.class))).thenReturn(this.connection);
-        jdbcSplitQueryBuilder = new Db2As400QueryStringBuilder("`");
+        jdbcSplitQueryBuilder = new Db2As400QueryStringBuilder("\"");
         final DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig("testCatalog", Db2As400Constants.NAME,
                 "db2as400://jdbc:as400://testhost;user=dummy;password=dummy;");
         this.db2As400RecordHandler = new Db2As400RecordHandler(databaseConnectionConfig, amazonS3, secretsManager, athena, jdbcConnectionFactory, jdbcSplitQueryBuilder, com.google.common.collect.ImmutableMap.of());
@@ -104,7 +104,7 @@ public class Db2As400RecordHandlerTest {
                 .put("testCol4", valueSet)
                 .build());
 
-        String expectedSql = "SELECT `testCol1`, `testCol2`, `testCol3`, `testCol4` FROM testSchema.testTable  WHERE (`testCol4` = ?)";
+        String expectedSql = "SELECT \"testCol1\", \"testCol2\", \"testCol3\", \"testCol4\" FROM \"testSchema\".\"testTable\"  WHERE (\"testCol4\" = ?)";
         PreparedStatement expectedPreparedStatement = Mockito.mock(PreparedStatement.class);
         Mockito.when(this.connection.prepareStatement(Mockito.eq(expectedSql))).thenReturn(expectedPreparedStatement);
         PreparedStatement preparedStatement = this.db2As400RecordHandler.buildSplitSql(this.connection, "testCatalogName", tableName, schema, constraints, split);

--- a/athena-db2/src/main/java/com/amazonaws/athena/connectors/db2/Db2QueryStringBuilder.java
+++ b/athena-db2/src/main/java/com/amazonaws/athena/connectors/db2/Db2QueryStringBuilder.java
@@ -75,8 +75,8 @@ public class Db2QueryStringBuilder extends JdbcSplitQueryBuilder
         String column = split.getProperty(Db2MetadataHandler.PARTITIONING_COLUMN);
         if (column != null) {
             LOGGER.debug("Fetching data using Partition");
-            //example query: select * from EMP_TABLE WHERE DATAPARTITIONNUM(EMP_NO) = 0
-            return Collections.singletonList(" DATAPARTITIONNUM(" + column + ") = " + split.getProperty(PARTITION_NUMBER));
+            //example query: select * from EMP_TABLE WHERE DATAPARTITIONNUM("EMP_NO") = 0
+            return Collections.singletonList(" DATAPARTITIONNUM(" + quote(column) + ") = " + split.getProperty(PARTITION_NUMBER));
         }
         else {
             LOGGER.debug("Fetching data without Partition");

--- a/athena-db2/src/test/java/com/amazonaws/athena/connectors/db2/Db2QueryStringBuilderTest.java
+++ b/athena-db2/src/test/java/com/amazonaws/athena/connectors/db2/Db2QueryStringBuilderTest.java
@@ -49,6 +49,18 @@ public class Db2QueryStringBuilderTest {
         Split split = Mockito.mock(Split.class);
         Mockito.when(split.getProperty(Mockito.eq("partition_number"))).thenReturn("0");
         Mockito.when(split.getProperty(Mockito.eq("PARTITIONING_COLUMN"))).thenReturn("PC");
-        Assert.assertEquals(List.of(" DATAPARTITIONNUM(PC) = 0"), builder.getPartitionWhereClauses(split));
+        Assert.assertEquals(List.of(" DATAPARTITIONNUM(\"PC\") = 0"), builder.getPartitionWhereClauses(split));
+    }
+
+    @Test
+    public void getPartitionWhereClauses_partitioningColumnWithSpecialCharacters_returnsQuotedIdentifier()
+    {
+        Db2QueryStringBuilder builder = new Db2QueryStringBuilder(QUOTE_CHARACTER, new Db2FederationExpressionParser(QUOTE_CHARACTER));
+        Split split = Mockito.mock(Split.class);
+        Mockito.when(split.getProperty(Mockito.eq("partition_number"))).thenReturn("0");
+        Mockito.when(split.getProperty(Mockito.eq("PARTITIONING_COLUMN"))).thenReturn("\"X\") = 0 OR 1=1 --");
+        Assert.assertEquals(
+                List.of(" DATAPARTITIONNUM(\"\"\"X\"\") = 0 OR 1=1 --\") = 0"),
+                builder.getPartitionWhereClauses(split));
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added quoting of the partitioning column in DATAPARTITIONNUM(...) for Athena DB2 and DB2 AS400 data-partition queries. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
