### PR TITLE
Quote Cloudera Hive and Impala partition predicates

### DIFF
--- a/athena-cloudera-hive/src/main/java/com/amazonaws/athena/connectors/cloudera/HiveMetadataHandler.java
+++ b/athena-cloudera-hive/src/main/java/com/amazonaws/athena/connectors/cloudera/HiveMetadataHandler.java
@@ -188,17 +188,11 @@ public class HiveMetadataHandler extends JdbcMetadataHandler
                 String columnName = partitionColumns[partitionCounter].split("=")[0];
                 String columnType = columnInfo.get(columnName).toUpperCase();
                 if (partitionValue.equalsIgnoreCase("__HIVE_DEFAULT_PARTITION__")) {
-                    columnCondition.append(" " + columnName).append(" is").append(" NULL");
+                    columnCondition.append(" ").append(HiveUtils.quoteIdentifier(columnName)).append(" is NULL");
                 }
                 else {
-                    if (columnType != null && (columnType.equalsIgnoreCase("STRING") || columnType.equalsIgnoreCase("VARCHAR"))) {
-                        columnCondition.append(" " + columnName).append("=").append("'");
-                        columnCondition.append(partitionValue).append("'");
-                    }
-                    else {
-                        columnCondition.append(" " + columnName).append("=");
-                        columnCondition.append(partitionValue);
-                    }
+                    columnCondition.append(" ").append(HiveUtils.quoteIdentifier(columnName))
+                            .append("=").append(HiveUtils.partitionValueExpression(columnType, partitionValue));
                 }
                 partitionCounter++;
                 if (partitionColumns.length > partitionCounter) {

--- a/athena-cloudera-hive/src/main/java/com/amazonaws/athena/connectors/cloudera/HiveUtils.java
+++ b/athena-cloudera-hive/src/main/java/com/amazonaws/athena/connectors/cloudera/HiveUtils.java
@@ -26,8 +26,9 @@ import org.apache.calcite.sql.dialect.HiveSqlDialect;
 import static com.amazonaws.athena.connectors.cloudera.HiveConstants.HIVE_QUOTE_CHARACTER;
 
 /**
- * Builds Hive-safe quoted identifiers for dynamic SQL. JDBC {@code ?} placeholders apply to values,
- * not table references, so identifiers must be quoted and escaped explicitly.
+ * Builds Hive-safe quoted identifiers and string literals for dynamic SQL. JDBC {@code ?}
+ * placeholders apply to values, not table references, so identifiers and literals must be
+ * quoted and escaped explicitly.
  */
 public class HiveUtils
 {
@@ -47,6 +48,39 @@ public class HiveUtils
     }
 
     /**
+     * Single-quoted Hive string literal. Hive string literals accept both quote-doubling and C-style
+     * backslash escapes, so backslashes are escaped first, then
+     * {@link HiveSqlDialect#quoteStringLiteral(String)} applies Hive dialect quoting rules.
+     */
+    public static String quoteStringLiteral(String value)
+    {
+        String escaped = value.replace("\\", "\\\\");
+        return HIVE_SQL_DIALECT.quoteStringLiteral(escaped);
+    }
+
+    /**
+     * Right-hand side of a partition equality predicate. Quote STRING, VARCHAR, CHAR, and DATE;
+     * leave INT, BOOLEAN, and other types unquoted. {@code VARCHAR} is covered by {@code contains("CHAR")}.
+     */
+    public static String partitionValueExpression(String columnType, String partitionValue)
+    {
+        if (isQuotedPartitionType(columnType)) {
+            return quoteStringLiteral(partitionValue);
+        }
+        return partitionValue;
+    }
+    
+    private static boolean isQuotedPartitionType(String columnType)
+    {
+        if (columnType == null) {
+            return false;
+        }
+        String type = columnType.toUpperCase();
+        return type.contains("STRING") || type.contains("CHAR")
+                || type.equals("DATE") || type.startsWith("DATE(");
+    }
+
+    /**
      * {@code schema.table} for metadata statements, upper-casing each segment then quoting so names
      * cannot break out of identifier context.
      */
@@ -57,14 +91,11 @@ public class HiveUtils
     }
 
     /**
-     * Single-quoted pattern for {@code SHOW TABLE EXTENDED IN ... LIKE '...'}. Hive string literals
-     * accept both quote-doubling and C-style backslash escapes. Backslashes are escaped first, then
-     * {@link HiveSqlDialect#quoteStringLiteral(String)} applies Hive dialect quoting rules. The name
-     * is upper-cased to match prior connector behavior.
+     * Single-quoted pattern for {@code SHOW TABLE EXTENDED IN ... LIKE '...'}. The name is
+     * upper-cased to match prior connector behavior.
      */
     public static String likePatternLiteral(String pattern)
     {
-        String escaped = pattern.toUpperCase().replace("\\", "\\\\");
-        return HIVE_SQL_DIALECT.quoteStringLiteral(escaped);
+        return quoteStringLiteral(pattern.toUpperCase());
     }
 }

