### PR TITLE
SQL Server Partition Function And Partition Column Identifier Quoting

### DIFF
--- a/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerConstants.java
+++ b/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerConstants.java
@@ -24,7 +24,10 @@ public final class SqlServerConstants
     public static final String NAME = "sqlserver";
     public static final String DRIVER_CLASS = "com.microsoft.sqlserver.jdbc.SQLServerDriver";
     public static final int DEFAULT_PORT = 1433;
-    public static final String SQLSERVER_QUOTE_CHARACTER = "\"";
+    /** Opening delimiter for SQL Server identifiers ({@code [name]}). */
+    public static final String SQLSERVER_QUOTE_START = "[";
+    /** Closing delimiter. An embedded {@code ]} is escaped as {@code ]]}. */
+    public static final String SQLSERVER_QUOTE_END = "]";
     static final String PARTITION_NUMBER = "partition_number";
     private SqlServerConstants() {}
 }

--- a/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerFederationExpressionParser.java
+++ b/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerFederationExpressionParser.java
@@ -19,17 +19,35 @@
  */
 package com.amazonaws.athena.connectors.sqlserver;
 
+import com.amazonaws.athena.connector.lambda.domain.predicate.expression.VariableExpression;
 import com.amazonaws.athena.connectors.jdbc.manager.JdbcFederationExpressionParser;
 import com.google.common.base.Joiner;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 
 import java.util.List;
 
+import static com.amazonaws.athena.connectors.sqlserver.SqlServerConstants.SQLSERVER_QUOTE_END;
+import static com.amazonaws.athena.connectors.sqlserver.SqlServerConstants.SQLSERVER_QUOTE_START;
+
 public class SqlServerFederationExpressionParser extends JdbcFederationExpressionParser
 {
-    public SqlServerFederationExpressionParser(String quoteChar)
+    /**
+     * Parent requires a quote-character argument. It is unused: wrapping uses
+     * {@link SqlServerConstants#SQLSERVER_QUOTE_START} and {@link SqlServerConstants#SQLSERVER_QUOTE_END}.
+     */
+    public SqlServerFederationExpressionParser()
     {
-        super(quoteChar);
+        super("");
+    }
+
+    /**
+     * SQL Server column names are quoted with square brackets ({@code [col]}), valid regardless of the
+     * session {@code QUOTED_IDENTIFIER} setting. An embedded closing bracket is escaped by doubling it.
+     */
+    @Override
+    public String parseVariableExpression(VariableExpression variableExpression)
+    {
+        return SQLSERVER_QUOTE_START + variableExpression.getColumnName().replace(SQLSERVER_QUOTE_END, SQLSERVER_QUOTE_END + SQLSERVER_QUOTE_END) + SQLSERVER_QUOTE_END;
     }
 
     @Override

--- a/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerQueryStringBuilder.java
+++ b/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerQueryStringBuilder.java
@@ -32,13 +32,33 @@ import java.util.Collections;
 import java.util.List;
 
 import static com.amazonaws.athena.connectors.sqlserver.SqlServerConstants.PARTITION_NUMBER;
+import static com.amazonaws.athena.connectors.sqlserver.SqlServerConstants.SQLSERVER_QUOTE_END;
+import static com.amazonaws.athena.connectors.sqlserver.SqlServerConstants.SQLSERVER_QUOTE_START;
 
 public class SqlServerQueryStringBuilder extends JdbcSplitQueryBuilder
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(SqlServerQueryStringBuilder.class);
-    public SqlServerQueryStringBuilder(final String quoteCharacters, final FederationExpressionParser federationExpressionParser)
+
+    /**
+     * Parent {@link JdbcSplitQueryBuilder} requires a quote-character string. Wrapping uses
+     * {@link SqlServerConstants#SQLSERVER_QUOTE_START} and {@link SqlServerConstants#SQLSERVER_QUOTE_END}
+     * in {@link #quote(String)}, not that parent field.
+     */
+    public SqlServerQueryStringBuilder(final FederationExpressionParser federationExpressionParser)
     {
-        super(quoteCharacters, federationExpressionParser);
+        super("", federationExpressionParser);
+    }
+
+    /**
+     * SQL Server identifiers are quoted with square brackets ({@code [name]}), which are valid
+     * regardless of the session {@code QUOTED_IDENTIFIER} setting (unlike double quotes). An embedded
+     * closing bracket is escaped by doubling it ({@code ]} becomes {@code ]]}). This matches the bracket
+     * quoting used by {@link SqlServerDialect} on the Calcite query-plan path.
+     */
+    @Override
+    protected String quote(String name)
+    {
+        return SQLSERVER_QUOTE_START + name.replace(SQLSERVER_QUOTE_END, SQLSERVER_QUOTE_END + SQLSERVER_QUOTE_END) + SQLSERVER_QUOTE_END;
     }
 
     @Override
@@ -68,19 +88,22 @@ public class SqlServerQueryStringBuilder extends JdbcSplitQueryBuilder
         String partitioningColumn = split.getProperty(SqlServerMetadataHandler.PARTITIONING_COLUMN);
         String partitionNumber = split.getProperty(PARTITION_NUMBER);
 
-        //example query: select * from MyPartitionTable where $PARTITION.myRangePF(col1) =2
+        // $PARTITION.func(col) uses call parentheses; identifiers are bracket-quoted.
+        // example: $PARTITION.[myRangePF]([col1]) = 2
         LOGGER.debug("PARTITION_FUNCTION: {}", partitionFunction);
         LOGGER.debug("PARTITIONING_COLUMN: {}", partitioningColumn);
 
         if (partitionFunction != null && partitioningColumn != null && partitionNumber != null && !partitionNumber.equals("0")) {
             LOGGER.info("Fetching data using Partition");
-            return Collections.singletonList(" $PARTITION." + partitionFunction + "(" + partitioningColumn + ") = " + partitionNumber);
+            // Identifiers cannot be bound with JDBC ?; quote() wraps names in [] and doubles embedded ].
+            return Collections.singletonList(" $PARTITION." + quote(partitionFunction) + "(" + quote(partitioningColumn) + ") = " + partitionNumber);
         }
         else {
             LOGGER.info("Fetching data without Partition");
         }
         return Collections.emptyList();
     }
