### PR TITLE
Enhance Snowflake metadata SQL with identifier quoting

### DIFF
--- a/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMetadataHandler.java
+++ b/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMetadataHandler.java
@@ -621,7 +621,7 @@ public class SnowflakeMetadataHandler extends JdbcMetadataHandler
         LOGGER.debug("getPrimaryKey tableName: " + tableName);
         List<String> primaryKeys = new ArrayList<String>();
         try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider())) {
-            try (PreparedStatement preparedStatement = connection.prepareStatement(SHOW_PRIMARY_KEYS_QUERY + "\"" + tableName.getSchemaName() + "\".\"" + tableName.getTableName() + "\"");
+            try (PreparedStatement preparedStatement = connection.prepareStatement(SHOW_PRIMARY_KEYS_QUERY + qualifiedTableName(tableName));
                  ResultSet rs = preparedStatement.executeQuery()) {
                 while (rs.next()) {
                     // Concatenate multiple primary keys if they exist
@@ -629,7 +629,7 @@ public class SnowflakeMetadataHandler extends JdbcMetadataHandler
                 }
             }
 
-            String primaryKeyString = primaryKeys.stream().map(s -> "\"" + s + "\"").collect(Collectors.joining(","));
+            String primaryKeyString = primaryKeys.stream().map(s -> snowflakeQueryStringBuilder.quote(s)).collect(Collectors.joining(","));
             if (!Strings.isNullOrEmpty(primaryKeyString) && hasUniquePrimaryKey(tableName, primaryKeyString)) {
                 return Optional.of(primaryKeyString);
             }
@@ -644,7 +644,7 @@ public class SnowflakeMetadataHandler extends JdbcMetadataHandler
     private boolean hasUniquePrimaryKey(TableName tableName, String primaryKey) throws Exception
     {
         try (Connection connection = getJdbcConnectionFactory().getConnection(getCredentialProvider())) {
-            try (PreparedStatement preparedStatement = connection.prepareStatement("SELECT " + primaryKey +  ", count(*) as COUNTS FROM " + "\"" + tableName.getSchemaName() + "\".\"" + tableName.getTableName() + "\"" + " GROUP BY " + primaryKey + " ORDER BY COUNTS DESC");
+            try (PreparedStatement preparedStatement = connection.prepareStatement("SELECT " + primaryKey + ", count(*) as COUNTS FROM " + qualifiedTableName(tableName) + " GROUP BY " + primaryKey + " ORDER BY COUNTS DESC");
                  ResultSet rs = preparedStatement.executeQuery()) {
                 if (rs.next()) {
                     if (rs.getInt(COUNTS_COLUMN_NAME) == 1) {
@@ -785,5 +785,12 @@ public class SnowflakeMetadataHandler extends JdbcMetadataHandler
                     request.getConstraints());
         }
         return generatedSql;
+    }
+
+    private String qualifiedTableName(TableName tableName)
+    {
+        return snowflakeQueryStringBuilder.quote(tableName.getSchemaName())
+                + "."
+                + snowflakeQueryStringBuilder.quote(tableName.getTableName());
     }
 }

--- a/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeQueryStringBuilder.java
+++ b/athena-snowflake/src/main/java/com/amazonaws/athena/connectors/snowflake/SnowflakeQueryStringBuilder.java
@@ -159,7 +159,8 @@ public class SnowflakeQueryStringBuilder
         return sql;
     }
 
-    protected String quote(String name)
+    @Override
+    public String quote(String name)
     {
         name = name.replace(DOUBLE_QUOTE_CHAR, DOUBLE_QUOTE_CHAR + DOUBLE_QUOTE_CHAR);
         return DOUBLE_QUOTE_CHAR + name + DOUBLE_QUOTE_CHAR;

--- a/athena-snowflake/src/test/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMetadataHandlerTest.java
+++ b/athena-snowflake/src/test/java/com/amazonaws/athena/connectors/snowflake/SnowflakeMetadataHandlerTest.java
@@ -34,8 +34,6 @@ import com.amazonaws.athena.connector.lambda.domain.predicate.SortedRangeSet;
 import com.amazonaws.athena.connector.lambda.domain.predicate.ValueSet;
 import com.amazonaws.athena.connector.lambda.metadata.GetSplitsRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetSplitsResponse;
-import com.amazonaws.athena.connector.lambda.metadata.GetDataSourceCapabilitiesRequest;
-import com.amazonaws.athena.connector.lambda.metadata.GetDataSourceCapabilitiesResponse;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableLayoutRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableLayoutResponse;
 import com.amazonaws.athena.connector.lambda.metadata.GetTableRequest;
@@ -51,8 +49,6 @@ import com.amazonaws.athena.connectors.jdbc.TestBase;
 import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionConfig;
 import com.amazonaws.athena.connectors.jdbc.connection.JdbcConnectionFactory;
 import com.google.common.collect.ImmutableList;
-import org.apache.arrow.vector.types.TimeUnit;
-import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.junit.Assert;
 import org.junit.Before;
@@ -301,6 +297,65 @@ public class SnowflakeMetadataHandlerTest
 
         assertNotNull(partitions);
         assertTrue(partitions.getRowCount() > 0);
+    }
+
+    @Test
+    public void getPartitions_whenTableHasUniquePrimaryKey_quotesSchemaTableAndPrimaryKeyInMetadataSql() throws Exception
+    {
+        Schema tableSchema = SchemaBuilder.newBuilder()
+                .addIntField("id")
+                .addStringField(BLOCK_PARTITION_COLUMN_NAME)
+                .build();
+
+        ResultSet viewResultSet = mockResultSet(
+                new String[] {"TABLE_SCHEM", "TABLE_NAME"},
+                new int[] {Types.VARCHAR, Types.VARCHAR},
+                new Object[][] {},
+                new AtomicInteger(-1));
+        PreparedStatement viewStmt = mock(PreparedStatement.class);
+        when(viewStmt.executeQuery()).thenReturn(viewResultSet);
+
+        ResultSet countResultSet = mockResultSet(
+                new String[] {"row_count"},
+                new int[] {Types.BIGINT},
+                new Object[][] {{1000L}},
+                new AtomicInteger(-1));
+        when(countResultSet.getLong(1)).thenReturn(1000L);
+        PreparedStatement countStmt = mock(PreparedStatement.class);
+        when(countStmt.executeQuery()).thenReturn(countResultSet);
+
+        ResultSet primaryKeyResultSet = mockResultSet(
+                new String[] {"column_name"},
+                new int[] {Types.VARCHAR},
+                new Object[][] {{"ID"}},
+                new AtomicInteger(-1));
+        PreparedStatement primaryKeyStmt = mock(PreparedStatement.class);
+        when(primaryKeyStmt.executeQuery()).thenReturn(primaryKeyResultSet);
+
+        ResultSet uniquenessResultSet = mockResultSet(
+                new String[] {"COUNTS"},
+                new int[] {Types.INTEGER},
+                new Object[][] {{1}},
+                new AtomicInteger(-1));
+        PreparedStatement uniquenessStmt = mock(PreparedStatement.class);
+        when(uniquenessStmt.executeQuery()).thenReturn(uniquenessResultSet);
+
+        when(connection.prepareStatement(contains("information_schema.views"))).thenReturn(viewStmt);
+        when(connection.prepareStatement(contains("information_schema.tables"))).thenReturn(countStmt);
+        when(connection.prepareStatement(contains("SHOW PRIMARY KEYS"))).thenReturn(primaryKeyStmt);
+        when(connection.prepareStatement(contains("COUNTS"))).thenReturn(uniquenessStmt);
+
+        GetTableLayoutRequest req = new GetTableLayoutRequest(this.federatedIdentity, "queryId", "default",
+                new TableName("schema1", "table1"),
+                new Constraints(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Map.of(), null),
+                tableSchema,
+                Collections.singleton(BLOCK_PARTITION_COLUMN_NAME));
+
+        GetTableLayoutResponse res = snowflakeMetadataHandler.doGetTableLayout(allocator, req);
+
+        assertTrue(res.getPartitions().getRowCount() > 0);
+        verify(connection).prepareStatement("SHOW PRIMARY KEYS IN \"schema1\".\"table1\"");
+        verify(connection).prepareStatement("SELECT \"ID\", count(*) as COUNTS FROM \"schema1\".\"table1\" GROUP BY \"ID\" ORDER BY COUNTS DESC");
     }
 
     @Test

--- a/athena-snowflake/src/test/java/com/amazonaws/athena/connectors/snowflake/SnowflakeQueryStringBuilderTest.java
+++ b/athena-snowflake/src/test/java/com/amazonaws/athena/connectors/snowflake/SnowflakeQueryStringBuilderTest.java
@@ -98,6 +98,12 @@ public class SnowflakeQueryStringBuilderTest
     }
 
     @Test
+    public void quote_whenIdentifierContainsDoubleQuote_escapesByDoubling()
+    {
+        assertEquals("\"COL\"\"NAME\"", queryBuilder.quote("COL\"NAME"));
+    }
+
+    @Test
     public void testBuildSqlWithSimpleConstraints() throws SQLException
     {
         Connection mockConnection = mock(Connection.class);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Quote schema, table, and primary-key identifiers in Snowflake partition metadata SQL (`SHOW PRIMARY KEYS IN "schema"."table"` and the uniqueness check `SELECT ... FROM "schema"."table"`), doubling any embedded `"`.
* Use `SnowflakeQueryStringBuilder.quote()` for those identifiers instead of concatenating raw double quotes.

PFA functional testing results
[SNOWFLAKE_FUNCTIONAL_TEST_2026-09-02.xlsx](https://github.com/user-attachments/files/31724432/SNOWFLAKE_FUNCTIONAL_TEST_2026-09-02.xlsx)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