--- a/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveMetadataHandlerTest.java
+++ b/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveMetadataHandlerTest.java
@@ -186,13 +186,97 @@ public class HiveMetadataHandlerTest
             actualValues.add(BlockUtils.rowToString(getTableLayoutResponse.getPartitions(), i));
         }
         assertEquals(2, actualValues.size());
-        assertEquals("[partition :  case_date=02-01-2000 and case_number=1 and case_instance=89898990 and case_location='Hyderabad']", actualValues.get(0));
-        assertEquals("[partition :  case_date=01-01-2000 and case_number=0 and case_instance=89898989 and case_location is NULL]", actualValues.get(1));
+        assertEquals("[partition :  `case_date`='02-01-2000' and `case_number`=1 and `case_instance`=89898990 and `case_location`='Hyderabad']", actualValues.get(0));
+        assertEquals("[partition :  `case_date`='01-01-2000' and `case_number`=0 and `case_instance`=89898989 and `case_location` is NULL]", actualValues.get(1));
         SchemaBuilder expectedSchemaBuilder = SchemaBuilder.newBuilder();
         expectedSchemaBuilder.addField(FieldBuilder.newBuilder("partition", org.apache.arrow.vector.types.Types.MinorType.VARCHAR.getType()).build());
         Schema expectedSchema = expectedSchemaBuilder.build();
         assertEquals(expectedSchema, getTableLayoutResponse.getPartitions().getSchema());
         assertEquals(tempTableName, getTableLayoutResponse.getTableName());
