### PR TITLE
Enhance Teradata partition SQL with identifier quoting

### DIFF
--- a/athena-teradata/src/main/java/com/amazonaws/athena/connectors/teradata/TeradataMetadataHandler.java
+++ b/athena-teradata/src/main/java/com/amazonaws/athena/connectors/teradata/TeradataMetadataHandler.java
@@ -183,8 +183,7 @@ public class TeradataMetadataHandler extends JdbcMetadataHandler
     {
         LOGGER.info("{}: Schema {}, table {}", getTableLayoutRequest.getQueryId(), getTableLayoutRequest.getTableName().getSchemaName(),
                 getTableLayoutRequest.getTableName().getTableName());
-        final String getPartitionsQuery = "Select DISTINCT partition FROM " + getTableLayoutRequest.getTableName().getSchemaName() + "." +
-                getTableLayoutRequest.getTableName().getTableName() + " where 1= ?";
+        final String getPartitionsQuery = "Select DISTINCT partition FROM " + qualifiedTableName(getTableLayoutRequest.getTableName()) + " where 1= ?";
         boolean viewFlag = false;
         //Check if input table is a view
         List<String> viewparameters = Arrays.asList(getTableLayoutRequest.getTableName().getSchemaName(), getTableLayoutRequest.getTableName().getTableName());
@@ -238,8 +237,7 @@ public class TeradataMetadataHandler extends JdbcMetadataHandler
      */
     private boolean useNonPartitionApproach(GetTableLayoutRequest getTableLayoutRequest) throws Exception
     {
-        final String getPartitionsCountQuery = "Select  count(distinct partition ) as partition_count FROM " + getTableLayoutRequest.getTableName().getSchemaName() + "." +
-                getTableLayoutRequest.getTableName().getTableName() + " where 1= ?";
+        final String getPartitionsCountQuery = "Select  count(distinct partition ) as partition_count FROM " + qualifiedTableName(getTableLayoutRequest.getTableName()) + " where 1= ?";
         String partitioncount = configOptions.containsKey("partition_count") ? configOptions.get("partition_count") : configOptions.getOrDefault("partitioncount", "500");
         int totalPartitionCount = Integer.parseInt(partitioncount);
         int  partitionCount = 0;
@@ -424,6 +422,15 @@ public class TeradataMetadataHandler extends JdbcMetadataHandler
             return schemaBuilder.build();
         }
     }
