### PR TITLE
Fix saphana partition clause validation

### DIFF
--- a/athena-saphana/src/main/java/com/amazonaws/athena/connectors/saphana/SaphanaQueryStringBuilder.java
+++ b/athena-saphana/src/main/java/com/amazonaws/athena/connectors/saphana/SaphanaQueryStringBuilder.java
@@ -26,6 +26,7 @@ import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
 import com.amazonaws.athena.connector.lambda.domain.predicate.Range;
 import com.amazonaws.athena.connector.lambda.domain.predicate.SortedRangeSet;
 import com.amazonaws.athena.connector.lambda.domain.predicate.ValueSet;
+import com.amazonaws.athena.connector.lambda.exceptions.AthenaConnectorException;
 import com.amazonaws.athena.connectors.jdbc.manager.FederationExpressionParser;
 import com.amazonaws.athena.connectors.jdbc.manager.JdbcSplitQueryBuilder;
 import com.amazonaws.athena.connectors.jdbc.manager.TypeAndValue;
@@ -41,6 +42,8 @@ import org.apache.calcite.sql.SqlDialect;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.glue.model.ErrorDetails;
+import software.amazon.awssdk.services.glue.model.FederationSourceErrorCode;
 
 import java.math.BigDecimal;
 import java.sql.Connection;
@@ -54,7 +57,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -70,6 +72,7 @@ public class SaphanaQueryStringBuilder extends JdbcSplitQueryBuilder
 
     private static final String SPATIAL_CONVERSION_FUNCTION_REGEX = "ST_([a-zA-Z]+)\\(\\)";
     private static final Pattern SPATIAL_CONVERSION_FUNCTION_PATTERN = Pattern.compile(SPATIAL_CONVERSION_FUNCTION_REGEX);
+    private static final Pattern POSITIVE_INTEGER_PARTITION_ID = Pattern.compile("^[1-9][0-9]*$");
 
     public SaphanaQueryStringBuilder(String quoteCharacters, final FederationExpressionParser federationExpressionParser)
     {
@@ -89,6 +92,9 @@ public class SaphanaQueryStringBuilder extends JdbcSplitQueryBuilder
         }
         tableName.append(quote(table));
 
+        // Always read the partition id by its known property key. Do not use keySet().iterator().next():
+        // splits may also carry CATALOG_CASING_FILTER (and other properties), and picking an arbitrary
+        // key would interpolate that value into PARTITION (...), producing invalid/unsafe SQL.
         String partitionName = split.getProperty(SaphanaConstants.BLOCK_PARTITION_COLUMN_NAME);
 
         String query;
@@ -105,15 +111,33 @@ public class SaphanaQueryStringBuilder extends JdbcSplitQueryBuilder
                     "returning query {}, partition {}", query, partitionName);
             return query;
         }
-        Set<String> partitionValues = split.getProperties().keySet();
-        String partValue = split.getProperty(partitionValues.iterator().next());
+
+        // HANA SELECT ... PARTITION (n) requires an integer PART_ID from SYS.TABLE_PARTITIONS.
+        // Identifiers cannot be bound with JDBC '?'; reject anything that is not a positive integer
+        // so a crafted/mis-routed split property cannot change the SQL statement.
+        if (!isValidPartitionId(partitionName)) {
+            throw new AthenaConnectorException(
+                    "Invalid SAP HANA partition id (expected positive integer PART_ID): " + partitionName,
+                    ErrorDetails.builder()
+                            .errorCode(FederationSourceErrorCode.INVALID_INPUT_EXCEPTION.toString())
+                            .build());
+        }
 
         // Sample query to fetch data for a partition, e.g., 1
         // SELECT * FROM ATHENA.COVID19_HASHHASHPARTITION  PARTITION (1)
-        query = String.format(" FROM %s ", tableName + " " + "PARTITION " + "(" + partValue + ")");
+        query = String.format(" FROM %s PARTITION (%s) ", tableName, partitionName);
         LOGGER.debug("SaphanaQueryStringBuilder:getFromClauseWithSplit when partitionName found " +
                 "returning query {}, partition {}", query, partitionName);
         return query;
+    }
+
+    /**
+     * SAP HANA physical partition ids are positive integers ({@code PART_ID} in {@code SYS.TABLE_PARTITIONS}).
+     * Caller must already exclude null/empty and {@code ALL_PARTITIONS} ("0").
+     */
+    private static boolean isValidPartitionId(String partitionName)
+    {
+        return POSITIVE_INTEGER_PARTITION_ID.matcher(partitionName).matches();
     }
 
     @Override

