### PR TITLE
fix: disable Dependabot auto-rebase to stop CI cascade

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,17 @@ updates:
   - package-ecosystem: "maven" # See documentation for possible values
     directory: "/" # Location of package manifests
     open-pull-requests-limit: 20
+    # Avoid Dependabot mass-rebasing every open PR whenever master moves.
+    # Merge queue / branch update still refreshes a PR when it is next to merge.
+    rebase-strategy: disabled
     schedule:
       interval: "weekly"
+    # Collapse patch/minor bumps into fewer PRs; majors stay individual for manual review.
+    groups:
+      maven-patch-and-minor:
+        update-types:
+          - "patch"
+          - "minor"
     ignore:
       - dependency-name: "com.google.cloud:google-cloud-bigquery"
       - dependency-name: "com.google.cloud:google-cloud-resourcemanager"
@@ -20,8 +29,14 @@ updates:
 
   - package-ecosystem: "github-actions"
     directory: "/"
+    rebase-strategy: disabled
     schedule:
       interval: "weekly"
+    groups:
+      github-actions-patch-and-minor:
+        update-types:
+          - "patch"
+          - "minor"
 
   - package-ecosystem: "npm"
     directory: "/validation_testing/cdk_federation_infra_provisioning/app"

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -15,12 +15,19 @@ jobs:
         id: dependabot-metadata
         uses: dependabot/fetch-metadata@v3
       - name: Enable auto-merge for Dependabot PRs
-        run: gh pr merge --auto --squash "$PR_URL"
+        # Prefer squash when the branch allows it. If a merge queue owns the strategy,
+        # --squash is rejected — fall back to --auto so the PR still enters the queue.
+        run: |
+          gh pr merge --auto --squash "$PR_URL" || gh pr merge --auto "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Approve patch and minor updates
-        if: ${{ (steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch' || steps.dependabot-metadata.outputs.update-type == 'version-update:semver-minor') &&
+        # Grouped PRs (patch/minor only in dependabot.yml) may not set update-type;
+        # approve those via dependency-group as well. Majors stay ungrouped + unapproved.
+        if: ${{ (steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.dependabot-metadata.outputs.update-type == 'version-update:semver-minor' ||
+          (steps.dependabot-metadata.outputs.dependency-group != '' && steps.dependabot-metadata.outputs.update-type != 'version-update:semver-major')) &&
             !contains(steps.dependabot-metadata.outputs.new-version, 'preview') &&
             !contains(steps.dependabot-metadata.outputs.new-version, 'alpha') &&
             !contains(steps.dependabot-metadata.outputs.new-version, 'beta') &&

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -5,6 +5,7 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  merge_group:
   schedule:
     - cron: '0 12 * * 6'
 

--- a/.github/workflows/maven_push.yml
+++ b/.github/workflows/maven_push.yml
@@ -1,6 +1,11 @@
 name: Java CI Push
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+  pull_request:
+  # Required so merge queue can run status checks on speculative merge commits.
+  merge_group:
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When multiple Dependabot PRs are open and one merges, Dependabot’s default auto-rebase can force-push the remaining PRs and restart full CI on each of them. Auto-merge cannot skip those rebuilds (new commits always re-trigger checks).

This change:
- Sets `rebase-strategy: disabled` for Maven and GitHub Actions so Dependabot does not mass-rebase open PRs when `master` moves (primary fix)
- Groups patch/minor updates into fewer PRs; majors stay individual for manual review
- Updates auto-approve so grouped patch/minor PRs are still approved; majors remain unapproved
- Adds `merge_group` triggers to Java CI and CodeQL so checks can run if a merge queue is enabled later
- Softens auto-merge enablement (`--squash` with fallback to `--auto`) when a merge queue owns the merge strategy

**Note:** `merge_group` workflow triggers alone do not enable a merge queue; that is configured in branch protection / repository rules. The Dependabot rebase fix works independently of a merge queue.

Please find the attached Dependabot CI Cascade Mitigation Document.
[Dependabot-CI-Cascade-Mitigation.docx](https://github.com/user-attachments/files/31302947/Dependabot-CI-Cascade-Mitigation.docx)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
