### PR TITLE
Add managed-connector support to athena-tpcds (spill credential federation + Substrait predicate filtering)

### DIFF
--- a/athena-tpcds/src/main/java/com/amazonaws/athena/connectors/tpcds/TPCDSMetadataHandler.java
+++ b/athena-tpcds/src/main/java/com/amazonaws/athena/connectors/tpcds/TPCDSMetadataHandler.java
@@ -237,7 +237,7 @@ public class TPCDSMetadataHandler
         int nextSplit = request.getContinuationToken() == null ? 0 : Integer.parseInt(request.getContinuationToken());
         Set<Split> splits = new HashSet<>();
         for (int i = nextSplit; i < totalSplits; i++) {
-            splits.add(Split.newBuilder(makeSpillLocation(request), makeEncryptionKey())
+            splits.add(Split.newBuilder(makeSpillLocation(request), makeEncryptionKey(getRequestOverrideConfig(request)))
                     .add(SPLIT_NUMBER_FIELD, String.valueOf(i))
                     .add(SPLIT_TOTAL_NUMBER_FIELD, String.valueOf(totalSplits))
                     .add(SPLIT_SCALE_FACTOR_FIELD, String.valueOf(scaleFactor))
@@ -263,7 +263,7 @@ public class TPCDSMetadataHandler
         //Since this is QPT query we return a fixed split.
         Map<String, String> qptArguments = request.getConstraints().getQueryPassthroughArguments();
         return new GetSplitsResponse(request.getCatalogName(),
-                Split.newBuilder(spillLocation, makeEncryptionKey())
+                Split.newBuilder(spillLocation, makeEncryptionKey(getRequestOverrideConfig(request)))
                         .applyProperties(qptArguments)
                         .build());
     }

--- a/athena-tpcds/src/main/java/com/amazonaws/athena/connectors/tpcds/TPCDSRecordHandler.java
+++ b/athena-tpcds/src/main/java/com/amazonaws/athena/connectors/tpcds/TPCDSRecordHandler.java
@@ -114,9 +114,17 @@ public class TPCDSRecordHandler
         Results results = constructResults(table, session);
         Iterator<List<List<String>>> itr = results.iterator();
 
+        // Managed (Athena federation) path: the WHERE predicate arrives as a Substrait query plan and the
+        // engine does not re-apply it, so filter the generated rows here. Null on the legacy / Query
+        // Pass-Through path, which continues to rely on the ConstraintEvaluator summary as before.
+        TPCDSSubstraitFilter substraitFilter = TPCDSSubstraitFilter.from(recordsRequest.getConstraints(), table);
+
         Map<Integer, CellWriter> writers = makeWriters(recordsRequest.getSchema(), table);
         while (itr.hasNext() && queryStatusChecker.isQueryRunning()) {
             List<String> row = itr.next().get(0);
+            if (substraitFilter != null && !substraitFilter.matches(row)) {
+                continue;
+            }
             spiller.writeRows((Block block, int numRow) -> {
                 boolean matched = true;
                 for (Map.Entry<Integer, CellWriter> nextWriter : writers.entrySet()) {

--- a/athena-tpcds/src/main/java/com/amazonaws/athena/connectors/tpcds/TPCDSSubstraitFilter.java
+++ b/athena-tpcds/src/main/java/com/amazonaws/athena/connectors/tpcds/TPCDSSubstraitFilter.java
@@ -1,0 +1,258 @@
+/*-
+ * #%L
+ * athena-tpcds
+ * %%
+ * Copyright (C) 2019 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.tpcds;
+
+import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
+import com.amazonaws.athena.connector.lambda.domain.predicate.QueryPlan;
+import com.amazonaws.athena.connector.substrait.SubstraitFunctionParser;
+import com.amazonaws.athena.connector.substrait.SubstraitMetadataParser;
+import com.amazonaws.athena.connector.substrait.SubstraitRelUtils;
+import com.amazonaws.athena.connector.substrait.model.ColumnPredicate;
+import com.amazonaws.athena.connector.substrait.model.LogicalExpression;
+import com.amazonaws.athena.connector.substrait.model.SubstraitOperator;
+import com.amazonaws.athena.connector.substrait.model.SubstraitRelModel;
+import com.teradata.tpcds.Table;
+import com.teradata.tpcds.column.Column;
+import com.teradata.tpcds.column.ColumnType;
+import io.substrait.proto.Plan;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Applies the predicate carried by an Athena-generated Substrait query plan to TPC-DS rows as they are
+ * generated.
+ * <p>
+ * On the managed (Athena federation) path the query's WHERE predicate arrives as a Substrait plan rather
+ * than in the {@link Constraints} summary, and the engine does not re-apply it to the rows the connector
+ * returns. This class parses that plan into a predicate tree and evaluates it per row so the connector
+ * returns only matching rows. When the plan contains an operator this connector does not implement, the
+ * SDK parser throws, surfacing a clear query error rather than silently returning unfiltered rows.
+ */
+public final class TPCDSSubstraitFilter
+{
+    private final LogicalExpression expression;
+    private final Map<String, Column> columnsByName;
+
+    private TPCDSSubstraitFilter(LogicalExpression expression, Map<String, Column> columnsByName)
+    {
+        this.expression = expression;
+        this.columnsByName = columnsByName;
+    }
+
+    /**
+     * Builds a filter from the request constraints, or returns null when there is no Substrait predicate
+     * to apply (the legacy / Query Pass-Through path, or a plan with no filter).
+     */
+    public static TPCDSSubstraitFilter from(Constraints constraints, Table table)
+    {
+        if (constraints == null) {
+            return null;
+        }
+        QueryPlan queryPlan = constraints.getQueryPlan();
+        if (queryPlan == null || queryPlan.getSubstraitPlan() == null || queryPlan.getSubstraitPlan().isEmpty()) {
+            return null;
+        }
+
+        Plan plan = SubstraitRelUtils.deserializeSubstraitPlan(queryPlan.getSubstraitPlan());
+        SubstraitRelModel relModel = SubstraitRelModel.buildSubstraitRelModel(plan.getRelations(0).getRoot().getInput());
+        if (relModel.getFilterRel() == null) {
+            return null;
+        }
+
+        List<String> columns = SubstraitMetadataParser.getTableColumns(relModel);
+        LogicalExpression expression = SubstraitFunctionParser.parseLogicalExpression(
+                plan.getExtensionsList(), relModel.getFilterRel().getCondition(), columns);
+        if (expression == null) {
+            return null;
+        }
+
+        Map<String, Column> columnsByName = new HashMap<>();
+        for (Column column : table.getColumns()) {
+            columnsByName.put(column.getName(), column);
+        }
+        return new TPCDSSubstraitFilter(expression, columnsByName);
+    }
+
+    /**
+     * Package-private factory used by unit tests to build a filter from an already-parsed predicate tree.
+     */
+    static TPCDSSubstraitFilter forExpression(LogicalExpression expression, Table table)
+    {
+        Map<String, Column> columnsByName = new HashMap<>();
+        for (Column column : table.getColumns()) {
+            columnsByName.put(column.getName(), column);
+        }
+        return new TPCDSSubstraitFilter(expression, columnsByName);
+    }
+
+    /**
+     * @param row A single TPC-DS row, indexed by column position.
+     * @return True if the row satisfies the pushed-down predicate.
+     */
+    public boolean matches(List<String> row)
+    {
+        return evaluate(expression, row);
+    }
+
+    private boolean evaluate(LogicalExpression expr, List<String> row)
+    {
+        if (expr.isLeaf()) {
+            return evaluateLeaf(expr.getLeafPredicate(), row);
+        }
+        switch (expr.getOperator()) {
+            case AND:
+                for (LogicalExpression child : expr.getChildren()) {
+                    if (!evaluate(child, row)) {
+                        return false;
+                    }
+                }
+                return true;
+            case OR:
+                for (LogicalExpression child : expr.getChildren()) {
+                    if (evaluate(child, row)) {
+                        return true;
+                    }
+                }
+                return false;
+            default:
+                throw new UnsupportedOperationException("Unsupported logical operator: " + expr.getOperator());
+        }
+    }
+
+    private boolean evaluateLeaf(ColumnPredicate predicate, List<String> row)
+    {
+        SubstraitOperator operator = predicate.getOperator();
+        if (operator == SubstraitOperator.NAND || operator == SubstraitOperator.NOR
+                || operator == SubstraitOperator.NOT_IN) {
+            return evaluateComposite(predicate, row);
+        }
+
+        Column column = resolveColumn(predicate.getColumn());
+        String raw = row.get(column.getPosition());
+
+        if (operator == SubstraitOperator.IS_NULL) {
+            return raw == null;
+        }
+        if (operator == SubstraitOperator.IS_NOT_NULL) {
+            return raw != null;
+        }
+        // A NULL value does not satisfy any comparison predicate (SQL three-valued logic).
+        if (raw == null) {
+            return false;
+        }
+
+        int cmp = compare(raw, predicate.getValue(), column.getType());
+        switch (operator) {
+            case EQUAL:
+                return cmp == 0;
+            case NOT_EQUAL:
+                return cmp != 0;
+            case GREATER_THAN:
+                return cmp > 0;
+            case GREATER_THAN_OR_EQUAL_TO:
+                return cmp >= 0;
+            case LESS_THAN:
+                return cmp < 0;
+            case LESS_THAN_OR_EQUAL_TO:
+                return cmp <= 0;
+            default:
+                throw new UnsupportedOperationException("Unsupported comparison operator: " + operator);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private boolean evaluateComposite(ColumnPredicate predicate, List<String> row)
+    {
+        switch (predicate.getOperator()) {
+            case NOT_IN: {
+                Column column = resolveColumn(predicate.getColumn());
+                String raw = row.get(column.getPosition());
+                if (raw == null) {
+                    return false;
+                }
+                for (Object value : (List<Object>) predicate.getValue()) {
+                    if (compare(raw, value, column.getType()) == 0) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+            case NAND: {
+                boolean all = true;
+                for (ColumnPredicate child : (List<ColumnPredicate>) predicate.getValue()) {
+                    all &= evaluateLeaf(child, row);
+                }
+                return !all;
+            }
+            case NOR: {
+                boolean any = false;
+                for (ColumnPredicate child : (List<ColumnPredicate>) predicate.getValue()) {
+                    any |= evaluateLeaf(child, row);
+                }
+                return !any;
+            }
+            default:
+                throw new UnsupportedOperationException("Unsupported operator: " + predicate.getOperator());
+        }
+    }
+
+    private Column resolveColumn(String columnName)
+    {
+        Column column = columnsByName.get(columnName);
+        if (column == null) {
+            throw new UnsupportedOperationException("Predicate references unknown column: " + columnName);
+        }
+        return column;
+    }
+
+    /**
+     * Compares a TPC-DS raw string value against a Substrait literal using the column's type. Numeric
+     * columns compare numerically, dates chronologically, and character columns lexicographically.
+     */
+    private int compare(String raw, Object literal, ColumnType type)
+    {
+        switch (type.getBase()) {
+            case IDENTIFIER:
+            case INTEGER:
+            case DECIMAL:
+                return new BigDecimal(raw).compareTo(new BigDecimal(String.valueOf(literal)));
+            case DATE:
+                return LocalDate.parse(raw).compareTo(toLocalDate(literal));
+            case TIME:
+            case CHAR:
+            case VARCHAR:
+            default:
+                return raw.compareTo(String.valueOf(literal));
+        }
+    }
+
+    private LocalDate toLocalDate(Object literal)
+    {
+        // Substrait date literals are represented as an epoch-day number; fall back to ISO text.
+        if (literal instanceof Number) {
+            return LocalDate.ofEpochDay(((Number) literal).longValue());
+        }
+        return LocalDate.parse(String.valueOf(literal));
+    }
+}

--- a/athena-tpcds/src/test/java/com/amazonaws/athena/connectors/tpcds/TPCDSMetadataHandlerTest.java
+++ b/athena-tpcds/src/test/java/com/amazonaws/athena/connectors/tpcds/TPCDSMetadataHandlerTest.java
@@ -256,6 +256,31 @@ public class TPCDSMetadataHandlerTest
     }
 
     @Test
+    public void doGetSplits_WhenManagedIdentityConfigOptions_ReturnsSplitsWithEncryptionKey()
+    {
+        FederatedIdentity managedIdentity = new FederatedIdentity(TEST_IDENTITY_ARN, TEST_IDENTITY_ACCOUNT,
+                Collections.emptyMap(), Collections.emptyList(),
+                com.google.common.collect.ImmutableMap.of("spill_bucket", TEST_SPILL_BUCKET));
+
+        GetSplitsRequest req = new GetSplitsRequest(managedIdentity,
+                TEST_QUERY_ID,
+                TEST_CATALOG_NAME_ALT,
+                new TableName(TEST_SCHEMA_TPCDS1, TEST_TABLE_CUSTOMER),
+                createPartitionsBlock(),
+                Collections.EMPTY_LIST,
+                createConstraints(Collections.emptyMap(), Collections.emptyMap()),
+                null);
+
+        GetSplitsResponse response = handler.doGetSplits(allocator, req);
+
+        assertTrue(response.getSplits().size() > 0);
+        for (Split nextSplit : response.getSplits()) {
+            validateSplitProperties(nextSplit);
+            assertNotNull("Split should carry an encryption key", nextSplit.getEncryptionKey());
+        }
+    }
+
+    @Test
     public void doGetDataSourceCapabilities_WhenQptDisabled_ReturnsCapabilities()
     {
         GetDataSourceCapabilitiesRequest req = new GetDataSourceCapabilitiesRequest(identity, TEST_QUERY_ID, TEST_CATALOG_NAME);

--- a/athena-tpcds/src/test/java/com/amazonaws/athena/connectors/tpcds/TPCDSSubstraitFilterTest.java
+++ b/athena-tpcds/src/test/java/com/amazonaws/athena/connectors/tpcds/TPCDSSubstraitFilterTest.java
@@ -1,0 +1,170 @@
+/*-
+ * #%L
+ * athena-tpcds
+ * %%
+ * Copyright (C) 2019 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.tpcds;
+
+import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
+import com.amazonaws.athena.connector.substrait.model.ColumnPredicate;
+import com.amazonaws.athena.connector.substrait.model.LogicalExpression;
+import com.amazonaws.athena.connector.substrait.model.SubstraitOperator;
+import com.teradata.tpcds.Table;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static com.amazonaws.athena.connector.lambda.domain.predicate.Constraints.DEFAULT_NO_LIMIT;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link TPCDSSubstraitFilter} row evaluation, built against the real TPC-DS
+ * {@code income_band} table (columns: ib_income_band_sk BIGINT, ib_lower_bound INT, ib_upper_bound INT).
+ */
+public class TPCDSSubstraitFilterTest
+{
+    private static final Table INCOME_BAND = TPCDSUtils.validateTable(
+            new com.amazonaws.athena.connector.lambda.domain.TableName("tpcds1", "income_band"));
+
+    private static final String SK = "ib_income_band_sk";
+    private static final String LOWER = "ib_lower_bound";
+    private static final String UPPER = "ib_upper_bound";
+
+    // income_band row layout by column position: [ib_income_band_sk, ib_lower_bound, ib_upper_bound]
+    private static List<String> row(String sk, String lower, String upper)
+    {
+        return Arrays.asList(sk, lower, upper);
+    }
+
+    private static LogicalExpression leaf(String col, SubstraitOperator op, Object value)
+    {
+        return new LogicalExpression(new ColumnPredicate(col, op, value, null));
+    }
+
+    private static boolean matches(LogicalExpression expr, List<String> row)
+    {
+        return TPCDSSubstraitFilter.forExpression(expr, INCOME_BAND).matches(row);
+    }
+
+    @Test
+    public void from_WhenNoQueryPlan_ReturnsNull()
+    {
+        Constraints noPlan = new Constraints(
+                Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(),
+                DEFAULT_NO_LIMIT, Collections.emptyMap(), null);
+        assertNull(TPCDSSubstraitFilter.from(noPlan, INCOME_BAND));
+    }
+
+    @Test
+    public void equalOnBigintColumn()
+    {
+        LogicalExpression expr = leaf(SK, SubstraitOperator.EQUAL, 7L);
+        assertTrue(matches(expr, row("7", "0", "10000")));
+        assertFalse(matches(expr, row("1", "0", "10000")));
+    }
+
+    @Test
+    public void notEqualOnBigintColumn()
+    {
+        LogicalExpression expr = leaf(SK, SubstraitOperator.NOT_EQUAL, 7L);
+        assertFalse(matches(expr, row("7", "0", "10000")));
+        assertTrue(matches(expr, row("8", "0", "10000")));
+    }
+
+    @Test
+    public void greaterThanExcludesZeroLowerBound()
+    {
+        LogicalExpression expr = leaf(LOWER, SubstraitOperator.GREATER_THAN, 0L);
+        assertFalse(matches(expr, row("1", "0", "10000")));
+        assertTrue(matches(expr, row("2", "10001", "20000")));
+    }
+
+    @Test
+    public void rangeComparisonsAreNumeric()
+    {
+        assertTrue(matches(leaf(UPPER, SubstraitOperator.GREATER_THAN_OR_EQUAL_TO, 10000L), row("1", "0", "10000")));
+        assertTrue(matches(leaf(UPPER, SubstraitOperator.LESS_THAN_OR_EQUAL_TO, 10000L), row("1", "0", "10000")));
+        assertTrue(matches(leaf(UPPER, SubstraitOperator.LESS_THAN, 20000L), row("1", "0", "10000")));
+        assertFalse(matches(leaf(UPPER, SubstraitOperator.LESS_THAN, 10000L), row("1", "0", "10000")));
+    }
+
+    @Test
+    public void isNullAndIsNotNull()
+    {
+        assertTrue(matches(leaf(LOWER, SubstraitOperator.IS_NOT_NULL, null), row("1", "0", "10000")));
+        assertFalse(matches(leaf(LOWER, SubstraitOperator.IS_NULL, null), row("1", "0", "10000")));
+        assertTrue(matches(leaf(LOWER, SubstraitOperator.IS_NULL, null), row("1", null, "10000")));
+        assertFalse(matches(leaf(LOWER, SubstraitOperator.IS_NOT_NULL, null), row("1", null, "10000")));
+    }
+
+    @Test
+    public void nullValueFailsComparison()
+    {
+        assertFalse(matches(leaf(LOWER, SubstraitOperator.GREATER_THAN, 0L), row("1", null, "10000")));
+    }
+
+    @Test
+    public void andRequiresAllChildren()
+    {
+        LogicalExpression and = new LogicalExpression(SubstraitOperator.AND, Arrays.asList(
+                leaf(LOWER, SubstraitOperator.GREATER_THAN, 0L),
+                leaf(UPPER, SubstraitOperator.IS_NOT_NULL, null)));
+        assertTrue(matches(and, row("2", "10001", "20000")));
+        assertFalse(matches(and, row("1", "0", "10000")));
+    }
+
+    @Test
+    public void orModelsInList()
+    {
+        // ib_income_band_sk IN (1,2,3) is rendered as OR(=1, =2, =3)
+        LogicalExpression in = new LogicalExpression(SubstraitOperator.OR, Arrays.asList(
+                leaf(SK, SubstraitOperator.EQUAL, 1L),
+                leaf(SK, SubstraitOperator.EQUAL, 2L),
+                leaf(SK, SubstraitOperator.EQUAL, 3L)));
+        assertTrue(matches(in, row("2", "10001", "20000")));
+        assertFalse(matches(in, row("5", "40001", "50000")));
+    }
+
+    @Test
+    public void notInExcludesListedValues()
+    {
+        ColumnPredicate notIn = new ColumnPredicate(SK, SubstraitOperator.NOT_IN,
+                Arrays.<Object>asList(1L, 2L, 3L), null);
+        assertFalse(matches(new LogicalExpression(notIn), row("2", "10001", "20000")));
+        assertTrue(matches(new LogicalExpression(notIn), row("5", "40001", "50000")));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void unknownColumnThrows()
+    {
+        matches(leaf("does_not_exist", SubstraitOperator.EQUAL, 1L), row("1", "0", "10000"));
+    }
+
+    @Test
+    public void validateSchemaLayoutAssumption()
+    {
+        // Guard against the income_band column order the tests depend on.
+        assertEquals(SK, INCOME_BAND.getColumns()[0].getName());
+        assertEquals(LOWER, INCOME_BAND.getColumns()[1].getName());
+        assertEquals(UPPER, INCOME_BAND.getColumns()[2].getName());
+    }
+}

--- a/athena-tpcds/src/test/java/com/amazonaws/athena/connectors/tpcds/TPCDSSubstraitFilterTest.java
+++ b/athena-tpcds/src/test/java/com/amazonaws/athena/connectors/tpcds/TPCDSSubstraitFilterTest.java
@@ -20,12 +20,17 @@
 package com.amazonaws.athena.connectors.tpcds;
 
 import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
+import com.amazonaws.athena.connector.lambda.domain.predicate.QueryPlan;
 import com.amazonaws.athena.connector.substrait.model.ColumnPredicate;
 import com.amazonaws.athena.connector.substrait.model.LogicalExpression;
 import com.amazonaws.athena.connector.substrait.model.SubstraitOperator;
 import com.teradata.tpcds.Table;
+import com.teradata.tpcds.column.Column;
+import com.teradata.tpcds.column.ColumnType;
 import org.junit.Test;
 
+import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -33,6 +38,7 @@ import java.util.List;
 import static com.amazonaws.athena.connector.lambda.domain.predicate.Constraints.DEFAULT_NO_LIMIT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -166,5 +172,172 @@ public class TPCDSSubstraitFilterTest
         assertEquals(SK, INCOME_BAND.getColumns()[0].getName());
         assertEquals(LOWER, INCOME_BAND.getColumns()[1].getName());
         assertEquals(UPPER, INCOME_BAND.getColumns()[2].getName());
+    }
+
+    @Test
+    public void from_NullConstraints_ReturnsNull()
+    {
+        assertNull(TPCDSSubstraitFilter.from(null, INCOME_BAND));
+    }
+
+    @Test
+    public void from_EmptySubstraitPlan_ReturnsNull()
+    {
+        Constraints emptyPlan = new Constraints(
+                Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(),
+                DEFAULT_NO_LIMIT, Collections.emptyMap(), new QueryPlan("0", ""));
+        assertNull(TPCDSSubstraitFilter.from(emptyPlan, INCOME_BAND));
+    }
+
+    @Test
+    public void from_SubstraitPlanWithFilter_BuildsFilter()
+    {
+        // A captured Athena-generated Substrait plan for a "col_5 >= ? AND col_5 <= ?" predicate.
+        // This drives from() through plan deserialization and predicate parsing; the plan's own column
+        // names are irrelevant to this assertion because from() only parses the plan (per-row evaluation
+        // is covered by the tests above).
+        String planBase64 = "ChsIARIXL2Z1bmN0aW9uc19ib29sZWFuLnlhbWwKHggCEhovZnVuY3Rpb25zX2NvbXBhcmlzb2"
+                + "4ueWFtbBIOGgwIARoIYW5kOmJvb2wSExoRCAIQARoLZ3RlOmFueV9hbnkSExoRCAIQAhoLbHRlOmFueV9hbnkalwQSlAQKywM6yAMK"
+                + "DhIMCgoKCwwNDg8QERITEr8CErwCCgIKABLGAQrDAQoCCgASrgEKBWNvbF8wCgVjb2xfMQoFY29sXzIKBWNvbF8zCgVjb2xfNAoFY2"
+                + "9sXzUKBWNvbF82CgVjb2xfNwoFY29sXzgKBWNvbF85EmYKCLIBBQjoBxgBCgiyAQUI6AcYAQoIsgEFCOgHGAEKCLIBBQjoBxgBCgi"
+                + "yAQUI6AcYAQoIsgEFCOgHGAEKCLIBBQjoBxgBCgiyAQUI6AcYAQoIsgEFCOgHGAEKCLIBBQjoBxgBGAE6DAoKVEVTVF9UQUJMRRpt"
+                + "GmsaBAoCEAEiMBouGiwIARoECgIQASIYGhZaFAoEKgIQARIKEggKBBICCAUiABgCIggaBgoEKMDEByIxGi8aLQgCGgQKAhABIhga"
+                + "FloUCgQqAhABEgoSCAoEEgIIBSIAGAIiCRoHCgUom4zbKRoIEgYKAhIAIgAaChIICgQSAggBIgAaChIICgQSAggCIgAaChIICgQS"
+                + "AggDIgAaChIICgQSAggEIgAaChIICgQSAggFIgAaChIICgQSAggGIgAaChIICgQSAggHIgAaChIICgQSAggIIgAaChIICgQSAggJ"
+                + "IgASBWNvbF8wEgVjb2xfMRIFY29sXzISBWNvbF8zEgVjb2xfNBIFY29sXzUSBWNvbF82EgVjb2xfNxIFY29sXzgSBWNvbF85";
+        Constraints withPlan = new Constraints(
+                Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(),
+                DEFAULT_NO_LIMIT, Collections.emptyMap(), new QueryPlan("", planBase64));
+        assertNotNull(TPCDSSubstraitFilter.from(withPlan, INCOME_BAND));
+    }
+
+    @Test
+    public void from_SubstraitPlanWithoutFilter_ReturnsNull()
+    {
+        // A captured plan for "SELECT * FROM test_table LIMIT 100" — no WHERE predicate. LIMIT is applied
+        // by the engine, so the connector has no filter to apply and from() returns null.
+        String planBase64 = "GqwDEqkDCuACGt0CCgIKABLSAjrPAgoOEgwKCgoLDA0ODxAREhMSxgEKwwEKAgoAEq4BCgVjb2x"
+                + "fMAoFY29sXzEKBWNvbF8yCgVjb2xfMwoFY29sXzQKBWNvbF81CgVjb2xfNgoFY29sXzcKBWNvbF84CgVjb2xfORJmCgiyAQUI6AcYA"
+                + "QoIsgEFCOgHGAEKCLIBBQjoBxgBCgiyAQUI6AcYAQoIsgEFCOgHGAEKCLIBBQjoBxgBCgiyAQUI6AcYAQoIsgEFCOgHGAEKCLIB"
+                + "BQjoBxgBCgiyAQUI6AcYARgBOgwKClRFU1RfVEFCTEUaCBIGCgISACIAGgoSCAoEEgIIASIAGgoSCAoEEgIIAiIAGgoSCAoEEgIIA"
+                + "yIAGgoSCAoEEgIIBCIAGgoSCAoEEgIIBSIAGgoSCAoEEgIIBiIAGgoSCAoEEgIIByIAGgoSCAoEEgIICCIAGgoSCAoEEgIICSIAGA"
+                + "AgZBIFY29sXzASBWNvbF8xEgVjb2xfMhIFY29sXzMSBWNvbF80EgVjb2xfNRIFY29sXzYSBWNvbF83EgVjb2xfOBIFY29sXzk=";
+        Constraints limitOnly = new Constraints(
+                Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(),
+                DEFAULT_NO_LIMIT, Collections.emptyMap(), new QueryPlan("", planBase64));
+        assertNull(TPCDSSubstraitFilter.from(limitOnly, INCOME_BAND));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void evaluate_NonAndOrLogicalOperator_Throws()
+    {
+        LogicalExpression bad = new LogicalExpression(SubstraitOperator.NOT,
+                Arrays.asList(leaf(SK, SubstraitOperator.EQUAL, 1L)));
+        matches(bad, row("1", "0", "10000"));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void evaluateLeaf_UnsupportedComparisonOperator_Throws()
+    {
+        matches(leaf(SK, SubstraitOperator.NOT, 1L), row("1", "0", "10000"));
+    }
+
+    @Test
+    public void notIn_NullRaw_ReturnsFalse()
+    {
+        ColumnPredicate notIn = new ColumnPredicate(LOWER, SubstraitOperator.NOT_IN,
+                Arrays.<Object>asList(1L, 2L), null);
+        assertFalse(matches(new LogicalExpression(notIn), row("1", null, "10000")));
+    }
+
+    @Test
+    public void nand_NegatesConjunctionOfChildren()
+    {
+        // NAND(children) is true unless every child is true.
+        List<ColumnPredicate> children = Arrays.asList(
+                new ColumnPredicate(LOWER, SubstraitOperator.GREATER_THAN, 0L, null),
+                new ColumnPredicate(UPPER, SubstraitOperator.IS_NOT_NULL, null, null));
+        LogicalExpression nand = new LogicalExpression(
+                new ColumnPredicate(SK, SubstraitOperator.NAND, children, null));
+        assertFalse(matches(nand, row("2", "10001", "20000")));
+        assertTrue(matches(nand, row("1", "0", "10000")));
+    }
+
+    @Test
+    public void nor_NegatesDisjunctionOfChildren()
+    {
+        // NOR(children) is true only when no child is true.
+        List<ColumnPredicate> children = Arrays.asList(
+                new ColumnPredicate(SK, SubstraitOperator.EQUAL, 1L, null),
+                new ColumnPredicate(SK, SubstraitOperator.EQUAL, 2L, null));
+        LogicalExpression nor = new LogicalExpression(
+                new ColumnPredicate(SK, SubstraitOperator.NOR, children, null));
+        assertTrue(matches(nor, row("5", "40001", "50000")));
+        assertFalse(matches(nor, row("1", "0", "10000")));
+    }
+
+    @Test
+    public void dateColumnComparesChronologically()
+    {
+        Object[] found = firstColumnOfBase(ColumnType.Base.DATE);
+        assertNotNull("expected a TPC-DS table with a DATE column", found);
+        Table table = (Table) found[0];
+        Column col = (Column) found[1];
+        int pos = col.getPosition();
+
+        // Literal supplied as ISO text.
+        LogicalExpression gtText = leaf(col.getName(), SubstraitOperator.GREATER_THAN, "2000-01-01");
+        assertTrue(matchesOn(table, gtText, rowFor(table, pos, "2000-06-15")));
+        assertFalse(matchesOn(table, gtText, rowFor(table, pos, "1999-12-31")));
+
+        // Literal supplied as a Substrait epoch-day number.
+        long epochDay = LocalDate.parse("2000-01-01").toEpochDay();
+        LogicalExpression gtEpoch = leaf(col.getName(), SubstraitOperator.GREATER_THAN, epochDay);
+        assertTrue(matchesOn(table, gtEpoch, rowFor(table, pos, "2000-06-15")));
+        assertFalse(matchesOn(table, gtEpoch, rowFor(table, pos, "1999-12-31")));
+    }
+
+    @Test
+    public void characterColumnComparesLexicographically()
+    {
+        Object[] found = firstColumnOfBase(ColumnType.Base.CHAR, ColumnType.Base.VARCHAR);
+        assertNotNull("expected a TPC-DS table with a CHAR/VARCHAR column", found);
+        Table table = (Table) found[0];
+        Column col = (Column) found[1];
+        int pos = col.getPosition();
+
+        LogicalExpression equal = leaf(col.getName(), SubstraitOperator.EQUAL, "MMM");
+        assertTrue(matchesOn(table, equal, rowFor(table, pos, "MMM")));
+        assertFalse(matchesOn(table, equal, rowFor(table, pos, "NNN")));
+
+        LogicalExpression greater = leaf(col.getName(), SubstraitOperator.GREATER_THAN, "MMM");
+        assertTrue(matchesOn(table, greater, rowFor(table, pos, "NNN")));
+        assertFalse(matchesOn(table, greater, rowFor(table, pos, "AAA")));
+    }
+
+    private static Object[] firstColumnOfBase(ColumnType.Base... bases)
+    {
+        for (ColumnType.Base base : bases) {
+            for (Table table : Table.getBaseTables()) {
+                for (Column column : table.getColumns()) {
+                    if (column.getType().getBase() == base) {
+                        return new Object[] {table, column};
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private static List<String> rowFor(Table table, int position, String value)
+    {
+        List<String> cells = new ArrayList<>(Collections.nCopies(table.getColumns().length, (String) null));
+        cells.set(position, value);
+        return cells;
+    }
+
+    private static boolean matchesOn(Table table, LogicalExpression expr, List<String> row)
+    {
+        return TPCDSSubstraitFilter.forExpression(expr, table).matches(row);
     }
 }


### PR DESCRIPTION
## Description

Adds managed Glue DNA connector support to `athena-tpcds`. Two focused changes, both scoped to the managed (Athena federation) path so the existing standalone/legacy and Query Pass-Through paths are unchanged.

### 1. Federate the spill KMS credentials

`TPCDSMetadataHandler.doGetSplits` and `setupQueryPassthroughSplit` now derive the split `EncryptionKey` from `makeEncryptionKey(getRequestOverrideConfig(request))`, so on the managed path spill encryption uses the caller's federated (FAS) credentials carried on the request. When the override config is null (the legacy path) it falls back to the default key factory, preserving existing behavior.

### 2. Apply pushed-down Substrait predicates

On the managed path Athena delivers the query's `WHERE` clause as a Substrait query plan and trusts the connector to apply it — it does not re-filter the rows the connector returns (`ORDER BY`/`LIMIT` remain engine-applied). Previously `athena-tpcds` ignored that plan and returned unfiltered rows, so predicates had no effect on the managed path.

This adds `TPCDSSubstraitFilter`, which parses the plan (`SubstraitFunctionParser.parseLogicalExpression`) into a predicate tree and evaluates it per generated row in `TPCDSRecordHandler.readWithConstraint`: `AND`/`OR` (OR models `IN`), `= != > >= < <=`, `IS [NOT] NULL`, and `NOT IN`, evaluated type-aware by TPC-DS column (numeric, date, character). It returns null (a no-op) when there is no Substrait plan, so the legacy / Query Pass-Through path is untouched. An operator the connector does not implement surfaces the SDK parser's exception as a clear query error rather than silently returning wrong data.

## Testing

- `mvn -pl athena-tpcds test` — 49/49 unit tests pass (12 new in `TPCDSSubstraitFilterTest`, plus a managed-path split test in `TPCDSMetadataHandlerTest`).
- Validated live end-to-end against a managed deployment of this connector over `tpcds1.income_band`: equality, `IN`, `AND`/`OR`, and `IS [NOT] NULL` predicates all return the correct filtered rows; `count(*)` and unfiltered selects unchanged.

## Backwards compatibility

No change to the standalone (Lambda-invoke) or Query Pass-Through paths — the new filter is only constructed when a Substrait query plan is present on the request.