--- a/athena-saphana/src/test/java/com/amazonaws/athena/connectors/saphana/SaphanaQueryStringBuilderTest.java
+++ b/athena-saphana/src/test/java/com/amazonaws/athena/connectors/saphana/SaphanaQueryStringBuilderTest.java
@@ -19,9 +19,11 @@
  */
 package com.amazonaws.athena.connectors.saphana;
 
+import com.amazonaws.athena.connector.lambda.connection.EnvironmentConstants;
 import com.amazonaws.athena.connector.lambda.domain.Split;
 import com.amazonaws.athena.connector.lambda.domain.predicate.Constraints;
 import com.amazonaws.athena.connector.lambda.domain.predicate.QueryPlan;
+import com.amazonaws.athena.connector.lambda.exceptions.AthenaConnectorException;
 import org.junit.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -33,7 +35,9 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static com.amazonaws.athena.connectors.saphana.SaphanaConstants.BLOCK_PARTITION_COLUMN_NAME;
@@ -42,6 +46,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -52,10 +57,10 @@ public class SaphanaQueryStringBuilderTest
     public void getFromClauseWithSplit_withPartition_returnsFromClauseWithPartition()
     {
         Split split = Mockito.mock(Split.class);
-        String expectedString1 = " FROM \"default\".\"table\" PARTITION (p0) ";
-        String expectedString2 = " FROM \"default\".\"schema\".\"table\" PARTITION (p0) ";
-        Mockito.when(split.getProperties()).thenReturn(Collections.singletonMap(BLOCK_PARTITION_COLUMN_NAME, "p0"));
-        Mockito.when(split.getProperty(Mockito.eq(BLOCK_PARTITION_COLUMN_NAME))).thenReturn("p0");
+        String expectedString1 = " FROM \"default\".\"table\" PARTITION (1) ";
+        String expectedString2 = " FROM \"default\".\"schema\".\"table\" PARTITION (1) ";
+        Mockito.when(split.getProperties()).thenReturn(Collections.singletonMap(BLOCK_PARTITION_COLUMN_NAME, "1"));
+        Mockito.when(split.getProperty(Mockito.eq(BLOCK_PARTITION_COLUMN_NAME))).thenReturn("1");
         SaphanaQueryStringBuilder builder = new SaphanaQueryStringBuilder(SAPHANA_QUOTE_CHARACTER, new SaphanaFederationExpressionParser(SAPHANA_QUOTE_CHARACTER));
         String fromClauseWithSplit1 = builder.getFromClauseWithSplit("default", "", "table", split);
         String fromClauseWithSplit2 = builder.getFromClauseWithSplit("default", "schema", "table", split);
@@ -80,8 +85,8 @@ public class SaphanaQueryStringBuilderTest
     {
         List<String> expectedPartitionWhereClauseList1 = new ArrayList<>();
         Split split = Mockito.mock(Split.class);
-        Mockito.when(split.getProperties()).thenReturn(Collections.singletonMap(BLOCK_PARTITION_COLUMN_NAME, "p0"));
-        Mockito.when(split.getProperty(Mockito.eq(BLOCK_PARTITION_COLUMN_NAME))).thenReturn("p0");
+        Mockito.when(split.getProperties()).thenReturn(Collections.singletonMap(BLOCK_PARTITION_COLUMN_NAME, "1"));
+        Mockito.when(split.getProperty(Mockito.eq(BLOCK_PARTITION_COLUMN_NAME))).thenReturn("1");
 
         SaphanaQueryStringBuilder builder = new SaphanaQueryStringBuilder(SAPHANA_QUOTE_CHARACTER, new SaphanaFederationExpressionParser(SAPHANA_QUOTE_CHARACTER));
         List<String> partitionWhereClauseList1 = builder.getPartitionWhereClauses(split);
@@ -105,13 +110,13 @@ public class SaphanaQueryStringBuilderTest
     public void getFromClauseWithSplit_withEmptyCatalog_returnsFromClauseWithSchemaAndTable()
     {
         Split split = Mockito.mock(Split.class);
-        Mockito.when(split.getProperties()).thenReturn(Collections.singletonMap(BLOCK_PARTITION_COLUMN_NAME, "p0"));
-        Mockito.when(split.getProperty(Mockito.eq(BLOCK_PARTITION_COLUMN_NAME))).thenReturn("p0");
+        Mockito.when(split.getProperties()).thenReturn(Collections.singletonMap(BLOCK_PARTITION_COLUMN_NAME, "1"));
+        Mockito.when(split.getProperty(Mockito.eq(BLOCK_PARTITION_COLUMN_NAME))).thenReturn("1");
         SaphanaQueryStringBuilder builder = new SaphanaQueryStringBuilder(SAPHANA_QUOTE_CHARACTER, new SaphanaFederationExpressionParser(SAPHANA_QUOTE_CHARACTER));
         String fromClauseWithSplit = builder.getFromClauseWithSplit("", "schema", "table", split);
         assertTrue("From clause should contain quoted schema name", fromClauseWithSplit.contains("\"schema\""));
         assertTrue("From clause should contain quoted table name", fromClauseWithSplit.contains("\"table\""));
-        assertTrue("From clause should contain PARTITION (p0)", fromClauseWithSplit.contains("PARTITION (p0)"));
+        assertTrue("From clause should contain PARTITION (1)", fromClauseWithSplit.contains("PARTITION (1)"));
     }
 
     @Test
@@ -119,6 +124,45 @@ public class SaphanaQueryStringBuilderTest
     {
         SaphanaQueryStringBuilder builder = new SaphanaQueryStringBuilder(SAPHANA_QUOTE_CHARACTER, new SaphanaFederationExpressionParser(SAPHANA_QUOTE_CHARACTER));
         assertEquals(SAPHanaSqlDialect.DEFAULT, builder.getSqlDialect());
+    }
+
+    @Test
+    public void getFromClauseWithSplit_withInvalidPartitionId_throwsAthenaConnectorException()
+    {
+        Split split = splitWithProperties(Map.of(BLOCK_PARTITION_COLUMN_NAME, "1); SELECT * FROM SYS.USERS--"));
+        SaphanaQueryStringBuilder builder = new SaphanaQueryStringBuilder(SAPHANA_QUOTE_CHARACTER,
+                new SaphanaFederationExpressionParser(SAPHANA_QUOTE_CHARACTER));
+
+        assertThrows(AthenaConnectorException.class,
+                () -> builder.getFromClauseWithSplit("", "SCHEMA", "TABLE", split));
+    }
+
+    /**
+     * When CATALOG_CASING_FILTER is also on the split, PARTITION must still use part_id.
+     */
+    @Test
+    public void getFromClauseWithSplit_withCasingFilterBeforePartId_usesNumericPartitionId()
+    {
+        Map<String, String> props = new LinkedHashMap<>();
+        props.put(EnvironmentConstants.CATALOG_CASING_FILTER, EnvironmentConstants.UPPERCASE_ONLY);
+        props.put(BLOCK_PARTITION_COLUMN_NAME, "2");
+        Split split = splitWithProperties(props);
+        SaphanaQueryStringBuilder builder = new SaphanaQueryStringBuilder(SAPHANA_QUOTE_CHARACTER,
+                new SaphanaFederationExpressionParser(SAPHANA_QUOTE_CHARACTER));
+
+        String fromClause = builder.getFromClauseWithSplit("", "SCHEMA", "TABLE", split);
+
+        assertEquals(" FROM \"SCHEMA\".\"TABLE\" PARTITION (2) ", fromClause);
+        assertFalse("Casing filter must not be interpolated into PARTITION clause",
+                fromClause.contains("PARTITION (" + EnvironmentConstants.UPPERCASE_ONLY + ")"));
+    }
+
+    private static Split splitWithProperties(Map<String, String> properties)
+    {
+        Split split = Mockito.mock(Split.class);
+        when(split.getProperties()).thenReturn(properties);
+        when(split.getProperty(anyString())).thenAnswer(invocation -> properties.get(invocation.getArgument(0)));
+        return split;
     }
 
     @ParameterizedTest


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix SAP HANA PARTITION clause generation to use the validated part_id from the split. The implementation now reads part_id directly and verifies that it is an integer before interpolating it into PARTITION (n).

Attached are the functional test results.
[SAPHANA_FUNCTIONAL_TEST_2026-08-28.xlsx](https://github.com/user-attachments/files/31553031/SAPHANA_FUNCTIONAL_TEST_2026-08-28.xlsx)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
