### PR TITLE
Fix NPE in BigQuery connector when STRUCT/RECORD field is null

### DIFF
--- a/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryUtils.java
+++ b/athena-google-bigquery/src/main/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryUtils.java
@@ -387,6 +387,9 @@ public class BigQueryUtils
 
     public static Object getComplexObjectFromFieldValue(Field field, FieldValue fieldValue) throws ParseException
     {
+        if (fieldValue == null || fieldValue.isNull()) {
+            return null;
+        }
         Types.MinorType minorTypeForArrowType = getMinorTypeForArrowType(field.getFieldType().getType());
         if (minorTypeForArrowType.equals(Types.MinorType.LIST)) {
             List<Object> valList = new ArrayList();

--- a/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryUtilsTest.java
+++ b/athena-google-bigquery/src/test/java/com/amazonaws/athena/connectors/google/bigquery/BigQueryUtilsTest.java
@@ -497,4 +497,21 @@ public class BigQueryUtilsTest
         String result = BigQueryUtils.fixCaseForDatasetName(BigQueryTestUtils.PROJECT_1_NAME, datasetName, bigQuery);
         assertNotNull(result);
     }
+
+    @Test
+    public void testGetComplexObjectFromFieldValueWithNullFieldValue() throws ParseException
+    {
+        org.apache.arrow.vector.types.pojo.Field structField = 
+            new org.apache.arrow.vector.types.pojo.Field("test_struct", FieldType.nullable(new ArrowType.Struct()), null);
+        assertNull(BigQueryUtils.getComplexObjectFromFieldValue(structField, null));
+    }
+
+    @Test
+    public void testGetComplexObjectFromFieldValueWithIsNullFieldValue() throws ParseException
+    {
+        org.apache.arrow.vector.types.pojo.Field structField =
+            new org.apache.arrow.vector.types.pojo.Field("test_struct", FieldType.nullable(new ArrowType.Struct()), null);
+        FieldValue nullRecordValue = FieldValue.of(FieldValue.Attribute.RECORD, null);
+        assertNull(BigQueryUtils.getComplexObjectFromFieldValue(structField, nullRecordValue));
+    }
 }


### PR DESCRIPTION
BigQueryUtils.getComplexObjectFromFieldValue() crashes with NPE when a BigQuery RECORD/STRUCT field has a null value. FieldValue.getRecordValue() calls Preconditions.checkNotNull internally, which throws when the value is null.

Add a null check at the top of getComplexObjectFromFieldValue() to return null early for null or isNull() field values.

Ticket: P457052656

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