+
+    private static String qualifiedTableName(TableName tableName)
+    {
+        String quote = TeradataConstants.TERADATA_QUOTE_CHARACTER;
+        return quote + tableName.getSchemaName().replace(quote, quote + quote) + quote
+                + "."
+                + quote + tableName.getTableName().replace(quote, quote + quote) + quote;
+    }
+
     public static ArrowType toArrowType(final int jdbcType, final int precision, final int scale)
     {
         try {

--- a/athena-teradata/src/main/java/com/amazonaws/athena/connectors/teradata/TeradataQueryStringBuilder.java
+++ b/athena-teradata/src/main/java/com/amazonaws/athena/connectors/teradata/TeradataQueryStringBuilder.java
@@ -22,16 +22,26 @@ package com.amazonaws.athena.connectors.teradata;
 
 import com.amazonaws.athena.connector.lambda.domain.Split;
 import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
+import com.amazonaws.athena.connector.lambda.exceptions.AthenaConnectorException;
 import com.amazonaws.athena.connectors.jdbc.manager.FederationExpressionParser;
 import com.amazonaws.athena.connectors.jdbc.manager.JdbcSplitQueryBuilder;
 import com.google.common.base.Strings;
 import org.apache.calcite.sql.SqlDialect;
+import software.amazon.awssdk.services.glue.model.ErrorDetails;
+import software.amazon.awssdk.services.glue.model.FederationSourceErrorCode;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.regex.Pattern;
 
 public class TeradataQueryStringBuilder extends JdbcSplitQueryBuilder
 {
+    /**
+     * Teradata's system-derived PARTITION column always reports a partition number, so a split value
+     * that is not a number cannot have come from the database and is never safe to inline.
+     */
+    private static final Pattern PARTITION_NUMBER = Pattern.compile("^\\d+$");
+
     public TeradataQueryStringBuilder(String quoteCharacters, final FederationExpressionParser federationExpressionParser)
     {
         super(quoteCharacters, federationExpressionParser);
@@ -55,11 +65,22 @@ public class TeradataQueryStringBuilder extends JdbcSplitQueryBuilder
     @Override
     protected List<String> getPartitionWhereClauses(Split split)
     {
-        if (!split.getProperty(TeradataMetadataHandler.BLOCK_PARTITION_COLUMN_NAME).equals("*")) {
-            return Collections.singletonList(TeradataMetadataHandler.BLOCK_PARTITION_COLUMN_NAME + " = " + split.getProperty(TeradataMetadataHandler.BLOCK_PARTITION_COLUMN_NAME));
+        String partition = split.getProperty(TeradataMetadataHandler.BLOCK_PARTITION_COLUMN_NAME);
+        if (TeradataMetadataHandler.ALL_PARTITIONS.equals(partition)) {
+            return Collections.emptyList();
         }
 
-        return Collections.emptyList();
+        if (!isValidPartitionNumber(partition)) {
+            throw new AthenaConnectorException("Invalid Teradata partition number (expected non-negative integer): " + partition,
+                    ErrorDetails.builder().errorCode(FederationSourceErrorCode.INVALID_INPUT_EXCEPTION.toString()).build());
+        }
+
+        return Collections.singletonList(TeradataMetadataHandler.BLOCK_PARTITION_COLUMN_NAME + " = " + partition);
+    }
+
+    private static boolean isValidPartitionNumber(String partition)
+    {
+        return partition != null && PARTITION_NUMBER.matcher(partition).matches();
     }
 
     //Returning empty string as Teradata does not support LIMIT clause

--- a/athena-teradata/src/test/java/com/amazonaws/athena/connectors/teradata/TeradataMetadataHandlerTest.java
+++ b/athena-teradata/src/test/java/com/amazonaws/athena/connectors/teradata/TeradataMetadataHandlerTest.java
@@ -190,8 +190,8 @@ public class TeradataMetadataHandlerTest
         GetTableLayoutRequest getTableLayoutRequest = new GetTableLayoutRequest(this.federatedIdentity, TEST_QUERY_ID, TEST_CATALOG_NAME, tableName, constraints, partitionSchema, partitionCols);
 
         PreparedStatement preparedStatement = Mockito.mock(PreparedStatement.class);
-        String GET_PARTITIONS_QUERY = "Select DISTINCT " + TEST_PARTITION_COLUMN + " FROM " + getTableLayoutRequest.getTableName().getSchemaName() + "." +
-                getTableLayoutRequest.getTableName().getTableName() + " where 1= ?";
+        String GET_PARTITIONS_QUERY = "Select DISTINCT " + TEST_PARTITION_COLUMN + " FROM \"" + getTableLayoutRequest.getTableName().getSchemaName() + "\".\"" +
+                getTableLayoutRequest.getTableName().getTableName() + "\" where 1= ?";
         Mockito.when(this.connection.prepareStatement(GET_PARTITIONS_QUERY)).thenReturn(preparedStatement);
 
         String[] columns = {TEST_PARTITION_COLUMN};
@@ -230,8 +230,8 @@ public class TeradataMetadataHandlerTest
         GetTableLayoutRequest getTableLayoutRequest = new GetTableLayoutRequest(this.federatedIdentity, TEST_QUERY_ID, TEST_CATALOG_NAME, tableName, constraints, partitionSchema, partitionCols);
 
         PreparedStatement preparedStatement = Mockito.mock(PreparedStatement.class);
-        String GET_PARTITIONS_QUERY = "Select DISTINCT " + TEST_PARTITION_COLUMN + " FROM " + getTableLayoutRequest.getTableName().getSchemaName() + "." +
-                getTableLayoutRequest.getTableName().getTableName() + " where 1= ?";
+        String GET_PARTITIONS_QUERY = "Select DISTINCT " + TEST_PARTITION_COLUMN + " FROM \"" + getTableLayoutRequest.getTableName().getSchemaName() + "\".\"" +
+                getTableLayoutRequest.getTableName().getTableName() + "\" where 1= ?";
         Mockito.when(this.connection.prepareStatement(GET_PARTITIONS_QUERY)).thenReturn(preparedStatement);
 
         String[] columns = {TEST_PARTITION_COLUMN};
@@ -300,8 +300,8 @@ public class TeradataMetadataHandlerTest
         Set<String> partitionCols = partitionSchema.getFields().stream().map(Field::getName).collect(Collectors.toSet());
         GetTableLayoutRequest getTableLayoutRequest = new GetTableLayoutRequest(this.federatedIdentity, "testQueryId", "testCatalogName", tableName, constraints, partitionSchema, partitionCols);
 
-        String GET_PARTITIONS_QUERY = "Select DISTINCT " + TEST_PARTITION_COLUMN + " FROM " + getTableLayoutRequest.getTableName().getSchemaName() + "." +
-                getTableLayoutRequest.getTableName().getTableName() + " where 1= ?";
+        String GET_PARTITIONS_QUERY = "Select DISTINCT " + TEST_PARTITION_COLUMN + " FROM \"" + getTableLayoutRequest.getTableName().getSchemaName() + "\".\"" +
+                getTableLayoutRequest.getTableName().getTableName() + "\" where 1= ?";
         Mockito.when(this.connection.prepareStatement(GET_PARTITIONS_QUERY)).thenReturn(preparedStatement);
 
         GetTableLayoutResponse getTableLayoutResponse = this.teradataMetadataHandler.doGetTableLayout(blockAllocator, getTableLayoutRequest);
@@ -330,8 +330,8 @@ public class TeradataMetadataHandlerTest
         GetTableLayoutRequest getTableLayoutRequest = new GetTableLayoutRequest(this.federatedIdentity, TEST_QUERY_ID, TEST_CATALOG_NAME, tableName, constraints, partitionSchema, partitionCols);
 
         PreparedStatement preparedStatement = Mockito.mock(PreparedStatement.class);
-        String GET_PARTITIONS_QUERY = "Select DISTINCT " + TEST_PARTITION_COLUMN + " FROM " + getTableLayoutRequest.getTableName().getSchemaName() + "." +
-                getTableLayoutRequest.getTableName().getTableName() + " where 1= ?";
+        String GET_PARTITIONS_QUERY = "Select DISTINCT " + TEST_PARTITION_COLUMN + " FROM \"" + getTableLayoutRequest.getTableName().getSchemaName() + "\".\"" +
+                getTableLayoutRequest.getTableName().getTableName() + "\" where 1= ?";
         Mockito.when(this.connection.prepareStatement(GET_PARTITIONS_QUERY)).thenReturn(preparedStatement);
 
         String[] columns = {TEST_PARTITION_COLUMN};
@@ -647,8 +647,8 @@ public class TeradataMetadataHandlerTest
 
     private String buildPartitionCountQuery(GetTableLayoutRequest request)
     {
-        return "Select  count(distinct " + TEST_PARTITION_COLUMN + " ) as " + PARTITION_COUNT_COLUMN + " FROM " + request.getTableName().getSchemaName() + "." +
-                request.getTableName().getTableName() + " where 1= ?";
+        return "Select  count(distinct " + TEST_PARTITION_COLUMN + " ) as " + PARTITION_COUNT_COLUMN + " FROM \"" + request.getTableName().getSchemaName() + "\".\"" +
+                request.getTableName().getTableName() + "\" where 1= ?";
     }
 
     private void mockPartitionCountQuery(GetTableLayoutRequest request, String countValue) throws SQLException
@@ -665,8 +665,8 @@ public class TeradataMetadataHandlerTest
 
     private String buildPartitionDetailsQuery(GetTableLayoutRequest request)
     {
-        return "Select DISTINCT " + TEST_PARTITION_COLUMN + " FROM " + request.getTableName().getSchemaName() + "." +
-                request.getTableName().getTableName() + " where 1= ?";
+        return "Select DISTINCT " + TEST_PARTITION_COLUMN + " FROM \"" + request.getTableName().getSchemaName() + "\".\"" +
+                request.getTableName().getTableName() + "\" where 1= ?";
     }
 
     private void mockPartitionDetailsQuery(GetTableLayoutRequest request, Object[][] values) throws SQLException

--- a/athena-teradata/src/test/java/com/amazonaws/athena/connectors/teradata/TeradataQueryStringBuilderTest.java
+++ b/athena-teradata/src/test/java/com/amazonaws/athena/connectors/teradata/TeradataQueryStringBuilderTest.java
@@ -21,6 +21,7 @@ package com.amazonaws.athena.connectors.teradata;
 
 import com.amazonaws.athena.connector.lambda.domain.Split;
 import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
+import com.amazonaws.athena.connector.lambda.exceptions.AthenaConnectorException;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -77,12 +78,31 @@ public class TeradataQueryStringBuilderTest
     public void getPartitionWhereClauses_withConcretePartitionValue_returnsEqualityClause()
     {
         Split split = Mockito.mock(Split.class);
-        Mockito.when(split.getProperty(TeradataMetadataHandler.BLOCK_PARTITION_COLUMN_NAME)).thenReturn("p1");
+        Mockito.when(split.getProperty(TeradataMetadataHandler.BLOCK_PARTITION_COLUMN_NAME)).thenReturn("1");
         
         List<String> result = queryBuilder.getPartitionWhereClauses(split);
         
         assertEquals(1, result.size());
-        assertEquals("partition = p1", result.get(0));
+        assertEquals("partition = 1", result.get(0));
+    }
+
+    @Test(expected = AthenaConnectorException.class)
+    public void getPartitionWhereClauses_withNonNumericPartitionValue_throwsAthenaConnectorException()
+    {
+        Split split = Mockito.mock(Split.class);
+        Mockito.when(split.getProperty(TeradataMetadataHandler.BLOCK_PARTITION_COLUMN_NAME))
+                .thenReturn("1 OR 1=1");
+
+        queryBuilder.getPartitionWhereClauses(split);
+    }
+
+    @Test(expected = AthenaConnectorException.class)
+    public void getPartitionWhereClauses_withNullPartitionValue_throwsAthenaConnectorException()
+    {
+        Split split = Mockito.mock(Split.class);
+        Mockito.when(split.getProperty(TeradataMetadataHandler.BLOCK_PARTITION_COLUMN_NAME)).thenReturn(null);
+
+        queryBuilder.getPartitionWhereClauses(split);
     }
 
     @Test

--- a/athena-teradata/src/test/java/com/amazonaws/athena/connectors/teradata/TeradataRecordHandlerTest.java
+++ b/athena-teradata/src/test/java/com/amazonaws/athena/connectors/teradata/TeradataRecordHandlerTest.java
@@ -127,8 +127,8 @@ public class TeradataRecordHandlerTest
 
 
         Split split = Mockito.mock(Split.class);
-        Mockito.when(split.getProperties()).thenReturn(Collections.singletonMap("partition", "p0"));
-        Mockito.when(split.getProperty(Mockito.eq("partition"))).thenReturn("p0");
+        Mockito.when(split.getProperties()).thenReturn(Collections.singletonMap("partition", "0"));
+        Mockito.when(split.getProperty(Mockito.eq("partition"))).thenReturn("0");
 
         Range range1a = Mockito.mock(Range.class, Mockito.RETURNS_DEEP_STUBS);
         Mockito.when(range1a.isSingleValue()).thenReturn(true);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Quote schema and table identifiers in Teradata partition metadata SQL (`SELECT DISTINCT partition FROM "schema"."table"` and the matching partition-count query), doubling any embedded `"`.
- Treat split partition values as numbers only: `*` still means all partitions; anything that is not a non-negative integer is rejected as `INVALID_INPUT` .

PFA functional testing results
[TERADATA_FUNCTIONAL_TEST_2026-08-28.xlsx](https://github.com/user-attachments/files/31547159/TERADATA_FUNCTIONAL_TEST_2026-08-28.xlsx)




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