+    }
+
+    @Test
+    public void doGetTableLayout_whenCharPartitionValueContainsOr_quotesValueAsStringLiteral()
+            throws Exception
+    {
+        String[] schema = {"data_type", "col_name"};
+        Object[][] values = {{"char(64)", "country"}};
+        ResultSet describeResultSet = mockResultSet(schema, values, new AtomicInteger(-1));
+        Constraints constraints = Mockito.mock(Constraints.class);
+        TableName tempTableName = new TableName(TEST_SCHEMA, TEST_TABLE);
+        Schema partitionSchema = this.hiveMetadataHandler.getPartitionSchema(CATALOG_NAME);
+        Set<String> partitionCols = new HashSet<>(Arrays.asList("partition"));
+        GetTableLayoutRequest getTableLayoutRequest = new GetTableLayoutRequest(this.federatedIdentity, QUERY_ID,
+                CATALOG_NAME, tempTableName, constraints, partitionSchema, partitionCols);
+        String[] partitionColumns = {"Partition"};
+        int[] partitionTypes = {Types.VARCHAR};
+        Object[][] partitionValues = {{"country=1 OR true --"}};
+        ResultSet showPartitionsResultSet = mockResultSet(partitionColumns, partitionTypes, partitionValues, new AtomicInteger(-1));
+        String[] partitionedColumns = {"col"};
+        int[] partitionedTypes = {Types.VARCHAR};
+        Object[][] partitionedValues = {{"PARTITIONED:true"}};
+        ResultSet partitionedResultSet = mockResultSet(partitionedColumns, partitionedTypes, partitionedValues, new AtomicInteger(-1));
+        Mockito.when(jdbcConnectionFactory.getConnection(nullable(CredentialsProvider.class))).thenReturn(connection);
+        final String qualifiedTable = HiveUtils.qualifiedTableForMetadataSql(getTableLayoutRequest.getTableName());
+        final String describeSql = HiveMetadataHandler.GET_METADATA_QUERY + qualifiedTable;
+        final String getPartitionExistsSql = "show table extended in "
+                + HiveUtils.quoteIdentifier(getTableLayoutRequest.getTableName().getSchemaName().toUpperCase())
+                + " like " + HiveUtils.likePatternLiteral(getTableLayoutRequest.getTableName().getTableName());
+        final String getPartitionDetailsSql = "show partitions " + qualifiedTable;
+        Statement statement = Mockito.mock(Statement.class);
+        Mockito.when(this.connection.createStatement()).thenReturn(statement);
+        Mockito.when(statement.executeQuery(describeSql)).thenReturn(describeResultSet);
+        Mockito.when(statement.executeQuery(getPartitionDetailsSql)).thenReturn(showPartitionsResultSet);
+        Mockito.when(statement.executeQuery(getPartitionExistsSql)).thenReturn(partitionedResultSet);
+        Mockito.when(partitionedResultSet.getString(1)).thenReturn("PARTITIONED:true");
+
+        GetTableLayoutResponse getTableLayoutResponse = this.hiveMetadataHandler.doGetTableLayout(blockAllocator, getTableLayoutRequest);
+
+        assertEquals(1, getTableLayoutResponse.getPartitions().getRowCount());
+        assertEquals("[partition :  `country`='1 OR true --']",
+                BlockUtils.rowToString(getTableLayoutResponse.getPartitions(), 0));
+    }
+
+    @Test
+    public void doGetTableLayout_whenBooleanPartition_emitsUnquotedTrueLiteral()
+            throws Exception
+    {
+        String[] schema = {"data_type", "col_name"};
+        Object[][] values = {{"boolean", "active"}};
+        ResultSet describeResultSet = mockResultSet(schema, values, new AtomicInteger(-1));
+        Constraints constraints = Mockito.mock(Constraints.class);
+        TableName tempTableName = new TableName(TEST_SCHEMA, TEST_TABLE);
+        Schema partitionSchema = this.hiveMetadataHandler.getPartitionSchema(CATALOG_NAME);
+        Set<String> partitionCols = new HashSet<>(Arrays.asList("partition"));
+        GetTableLayoutRequest getTableLayoutRequest = new GetTableLayoutRequest(this.federatedIdentity, QUERY_ID,
+                CATALOG_NAME, tempTableName, constraints, partitionSchema, partitionCols);
+        String[] partitionColumns = {"Partition"};
+        int[] partitionTypes = {Types.VARCHAR};
+        Object[][] partitionValues = {{"active=true"}};
+        ResultSet showPartitionsResultSet = mockResultSet(partitionColumns, partitionTypes, partitionValues, new AtomicInteger(-1));
+        String[] partitionedColumns = {"col"};
+        int[] partitionedTypes = {Types.VARCHAR};
+        Object[][] partitionedValues = {{"PARTITIONED:true"}};
+        ResultSet partitionedResultSet = mockResultSet(partitionedColumns, partitionedTypes, partitionedValues, new AtomicInteger(-1));
+        Mockito.when(jdbcConnectionFactory.getConnection(nullable(CredentialsProvider.class))).thenReturn(connection);
+        final String qualifiedTable = HiveUtils.qualifiedTableForMetadataSql(getTableLayoutRequest.getTableName());
+        final String describeSql = HiveMetadataHandler.GET_METADATA_QUERY + qualifiedTable;
+        final String getPartitionExistsSql = "show table extended in "
+                + HiveUtils.quoteIdentifier(getTableLayoutRequest.getTableName().getSchemaName().toUpperCase())
+                + " like " + HiveUtils.likePatternLiteral(getTableLayoutRequest.getTableName().getTableName());
+        final String getPartitionDetailsSql = "show partitions " + qualifiedTable;
+        Statement statement = Mockito.mock(Statement.class);
+        Mockito.when(this.connection.createStatement()).thenReturn(statement);
+        Mockito.when(statement.executeQuery(describeSql)).thenReturn(describeResultSet);
+        Mockito.when(statement.executeQuery(getPartitionDetailsSql)).thenReturn(showPartitionsResultSet);
+        Mockito.when(statement.executeQuery(getPartitionExistsSql)).thenReturn(partitionedResultSet);
+        Mockito.when(partitionedResultSet.getString(1)).thenReturn("PARTITIONED:true");
+
+        GetTableLayoutResponse getTableLayoutResponse = this.hiveMetadataHandler.doGetTableLayout(blockAllocator, getTableLayoutRequest);
+
+        assertEquals(1, getTableLayoutResponse.getPartitions().getRowCount());
+        assertEquals("[partition :  `active`=true]",
+                BlockUtils.rowToString(getTableLayoutResponse.getPartitions(), 0));
     }
 
     @Test

