### PR TITLE
Quote MySQL Partition Name Identifiers

### DIFF
--- a/athena-mysql/src/main/java/com/amazonaws/athena/connectors/mysql/MySqlQueryStringBuilder.java
+++ b/athena-mysql/src/main/java/com/amazonaws/athena/connectors/mysql/MySqlQueryStringBuilder.java
@@ -64,7 +64,8 @@ public class MySqlQueryStringBuilder
             return String.format(" FROM %s ", tableName);
         }
 
-        return String.format(" FROM %s PARTITION(%s) ", tableName, partitionName);
+        // Identifiers cannot be bound with JDBC ?; quote() wraps and doubles embedded backticks.
+        return String.format(" FROM %s PARTITION(%s) ", tableName, quote(partitionName));
     }
 
     @Override

--- a/athena-mysql/src/test/java/com/amazonaws/athena/connectors/mysql/MySqlQueryStringBuilderTest.java
+++ b/athena-mysql/src/test/java/com/amazonaws/athena/connectors/mysql/MySqlQueryStringBuilderTest.java
@@ -73,7 +73,7 @@ public class MySqlQueryStringBuilderTest
         Map<String, ValueSet> constraintsMap = ImmutableMap.of("testCol2", SortedRangeSet.of(false, Range.all(allocator, org.apache.arrow.vector.types.Types.MinorType.INT.getType())));
         Constraints constraints = new Constraints(constraintsMap, Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null);
 
-        String expectedSql = "SELECT `testCol1`, `testCol2`, `testCol3`, `testCol4`, `dateCol` FROM `testCatalog`.`testTable`.`testSchema` PARTITION(p0)  WHERE (`testCol2` IS NOT NULL)";
+        String expectedSql = "SELECT `testCol1`, `testCol2`, `testCol3`, `testCol4`, `dateCol` FROM `testCatalog`.`testTable`.`testSchema` PARTITION(`p0`)  WHERE (`testCol2` IS NOT NULL)";
         PreparedStatement expectedPreparedStatement = Mockito.mock(PreparedStatement.class);
         Mockito.when(connection.prepareStatement(Mockito.eq(expectedSql))).thenReturn(expectedPreparedStatement);
 
@@ -89,7 +89,7 @@ public class MySqlQueryStringBuilderTest
         Map<String, ValueSet> constraintsMap = ImmutableMap.of("testCol2", SortedRangeSet.of(false, Range.lessThan(allocator, org.apache.arrow.vector.types.Types.MinorType.INT.getType(), 138), Range.greaterThan(allocator, org.apache.arrow.vector.types.Types.MinorType.INT.getType(), 138)));
         Constraints constraints = new Constraints(constraintsMap, Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null);
 
-        String expectedSql = "SELECT `testCol1`, `testCol2`, `testCol3`, `testCol4`, `dateCol` FROM `testCatalog`.`testTable`.`testSchema` PARTITION(p0)  WHERE ((`testCol2` < ?) OR (`testCol2` > ?))";
+        String expectedSql = "SELECT `testCol1`, `testCol2`, `testCol3`, `testCol4`, `dateCol` FROM `testCatalog`.`testTable`.`testSchema` PARTITION(`p0`)  WHERE ((`testCol2` < ?) OR (`testCol2` > ?))";
         PreparedStatement expectedPreparedStatement = Mockito.mock(PreparedStatement.class);
         Mockito.when(connection.prepareStatement(Mockito.eq(expectedSql))).thenReturn(expectedPreparedStatement);
 
@@ -107,7 +107,7 @@ public class MySqlQueryStringBuilderTest
                         Range.lessThan(allocator, Types.MinorType.DATEDAY.getType(), 8035),
                         Range.greaterThan(allocator, Types.MinorType.DATEDAY.getType(), 10440)));
 
