### PR TITLE
Cloudera Hive connector: Substrait query-plan rendering and credential federation for managed-connector mode

### DIFF
--- a/athena-cloudera-hive/src/main/java/com/amazonaws/athena/connectors/cloudera/HiveDialect.java
+++ b/athena-cloudera-hive/src/main/java/com/amazonaws/athena/connectors/cloudera/HiveDialect.java
@@ -1,0 +1,50 @@
+/*-
+ * #%L
+ * athena-cloudera-hive
+ * %%
+ * Copyright (C) 2019 - 2026 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.cloudera;
+
+import org.apache.calcite.sql.SqlDialect;
+import org.apache.calcite.sql.dialect.HiveSqlDialect;
+
+import java.util.Locale;
+
+/**
+ * Hive SQL dialect used to render Substrait-derived query plans. Hive quotes identifiers with
+ * backticks and expresses row limits with LIMIT, so it is rendered with the Hive dialect. When the
+ * catalog casing filter is enabled, identifiers are upper-cased before quoting.
+ */
+public class HiveDialect extends HiveSqlDialect
+{
+    public static final SqlDialect DEFAULT = HiveSqlDialect.DEFAULT;
+
+    private final boolean catalogCasingFilter;
+
+    public HiveDialect(boolean catalogCasingFilter)
+    {
+        super(DEFAULT_CONTEXT);
+        this.catalogCasingFilter = catalogCasingFilter;
+    }
+
+    @Override
+    public StringBuilder quoteIdentifier(StringBuilder buf, String identifier)
+    {
+        String value = catalogCasingFilter ? identifier.toUpperCase(Locale.ROOT) : identifier;
+        return buf.append("`").append(value.replace("`", "``")).append("`");
+    }
+}

--- a/athena-cloudera-hive/src/main/java/com/amazonaws/athena/connectors/cloudera/HiveMetadataHandler.java
+++ b/athena-cloudera-hive/src/main/java/com/amazonaws/athena/connectors/cloudera/HiveMetadataHandler.java
@@ -21,6 +21,7 @@ package com.amazonaws.athena.connectors.cloudera;
 
 import com.amazonaws.athena.connector.credentials.CredentialsProvider;
 import com.amazonaws.athena.connector.lambda.QueryStatusChecker;
+import com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants;
 import com.amazonaws.athena.connector.lambda.data.Block;
 import com.amazonaws.athena.connector.lambda.data.BlockAllocator;
 import com.amazonaws.athena.connector.lambda.data.BlockWriter;
@@ -136,7 +137,7 @@ public class HiveMetadataHandler extends JdbcMetadataHandler
         String showExtendedSql = "show table extended in "
                 + HiveUtils.quoteIdentifier(table.getSchemaName().toUpperCase())
                 + " like " + HiveUtils.likePatternLiteral(table.getTableName());