+
     //Returning empty string as SQLServer does not support LIMIT clause
     @Override
     protected String appendLimitOffset(Split split, Constraints constraints)

--- a/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerRecordHandler.java
+++ b/athena-sqlserver/src/main/java/com/amazonaws/athena/connectors/sqlserver/SqlServerRecordHandler.java
@@ -44,8 +44,6 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
-import static com.amazonaws.athena.connectors.sqlserver.SqlServerConstants.SQLSERVER_QUOTE_CHARACTER;
-
 public class SqlServerRecordHandler extends JdbcRecordHandler
 {
     private static final int FETCH_SIZE = 1000;
@@ -65,7 +63,7 @@ public class SqlServerRecordHandler extends JdbcRecordHandler
     public SqlServerRecordHandler(DatabaseConnectionConfig databaseConnectionConfig, JdbcConnectionFactory jdbcConnectionFactory, java.util.Map<String, String> configOptions)
     {
         this(databaseConnectionConfig, S3Client.create(), SecretsManagerClient.create(),
-                AthenaClient.create(), jdbcConnectionFactory, new SqlServerQueryStringBuilder(SQLSERVER_QUOTE_CHARACTER, new SqlServerFederationExpressionParser(SQLSERVER_QUOTE_CHARACTER)), configOptions);
+                AthenaClient.create(), jdbcConnectionFactory, new SqlServerQueryStringBuilder(new SqlServerFederationExpressionParser()), configOptions);
     }
 
     @VisibleForTesting