-        String expectedSql = "SELECT `testCol1`, `testCol2`, `testCol3`, `testCol4`, `dateCol` FROM `testCatalog`.`testTable`.`testSchema` PARTITION(p0)  WHERE ((`dateCol` < ?) OR (`dateCol` > ?))";
+        String expectedSql = "SELECT `testCol1`, `testCol2`, `testCol3`, `testCol4`, `dateCol` FROM `testCatalog`.`testTable`.`testSchema` PARTITION(`p0`)  WHERE ((`dateCol` < ?) OR (`dateCol` > ?))";
         Constraints constraints = new Constraints(constraintsMap, Collections.emptyList(), Collections.emptyList(), DEFAULT_NO_LIMIT, Collections.emptyMap(), null);
 
         PreparedStatement expectedPreparedStatement = Mockito.mock(PreparedStatement.class);
@@ -126,5 +126,15 @@ public class MySqlQueryStringBuilderTest
         //End date = 1998-8-2
         Date endDate = new Date(98, 7, 2);
         Mockito.verify(expectedPreparedStatement, times(1)).setDate(2, endDate);
+    }
+
+    @Test
+    public void getFromClauseWithSplit_withEmbeddedBacktickInPartition_escapesBackticks()
+    {
+        Split split = Split.newBuilder(s3SpillLocation, null)
+                .add(MySqlMetadataHandler.BLOCK_PARTITION_COLUMN_NAME, "p`0")
+                .build();
+        assertEquals(" FROM `testCatalog`.`testSchema`.`testTable` PARTITION(`p``0`) ",
+                mySqlQueryStringBuilder.getFromClauseWithSplit("testCatalog", "testSchema", "testTable", split));
     }
 }

--- a/athena-mysql/src/test/java/com/amazonaws/athena/connectors/mysql/MySqlRecordHandlerTest.java
+++ b/athena-mysql/src/test/java/com/amazonaws/athena/connectors/mysql/MySqlRecordHandlerTest.java
@@ -140,7 +140,7 @@ public class MySqlRecordHandlerTest
                 Collections.emptyMap(), null
         );
 
-        String expectedSql = "SELECT `testCol1`, `testCol2`, `testCol3`, `testCol4`, `testCol5`, `testCol6`, `testCol7`, `testCol8` FROM `testSchema`.`testTable` PARTITION(p0)  WHERE (`testCol1` IN (?,?)) AND ((`testCol2` >= ? AND `testCol2` < ?)) AND ((`testCol3` > ? AND `testCol3` <= ?)) AND (`testCol4` = ?) AND (`testCol5` = ?) AND (`testCol6` = ?) AND (`testCol7` = ?) AND (`testCol8` = ?) ORDER BY `testCol1` ASC, ISNULL(`testCol3`) DESC, `testCol3` DESC LIMIT 100";
+        String expectedSql = "SELECT `testCol1`, `testCol2`, `testCol3`, `testCol4`, `testCol5`, `testCol6`, `testCol7`, `testCol8` FROM `testSchema`.`testTable` PARTITION(`p0`)  WHERE (`testCol1` IN (?,?)) AND ((`testCol2` >= ? AND `testCol2` < ?)) AND ((`testCol3` > ? AND `testCol3` <= ?)) AND (`testCol4` = ?) AND (`testCol5` = ?) AND (`testCol6` = ?) AND (`testCol7` = ?) AND (`testCol8` = ?) ORDER BY `testCol1` ASC, ISNULL(`testCol3`) DESC, `testCol3` DESC LIMIT 100";
         PreparedStatement expectedPreparedStatement = Mockito.mock(PreparedStatement.class);
         Mockito.when(this.connection.prepareStatement(Mockito.eq(expectedSql))).thenReturn(expectedPreparedStatement);
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Partition names are now quoted as MySQL identifiers using backticks (`), with embedded backticks escaped by doubling them (``). This aligns with the existing identifier-quoting strategy used for catalog, schema, and table names, ensuring that partition names are interpreted as identifiers rather than executable SQL.

PFA functional testing results
[MYSQL_FUNCTIONAL_TEST_2026-09-02.xlsx](https://github.com/user-attachments/files/31728458/MYSQL_FUNCTIONAL_TEST_2026-09-02.xlsx)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
