### PR TITLE
Quote Oracle Partition Name Identifiers

### DIFF
--- a/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleMetadataHandler.java
+++ b/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleMetadataHandler.java
@@ -160,7 +160,10 @@ public class OracleMetadataHandler
             TableName casedTableName = getTableLayoutRequest.getTableName();
             LOGGER.debug("{}: Schema {}, table {}", getTableLayoutRequest.getQueryId(), casedTableName.getSchemaName(),
                 casedTableName.getTableName());
-            List<String> parameters = Arrays.asList(OracleJDBCCaseResolver.convertToLiteral(casedTableName.getTableName()));
+            // GET_PARTITIONS_QUERY uses table_name = ?; bind the raw dictionary name.
+            // convertToLiteral() would put extra quotes into the JDBC parameter and
+            // miss USER_TAB_PARTITIONS rows.
+            List<String> parameters = Arrays.asList(casedTableName.getTableName());
             try (PreparedStatement preparedStatement = new PreparedStatementBuilder().withConnection(connection).withQuery(GET_PARTITIONS_QUERY).withParameters(parameters).build();
                 ResultSet resultSet = preparedStatement.executeQuery()) {
                 // Return a single partition if no partitions defined

--- a/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleQueryStringBuilder.java
+++ b/athena-oracle/src/main/java/com/amazonaws/athena/connectors/oracle/OracleQueryStringBuilder.java
@@ -28,7 +28,6 @@ import org.apache.calcite.sql.SqlDialect;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 
 /**
  * Extends {@link JdbcSplitQueryBuilder} and implements ORACLE specific SQL clauses for split.
@@ -61,10 +60,10 @@ public class OracleQueryStringBuilder
             // No partitions
             return String.format(" FROM %s ", tableName);
         }
-
-        Set<String> partitionVals = split.getProperties().keySet();
-        String partValue = split.getProperty(partitionVals.iterator().next());
-        return String.format(" FROM %s ", tableName + " " + "PARTITION " + "(" + partValue + ")");
+        // Always read the partition name by its known property key. Do not use keySet().iterator().next():
+        // splits may also carry CATALOG_CASING_FILTER (and other properties), and picking an arbitrary
+        // key would interpolate that value into PARTITION (...), producing invalid/unsafe SQL.
+        return String.format(" FROM %s PARTITION (%s) ", tableName, quote(partitionName));
     }
 
     @Override

--- a/athena-oracle/src/test/java/com/amazonaws/athena/connectors/oracle/OracleMetadataHandlerTest.java
+++ b/athena-oracle/src/test/java/com/amazonaws/athena/connectors/oracle/OracleMetadataHandlerTest.java
@@ -140,7 +140,7 @@ public class OracleMetadataHandlerTest
             throws Exception
     {
         Constraints constraints = Mockito.mock(Constraints.class);
-        TableName tableName = new TableName("testSchema", "\'TESTTABLE\'");
+        TableName tableName = new TableName("testSchema", "TESTTABLE");
         Schema partitionSchema = this.oracleMetadataHandler.getPartitionSchema(CATALOG_NAME);
         Set<String> partitionCols = partitionSchema.getFields().stream().map(Field::getName).collect(Collectors.toSet());
         GetTableLayoutRequest getTableLayoutRequest = new GetTableLayoutRequest(this.federatedIdentity, "testQUERY_ID", CATALOG_NAME, tableName, constraints, partitionSchema, partitionCols);
@@ -172,6 +172,7 @@ public class OracleMetadataHandlerTest
         assertEquals(expectedSchema, getTableLayoutResponse.getPartitions().getSchema());
         assertEquals(tableName, getTableLayoutResponse.getTableName());
 
+        // Bind the raw dictionary name, not convertToLiteral()'s quoted form ('TESTTABLE').
         verify(preparedStatement, Mockito.times(1)).setString(1, tableName.getTableName());
     }
 
@@ -180,7 +181,7 @@ public class OracleMetadataHandlerTest
             throws Exception
     {
         Constraints constraints = Mockito.mock(Constraints.class);
-        TableName tableName = new TableName("testSchema", "\'TESTTABLE\'");
+        TableName tableName = new TableName("testSchema", "TESTTABLE");
         Schema partitionSchema = this.oracleMetadataHandler.getPartitionSchema(CATALOG_NAME);
         Set<String> partitionCols = partitionSchema.getFields().stream().map(Field::getName).collect(Collectors.toSet());
         GetTableLayoutRequest getTableLayoutRequest = new GetTableLayoutRequest(this.federatedIdentity, "testQUERY_ID", CATALOG_NAME, tableName, constraints, partitionSchema, partitionCols);
@@ -211,7 +212,8 @@ public class OracleMetadataHandlerTest
         Schema expectedSchema = expectedSchemaBuilder.build();
         assertEquals(expectedSchema, getTableLayoutResponse.getPartitions().getSchema());
         assertEquals(tableName, getTableLayoutResponse.getTableName());
-
+        
+        // Bind the raw dictionary name, not convertToLiteral()'s quoted form ('TESTTABLE').
         verify(preparedStatement, Mockito.times(1)).setString(1, tableName.getTableName());
     }
 

--- a/athena-oracle/src/test/java/com/amazonaws/athena/connectors/oracle/OracleRecordHandlerTest.java
+++ b/athena-oracle/src/test/java/com/amazonaws/athena/connectors/oracle/OracleRecordHandlerTest.java
@@ -183,7 +183,7 @@ public class OracleRecordHandlerTest
 
         when(constraints.getLimit()).thenReturn(5L);
 
-        String expectedSql = "SELECT \"testCol1\", \"testCol2\", \"testCol3\", \"testCol4\", \"testCol5\", \"testCol6\", \"testCol7\", \"testCol8\", \"testCol9\", \"testCol10\" FROM \"testSchema\".\"testTable\" PARTITION (p0)  WHERE (\"testCol1\" IN (?,?)) AND ((\"testCol2\" >= ? AND \"testCol2\" < ?)) AND ((\"testCol3\" > ? AND \"testCol3\" <= ?)) AND (\"testCol4\" = ?) AND (\"testCol5\" = ?) AND (\"testCol6\" = ?) AND (\"testCol7\" = ?) AND (\"testCol8\" = ?) AND (\"testCol9\" = ?) AND (\"testCol10\" = ?) FETCH FIRST 5 ROWS ONLY ";
+        String expectedSql = "SELECT \"testCol1\", \"testCol2\", \"testCol3\", \"testCol4\", \"testCol5\", \"testCol6\", \"testCol7\", \"testCol8\", \"testCol9\", \"testCol10\" FROM \"testSchema\".\"testTable\" PARTITION (\"p0\")  WHERE (\"testCol1\" IN (?,?)) AND ((\"testCol2\" >= ? AND \"testCol2\" < ?)) AND ((\"testCol3\" > ? AND \"testCol3\" <= ?)) AND (\"testCol4\" = ?) AND (\"testCol5\" = ?) AND (\"testCol6\" = ?) AND (\"testCol7\" = ?) AND (\"testCol8\" = ?) AND (\"testCol9\" = ?) AND (\"testCol10\" = ?) FETCH FIRST 5 ROWS ONLY ";
         PreparedStatement expectedPreparedStatement = mock(PreparedStatement.class);
         when(this.connection.prepareStatement(Mockito.eq(expectedSql))).thenReturn(expectedPreparedStatement);
         PreparedStatement preparedStatement = this.oracleRecordHandler.buildSplitSql(this.connection, "testCatalogName", tableName, schema, constraints, split);
@@ -257,7 +257,7 @@ public class OracleRecordHandlerTest
                 null
         );
 
-        String expectedSql = "SELECT \"col1\", \"col2\", \"col3\" FROM \"testSchema\".\"testTable\" PARTITION (p0)  WHERE ((\"col1\" > ? AND \"col1\" <= ?)) AND ((\"col2\" >= ? AND \"col2\" < ?)) AND ((\"col3\" >= ? AND \"col3\" <= ?))";
+        String expectedSql = "SELECT \"col1\", \"col2\", \"col3\" FROM \"testSchema\".\"testTable\" PARTITION (\"p0\")  WHERE ((\"col1\" > ? AND \"col1\" <= ?)) AND ((\"col2\" >= ? AND \"col2\" < ?)) AND ((\"col3\" >= ? AND \"col3\" <= ?))";
         PreparedStatement expectedPreparedStatement = createMockPreparedStatement(expectedSql);
 
         PreparedStatement preparedStatement = this.oracleRecordHandler.buildSplitSql(this.connection, "testCatalogName", tableName, schema, constraints, split);
@@ -280,13 +280,25 @@ public class OracleRecordHandlerTest
         Split split = createMockSplit();
         Constraints constraints = createConstraintsWithLimit(LIMIT_10);
 
-        String expectedSql = "SELECT \"id\", \"value\" FROM \"testSchema\".\"testTable\" PARTITION (p0)  FETCH FIRST " + LIMIT_10 + " ROWS ONLY ";
+        String expectedSql = "SELECT \"id\", \"value\" FROM \"testSchema\".\"testTable\" PARTITION (\"p0\")  FETCH FIRST " + LIMIT_10 + " ROWS ONLY ";
         PreparedStatement expectedPreparedStatement = createMockPreparedStatement(expectedSql);
 
         PreparedStatement preparedStatement = this.oracleRecordHandler.buildSplitSql(this.connection, "testCatalogName", tableName, schema, constraints, split);
 
         Assert.assertEquals(expectedPreparedStatement, preparedStatement);
         verifyFetchSize(expectedPreparedStatement);
+    }
+
+    @Test
+    public void getFromClauseWithSplit_withEmbeddedDoubleQuote_escapesByDoubling()
+    {
+        Split split = mock(Split.class);
+        when(split.getProperty(Mockito.eq(OracleMetadataHandler.BLOCK_PARTITION_COLUMN_NAME))).thenReturn("p\"x");
+
+        String result = ((OracleQueryStringBuilder) jdbcSplitQueryBuilder)
+                .getFromClauseWithSplit(TEST_CATALOG, TEST_SCHEMA, TEST_TABLE, split);
+
+        Assert.assertEquals(" FROM \"testCatalog\".\"testSchema\".\"testTable\" PARTITION (\"p\"\"x\") ", result);
     }
 
     @Test
@@ -311,7 +323,7 @@ public class OracleRecordHandlerTest
                 null
         );
 
-        String expectedSql = "SELECT \"id\", \"name\", \"value\" FROM \"testSchema\".\"testTable\" PARTITION (p0)  ORDER BY \"value\" DESC NULLS LAST, \"name\" ASC NULLS LAST";
+        String expectedSql = "SELECT \"id\", \"name\", \"value\" FROM \"testSchema\".\"testTable\" PARTITION (\"p0\")  ORDER BY \"value\" DESC NULLS LAST, \"name\" ASC NULLS LAST";
         PreparedStatement expectedPreparedStatement = createMockPreparedStatement(expectedSql);
 
         PreparedStatement preparedStatement = this.oracleRecordHandler.buildSplitSql(this.connection, "testCatalogName", tableName, schema, constraints, split);
@@ -328,7 +340,7 @@ public class OracleRecordHandlerTest
         Split split = createMockSplit();
         Constraints constraints = createConstraintsWithLimit(LIMIT_5);
         
-        String expectedSql = "SELECT \"id\", \"value\" FROM \"testSchema\".\"testTable\" PARTITION (p0)  FETCH FIRST " + LIMIT_5 + " ROWS ONLY ";
+        String expectedSql = "SELECT \"id\", \"value\" FROM \"testSchema\".\"testTable\" PARTITION (\"p0\")  FETCH FIRST " + LIMIT_5 + " ROWS ONLY ";
         PreparedStatement expectedPreparedStatement = createMockPreparedStatement(expectedSql);
 
         PreparedStatement preparedStatement = this.oracleRecordHandler.buildSplitSql(this.connection, "testCatalogName", tableName, schema, constraints, split);
@@ -367,7 +379,7 @@ public class OracleRecordHandlerTest
                 Collections.emptyMap(),
                 null);
 
-        String expectedSql = "SELECT \"intCol\", \"doubleCol\", \"stringCol\" FROM \"testSchema\".\"testTable\" PARTITION (p0)  WHERE (\"intCol\" IN (?,?,?)) AND ((\"doubleCol\" >= ? AND \"doubleCol\" < ?)) AND (\"stringCol\" IN (?,?))";
+        String expectedSql = "SELECT \"intCol\", \"doubleCol\", \"stringCol\" FROM \"testSchema\".\"testTable\" PARTITION (\"p0\")  WHERE (\"intCol\" IN (?,?,?)) AND ((\"doubleCol\" >= ? AND \"doubleCol\" < ?)) AND (\"stringCol\" IN (?,?))";
         PreparedStatement expectedPreparedStatement = createMockPreparedStatement(expectedSql);
 
         PreparedStatement preparedStatement = this.oracleRecordHandler.buildSplitSql(this.connection, "testCatalogName", tableName, schema, constraints, split);
@@ -413,7 +425,7 @@ public class OracleRecordHandlerTest
                 Collections.emptyMap(),
                 null);
 
-        String expectedSql = "SELECT \"dateCol\", \"timestampCol\", \"decimalCol\" FROM \"testSchema\".\"testTable\" PARTITION (p0)  WHERE ((\"dateCol\" >= ? AND \"dateCol\" <= ?)) AND ((\"decimalCol\" > ? AND \"decimalCol\" < ?))";
+        String expectedSql = "SELECT \"dateCol\", \"timestampCol\", \"decimalCol\" FROM \"testSchema\".\"testTable\" PARTITION (\"p0\")  WHERE ((\"dateCol\" >= ? AND \"dateCol\" <= ?)) AND ((\"decimalCol\" > ? AND \"decimalCol\" < ?))";
         PreparedStatement expectedPreparedStatement = createMockPreparedStatement(expectedSql);
 
         PreparedStatement preparedStatement = this.oracleRecordHandler.buildSplitSql(this.connection, "testCatalogName", tableName, schema, constraints, split);
@@ -470,7 +482,7 @@ public class OracleRecordHandlerTest
                 null
         );
 
-        String expectedSql = "SELECT \"" + COL_ID + "\", \"" + COL_NAME + "\" FROM \"testSchema\".\"testTable\" PARTITION (p0) ";
+        String expectedSql = "SELECT \"" + COL_ID + "\", \"" + COL_NAME + "\" FROM \"testSchema\".\"testTable\" PARTITION (\"p0\") ";
         PreparedStatement preparedStatement = createMockPreparedStatement(expectedSql);
 
         PreparedStatement result = this.oracleRecordHandler.buildSplitSql(this.connection, TEST_CATALOG, tableName, schema, constraints, split);
@@ -498,7 +510,7 @@ public class OracleRecordHandlerTest
                 null
         );
 
-        String expectedSql = "SELECT \"" + COL_ID + "\", \"" + COL_NAME + "\" FROM \"testSchema\".\"testTable\" PARTITION (p0)  ORDER BY \"" + COL_ID + "\" ASC NULLS LAST, \"" + COL_NAME + "\" DESC NULLS LAST";
+        String expectedSql = "SELECT \"" + COL_ID + "\", \"" + COL_NAME + "\" FROM \"testSchema\".\"testTable\" PARTITION (\"p0\")  ORDER BY \"" + COL_ID + "\" ASC NULLS LAST, \"" + COL_NAME + "\" DESC NULLS LAST";
         PreparedStatement preparedStatement = createMockPreparedStatement(expectedSql);
 
         PreparedStatement result = this.oracleRecordHandler.buildSplitSql(this.connection, TEST_CATALOG, tableName, schema, constraints, split);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Quote Oracle partition name identifiers in generated scan SQL (FROM "schema"."table" PARTITION ("P1")), escaping any embedded double quotes by doubling them (" → ""). Since JDBC parameter binding (?) cannot be used for identifiers, schema and table names were already quoted; this change extends the same protection to the PARTITION (...) clause. Also, always use the partition_name split property instead of relying on the first map key.

- Fix partition discovery query parameter binding. When querying USER_TAB_PARTITIONS, bind the table name using a parameterized predicate (WHERE table_name = ?) and pass the raw table name value from the data source. Previously, convertToLiteral() wrapped the table name in quotes (for example, 'TABLE'), causing the bound parameter to include literal quote characters and preventing partition discovery from returning matching partitions.

Please find the attached functional testing results.
[ORACLE_FUNCTIONAL_TEST_2026-09-03.xlsx](https://github.com/user-attachments/files/31787062/ORACLE_FUNCTIONAL_TEST_2026-09-03.xlsx)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