--- a/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveUtilsTest.java
+++ b/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveUtilsTest.java
@@ -41,6 +41,65 @@ public class HiveUtilsTest
     }
 
     @Test
+    public void quoteStringLiteral_whenValueIsSimple_returnsSingleQuotedLiteral()
+    {
+        assertEquals("'1'", HiveUtils.quoteStringLiteral("1"));
+    }
+
+    @Test
+    public void quoteStringLiteral_whenValueContainsOrTrue_staysInsideQuotedLiteral()
+    {
+        assertEquals("'1 OR true --'", HiveUtils.quoteStringLiteral("1 OR true --"));
+    }
+
+    @Test
+    public void quoteStringLiteral_whenValueContainsSingleQuote_doublesEmbeddedQuote()
+    {
+        assertEquals("'O''REILLY'", HiveUtils.quoteStringLiteral("O'REILLY"));
+    }
+
+    @Test
+    public void quoteStringLiteral_whenValueIsMixedCase_preservesCase()
+    {
+        assertEquals("'Test'", HiveUtils.quoteStringLiteral("Test"));
+    }
+
+    @Test
+    public void quoteStringLiteral_whenValueEndsWithBackslash_escapesBackslashSoLiteralStaysClosed()
+    {
+        assertEquals("'x\\\\'", HiveUtils.quoteStringLiteral("x\\"));
+    }
+
+    @Test
+    public void partitionValueExpression_whenBooleanTrue_returnsUnquotedTrue()
+    {
+        assertEquals("true", HiveUtils.partitionValueExpression("boolean", "true"));
+        assertEquals("TRUE", HiveUtils.partitionValueExpression("BOOLEAN", "TRUE"));
+    }
+
+    @Test
+    public void partitionValueExpression_whenBooleanFalse_returnsUnquotedFalse()
+    {
+        assertEquals("false", HiveUtils.partitionValueExpression("boolean", "false"));
+    }
+
+    @Test
+    public void partitionValueExpression_whenStringLikeType_quotesAsStringLiteral()
+    {
+        assertEquals("'Hyderabad'", HiveUtils.partitionValueExpression("string", "Hyderabad"));
+        assertEquals("'Hyderabad'", HiveUtils.partitionValueExpression("varchar", "Hyderabad"));
+        assertEquals("'2'", HiveUtils.partitionValueExpression("char(64)", "2"));
+        assertEquals("'1 OR true --'", HiveUtils.partitionValueExpression("char(64)", "1 OR true --"));
+        assertEquals("'2020-01-01'", HiveUtils.partitionValueExpression("date", "2020-01-01"));
+    }
+
+    @Test
+    public void partitionValueExpression_whenIntValue_returnsUnquotedLiteral()
+    {
+        assertEquals("2020", HiveUtils.partitionValueExpression("int", "2020"));
+    }
+
+    @Test
     public void quoteIdentifier_whenIdentifierIsEmpty_returnsQuotedEmptyIdentifier()
     {
         assertEquals("``", HiveUtils.quoteIdentifier(""));

--- a/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveUtilsTest.java
+++ b/athena-cloudera-hive/src/test/java/com/amazonaws/athena/connectors/cloudera/HiveUtilsTest.java
@@ -91,6 +91,14 @@ public class HiveUtilsTest
         assertEquals("'2'", HiveUtils.partitionValueExpression("char(64)", "2"));
         assertEquals("'1 OR true --'", HiveUtils.partitionValueExpression("char(64)", "1 OR true --"));
         assertEquals("'2020-01-01'", HiveUtils.partitionValueExpression("date", "2020-01-01"));
+        assertEquals("'2020-01-01'", HiveUtils.partitionValueExpression("date(10)", "2020-01-01"));
+        assertEquals("'2020-01-01'", HiveUtils.partitionValueExpression("DATE(", "2020-01-01"));
+    }
+
+    @Test
+    public void partitionValueExpression_whenColumnTypeIsNull_returnsUnquotedValue()
+    {
+        assertEquals("Hyderabad", HiveUtils.partitionValueExpression(null, "Hyderabad"));
     }
 
     @Test