--- a/athena-sqlserver/src/test/java/com/amazonaws/athena/connectors/sqlserver/SqlServerFederationExpressionParserTest.java
+++ b/athena-sqlserver/src/test/java/com/amazonaws/athena/connectors/sqlserver/SqlServerFederationExpressionParserTest.java
@@ -1,0 +1,45 @@
+/*-
+ * #%L
+ * athena-sqlserver
+ * %%
+ * Copyright (C) 2019 - 2026 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.connectors.sqlserver;
+
+import com.amazonaws.athena.connector.lambda.domain.predicate.expression.VariableExpression;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class SqlServerFederationExpressionParserTest
+{
+    private final SqlServerFederationExpressionParser parser = new SqlServerFederationExpressionParser();
+    
+    @Test
+    public void parseVariableExpression_whenIdentifierIsPresent_returnsBracketQuotedName()
+    {
+        VariableExpression expr = new VariableExpression("col", new ArrowType.Int(32, true));
+        assertEquals("[col]", parser.parseVariableExpression(expr));
+    }
+    
+    @Test
+    public void parseVariableExpression_whenNameContainsClosingBracket_doublesEmbeddedBracket()
+    {
+        VariableExpression expr = new VariableExpression("col]x", new ArrowType.Int(32, true));
+        assertEquals("[col]]x]", parser.parseVariableExpression(expr));
+    }
+}

--- a/athena-sqlserver/src/test/java/com/amazonaws/athena/connectors/sqlserver/SqlServerQueryStringBuilderTest.java
+++ b/athena-sqlserver/src/test/java/com/amazonaws/athena/connectors/sqlserver/SqlServerQueryStringBuilderTest.java
@@ -30,7 +30,6 @@ import java.util.Collections;
 import java.util.List;
 
 import static com.amazonaws.athena.connectors.sqlserver.SqlServerConstants.PARTITION_NUMBER;
-import static com.amazonaws.athena.connectors.sqlserver.SqlServerConstants.SQLSERVER_QUOTE_CHARACTER;
 
 public class SqlServerQueryStringBuilderTest
 {
@@ -44,15 +43,15 @@ public class SqlServerQueryStringBuilderTest
         Split split = Mockito.mock(Split.class);
         Mockito.when(split.getProperties()).thenReturn(Collections.singletonMap("partition", "p0"));
         Mockito.when(split.getProperty(Mockito.eq("partition"))).thenReturn("p0");
-        SqlServerQueryStringBuilder builder = new SqlServerQueryStringBuilder(SQLSERVER_QUOTE_CHARACTER, new SqlServerFederationExpressionParser(SQLSERVER_QUOTE_CHARACTER));
-        Assert.assertEquals(" FROM \"default\".\"table\" ", builder.getFromClauseWithSplit("default", "", "table", split));
-        Assert.assertEquals(" FROM \"default\".\"schema\".\"table\" ", builder.getFromClauseWithSplit("default", "schema", "table", split));
+        SqlServerQueryStringBuilder builder = new SqlServerQueryStringBuilder(new SqlServerFederationExpressionParser());
+        Assert.assertEquals(" FROM [default].[table] ", builder.getFromClauseWithSplit("default", "", "table", split));
+        Assert.assertEquals(" FROM [default].[schema].[table] ", builder.getFromClauseWithSplit("default", "schema", "table", split));
     }
 
     @Test
     public void testGetPartitionWhereClauses()
     {
-        SqlServerQueryStringBuilder builder = new SqlServerQueryStringBuilder(SQLSERVER_QUOTE_CHARACTER, new SqlServerFederationExpressionParser(SQLSERVER_QUOTE_CHARACTER));
+        SqlServerQueryStringBuilder builder = new SqlServerQueryStringBuilder(new SqlServerFederationExpressionParser());
 
         Split split = Mockito.mock(Split.class);
         Mockito.when(split.getProperties()).thenReturn(Collections.singletonMap("partition", "0"));
@@ -63,14 +62,14 @@ public class SqlServerQueryStringBuilderTest
         Mockito.when(split1.getProperty(SqlServerMetadataHandler.PARTITION_FUNCTION)).thenReturn("pf");
         Mockito.when(split1.getProperty(SqlServerMetadataHandler.PARTITIONING_COLUMN)).thenReturn("col");
         Mockito.when(split1.getProperty(PARTITION_NUMBER)).thenReturn("1");
-        Assert.assertEquals(Collections.singletonList(" $PARTITION.pf(col) = 1"), builder.getPartitionWhereClauses(split1));
+        Assert.assertEquals(Collections.singletonList(" $PARTITION.[pf]([col]) = 1"), builder.getPartitionWhereClauses(split1));
 
     }
 
     @Test
     public void getPartitionWhereClausesWhenPartitionFunctionIsNull()
     {
-        SqlServerQueryStringBuilder builder = new SqlServerQueryStringBuilder(SQLSERVER_QUOTE_CHARACTER, new SqlServerFederationExpressionParser(SQLSERVER_QUOTE_CHARACTER));
+        SqlServerQueryStringBuilder builder = new SqlServerQueryStringBuilder(new SqlServerFederationExpressionParser());
         Split split = Mockito.mock(Split.class);
         Mockito.when(split.getProperty(SqlServerMetadataHandler.PARTITION_FUNCTION)).thenReturn(null);
         Mockito.when(split.getProperty(SqlServerMetadataHandler.PARTITIONING_COLUMN)).thenReturn("col");
@@ -83,7 +82,7 @@ public class SqlServerQueryStringBuilderTest
     @Test
     public void getPartitionWhereClausesWhenPartitioningColumnIsNull()
     {
-        SqlServerQueryStringBuilder builder = new SqlServerQueryStringBuilder(SQLSERVER_QUOTE_CHARACTER, new SqlServerFederationExpressionParser(SQLSERVER_QUOTE_CHARACTER));
+        SqlServerQueryStringBuilder builder = new SqlServerQueryStringBuilder(new SqlServerFederationExpressionParser());
         Split split = Mockito.mock(Split.class);
         Mockito.when(split.getProperty(SqlServerMetadataHandler.PARTITION_FUNCTION)).thenReturn("pf");
         Mockito.when(split.getProperty(SqlServerMetadataHandler.PARTITIONING_COLUMN)).thenReturn(null);
@@ -96,7 +95,7 @@ public class SqlServerQueryStringBuilderTest
     @Test
     public void getPartitionWhereClausesWhenPartitionFunctionAndColumnAreNull()
     {
-        SqlServerQueryStringBuilder builder = new SqlServerQueryStringBuilder(SQLSERVER_QUOTE_CHARACTER, new SqlServerFederationExpressionParser(SQLSERVER_QUOTE_CHARACTER));
+        SqlServerQueryStringBuilder builder = new SqlServerQueryStringBuilder(new SqlServerFederationExpressionParser());
         Split split = Mockito.mock(Split.class);
         Mockito.when(split.getProperty(SqlServerMetadataHandler.PARTITION_FUNCTION)).thenReturn(null);
         Mockito.when(split.getProperty(SqlServerMetadataHandler.PARTITIONING_COLUMN)).thenReturn(null);
@@ -107,12 +106,22 @@ public class SqlServerQueryStringBuilderTest
     }
 
     @Test
+    public void getPartitionWhereClausesQuotesIdentifiers()
+    {
+        SqlServerQueryStringBuilder builder = new SqlServerQueryStringBuilder(new SqlServerFederationExpressionParser());
+        Split quotedNames = Mockito.mock(Split.class);
+        Mockito.when(quotedNames.getProperty(SqlServerMetadataHandler.PARTITION_FUNCTION)).thenReturn("pf]x");
+        Mockito.when(quotedNames.getProperty(SqlServerMetadataHandler.PARTITIONING_COLUMN)).thenReturn("col]y");
+        Mockito.when(quotedNames.getProperty(PARTITION_NUMBER)).thenReturn("2");
+        Assert.assertEquals(Collections.singletonList(" $PARTITION.[pf]]x]([col]]y]) = 2"), builder.getPartitionWhereClauses(quotedNames));
+    }
+
+    @Test
     public void testLimitClause()
     {
         Split split = Mockito.mock(Split.class);
-        SqlServerQueryStringBuilder builder = new SqlServerQueryStringBuilder(SQLSERVER_QUOTE_CHARACTER, new SqlServerFederationExpressionParser(SQLSERVER_QUOTE_CHARACTER));
+        SqlServerQueryStringBuilder builder = new SqlServerQueryStringBuilder(new SqlServerFederationExpressionParser());
         Constraints constraints = new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), 5L, Collections.emptyMap(), null);
         Assert.assertEquals("", builder.appendLimitOffset(split, constraints));
     }
-
 }

--- a/athena-sqlserver/src/test/java/com/amazonaws/athena/connectors/sqlserver/SqlServerRecordHandlerTest.java
+++ b/athena-sqlserver/src/test/java/com/amazonaws/athena/connectors/sqlserver/SqlServerRecordHandlerTest.java
@@ -62,7 +62,6 @@ import static com.amazonaws.athena.connector.lambda.metadata.optimizations.query
 import static com.amazonaws.athena.connectors.jdbc.qpt.JdbcQueryPassthrough.ENABLE_QUERY_PASSTHROUGH;
 import static com.amazonaws.athena.connectors.jdbc.qpt.JdbcQueryPassthrough.QUERY;
 import static com.amazonaws.athena.connectors.sqlserver.SqlServerConstants.PARTITION_NUMBER;
-import static com.amazonaws.athena.connectors.sqlserver.SqlServerConstants.SQLSERVER_QUOTE_CHARACTER;
 import static org.mockito.ArgumentMatchers.nullable;
 
 public class SqlServerRecordHandlerTest
@@ -113,7 +112,7 @@ public class SqlServerRecordHandlerTest
         this.connection = Mockito.mock(Connection.class);
         this.jdbcConnectionFactory = Mockito.mock(JdbcConnectionFactory.class);
         Mockito.when(this.jdbcConnectionFactory.getConnection(nullable(CredentialsProvider.class))).thenReturn(this.connection);
-        jdbcSplitQueryBuilder = new SqlServerQueryStringBuilder(SQLSERVER_QUOTE_CHARACTER ,new SqlServerFederationExpressionParser(SQLSERVER_QUOTE_CHARACTER));
+        jdbcSplitQueryBuilder = new SqlServerQueryStringBuilder(new SqlServerFederationExpressionParser());
         final DatabaseConnectionConfig databaseConnectionConfig = new DatabaseConnectionConfig(TEST_CATALOG, SqlServerConstants.NAME,
                 "sqlserver://jdbc:sqlserver://hostname;databaseName=fakedatabase");
 
@@ -143,7 +142,7 @@ public class SqlServerRecordHandlerTest
                 ImmutableMap.of(TEST_COL4, valueSet)
         );
 
-        String expectedSql = "SELECT \"testCol1\", \"testCol2\", \"testCol3\", \"testCol4\" FROM \"testSchema\".\"testTable\"  WHERE (\"testCol4\" = ?) AND  $PARTITION.pf(testCol1) = 1";
+        String expectedSql = "SELECT [testCol1], [testCol2], [testCol3], [testCol4] FROM [testSchema].[testTable]  WHERE ([testCol4] = ?) AND  $PARTITION.[pf]([testCol1]) = 1";
         PreparedStatement expectedPreparedStatement = Mockito.mock(PreparedStatement.class);
         Mockito.when(this.connection.prepareStatement(Mockito.eq(expectedSql))).thenReturn(expectedPreparedStatement);
         PreparedStatement preparedStatement = this.sqlServerRecordHandler.buildSplitSql(this.connection, TEST_CATALOG_NAME, tableName, schema, constraints, split);
@@ -188,7 +187,7 @@ public class SqlServerRecordHandlerTest
                 )
         );
 
-        String expectedSql = "SELECT \"id\", \"name\", \"age\", \"salary\", \"department\", \"is_active\", \"amount\" FROM \"testSchema\".\"testTable\"  WHERE (\"id\" IN (?,?,?,?,?)) AND ((\"age\" >= ? AND \"age\" <= ?)) AND ((\"salary\" > ? AND \"salary\" < ?)) AND (\"department\" = ?) AND (\"is_active\" = ?) AND (\"amount\" = ?)";
+        String expectedSql = "SELECT [id], [name], [age], [salary], [department], [is_active], [amount] FROM [testSchema].[testTable]  WHERE ([id] IN (?,?,?,?,?)) AND (([age] >= ? AND [age] <= ?)) AND (([salary] > ? AND [salary] < ?)) AND ([department] = ?) AND ([is_active] = ?) AND ([amount] = ?)";
         PreparedStatement expectedPreparedStatement = createMockPreparedStatement(expectedSql);
 
         PreparedStatement preparedStatement = this.sqlServerRecordHandler.buildSplitSql(this.connection, TEST_CATALOG_NAME, tableName, schema, constraints, split);
@@ -235,7 +234,7 @@ public class SqlServerRecordHandlerTest
                 )
         );
 
-        String expectedSql = "SELECT \"price\", \"quantity\", \"discount\" FROM \"testSchema\".\"testTable\"  WHERE ((\"price\" > ? AND \"price\" <= ?)) AND ((\"quantity\" >= ? AND \"quantity\" < ?)) AND ((\"discount\" > ? AND \"discount\" < ?))";
+        String expectedSql = "SELECT [price], [quantity], [discount] FROM [testSchema].[testTable]  WHERE (([price] > ? AND [price] <= ?)) AND (([quantity] >= ? AND [quantity] < ?)) AND (([discount] > ? AND [discount] < ?))";
         PreparedStatement expectedPreparedStatement = createMockPreparedStatement(expectedSql);
 
         PreparedStatement preparedStatement = this.sqlServerRecordHandler.buildSplitSql(this.connection, TEST_CATALOG_NAME, tableName, schema, constraints, split);
@@ -271,7 +270,7 @@ public class SqlServerRecordHandlerTest
                 10
         );
 
-        String expectedSql = "SELECT \"id\", \"name\", \"salary\" FROM \"testSchema\".\"testTable\"  ORDER BY \"salary\" DESC NULLS LAST";
+        String expectedSql = "SELECT [id], [name], [salary] FROM [testSchema].[testTable]  ORDER BY [salary] DESC NULLS LAST";
         PreparedStatement expectedPreparedStatement = createMockPreparedStatement(expectedSql);
 
         PreparedStatement preparedStatement = this.sqlServerRecordHandler.buildSplitSql(this.connection, TEST_CATALOG_NAME, tableName, schema, constraints, split);
@@ -303,7 +302,7 @@ public class SqlServerRecordHandlerTest
                 Constraints.DEFAULT_NO_LIMIT
         );
 
-        String expectedSql = "SELECT \"department\", \"salary\", \"name\" FROM \"testSchema\".\"testTable\"  ORDER BY \"department\" ASC NULLS LAST, \"salary\" DESC NULLS FIRST, \"name\" ASC NULLS LAST";
+        String expectedSql = "SELECT [department], [salary], [name] FROM [testSchema].[testTable]  ORDER BY [department] ASC NULLS LAST, [salary] DESC NULLS FIRST, [name] ASC NULLS LAST";
         PreparedStatement expectedPreparedStatement = createMockPreparedStatement(expectedSql);
 
         PreparedStatement preparedStatement = this.sqlServerRecordHandler.buildSplitSql(this.connection, TEST_CATALOG_NAME, tableName, schema, constraints, split);
@@ -324,7 +323,7 @@ public class SqlServerRecordHandlerTest
 
         Constraints constraints = createConstraints(Collections.emptyMap());
 
-        String expectedSql = "SELECT \"id\" FROM \"testSchema\".\"testTable\" ";
+        String expectedSql = "SELECT [id] FROM [testSchema].[testTable] ";
         PreparedStatement expectedPreparedStatement = createMockPreparedStatement(expectedSql);
 
         PreparedStatement preparedStatement = this.sqlServerRecordHandler.buildSplitSql(this.connection, TEST_CATALOG_NAME, tableName, schema, constraints, split);
@@ -347,7 +346,7 @@ public class SqlServerRecordHandlerTest
         ValueSet singleValueSet = createSingleValueSet(1);
         Constraints constraints = createConstraints(ImmutableMap.of(COL_ID, singleValueSet));
 
-        String expectedSql = "SELECT \"id\" FROM \"testSchema\".\"testTable\"  WHERE (\"id\" = ?)";
+        String expectedSql = "SELECT [id] FROM [testSchema].[testTable]  WHERE ([id] = ?)";
         PreparedStatement expectedPreparedStatement = createMockPreparedStatement(expectedSql);
 
         PreparedStatement preparedStatement = this.sqlServerRecordHandler.buildSplitSql(this.connection, TEST_CATALOG_NAME, tableName, schema, constraints, split);
@@ -373,7 +372,7 @@ public class SqlServerRecordHandlerTest
         ValueSet largeInSet = createMultiValueSet(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         Constraints constraints = createConstraints(ImmutableMap.of(COL_ID, largeInSet));
 
-        String expectedSql = "SELECT \"id\" FROM \"testSchema\".\"testTable\"  WHERE (\"id\" IN (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?))";
+        String expectedSql = "SELECT [id] FROM [testSchema].[testTable]  WHERE ([id] IN (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?))";
         PreparedStatement expectedPreparedStatement = createMockPreparedStatement(expectedSql);
 
         PreparedStatement preparedStatement = this.sqlServerRecordHandler.buildSplitSql(this.connection, TEST_CATALOG_NAME, tableName, schema, constraints, split);
@@ -419,7 +418,7 @@ public class SqlServerRecordHandlerTest
         );
 
         // SQL Server doesn't support LIMIT, so it should be ignored
-        String expectedSql = "SELECT \"id\", \"name\" FROM \"testSchema\".\"testTable\" ";
+        String expectedSql = "SELECT [id], [name] FROM [testSchema].[testTable] ";
         PreparedStatement expectedPreparedStatement = createMockPreparedStatement(expectedSql);
 
         PreparedStatement preparedStatement = this.sqlServerRecordHandler.buildSplitSql(this.connection, TEST_CATALOG_NAME, tableName, schema, constraints, split);
@@ -474,7 +473,7 @@ public class SqlServerRecordHandlerTest
 
         Assert.assertFalse("Expected isQueryPassThrough to return false", constraints.isQueryPassThrough());
 
-        String expectedSql = "SELECT \"intCol\", \"varcharCol\", \"bigintCol\", \"floatCol\", \"doubleCol\", \"dateCol\", \"timestampCol\", \"boolCol\" FROM \"testSchema\".\"testTable\"  WHERE (\"intCol\" = ?) AND (\"varcharCol\" = ?)";
+        String expectedSql = "SELECT [intCol], [varcharCol], [bigintCol], [floatCol], [doubleCol], [dateCol], [timestampCol], [boolCol] FROM [testSchema].[testTable]  WHERE ([intCol] = ?) AND ([varcharCol] = ?)";
         PreparedStatement expectedPreparedStatement = createMockPreparedStatement(expectedSql);
 
         PreparedStatement result = this.sqlServerRecordHandler.buildSplitSql(this.connection, TEST_CATALOG_NAME, tableName, schema, constraints, split);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Quote partition function and partitioning column identifiers in generated partition SQL expressions, as JDBC parameter binding (?) cannot be used for identifiers.
- Additionally, switch SQL Server identifier quoting from double quotes ("name") to square brackets ([name]), escaping any embedded closing brackets by doubling them (]]). This approach ensures compatibility regardless of the QUOTED_IDENTIFIER setting.

Please find the attached functional testing results.
[SQLSERVER_FUNCTIONAL_TEST_2026-08-31.xlsx](https://github.com/user-attachments/files/31644246/SQLSERVER_FUNCTIONAL_TEST_2026-08-31.xlsx)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