-        try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider());
+        try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider(getRequestOverrideConfig(getTableLayoutRequest)));
              Statement stmt = connection.createStatement()) {
             boolean isTablePartitioned = false;
             ResultSet partitionResultset = stmt.executeQuery(showExtendedSql);
@@ -237,12 +238,18 @@ public class HiveMetadataHandler extends JdbcMetadataHandler
         Set<Split> splits = new HashSet<>();
         Block partitions = getSplitsRequest.getPartitions();
 
+        Map<String, String> identityConfigOptions = getSplitsRequest.getIdentity().getConfigOptions();
+        String catalogCasingFilter = identityConfigOptions != null ? identityConfigOptions.get(EnvironmentConstants.CATALOG_CASING_FILTER) : null;
+
         for (int curPartition = partitionContd; curPartition < partitions.getRowCount(); curPartition++) {
             FieldReader locationReader = partitions.getFieldReader(HiveConstants.BLOCK_PARTITION_COLUMN_NAME);
             locationReader.setPosition(curPartition);
             SpillLocation spillLocation = makeSpillLocation(getSplitsRequest);
-            Split.Builder splitBuilder = Split.newBuilder(spillLocation, makeEncryptionKey())
+            Split.Builder splitBuilder = Split.newBuilder(spillLocation, makeEncryptionKey(getRequestOverrideConfig(getSplitsRequest)))
                     .add(HiveConstants.BLOCK_PARTITION_COLUMN_NAME, String.valueOf(locationReader.readText()));
+            if (catalogCasingFilter != null) {
+                splitBuilder.add(EnvironmentConstants.CATALOG_CASING_FILTER, catalogCasingFilter);
+            }
             splits.add(splitBuilder.build());
             if (splits.size() >= HiveConstants.MAX_SPLITS_PER_REQUEST) {
                 return new GetSplitsResponse(getSplitsRequest.getCatalogName(), splits,
@@ -310,7 +317,7 @@ public class HiveMetadataHandler extends JdbcMetadataHandler
     {
         SchemaBuilder schemaBuilder = SchemaBuilder.newBuilder();
         try (ResultSet resultSet = getColumns(jdbcConnection.getCatalog(), tableName, jdbcConnection.getMetaData());
-                Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider())) {
+                Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider(requestOverrideConfiguration))) {
             try (Statement stmt = connection.createStatement()) {
                 Map<String, String> meteHashMap = getMetadataForGivenTable(stmt,
                         GET_METADATA_QUERY + HiveUtils.qualifiedTableForMetadataSql(tableName));

--- a/athena-cloudera-hive/src/main/java/com/amazonaws/athena/connectors/cloudera/HiveQueryStringBuilder.java
+++ b/athena-cloudera-hive/src/main/java/com/amazonaws/athena/connectors/cloudera/HiveQueryStringBuilder.java
@@ -26,6 +26,7 @@ import com.amazonaws.athena.connectors.jdbc.manager.TypeAndValue;
 import com.google.common.base.Strings;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.calcite.sql.SqlDialect;
 
 import java.util.Collections;
 import java.util.List;
@@ -35,6 +36,18 @@ public class HiveQueryStringBuilder extends JdbcSplitQueryBuilder
     public HiveQueryStringBuilder(final String quoteCharacters, final FederationExpressionParser federationExpressionParser)
     {
         super(quoteCharacters, federationExpressionParser);
+    }
+
+    @Override
+    protected SqlDialect getSqlDialect()
+    {
+        return HiveDialect.DEFAULT;
+    }
+
+    @Override
+    protected SqlDialect getSqlDialect(boolean catalogCasingFilter)
+    {
+        return new HiveDialect(catalogCasingFilter);
     }
 
     @Override

--- a/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveDialectTest.java
+++ b/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveDialectTest.java
@@ -1,0 +1,82 @@
+/*-
+ * #%L
+ * athena-cloudera-hive
+ * %%
+ * Copyright (C) 2019 - 2026 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.cloudera;
+
+import org.apache.calcite.sql.dialect.HiveSqlDialect;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class HiveDialectTest
+{
+    @Test
+    public void testDefaultDialect()
+    {
+        assertNotNull(HiveDialect.DEFAULT);
+        assertTrue(HiveDialect.DEFAULT instanceof HiveSqlDialect);
+    }
+
+    @Test
+    public void testQuoteIdentifierWithFilter()
+    {
+        HiveDialect dialect = new HiveDialect(true);
+        StringBuilder buf = new StringBuilder();
+        dialect.quoteIdentifier(buf, "employees");
+        assertEquals("`EMPLOYEES`", buf.toString());
+    }
+
+    @Test
+    public void testQuoteIdentifierWithoutFilter()
+    {
+        HiveDialect dialect = new HiveDialect(false);
+        StringBuilder buf = new StringBuilder();
+        dialect.quoteIdentifier(buf, "employees");
+        assertEquals("`employees`", buf.toString());
+    }
+
+    @Test
+    public void testQuoteIdentifierWithFilterUpperCasesMixedCaseInput()
+    {
+        HiveDialect dialect = new HiveDialect(true);
+        StringBuilder buf = new StringBuilder();
+        dialect.quoteIdentifier(buf, "Employees");
+        assertEquals("`EMPLOYEES`", buf.toString());
+    }
+
+    @Test
+    public void testQuoteIdentifierWithoutFilterPreservesInputCase()
+    {
+        HiveDialect dialect = new HiveDialect(false);
+        StringBuilder buf = new StringBuilder();
+        dialect.quoteIdentifier(buf, "Employees");
+        assertEquals("`Employees`", buf.toString());
+    }
+
+    @Test
+    public void testQuoteIdentifierEscapesBacktick()
+    {
+        HiveDialect dialect = new HiveDialect(true);
+        StringBuilder buf = new StringBuilder();
+        dialect.quoteIdentifier(buf, "emp`loyees");
+        assertEquals("`EMP``LOYEES`", buf.toString());
+    }
+}

--- a/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveMetadataHandlerTest.java
+++ b/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveMetadataHandlerTest.java
@@ -28,6 +28,7 @@ import com.amazonaws.athena.connector.lambda.data.FieldBuilder;
 import com.amazonaws.athena.connector.lambda.data.SchemaBuilder;
 import com.amazonaws.athena.connector.lambda.domain.TableName;
 import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
+import com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants;
 import com.amazonaws.athena.connector.lambda.metadata.GetDataSourceCapabilitiesRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetDataSourceCapabilitiesResponse;
 import com.amazonaws.athena.connector.lambda.metadata.GetSplitsRequest;
@@ -375,6 +376,63 @@ public class HiveMetadataHandlerTest
                 .collect(Collectors.toSet());
         assertEquals(expectedPartitions, actualPartitions);
         assertEquals(CATALOG_NAME, getSplitsResponse.getCatalogName());
+    }
+
+    @Test
+    public void doGetSplits_whenCatalogCasingFilterSet_propagatesFilterToSplits() {
+        TableName tableName = new TableName(TEST_SCHEMA, TEST_TABLE);
+        Schema partitionSchema = this.hiveMetadataHandler.getPartitionSchema(CATALOG_NAME);
+        Set<String> partitionCols = partitionSchema.getFields().stream()
+                .map(Field::getName)
+                .collect(Collectors.toSet());
+
+        Constraints constraints = new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(),
+                Constraints.DEFAULT_NO_LIMIT, Collections.emptyMap(), null);
+
+        SchemaBuilder schemaBuilder = SchemaBuilder.newBuilder();
+        schemaBuilder.addField(HiveConstants.BLOCK_PARTITION_COLUMN_NAME, org.apache.arrow.vector.types.Types.MinorType.VARCHAR.getType());
+        Block partitionsBlock = blockAllocator.createBlock(schemaBuilder.build());
+        partitionsBlock.setValue(HiveConstants.BLOCK_PARTITION_COLUMN_NAME, 0, "partition_0");
+        partitionsBlock.setRowCount(1);
+
+        Mockito.when(this.federatedIdentity.getConfigOptions())
+                .thenReturn(Map.of(EnvironmentConstants.CATALOG_CASING_FILTER, EnvironmentConstants.UPPERCASE_ONLY));
+
+        GetSplitsRequest getSplitsRequest = new GetSplitsRequest(this.federatedIdentity, QUERY_ID, CATALOG_NAME,
+                tableName, partitionsBlock, new ArrayList<>(partitionCols), constraints, null);
+        GetSplitsResponse getSplitsResponse = this.hiveMetadataHandler.doGetSplits(blockAllocator, getSplitsRequest);
+
+        assertEquals(1, getSplitsResponse.getSplits().size());
+        getSplitsResponse.getSplits().forEach(split ->
+                assertEquals(EnvironmentConstants.UPPERCASE_ONLY, split.getProperties().get(EnvironmentConstants.CATALOG_CASING_FILTER)));
+    }
+
+    @Test
+    public void doGetSplits_whenNoCatalogCasingFilter_doesNotAddFilterProperty() {
+        TableName tableName = new TableName(TEST_SCHEMA, TEST_TABLE);
+        Schema partitionSchema = this.hiveMetadataHandler.getPartitionSchema(CATALOG_NAME);
+        Set<String> partitionCols = partitionSchema.getFields().stream()
+                .map(Field::getName)
+                .collect(Collectors.toSet());
+
+        Constraints constraints = new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(),
+                Constraints.DEFAULT_NO_LIMIT, Collections.emptyMap(), null);
+
+        SchemaBuilder schemaBuilder = SchemaBuilder.newBuilder();
+        schemaBuilder.addField(HiveConstants.BLOCK_PARTITION_COLUMN_NAME, org.apache.arrow.vector.types.Types.MinorType.VARCHAR.getType());
+        Block partitionsBlock = blockAllocator.createBlock(schemaBuilder.build());
+        partitionsBlock.setValue(HiveConstants.BLOCK_PARTITION_COLUMN_NAME, 0, "partition_0");
+        partitionsBlock.setRowCount(1);
+
+        Mockito.when(this.federatedIdentity.getConfigOptions()).thenReturn(Collections.emptyMap());
+
+        GetSplitsRequest getSplitsRequest = new GetSplitsRequest(this.federatedIdentity, QUERY_ID, CATALOG_NAME,
+                tableName, partitionsBlock, new ArrayList<>(partitionCols), constraints, null);
+        GetSplitsResponse getSplitsResponse = this.hiveMetadataHandler.doGetSplits(blockAllocator, getSplitsRequest);
+
+        assertEquals(1, getSplitsResponse.getSplits().size());
+        getSplitsResponse.getSplits().forEach(split ->
+                assertEquals(null, split.getProperties().get(EnvironmentConstants.CATALOG_CASING_FILTER)));
     }
 
     @Test

--- a/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveMetadataHandlerTest.java
+++ b/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveMetadataHandlerTest.java
@@ -436,6 +436,35 @@ public class HiveMetadataHandlerTest
     }
 
     @Test
+    public void doGetSplits_whenConfigOptionsNull_doesNotAddFilterProperty() {
+        TableName tableName = new TableName(TEST_SCHEMA, TEST_TABLE);
+        Schema partitionSchema = this.hiveMetadataHandler.getPartitionSchema(CATALOG_NAME);
+        Set<String> partitionCols = partitionSchema.getFields().stream()
+                .map(Field::getName)
+                .collect(Collectors.toSet());
+
+        Constraints constraints = new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(),
+                Constraints.DEFAULT_NO_LIMIT, Collections.emptyMap(), null);
+
+        SchemaBuilder schemaBuilder = SchemaBuilder.newBuilder();
+        schemaBuilder.addField(HiveConstants.BLOCK_PARTITION_COLUMN_NAME, org.apache.arrow.vector.types.Types.MinorType.VARCHAR.getType());
+        Block partitionsBlock = blockAllocator.createBlock(schemaBuilder.build());
+        partitionsBlock.setValue(HiveConstants.BLOCK_PARTITION_COLUMN_NAME, 0, "partition_0");
+        partitionsBlock.setRowCount(1);
+
+        // Null config options exercises the identity-config-options null guard in doGetSplits.
+        Mockito.when(this.federatedIdentity.getConfigOptions()).thenReturn(null);
+
+        GetSplitsRequest getSplitsRequest = new GetSplitsRequest(this.federatedIdentity, QUERY_ID, CATALOG_NAME,
+                tableName, partitionsBlock, new ArrayList<>(partitionCols), constraints, null);
+        GetSplitsResponse getSplitsResponse = this.hiveMetadataHandler.doGetSplits(blockAllocator, getSplitsRequest);
+
+        assertEquals(1, getSplitsResponse.getSplits().size());
+        getSplitsResponse.getSplits().forEach(split ->
+                assertEquals(null, split.getProperties().get(EnvironmentConstants.CATALOG_CASING_FILTER)));
+    }
+
+    @Test
     public void decodeContinuationToken_whenTokenIsOne_returnsNonNullTokenValue() throws Exception {
         TableName tableName = new TableName(TEST_SCHEMA, TEST_TABLE);
         Constraints constraints = Mockito.mock(Constraints.class);

--- a/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveQueryStringBuilderTest.java
+++ b/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveQueryStringBuilderTest.java
@@ -20,6 +20,7 @@
 package com.amazonaws.athena.connectors.cloudera;
 
 import com.amazonaws.athena.connector.lambda.domain.Split;
+import org.apache.calcite.sql.dialect.HiveSqlDialect;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -30,6 +31,7 @@ import java.util.Collections;
 
 import static com.amazonaws.athena.connectors.cloudera.HiveConstants.HIVE_QUOTE_CHARACTER;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 @SuppressWarnings("deprecation")
 @RunWith(MockitoJUnitRunner.class)
@@ -58,5 +60,19 @@ public class HiveQueryStringBuilderTest
 		HiveQueryStringBuilder builder = new HiveQueryStringBuilder(HIVE_QUOTE_CHARACTER, new HiveFederationExpressionParser(HIVE_QUOTE_CHARACTER));
 		
 		assertEquals(Collections.emptyList(), builder.getPartitionWhereClauses(split));
+	}
+
+	@Test
+	public void getSqlDialect_default_returnsHiveDialect()
+	{
+		HiveQueryStringBuilder builder = new HiveQueryStringBuilder(HIVE_QUOTE_CHARACTER, new HiveFederationExpressionParser(HIVE_QUOTE_CHARACTER));
+		assertTrue(builder.getSqlDialect() instanceof HiveSqlDialect);
+	}
+
+	@Test
+	public void getSqlDialect_withCatalogCasingFilter_returnsHiveDialect()
+	{
+		HiveQueryStringBuilder builder = new HiveQueryStringBuilder(HIVE_QUOTE_CHARACTER, new HiveFederationExpressionParser(HIVE_QUOTE_CHARACTER));
+		assertTrue(builder.getSqlDialect(true) instanceof HiveDialect);
 	}
 }


### PR DESCRIPTION


---

## Title
Cloudera Hive connector: Substrait query-plan rendering and credential federation for managed-connector mode

## Body

### Description
Enables the `athena-cloudera-hive` connector to run in Amazon Glue's managed (DNA) connector mode by (1) rendering Substrait-derived query plans as HiveQL via a Hive SQL dialect and (2) threading federated (FAS) credentials and the customer-managed KMS key through the metadata path. All changes are additive and only take effect on the managed path; the existing classic (Lambda / environment-driven) connector behavior is unchanged.

### Changes
- **`HiveDialect`** (new) — extends Calcite's `HiveSqlDialect`. Overrides `quoteIdentifier` to backtick-quote identifiers (escaping any embedded backtick as ``` `` ```) and, when the catalog casing filter is enabled, upper-cases the identifier before quoting. Used to render Substrait plans to HiveQL (Hive uses backtick quoting and `LIMIT` for row limits).
- **`HiveQueryStringBuilder`** — overrides `getSqlDialect()` and `getSqlDialect(boolean catalogCasingFilter)` to return `HiveDialect.DEFAULT` / `new HiveDialect(catalogCasingFilter)` so generated SQL is rendered with the Hive dialect.
- **`HiveMetadataHandler`**:
  - Pass `getRequestOverrideConfig(...)` into `getCredentialProvider(...)` for the table-layout (`show table extended`) and `getSchema` JDBC connections, so federated (FAS) credentials from the request are used.
  - Build splits with `makeEncryptionKey(getRequestOverrideConfig(getSplitsRequest))` so spill encryption uses the customer-managed KMS key from the request.
  - In `doGetSplits`, read `CATALOG_CASING_FILTER` from the identity config options and attach it to each `Split` when present.
- **Tests** — new `HiveDialectTest` (quoting, casing, backtick-escaping); additions to `HiveMetadataHandlerTest` (casing-filter propagation) and `HiveQueryStringBuilderTest` (`getSqlDialect` overrides).

### Backwards compatibility
- New behavior is gated to the managed-connector path (Substrait dialect rendering, FAS credential override, KMS override, casing filter). The classic connector path is unchanged.
- No changes to existing public method signatures; `HiveDialect` is a new class and the `HiveQueryStringBuilder`/`HiveMetadataHandler` changes are overrides/added arguments sourced from the request.

### Testing
- Unit tests (Corretto 17): **82/82 passing** for `athena-cloudera-hive`.
- Validated end-to-end in Glue managed-connector mode: non-VPC and VPC connections, and the catalog casing filter (LOWERCASE/UPPERCASE), plus the managed-connector integration test suite (metadata + Substrait read).