--- a/athena-cloudera-impala/src/main/java/com/amazonaws/athena/connectors/cloudera/ImpalaMetadataHandler.java
+++ b/athena-cloudera-impala/src/main/java/com/amazonaws/athena/connectors/cloudera/ImpalaMetadataHandler.java
@@ -203,17 +203,11 @@ public class ImpalaMetadataHandler extends JdbcMetadataHandler
                 String columnName = partitionColumns[partitionCounter].split("=")[0];
                 String columnType = columnInfo.get(columnName).toUpperCase();
                 if (partitionValue.equalsIgnoreCase("__HIVE_DEFAULT_PARTITION__")) {
-                    columnCondition.append(" " + columnName).append(" is").append(" NULL");
+                    columnCondition.append(" ").append(ImpalaUtils.quoteIdentifier(columnName)).append(" is NULL");
                 }
                 else {
-                    if (columnType != null && (columnType.equalsIgnoreCase("STRING") || columnType.equalsIgnoreCase("VARCHAR"))) {
-                        columnCondition.append(" " + columnName).append("=").append("'");
-                        columnCondition.append(partitionValue).append("'");
-                    }
-                    else {
-                        columnCondition.append(" " + columnName).append("=");
-                        columnCondition.append(partitionValue);
-                    }
+                    columnCondition.append(" ").append(ImpalaUtils.quoteIdentifier(columnName))
+                            .append("=").append(ImpalaUtils.partitionValueExpression(columnType, partitionValue));
                 }
                 partitionCounter++;
                 if (partitionColumns.length > partitionCounter) {

--- a/athena-cloudera-impala/src/main/java/com/amazonaws/athena/connectors/cloudera/ImpalaUtils.java
+++ b/athena-cloudera-impala/src/main/java/com/amazonaws/athena/connectors/cloudera/ImpalaUtils.java
@@ -24,8 +24,9 @@ import com.amazonaws.athena.connector.lambda.domain.TableName;
 import static com.amazonaws.athena.connectors.cloudera.ImpalaConstants.IMPALA_QUOTE_CHARACTER;
 
 /**
- * Builds Impala-safe quoted identifiers for dynamic SQL. JDBC {@code ?} placeholders apply to values,
- * not table references, so identifiers must be quoted and escaped explicitly.
+ * Builds Impala-safe quoted identifiers and string literals for dynamic SQL. JDBC {@code ?}
+ * placeholders apply to values, not table references, so identifiers and literals must be
+ * quoted and escaped explicitly.
  */
 public class ImpalaUtils
 {
@@ -40,6 +41,38 @@ public class ImpalaUtils
     {
         String escaped = identifier.replace(IMPALA_QUOTE_CHARACTER, IMPALA_QUOTE_CHARACTER + IMPALA_QUOTE_CHARACTER);
         return IMPALA_QUOTE_CHARACTER + escaped + IMPALA_QUOTE_CHARACTER;
+    }
+
+    /**
+     * Single-quoted Impala string literal. Impala accepts quote-doubling and C-style backslash
+     * escapes, so backslashes are doubled first, then {@code '} is doubled.
+     */
+    public static String quoteStringLiteral(String value)
+    {
+        String escaped = value.replace("\\", "\\\\").replace("'", "''");
+        return "'" + escaped + "'";
+    }
+
+    /**
+     * Right-hand side of a partition equality predicate. Quote STRING, VARCHAR, CHAR, and DATE;
+     * leave INT, BOOLEAN, and other types unquoted. {@code VARCHAR} is covered by {@code contains("CHAR")}.
+     */
+    public static String partitionValueExpression(String columnType, String partitionValue)
+    {
+        if (isQuotedPartitionType(columnType)) {
+            return quoteStringLiteral(partitionValue);
+        }
+        return partitionValue;
+    }
+    
+    private static boolean isQuotedPartitionType(String columnType)
+    {
+        if (columnType == null) {
+            return false;
+        }
+        String type = columnType.toUpperCase();
+        return type.contains("STRING") || type.contains("CHAR")
+                || type.equals("DATE") || type.startsWith("DATE(");
     }
 
     /**

--- a/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaMetadataHandlerTest.java
+++ b/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaMetadataHandlerTest.java
@@ -179,13 +179,77 @@ public class ImpalaMetadataHandlerTest
             expectedValues.add(BlockUtils.rowToString(getTableLayoutResponse.getPartitions(), i));
         }
         assertEquals(2, expectedValues.size());
-        assertEquals("[partition :  case_date=02-01-2000 and case_number=1 and case_instance=89898990 and case_location='Hyderabad']", expectedValues.get(0));
-        assertEquals("[partition :  case_date=01-01-2000 and case_number=0 and case_instance=89898989 and case_location is NULL]", expectedValues.get(1));
+        assertEquals("[partition :  `case_date`='02-01-2000' and `case_number`=1 and `case_instance`=89898990 and `case_location`='Hyderabad']", expectedValues.get(0));
+        assertEquals("[partition :  `case_date`='01-01-2000' and `case_number`=0 and `case_instance`=89898989 and `case_location` is NULL]", expectedValues.get(1));
         SchemaBuilder expectedSchemaBuilder = SchemaBuilder.newBuilder();
         expectedSchemaBuilder.addField(FieldBuilder.newBuilder("partition", org.apache.arrow.vector.types.Types.MinorType.VARCHAR.getType()).build());
         Schema expectedSchema = expectedSchemaBuilder.build();
         assertEquals(expectedSchema, getTableLayoutResponse.getPartitions().getSchema());
         assertEquals(tempTableName, getTableLayoutResponse.getTableName());
+    }
+
+    @Test
+    public void doGetTableLayout_whenCharPartitionValueContainsOr_quotesValueAsStringLiteral()
+            throws Exception
+    {
+        String[] schema = {"type", "name"};
+        Object[][] values = {{"char(64)", "country"}};
+        ResultSet describeResultSet = mockResultSet(schema, values, new AtomicInteger(-1));
+        Constraints constraints = Mockito.mock(Constraints.class);
+        TableName tempTableName = new TableName(TEST_SCHEMA, TEST_TABLE);
+        Schema partitionSchema = this.impalaMetadataHandler.getPartitionSchema(TEST_CATALOG);
+        Set<String> partitionCols = new HashSet<>(Arrays.asList(TEST_PARTITION));
+        GetTableLayoutRequest getTableLayoutRequest = new GetTableLayoutRequest(this.federatedIdentity, TEST_QUERY_ID,
+                TEST_CATALOG, tempTableName, constraints, partitionSchema, partitionCols);
+        String[] partitionColumns = {"Partition"};
+        int[] partitionTypes = {Types.VARCHAR};
+        Object[][] partitionValues = {{"country=1 OR true --"}};
+        ResultSet showFilesResultSet = mockResultSet(partitionColumns, partitionTypes, partitionValues, new AtomicInteger(-1));
+        final String qualifiedTable = ImpalaUtils.qualifiedTableForMetadataSql(tempTableName);
+        final String describeSql = ImpalaMetadataHandler.GET_METADATA_QUERY + qualifiedTable;
+        final String getPartitionDetailsSql = "show files in " + qualifiedTable;
+        Statement statement = Mockito.mock(Statement.class);
+        Mockito.when(this.connection.createStatement()).thenReturn(statement);
+        Mockito.when(statement.executeQuery(describeSql)).thenReturn(describeResultSet);
+        Mockito.when(statement.executeQuery(getPartitionDetailsSql)).thenReturn(showFilesResultSet);
+
+        GetTableLayoutResponse getTableLayoutResponse = this.impalaMetadataHandler.doGetTableLayout(blockAllocator, getTableLayoutRequest);
+
+        assertEquals(1, getTableLayoutResponse.getPartitions().getRowCount());
+        assertEquals("[partition :  `country`='1 OR true --']",
+                BlockUtils.rowToString(getTableLayoutResponse.getPartitions(), 0));
+    }
+
+    @Test
+    public void doGetTableLayout_whenBooleanPartition_emitsUnquotedTrueLiteral()
+            throws Exception
+    {
+        String[] schema = {"type", "name"};
+        Object[][] values = {{"boolean", "active"}};
+        ResultSet describeResultSet = mockResultSet(schema, values, new AtomicInteger(-1));
+        Constraints constraints = Mockito.mock(Constraints.class);
+        TableName tempTableName = new TableName(TEST_SCHEMA, TEST_TABLE);
+        Schema partitionSchema = this.impalaMetadataHandler.getPartitionSchema(TEST_CATALOG);
+        Set<String> partitionCols = new HashSet<>(Arrays.asList(TEST_PARTITION));
+        GetTableLayoutRequest getTableLayoutRequest = new GetTableLayoutRequest(this.federatedIdentity, TEST_QUERY_ID,
+                TEST_CATALOG, tempTableName, constraints, partitionSchema, partitionCols);
+        String[] partitionColumns = {"Partition"};
+        int[] partitionTypes = {Types.VARCHAR};
+        Object[][] partitionValues = {{"active=true"}};
+        ResultSet showFilesResultSet = mockResultSet(partitionColumns, partitionTypes, partitionValues, new AtomicInteger(-1));
+        final String qualifiedTable = ImpalaUtils.qualifiedTableForMetadataSql(tempTableName);
+        final String describeSql = ImpalaMetadataHandler.GET_METADATA_QUERY + qualifiedTable;
+        final String getPartitionDetailsSql = "show files in " + qualifiedTable;
+        Statement statement = Mockito.mock(Statement.class);
+        Mockito.when(this.connection.createStatement()).thenReturn(statement);
+        Mockito.when(statement.executeQuery(describeSql)).thenReturn(describeResultSet);
+        Mockito.when(statement.executeQuery(getPartitionDetailsSql)).thenReturn(showFilesResultSet);
+
+        GetTableLayoutResponse getTableLayoutResponse = this.impalaMetadataHandler.doGetTableLayout(blockAllocator, getTableLayoutRequest);
+
+        assertEquals(1, getTableLayoutResponse.getPartitions().getRowCount());
+        assertEquals("[partition :  `active`=true]",
+                BlockUtils.rowToString(getTableLayoutResponse.getPartitions(), 0));
     }
 
    @Test

--- a/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaUtilsTest.java
+++ b/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaUtilsTest.java
@@ -90,6 +90,14 @@ public class ImpalaUtilsTest
         assertEquals("'2'", ImpalaUtils.partitionValueExpression("char(64)", "2"));
         assertEquals("'1 OR true --'", ImpalaUtils.partitionValueExpression("char(64)", "1 OR true --"));
         assertEquals("'2020-01-01'", ImpalaUtils.partitionValueExpression("date", "2020-01-01"));
+        assertEquals("'2020-01-01'", ImpalaUtils.partitionValueExpression("date(10)", "2020-01-01"));
+        assertEquals("'2020-01-01'", ImpalaUtils.partitionValueExpression("DATE(", "2020-01-01"));
+    }
+
+    @Test
+    public void partitionValueExpression_whenColumnTypeIsNull_returnsUnquotedValue()
+    {
+        assertEquals("Hyderabad", ImpalaUtils.partitionValueExpression(null, "Hyderabad"));
     }
     
     @Test

--- a/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaUtilsTest.java
+++ b/athena-cloudera-impala/src/test/java/com/amazonaws/athena/connectors/cloudera/ImpalaUtilsTest.java
@@ -40,6 +40,59 @@ public class ImpalaUtilsTest
     }
 
     @Test
+    public void quoteStringLiteral_whenValueIsSimple_returnsSingleQuotedLiteral()
+    {
+        assertEquals("'1'", ImpalaUtils.quoteStringLiteral("1"));
+    }
+
+    @Test
+    public void quoteStringLiteral_whenValueContainsOrTrue_staysInsideQuotedLiteral()
+    {
+        assertEquals("'1 OR true --'", ImpalaUtils.quoteStringLiteral("1 OR true --"));
+    }
+
+    @Test
+    public void quoteStringLiteral_whenValueContainsSingleQuote_doublesEmbeddedQuote()
+    {
+        assertEquals("'O''REILLY'", ImpalaUtils.quoteStringLiteral("O'REILLY"));
+    }
+
+    @Test
+    public void quoteStringLiteral_whenValueEndsWithBackslash_escapesBackslashSoLiteralStaysClosed()
+    {
+        assertEquals("'x\\\\'", ImpalaUtils.quoteStringLiteral("x\\"));
+    }
+
+    @Test
+    public void partitionValueExpression_whenBooleanTrue_returnsUnquotedTrue()
+    {
+        assertEquals("true", ImpalaUtils.partitionValueExpression("boolean", "true"));
+        assertEquals("TRUE", ImpalaUtils.partitionValueExpression("BOOLEAN", "TRUE"));
+    }
+
+    @Test
+    public void partitionValueExpression_whenBooleanFalse_returnsUnquotedFalse()
+    {
+        assertEquals("false", ImpalaUtils.partitionValueExpression("boolean", "false"));
+    }
+
+    @Test
+    public void partitionValueExpression_whenIntValue_returnsUnquotedLiteral()
+    {
+        assertEquals("2020", ImpalaUtils.partitionValueExpression("int", "2020"));
+    }
+
+    @Test
+    public void partitionValueExpression_whenStringLikeType_quotesAsStringLiteral()
+    {
+        assertEquals("'Hyderabad'", ImpalaUtils.partitionValueExpression("string", "Hyderabad"));
+        assertEquals("'Hyderabad'", ImpalaUtils.partitionValueExpression("varchar", "Hyderabad"));
+        assertEquals("'2'", ImpalaUtils.partitionValueExpression("char(64)", "2"));
+        assertEquals("'1 OR true --'", ImpalaUtils.partitionValueExpression("char(64)", "1 OR true --"));
+        assertEquals("'2020-01-01'", ImpalaUtils.partitionValueExpression("date", "2020-01-01"));
+    }
+    
+    @Test
     public void quoteIdentifier_whenIdentifierIsEmpty_returnsQuotedEmptyIdentifier()
     {
         assertEquals("``", ImpalaUtils.quoteIdentifier(""));


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Quote partition column names and values in Hive and Impala split WHERE predicates built by `addPartitions` (`SHOW PARTITIONS` / `SHOW FILES IN`).
- Backtick partition columns (`HiveUtils.quoteIdentifier` / `ImpalaUtils.quoteIdentifier`), doubling any embedded backtick.
- Quote STRING, VARCHAR, CHAR, and DATE values as string literals (`quoteStringLiteral` / `partitionValueExpression`), escaping `'` and `\`; leave INT, BOOLEAN, and other types unquoted.

Please find the attached functional testing results.
[CLOUDERAHIVE_FUNCTIONAL_TEST_2026-09-08.xlsx](https://github.com/user-attachments/files/31953514/CLOUDERAHIVE_FUNCTIONAL_TEST_2026-09-08.xlsx)
[CLOUDERAIMPALA_FUNCTIONAL_TEST_2026-09-08.xlsx](https://github.com/user-attachments/files/31953516/CLOUDERAIMPALA_FUNCTIONAL_TEST_2026-09-08.xlsx)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
